### PR TITLE
docs(website): a Gtk section beside Adwaita

### DIFF
--- a/scripts/check-doc-fences.mjs
+++ b/scripts/check-doc-fences.mjs
@@ -99,7 +99,17 @@ import { fileURLToPath } from 'node:url';
 const rootFlag = process.argv.indexOf('--root');
 const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : process.argv[rootFlag + 1];
 
-const DOCS_DIR = join(ROOT, 'website/src/content/docs/adwaita');
+/**
+ * The gallery's section directories, one per widget library.
+ *
+ * Two since ADR 0034 § 1 put `Gtk` beside `Adwaita`. A fence under `gtk/` compiles
+ * and resolves exactly like one under `adwaita/`, so a single-directory scan would
+ * simply stop reading four blocks on the day they moved. It would stay green over a
+ * set smaller than the one it names.
+ */
+const DOCS_SECTIONS = ['adwaita', 'gtk'];
+const docsDir = (section) => join(ROOT, 'website/src/content/docs', section);
+
 /**
  * Scanned by the TOKENS arm ONLY, and the narrowness is deliberate: three of the
  * four blank snippets were here rather than in the gallery, and widening the whole
@@ -576,7 +586,7 @@ const exempt = new Set(Object.keys(ledger.exemptions ?? {}));
 // A missing root is "could not look", not "found nothing" — and it crashed with a
 // Node stack trace, which reads like a broken gate rather than a bad argument.
 for (const [label, dir] of [
-    ['the Adwaita docs', DOCS_DIR],
+    ...DOCS_SECTIONS.map((section) => [`the ${section} gallery pages`, docsDir(section)]),
     ['@gjsify/adwaita-icons', ICONS_PKG],
     ["adwaita-web's scss", WEB_SCSS],
 ]) {
@@ -592,9 +602,11 @@ const webIcons = readWebIconNames();
 const styled = readStyledClasses();
 
 const sources = [
-    ...readdirSync(DOCS_DIR)
-        .filter((f) => f.endsWith('.mdx'))
-        .map((f) => `website/src/content/docs/adwaita/${f}`),
+    ...DOCS_SECTIONS.flatMap((section) =>
+        readdirSync(docsDir(section))
+            .filter((f) => f.endsWith('.mdx'))
+            .map((f) => `website/src/content/docs/${section}/${f}`),
+    ),
     ...EXTRA_SOURCES,
 ];
 

--- a/scripts/check-generated-website-data.mjs
+++ b/scripts/check-generated-website-data.mjs
@@ -117,7 +117,13 @@ import {
 const rootFlag = process.argv.indexOf('--root');
 const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : process.argv[rootFlag + 1];
 
-const DOCS_DIR = join(ROOT, 'website/src/content/docs/adwaita');
+/**
+ * The gallery's section directories, one per widget library. Two since ADR 0034 § 1
+ * put `Gtk` beside `Adwaita`; arm 4 below counts BLOCKS, so reading one directory
+ * would report a smaller gallery than the site ships and call it complete.
+ */
+const DOCS_SECTIONS = ['adwaita', 'gtk'];
+const docsDir = (section) => join(ROOT, 'website/src/content/docs', section);
 
 /**
  * The generators whose output is committed, each with the `--check` mode that
@@ -181,7 +187,7 @@ const notes = [];
 // throws first, and a Node stack trace reads like a broken gate instead of a bad
 // argument.
 for (const [label, path] of [
-    ['the Adwaita gallery pages', DOCS_DIR],
+    ...DOCS_SECTIONS.map((section) => [`the ${section} gallery pages`, docsDir(section)]),
     ['the element reader', join(ROOT, 'scripts/adwaita-elements.mjs')],
 ]) {
     if (!existsSync(path)) {
@@ -235,8 +241,14 @@ const seenTitles = new Set();
 let blocks = 0;
 let tabled = 0;
 
-for (const page of readdirSync(DOCS_DIR).filter((f) => f.endsWith('.mdx'))) {
-    const text = readFileSync(join(DOCS_DIR, page), 'utf8');
+for (const { page, file } of DOCS_SECTIONS.flatMap((section) =>
+    readdirSync(docsDir(section))
+        .filter((f) => f.endsWith('.mdx'))
+        // `buttons.mdx` now exists in both sections, so a bare filename in a failure
+        // no longer says which page it is.
+        .map((f) => ({ page: `${section}/${f}`, file: join(docsDir(section), f) })),
+)) {
+    const text = readFileSync(file, 'utf8');
     for (const [, title] of text.matchAll(/<AdwWidget\s+title="([^"]+)"/g)) {
         blocks++;
         seenTitles.add(title);

--- a/scripts/check-website-adwaita-gallery.mjs
+++ b/scripts/check-website-adwaita-gallery.mjs
@@ -3,7 +3,7 @@
 //
 // THE INCIDENT
 //
-// `website/src/content/docs/adwaita/` is hand-derived from the storybook: a human
+// `website/src/content/docs/{adwaita,gtk}/` is hand-derived from the storybook: a human
 // reads the `*.meta.ts` set and writes an `<AdwWidget>` block per widget. On
 // 2026-07-24 that was 35 against 35. Five metas landed after it, and on 2026-08-18
 // the gallery pages were RE-AUTHORED wholesale (#1228) — three days later, by
@@ -30,6 +30,23 @@
 //      exists at its URL and is offered to nobody, so the gate would force a page no
 //      reader can reach. `adwaita/controls` was added there by hand in the very
 //      commit that first satisfied arm 1.
+//  11. Every block is filed under the LIBRARY THAT OWNS ITS GTYPE, in both places
+//      the filing is written down: the section directory the page sits in, and the
+//      sidebar GROUP the page's slug is listed in. ADR 0034 § 1.
+//
+//      The gallery documented `Gtk.Entry`, `Gtk.DropDown`, `Gtk.Button` and
+//      `Gtk.MenuButton` under a section named `Adwaita`, and `controls.mdx` carried
+//      no Adwaita widget at all. Arms 1-3 could not see it: each of those blocks has
+//      a title, each title has a meta, and the meta says nothing about which section
+//      the page belongs to.
+//
+//      The SIDEBAR half is the same blindness one level up, and it is the reason arm
+//      4 is not enough. Arm 4 reads Starlight's groups as one flat set of slugs, so a
+//      `gtk/*` page listed inside the `Adwaita` group satisfies it completely, while
+//      the reader meets a GTK page under an Adwaita heading, which is the very defect
+//      this arm is named after, moved from the directory to the navigation. Same shape as
+//      arm 10's known limit, which holds window TITLES and therefore cannot see a new
+//      TAB inside a window whose title is already named.
 //   5. Every `<Fragment slot="…">` inside a block names a slot `AdwWidget` renders.
 //      Astro drops an unmatched slot in SILENCE — no warning, no build failure — so a
 //      misspelled port is a snippet that is written, reviewed, committed and shown to
@@ -106,8 +123,29 @@ const args = process.argv.slice(2);
 const rootFlag = args.indexOf('--root');
 const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootFlag + 1];
 
-/** The gallery: one page per storybook category, each a list of `<AdwWidget>` blocks. */
-const GALLERY = 'website/src/content/docs/adwaita';
+/**
+ * The gallery: one section per widget LIBRARY, each a set of pages of `<AdwWidget>`
+ * blocks.
+ *
+ * ONE declaration carrying all three joins a section has, the directory its pages
+ * live in, the GIR namespace whose widgets belong in it, and the sidebar group it is
+ * navigated by. The three drifting apart is exactly what arm 11 refuses. A third
+ * section (Material, say) is three strings here and nothing else.
+ *
+ * Spelled out rather than globbed over `content/docs`, because most sections there
+ * are not gallery sections and a sweep would ask arm 1 of pages that document no
+ * widget at all.
+ */
+const GALLERY_SECTIONS = [
+    { dir: 'adwaita', namespace: 'Adw', group: 'Adwaita' },
+    { dir: 'gtk', namespace: 'Gtk', group: 'Gtk' },
+];
+
+/** A section's directory, posix-spelled, because failures PRINT it. */
+const sectionDir = (section) => `website/src/content/docs/${section}`;
+
+/** Every section directory, for the messages that say where a scan looked. */
+const GALLERY = GALLERY_SECTIONS.map((section) => sectionDir(section.dir)).join(' and ');
 
 /**
  * Story metas the gallery deliberately does not carry, and why.
@@ -147,21 +185,30 @@ const TITLED_AFTER = {
     },
 };
 
-/** The gallery's own pages — the input to both the title arm and the sidebar arm. */
+/**
+ * The gallery's own pages, the input to the title arm, the sidebar arm and arm 11.
+ *
+ * Each page carries the SECTION it was found in, because that is half of what arm 11
+ * decides and a bare filename cannot say it: `buttons.mdx` exists in both sections
+ * and documents a different library in each.
+ */
 const galleryPages = (root) =>
-    readdirSync(join(root, GALLERY), { withFileTypes: true })
-        .filter((entry) => entry.isFile() && entry.name.endsWith('.mdx'))
-        .map((entry) => entry.name)
-        .sort();
+    GALLERY_SECTIONS.flatMap(({ dir }) =>
+        readdirSync(join(root, sectionDir(dir)), { withFileTypes: true })
+            .filter((entry) => entry.isFile() && entry.name.endsWith('.mdx'))
+            .map((entry) => entry.name)
+            .sort()
+            .map((file) => ({ dir, file, path: `${sectionDir(dir)}/${file}` })),
+    );
 
 /** `<AdwWidget … title="X">` → X, for every page in the gallery. */
 function galleryTitles(root, pages) {
     /** @type {Map<string, string>} */
     const found = new Map();
     for (const page of pages) {
-        const text = readFileSync(join(root, GALLERY, page), 'utf8');
+        const text = readFileSync(join(root, page.path), 'utf8');
         for (const [, title] of text.matchAll(/<AdwWidget\b[^>]*?\btitle="([^"]+)"/g)) {
-            if (!found.has(title)) found.set(title, `${GALLERY}/${page}`);
+            if (!found.has(title)) found.set(title, page.path);
         }
     }
     return found;
@@ -171,10 +218,10 @@ function galleryTitles(root, pages) {
 function widgetBlocks(root, pages) {
     const blocks = [];
     for (const page of pages) {
-        const text = readFileSync(join(root, GALLERY, page), 'utf8');
+        const text = readFileSync(join(root, page.path), 'utf8');
         const shape = /<AdwWidget\b[^>]*?\btitle="([^"]+)"[^>]*>([\s\S]*?)<\/AdwWidget>/g;
         for (const [, title, body] of text.matchAll(shape)) {
-            blocks.push({ page: `${GALLERY}/${page}`, title, body });
+            blocks.push({ page: page.path, dir: page.dir, title, body });
         }
     }
     return blocks;
@@ -314,10 +361,56 @@ const pageProse = (text) =>
 
 /** Where the site's navigation is hand-written, and how a page is spelled in it. */
 const SIDEBAR = 'website/astro.config.mjs';
-const SIDEBAR_SLUG = /\bslug:\s*'(adwaita(?:\/[a-z0-9-]+)?)'/g;
+const SIDEBAR_SLUG = new RegExp(
+    `\\bslug:\\s*'((?:${GALLERY_SECTIONS.map(({ dir }) => dir).join('|')})(?:\\/[a-z0-9-]+)?)'`,
+    'g',
+);
 
-/** `controls.mdx` → `adwaita/controls`; the index page is the bare section slug. */
-const pageSlug = (page) => (page === 'index.mdx' ? 'adwaita' : `adwaita/${page.slice(0, -'.mdx'.length)}`);
+/** The index page of a section is spelled as the bare section slug. */
+const SECTION_INDEX = 'index.mdx';
+
+/** `{dir: 'gtk', file: 'controls.mdx'}` → `gtk/controls`. */
+const pageSlug = (page) =>
+    page.file === SECTION_INDEX ? page.dir : `${page.dir}/${page.file.slice(0, -'.mdx'.length)}`;
+
+/**
+ * The slugs listed inside one hand-written sidebar GROUP, or null if no group of
+ * that label exists.
+ *
+ * Arm 4 reads every `slug:` in the file as one flat set, which is all it needs, since
+ * a page is reachable or it is not. Arm 11's sidebar half needs the group each slug
+ * sits IN, because a `gtk/*` page listed under `Adwaita` is reachable and filed
+ * wrong, and only the second read can tell those apart.
+ *
+ * A Starlight `items:` array here holds one object per line and no nested array, so
+ * the first `]` after the opening one closes it. The vacuity guard below is what
+ * catches the day that stops being true: a group whose slugs come back empty is
+ * reported, not passed over.
+ */
+function sidebarGroup(text, label) {
+    const open = new RegExp(`\\blabel: '${label}',\\s*\\n\\s*items: \\[`).exec(text);
+    if (open === null) return null;
+    const start = open.index + open[0].length;
+    const end = text.indexOf(']', start);
+    if (end === -1) return null;
+    return [...text.slice(start, end).matchAll(/\bslug:\s*'([^']+)'/g)].map(([, slug]) => slug);
+}
+
+// A section declares the GIR namespace its widgets carry, and `bareName` decides
+// which titles the gallery accepts at all. Two hardcoded lists, and if they drift the
+// drift is SILENT in the expensive direction: arm 1 would reject every block of the
+// new section as a malformed title, so the section would look empty rather than
+// misfiled, and arm 11 would have nothing to file. Held here, before any data is read.
+for (const { namespace, group } of GALLERY_SECTIONS) {
+    if (bareName(`${namespace}.Widget`) !== null) continue;
+    console.error(
+        `check-website-adwaita-gallery: the ${group} section declares the namespace "${namespace}", and\n` +
+            `  bareName() does not accept "${namespace}.Widget". Arm 1 would reject every block in that\n` +
+            '  section as a malformed title and arm 11 would file none of them, so the section would be\n' +
+            '  policed by nothing at all. Widen bareName() to the namespaces GALLERY_SECTIONS declares.',
+    );
+    process.exit(1);
+}
 
 /** @type {Map<string, {path: string, file: string, titles: string[], source: string}>} */
 let metas;
@@ -397,12 +490,11 @@ for (const [name, entry] of Object.entries(TITLED_AFTER)) {
     );
 }
 
-const navigated = new Set(
-    [...readFileSync(join(ROOT, SIDEBAR), 'utf8').matchAll(SIDEBAR_SLUG)].map(([, slug]) => slug),
-);
+const sidebarSource = readFileSync(join(ROOT, SIDEBAR), 'utf8');
+const navigated = new Set([...sidebarSource.matchAll(SIDEBAR_SLUG)].map(([, slug]) => slug));
 if (navigated.size === 0) {
     console.error(
-        `check-website-adwaita-gallery: no adwaita entry found in ${SIDEBAR} — that is a broken scan,\n` +
+        `check-website-adwaita-gallery: no gallery entry found in ${SIDEBAR} — that is a broken scan,\n` +
             '  not a site with no navigation.',
     );
     process.exit(1);
@@ -410,7 +502,7 @@ if (navigated.size === 0) {
 for (const page of pages) {
     if (navigated.has(pageSlug(page))) continue;
     failures.push(
-        `${GALLERY}/${page} is in no sidebar group of ${SIDEBAR}. Starlight lists what that array\n` +
+        `${page.path} is in no sidebar group of ${SIDEBAR}. Starlight lists what that array\n` +
             `    names and nothing else, so the page exists at /${pageSlug(page)}/ and is offered to nobody.\n` +
             `    Add { slug: '${pageSlug(page)}' }, in the position the storybook's category order puts it.`,
     );
@@ -558,6 +650,12 @@ if (panePosition !== null) {
  * the pages it introduces. It carried the stale name too, and skipping it would have
  * left the one page a reader meets first outside the rule.
  *
+ * That union is PER SECTION, not over the whole gallery. `gtk/index.mdx` introduces
+ * the GTK pages and nothing else, so a window only the Adwaita pages draw is one its
+ * prose must not name. A gallery-wide union would let a section index describe
+ * windows a reader never meets there, in the exact voice this arm exists to keep
+ * honest.
+ *
  * MEASURED against the four ways it can be wrong, each restored afterwards:
  *
  *   · rename the window in the component alone — exit 1, on all 9 pages, which is
@@ -568,7 +666,6 @@ if (panePosition !== null) {
  *   · break the title read (`title:` -> `heading:`) — exit 1 on the vacuity guard,
  *     not a green run against an empty set
  */
-const SECTION_INDEX = 'index.mdx';
 const titledWindows = windows.filter((window) => window.title !== null);
 if (titledWindows.length === 0) {
     failures.push(
@@ -577,38 +674,127 @@ if (titledWindows.length === 0) {
     );
 }
 
-/** page → the titled windows its own blocks draw. */
-const shownBy = new Map(pages.map((page) => [page, new Set()]));
+/** page path → the titled windows its own blocks draw. */
+const shownBy = new Map(pages.map((page) => [page.path, new Set()]));
 for (const block of blocks) {
-    const page = block.page.slice(`${GALLERY}/`.length);
     const slots = new Set([...block.body.matchAll(/<Fragment slot="([^"]+)"/g)].map(([, slot]) => slot));
     for (const window of titledWindows) {
-        if (window.data || window.slots.some((slot) => slots.has(slot))) shownBy.get(page).add(window.title);
+        if (window.data || window.slots.some((slot) => slots.has(slot))) shownBy.get(block.page).add(window.title);
     }
 }
-const everywhere = new Set([...shownBy.values()].flatMap((titles) => [...titles]));
+/** section dir → the union over that section's own pages, which its index stands for. */
+const sectionWindows = new Map(GALLERY_SECTIONS.map(({ dir }) => [dir, new Set()]));
+for (const page of pages) {
+    for (const title of shownBy.get(page.path)) sectionWindows.get(page.dir).add(title);
+}
 
 for (const page of pages) {
-    const shown = page === SECTION_INDEX ? everywhere : shownBy.get(page);
-    // A page with no block draws nothing, and the index stands for the section.
+    const shown = page.file === SECTION_INDEX ? sectionWindows.get(page.dir) : shownBy.get(page.path);
+    // A page with no block draws nothing, and the index stands for its section.
     if (shown.size === 0) continue;
-    const prose = pageProse(readFileSync(join(ROOT, GALLERY, page), 'utf8'));
+    const prose = pageProse(readFileSync(join(ROOT, page.path), 'utf8'));
     for (const title of titledWindows.map((window) => window.title)) {
         const named = prose.includes(title);
         if (named === shown.has(title)) continue;
         failures.push(
             named
-                ? `${GALLERY}/${page} names the window "${title}" in its prose, and no block on it draws\n` +
+                ? `${page.path} names the window "${title}" in its prose, and no block on it draws\n` +
                       '    that window. A reader is told to look for a window that is not there — and the\n' +
                       '    enumeration is the only place the window titles are explained, so being wrong\n' +
                       '    there is worse than being silent.'
-                : `${GALLERY}/${page} draws the window "${title}" and its prose never names it. Every\n` +
+                : `${page.path} draws the window "${title}" and its prose never names it. Every\n` +
                       `    gallery page introduces the stack of windows by title, and ${WIDGET_COMPONENT}\n` +
                       '    relies on that: what a window title cannot say (the four runtimes, the three\n' +
                       '    dialects) the page says instead. Rename a window here and nowhere else, or grow\n' +
                       '    the stack by one, and the intro describes a page that no longer exists.',
         );
     }
+}
+
+// --- arm 11: a block is filed under the library that owns its GType ---
+//
+// Two reads of the same fact, because the filing is written down twice. The
+// directory is what a page IS; the sidebar group is what a reader MEETS. Getting
+// either one wrong puts a widget under the name of a library it does not belong to,
+// and neither arm above can see it.
+
+/** dir → the section, for the block half. */
+const sectionOf = new Map(GALLERY_SECTIONS.map((section) => [section.dir, section]));
+/** namespace → the section a block of that namespace belongs in. */
+const sectionOfNamespace = new Map(GALLERY_SECTIONS.map((section) => [section.namespace, section]));
+
+/**
+ * The namespace a block's title opens with, built FROM the table.
+ *
+ * A literal `/^(Adw|Gtk)\./` here would be a second list beside `GALLERY_SECTIONS`,
+ * and the day they disagreed arm 11 would skip every block of the unlisted namespace
+ * in silence, which is the one failure mode this arm must not have. The guard above
+ * holds the same pair against `bareName`, so all three move together or one of them
+ * goes red.
+ */
+const TITLE_NAMESPACE = new RegExp(`^(${GALLERY_SECTIONS.map(({ namespace }) => namespace).join('|')})\\.`);
+
+for (const block of blocks) {
+    const namespace = TITLE_NAMESPACE.exec(block.title);
+    // A title outside `Adw.Class` / `Gtk.Class` is already arm 1's failure; reporting
+    // it twice would say the same thing in two voices.
+    if (namespace === null) continue;
+    const belongs = sectionOfNamespace.get(namespace[1]);
+    if (belongs.dir === block.dir) continue;
+    failures.push(
+        `${block.page}: <AdwWidget title="${block.title}"> is a ${namespace[1]} widget filed under the\n` +
+            `    ${sectionOf.get(block.dir)?.group ?? block.dir} section. ADR 0034 § 1 names a widget after the\n` +
+            '    library that owns its GType, and the documentation follows the same split. A widget\n' +
+            '    documented under a library it does not belong to has moved the inconsistency, not removed\n' +
+            `    it. Move the block to ${sectionDir(belongs.dir)}/.`,
+    );
+}
+
+for (const section of GALLERY_SECTIONS) {
+    const listed = sidebarGroup(sidebarSource, section.group);
+    if (listed === null) {
+        failures.push(
+            `${SIDEBAR} declares no sidebar group labelled "${section.group}", so every page under\n` +
+                `    ${sectionDir(section.dir)} is filed under some other library's heading or under none.`,
+        );
+        continue;
+    }
+    if (listed.length === 0) {
+        failures.push(
+            `${SIDEBAR}: the "${section.group}" group parsed to zero slugs, so arm 11's sidebar half would\n` +
+                '    hold this section against an empty set and pass vacuously. The group reader is broken,\n' +
+                '    not the sidebar.',
+        );
+        continue;
+    }
+    for (const slug of listed) {
+        const dir = slug.split('/')[0];
+        if (dir === section.dir) continue;
+        failures.push(
+            `${SIDEBAR}: the "${section.group}" sidebar group lists { slug: '${slug}' }, which is a page of\n` +
+                `    the ${sectionOf.get(dir)?.group ?? dir} section. Arm 4 cannot see this: it reads every group as\n` +
+                '    one flat set, so the page is reachable and still meets the reader under the wrong\n' +
+                '    library.',
+        );
+    }
+    for (const page of pages.filter((entry) => entry.dir === section.dir)) {
+        if (listed.includes(pageSlug(page))) continue;
+        if (!navigated.has(pageSlug(page))) continue; // arm 4 already reports it as unreachable
+        failures.push(
+            `${page.path} is listed in ${SIDEBAR}, but not in the "${section.group}" group its section is\n` +
+                "    named by. It is reachable under another library's heading, which is the defect this\n" +
+                '    section split exists to remove.',
+        );
+    }
+}
+
+for (const section of GALLERY_SECTIONS) {
+    if (blocks.some((block) => block.dir === section.dir)) continue;
+    failures.push(
+        `${sectionDir(section.dir)} holds no <AdwWidget> block at all, so arm 11 polices an empty set for\n` +
+            `    the ${section.group} section. A declared section with no widget in it is a heading offered to\n` +
+            '    the reader with nothing behind it.',
+    );
 }
 
 if (failures.length > 0) {
@@ -627,6 +813,16 @@ console.log(
     `check-website-adwaita-gallery: ${metas.size} story metas — ${metas.size - exempt} documented by ` +
         `${gallery.size} <AdwWidget> blocks across ${pages.length} pages, all of them in the sidebar, ` +
         `${exempt} ledgered with a reason.`,
+);
+console.log(
+    `check-website-adwaita-gallery: ${GALLERY_SECTIONS.length} section(s) — ` +
+        GALLERY_SECTIONS.map(
+            ({ dir, namespace, group }) =>
+                `${group} [${blocks.filter((block) => block.dir === dir).length} ${namespace}.* block(s), ` +
+                `${(sidebarGroup(sidebarSource, group) ?? []).length} sidebar slug(s)]`,
+        ).join(', ') +
+        ' — every block under the library that owns its GType, and every page in the sidebar group its ' +
+        'section is named by.',
 );
 console.log(
     `check-website-adwaita-gallery: ${windows.length} window(s) in ${WIDGET_COMPONENT} — ` +

--- a/scripts/check-website-attr-samples.mjs
+++ b/scripts/check-website-attr-samples.mjs
@@ -47,7 +47,13 @@ import { observedAttributes } from './adwaita-elements.mjs';
 
 const rootFlag = process.argv.indexOf('--root');
 const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : process.argv[rootFlag + 1];
-const DOCS_DIR = join(ROOT, 'website/src/content/docs/adwaita');
+/**
+ * The gallery's section directories, one per widget library. Two since ADR 0034 § 1
+ * put `Gtk` beside `Adwaita`; this gate counts CELLS across gallery blocks, so a
+ * single-directory scan would go green over a set four blocks short of the site's.
+ */
+const DOCS_SECTIONS = ['adwaita', 'gtk'];
+const docsDir = (section) => join(ROOT, 'website/src/content/docs', section);
 
 const failures = [];
 const fail = (what, expected, actual) => failures.push(`${what}\n      expected ${expected}\n      actual   ${actual}`);
@@ -150,8 +156,14 @@ const elementTag = (title) =>
 const { byTag } = observedAttributes(ROOT);
 let blocks = 0;
 let cellsSeen = 0;
-for (const page of readdirSync(DOCS_DIR).filter((f) => f.endsWith('.mdx'))) {
-    const text = readFileSync(join(DOCS_DIR, page), 'utf8');
+for (const { page, file } of DOCS_SECTIONS.flatMap((section) =>
+    readdirSync(docsDir(section))
+        .filter((f) => f.endsWith('.mdx'))
+        // `buttons.mdx` now exists in both sections, so a bare filename in a failure
+        // no longer says which page it is.
+        .map((f) => ({ page: `${section}/${f}`, file: join(docsDir(section), f) })),
+)) {
+    const text = readFileSync(file, 'utf8');
     for (const block of text.split('<AdwWidget').slice(1)) {
         const title = /^[^>]*title="([^"]+)"/.exec(block)?.[1];
         if (title === undefined) continue;

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -18,6 +18,27 @@ export default defineConfig({
     // `/widgets/*` became `/adwaita/*`: the section only ever covered Adwaita,
     // and naming it after the design system leaves room for a second one
     // (Material, say) beside it rather than under it.
+    //
+    // That is the same sentence this change applies a SECOND time, because its
+    // premise stopped holding. The section had grown four `Gtk.*` gallery blocks,
+    // and `controls.mdx` carried no Adwaita widget at all, 0 `Adw.*` against 2
+    // `Gtk.*`. That is measurable per page:
+    //
+    //     for f in website/src/content/docs/*/[a-z]*.mdx; do
+    //       printf '%-34s Adw=%s Gtk=%s\n' "$f" \
+    //         "$(grep -c '<AdwWidget title="Adw\.' $f)" "$(grep -c '<AdwWidget title="Gtk\.' $f)"
+    //     done
+    //
+    // So `Gtk` is a section BESIDE `Adwaita` rather than under it, and the split
+    // follows ADR 0034 § 1, where a widget belongs to the library that owns its
+    // GType, read from the GIR and never chosen per surface.
+    //
+    // `controls.mdx` moved whole; the two `Gtk.*` blocks on `adwaita/buttons.mdx`
+    // moved to `gtk/buttons.mdx`. Only the first is a URL change, so only the
+    // first needs an entry below. There is no `/widgets/controls` entry, because
+    // that page was created AFTER the `/widgets/*` rename and the old URL never
+    // existed. `git log --diff-filter=A -- .../adwaita/controls.mdx` is #1244
+    // (2026-08-21); the rename is #1228 (2026-08-18).
     redirects: {
         // The framework pages moved out of `guides/` into their own section. They
         // shipped days earlier, so the old paths are already in the wild.
@@ -36,6 +57,7 @@ export default defineConfig({
         '/widgets/presentation': '/gjsify/adwaita/presentation/',
         '/widgets/feedback': '/gjsify/adwaita/feedback/',
         '/widgets/theming': '/gjsify/adwaita/theming/',
+        '/adwaita/controls': '/gjsify/gtk/controls/',
     },
     vite: {
         resolve: {
@@ -110,6 +132,12 @@ export default defineConfig({
             // bridge projects live, so the pages a newcomer reads first are not
             // carrying them. `Adwaita` is named after the design system rather than
             // "Widgets" so a second one can sit beside it later instead of under it.
+            // `Gtk` is that second one. ADR 0034 § 1 decides which of the two a
+            // widget goes in, by the library that owns its GType. Arm 11 of
+            // `scripts/check-website-adwaita-gallery.mjs` holds both halves of
+            // that, a block's namespace against its section directory and a page's
+            // slug against the GROUP it is listed in. The older sidebar arm reads
+            // the groups as one flat set and can see neither.
             sidebar: [
                 {
                     label: 'Start',
@@ -148,7 +176,6 @@ export default defineConfig({
                     items: [
                         { slug: 'adwaita', label: 'Gallery' },
                         { slug: 'adwaita/boxed-lists' },
-                        { slug: 'adwaita/controls' },
                         { slug: 'adwaita/buttons' },
                         { slug: 'adwaita/layout' },
                         { slug: 'adwaita/navigation' },
@@ -157,6 +184,13 @@ export default defineConfig({
                         { slug: 'adwaita/feedback' },
                         { slug: 'adwaita/theming' },
                     ],
+                },
+                // Beside `Adwaita`, not under it. The pages here document widgets
+                // whose GType belongs to GTK, which is ADR 0034 § 1's rule and the
+                // one `@gjsify/gtk-host` already names its tags by.
+                {
+                    label: 'Gtk',
+                    items: [{ slug: 'gtk', label: 'Gallery' }, { slug: 'gtk/controls' }, { slug: 'gtk/buttons' }],
                 },
                 {
                     label: 'Ship your app',

--- a/website/src/content/docs/adwaita/boxed-lists.mdx
+++ b/website/src/content/docs/adwaita/boxed-lists.mdx
@@ -609,7 +609,10 @@ Adwaita style classes (`.suggested-action`, `.destructive-action`).
 
 ## Related
 
-- [Buttons](../buttons/): standalone buttons and the style classes reused here.
+- [Buttons](../buttons/): button content, split buttons and toggle groups.
+- [Gtk Controls](/gjsify/gtk/controls/): the standalone entry and drop down that
+  the entry row and combo row are twins of.
+- [Gtk Buttons](/gjsify/gtk/buttons/): the style classes these rows reuse.
 - [Layout](../layout/): the `Clamp` that keeps a boxed list at a readable width.
 - [Feedback](../feedback/): the preferences dialog these groups go into.
 - [Adwaita Storybook](../../showcases/adwaita-storybook/): the same widgets in a

--- a/website/src/content/docs/adwaita/buttons.mdx
+++ b/website/src/content/docs/adwaita/buttons.mdx
@@ -1,16 +1,18 @@
 ---
 title: Buttons
-description: "Adwaita buttons: icon-plus-label content, the style classes, menu buttons, split buttons and toggle groups. A live preview with its markup, plus the TypeScript, Blueprint and NativeScript code."
+description: "Adwaita buttons, icon-plus-label content, split buttons and toggle groups. A live preview with its markup, plus the TypeScript, Blueprint and NativeScript code."
 ---
 
 import AdwWidget from '../../../components/AdwWidget.astro';
 
-A button is the most direct control Adwaita has: you press it and something
-happens. This page covers the five things you will want from one. Give it an
-**icon plus a label**, apply a **style class** to set its shape and intent, use a
-**menu button** when the press should only open a menu, a **split button** to
-pair an action with a menu of alternatives, or a **toggle group** when a row of
-linked buttons should act as a single-choice selector.
+Libadwaita adds three button widgets to GTK's own. Put an **icon plus a label**
+on a button with button content, use a **split button** to pair an action with a
+menu of alternatives, or reach for a **toggle group** when a row of linked
+buttons should act as a single-choice selector.
+
+The plain button and the menu button belong to GTK. They are `Gtk.Button` and
+`Gtk.MenuButton`, documented under [Gtk Buttons](/gjsify/gtk/buttons/) with the
+style classes that shape them.
 
 Each block below is a stack of windows. The first one RUNS the widget: the preview
 is the live browser port, so it follows the light and dark toggle the way a real
@@ -98,210 +100,6 @@ short.
     button.orientation = 'horizontal';
     button.className = 'adw-button suggested-action pill';
     button.addChild(content);
-    ```
-  </Fragment>
-</AdwWidget>
-
-## Button Styles
-
-Add a **style class** to restyle any button. `.pill` makes it rounded and
-prominent, `.circular` suits an icon-only button, `.suggested-action` and
-`.destructive-action` colour an affirmative or a dangerous action, and `.flat`
-drops the visible background. They compose with each other and mean the same
-thing everywhere in the toolkit, so a `.destructive-action` in a header bar reads
-like one in a dialog.
-
-<AdwWidget title="Gtk.Button">
-  <Fragment slot="preview">
-    ```html
-    <div style="display:flex;flex-wrap:wrap;gap:12px;justify-content:center;align-items:center;">
-      <adw-button label="Pill" pill></adw-button>
-      <adw-button icon="list-add" circular></adw-button>
-      <adw-button label="Suggested" suggested></adw-button>
-      <adw-button label="Delete" destructive></adw-button>
-      <adw-button label="Flat" flat></adw-button>
-    </div>
-    ```
-  </Fragment>
-  <Fragment slot="gjs">
-    ```ts
-    import Adw from '@girs/adw-1';
-    import Gtk from '@girs/gtk-4.0';
-
-    const box = new Adw.WrapBox({ childSpacing: 12, lineSpacing: 12, halign: Gtk.Align.CENTER });
-
-    const pill = new Gtk.Button({ label: 'Pill' });
-    pill.add_css_class('pill');
-    box.append(pill);
-
-    const circular = new Gtk.Button({ iconName: 'list-add-symbolic' });
-    circular.add_css_class('circular');
-    box.append(circular);
-
-    const suggested = new Gtk.Button({ label: 'Suggested' });
-    suggested.add_css_class('suggested-action');
-    box.append(suggested);
-
-    const destructive = new Gtk.Button({ label: 'Delete' });
-    destructive.add_css_class('destructive-action');
-    box.append(destructive);
-
-    const flat = new Gtk.Button({ label: 'Flat' });
-    flat.add_css_class('flat');
-    box.append(flat);
-    ```
-  </Fragment>
-  <Fragment slot="blueprint">
-    ```blueprint
-    using Gtk 4.0;
-    using Adw 1;
-
-    Adw.WrapBox {
-      child-spacing: 12;
-      line-spacing: 12;
-      halign: center;
-
-      Gtk.Button {
-        label: _("Pill");
-
-        styles ["pill"]
-      }
-
-      Gtk.Button {
-        icon-name: "list-add-symbolic";
-
-        styles ["circular"]
-      }
-
-      Gtk.Button {
-        label: _("Suggested");
-
-        styles ["suggested-action"]
-      }
-
-      Gtk.Button {
-        label: _("Delete");
-
-        styles ["destructive-action"]
-      }
-
-      Gtk.Button {
-        label: _("Flat");
-
-        styles ["flat"]
-      }
-    }
-    ```
-  </Fragment>
-  <Fragment slot="nativescript">
-    ```ts
-    import { AdwButton, AdwWrapBox } from '@gjsify/adwaita-nativescript';
-
-    const box = new AdwWrapBox();
-    box.childSpacing = 12;
-    box.lineSpacing = 12;
-
-    const pill = new AdwButton();
-    pill.text = 'Pill';
-    pill.variant = 'pill';
-    box.add(pill);
-
-    const suggested = new AdwButton();
-    suggested.text = 'Suggested';
-    suggested.variant = 'suggested-action';
-    box.add(suggested);
-
-    const destructive = new AdwButton();
-    destructive.text = 'Delete';
-    destructive.variant = 'destructive-action';
-    box.add(destructive);
-
-    const flat = new AdwButton();
-    flat.text = 'Flat';
-    flat.variant = 'flat';
-    box.add(flat);
-    ```
-  </Fragment>
-</AdwWidget>
-
-## Menu Button
-
-When a button's only job is to open a menu, use a **menu button**. It is the
-hamburger at the end of a header bar: no primary action of its own, every choice
-in the popover it opens. Libadwaita ships no menu button — this is
-`Gtk.MenuButton`, which the Adwaita stylesheet gives its flat, rounded-square
-shape.
-
-<AdwWidget title="Gtk.MenuButton">
-  <Fragment slot="preview">
-    ```html
-    <adw-menu-button
-      icon-name="open-menu"
-      menu-title="Document"
-      menu='[{"label":"Save as…"},{"label":"Export"},{"label":"Print"}]'
-    ></adw-menu-button>
-    ```
-  </Fragment>
-  <Fragment slot="gjs">
-    ```ts
-    import Gio from '@girs/gio-2.0';
-    import Gtk from '@girs/gtk-4.0';
-
-    const menu = new Gio.Menu();
-    menu.append('Save as…', 'app.save-as');
-    menu.append('Export', 'app.export');
-    menu.append('Print', 'app.print');
-
-    const button = new Gtk.MenuButton({
-        iconName: 'open-menu-symbolic',
-        menuModel: menu,
-        primary: true, // opens on F10, the way an app menu should
-    });
-    button.add_css_class('flat');
-    ```
-  </Fragment>
-  <Fragment slot="blueprint">
-    ```blueprint
-    using Gtk 4.0;
-
-    Gtk.MenuButton {
-      icon-name: "open-menu-symbolic";
-      primary: true;
-      menu-model: primary-menu;
-
-      styles ["flat"]
-    }
-
-    menu primary-menu {
-      section {
-        item {
-          label: _("Save as…");
-          action: "app.save-as";
-        }
-
-        item {
-          label: _("Export");
-          action: "app.export";
-        }
-
-        item {
-          label: _("Print");
-          action: "app.print";
-        }
-      }
-    }
-    ```
-  </Fragment>
-  <Fragment slot="nativescript">
-    ```ts
-    import { AdwMenuButton } from '@gjsify/adwaita-nativescript';
-    import { openMenuSymbolic } from '@gjsify/adwaita-icons/actions';
-
-    const button = new AdwMenuButton();
-    button.icon = openMenuSymbolic; // an Adwaita symbolic icon (SVG string)
-    button.menuTitle = 'Document';
-    button.menuItems = [{ label: 'Save as…' }, { label: 'Export' }, { label: 'Print' }];
-    // NativeScript has no popover, so the menu opens as the platform action sheet.
     ```
   </Fragment>
 </AdwWidget>
@@ -474,6 +272,8 @@ once set", and the only setter is class-level.
 
 ## Related
 
+- [Gtk Buttons](/gjsify/gtk/buttons/): the plain button, its style classes and
+  the menu button.
 - [Boxed Lists](../boxed-lists/): rows that embed these buttons and reuse the
   same style classes.
 - [Layout](../layout/): the containers that arrange buttons within a window.

--- a/website/src/content/docs/adwaita/index.mdx
+++ b/website/src/content/docs/adwaita/index.mdx
@@ -22,7 +22,9 @@ and every widget block on the site follows it.
 
 Adwaita is one design system GJSify supports, not a requirement. Your app is an
 ordinary GTK 4 program, so you can mix in plain `Gtk.*` widgets or style your
-own, and the browser components live in a package you opt into.
+own, and the browser components live in a package you opt into. Libadwaita ships
+no entry, drop down, plain button or menu button, and those GTK widgets are
+documented under [Gtk](/gjsify/gtk/).
 
 ## Get the widgets
 
@@ -71,21 +73,14 @@ To change how any of it looks, set the [design tokens](./theming/).
       </adw-preferences-group>
     </Fragment>
   </AdwGalleryCard>
-  <AdwGalleryCard title="Controls" href="/gjsify/adwaita/controls/" description="The standalone entry and drop down — GTK widgets Adwaita styles, with row twins in the boxed lists.">
+  <AdwGalleryCard title="Buttons" href="/gjsify/adwaita/buttons/" description="Button content, split buttons and linked toggle groups.">
     <Fragment slot="preview">
-      <div style="display:flex;flex-direction:column;gap:8px;align-items:center;width:100%;max-width:240px;">
-        <adw-entry placeholder="Search files…" style="width:100%;"></adw-entry>
-        <adw-drop-down options='["Automatic","Always","Never"]' selected="0"></adw-drop-down>
-      </div>
-    </Fragment>
-  </AdwGalleryCard>
-  <AdwGalleryCard title="Buttons" href="/gjsify/adwaita/buttons/" description="Button content, the style classes, menu buttons, split buttons and linked toggle groups.">
-    <Fragment slot="preview">
-      <div style="display:flex;flex-wrap:wrap;gap:8px;justify-content:center;align-items:center;">
-        <adw-button label="Suggested" suggested></adw-button>
-        <adw-button label="Delete" destructive></adw-button>
-        <adw-button icon="list-add" circular></adw-button>
-        <adw-button label="Pill" pill></adw-button>
+      <div style="display:flex;flex-direction:column;gap:8px;justify-content:center;align-items:center;width:100%;max-width:240px;">
+        <adw-split-button label="Save" icon-name="document-save" menu='[{"label":"Save as…"},{"label":"Export"}]'></adw-split-button>
+        <adw-toggle-group active="0">
+          <adw-toggle label="List" icon-name="view-list"></adw-toggle>
+          <adw-toggle label="Grid" icon-name="view-grid"></adw-toggle>
+        </adw-toggle-group>
       </div>
     </Fragment>
   </AdwGalleryCard>

--- a/website/src/content/docs/gtk/buttons.mdx
+++ b/website/src/content/docs/gtk/buttons.mdx
@@ -1,0 +1,252 @@
+---
+title: Buttons
+description: "GTK's button and menu button, the style classes that shape them and the popover menu. A live preview with its markup, plus the TypeScript, Blueprint and NativeScript code."
+---
+
+import AdwWidget from '../../../components/AdwWidget.astro';
+
+The two buttons on this page belong to GTK. `Gtk.Button` is the plain button
+every other one is built on, and `Gtk.MenuButton` is the one whose press opens a
+menu. Libadwaita ships neither, and the Adwaita stylesheet gives both their GNOME
+shape.
+
+The buttons libadwaita does ship are on
+[Adwaita Buttons](/gjsify/adwaita/buttons/), which covers button content, the
+split button and the toggle group.
+
+Each block below is a stack of windows. The first one RUNS the widget: the preview
+is the live browser port, so it follows the light and dark toggle the way a real
+window would, and the HTML tab beside it holds the very markup that paints it —
+one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
+one window per kind of implementation — **Native TypeScript**, the `@girs` program
+that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
+declaration beside it, **UI frameworks**, the same widget written in Solid, Vue and
+React through `@gjsify/gtk-host` — or, where the widget is built imperatively rather
+than declared, the recorded reason it has no such snippet — and **NativeScript**,
+the port that runs on a phone. That last window splits the way the first one does. An
+XML template holds the tree, and the TypeScript beside it is the loader.
+
+GTK 4 is the reference here, typed by
+[`@girs/gtk-4.0`](https://www.npmjs.com/package/@girs/gtk-4.0). The browser and
+NativeScript ports spell both buttons with an `adw` prefix, `<adw-button>` and
+`<adw-menu-button>` in the browser, `AdwButton` and `AdwMenuButton` on
+NativeScript. Each ships one Adwaita-styled widget set and does not divide it by
+owning library. Where a port behaves differently, its own window says so.
+
+:::note
+The previews run the browser port, so behaviour the toolkits drive natively can
+be simplified here. Only the menu button diverges. NativeScript has no popover,
+so its menu opens as the platform action sheet.
+:::
+
+## Button Styles
+
+A plain button is `Gtk.Button`. Add a **style class** to restyle it. `.pill`
+makes it rounded and prominent, `.circular` suits an icon-only button,
+`.suggested-action` and `.destructive-action` colour an affirmative or a
+dangerous action, and `.flat` drops the visible background. They compose with
+each other and mean the same thing everywhere in the toolkit, so a
+`.destructive-action` in a header bar reads like one in a dialog.
+
+<AdwWidget title="Gtk.Button">
+  <Fragment slot="preview">
+    ```html
+    <div style="display:flex;flex-wrap:wrap;gap:12px;justify-content:center;align-items:center;">
+      <adw-button label="Pill" pill></adw-button>
+      <adw-button icon="list-add" circular></adw-button>
+      <adw-button label="Suggested" suggested></adw-button>
+      <adw-button label="Delete" destructive></adw-button>
+      <adw-button label="Flat" flat></adw-button>
+    </div>
+    ```
+  </Fragment>
+  <Fragment slot="gjs">
+    ```ts
+    import Adw from '@girs/adw-1';
+    import Gtk from '@girs/gtk-4.0';
+
+    const box = new Adw.WrapBox({ childSpacing: 12, lineSpacing: 12, halign: Gtk.Align.CENTER });
+
+    const pill = new Gtk.Button({ label: 'Pill' });
+    pill.add_css_class('pill');
+    box.append(pill);
+
+    const circular = new Gtk.Button({ iconName: 'list-add-symbolic' });
+    circular.add_css_class('circular');
+    box.append(circular);
+
+    const suggested = new Gtk.Button({ label: 'Suggested' });
+    suggested.add_css_class('suggested-action');
+    box.append(suggested);
+
+    const destructive = new Gtk.Button({ label: 'Delete' });
+    destructive.add_css_class('destructive-action');
+    box.append(destructive);
+
+    const flat = new Gtk.Button({ label: 'Flat' });
+    flat.add_css_class('flat');
+    box.append(flat);
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.WrapBox {
+      child-spacing: 12;
+      line-spacing: 12;
+      halign: center;
+
+      Gtk.Button {
+        label: _("Pill");
+
+        styles ["pill"]
+      }
+
+      Gtk.Button {
+        icon-name: "list-add-symbolic";
+
+        styles ["circular"]
+      }
+
+      Gtk.Button {
+        label: _("Suggested");
+
+        styles ["suggested-action"]
+      }
+
+      Gtk.Button {
+        label: _("Delete");
+
+        styles ["destructive-action"]
+      }
+
+      Gtk.Button {
+        label: _("Flat");
+
+        styles ["flat"]
+      }
+    }
+    ```
+  </Fragment>
+  <Fragment slot="nativescript">
+    ```ts
+    import { AdwButton, AdwWrapBox } from '@gjsify/adwaita-nativescript';
+
+    const box = new AdwWrapBox();
+    box.childSpacing = 12;
+    box.lineSpacing = 12;
+
+    const pill = new AdwButton();
+    pill.text = 'Pill';
+    pill.variant = 'pill';
+    box.add(pill);
+
+    const suggested = new AdwButton();
+    suggested.text = 'Suggested';
+    suggested.variant = 'suggested-action';
+    box.add(suggested);
+
+    const destructive = new AdwButton();
+    destructive.text = 'Delete';
+    destructive.variant = 'destructive-action';
+    box.add(destructive);
+
+    const flat = new AdwButton();
+    flat.text = 'Flat';
+    flat.variant = 'flat';
+    box.add(flat);
+    ```
+  </Fragment>
+</AdwWidget>
+
+## Menu Button
+
+When a button's only job is to open a menu, use a **menu button**. It is the
+hamburger at the end of a header bar, with no action of its own and every choice
+in the popover it opens. Libadwaita ships no menu button, so this is
+`Gtk.MenuButton`. The Adwaita stylesheet gives it the flat, rounded-square shape.
+
+<AdwWidget title="Gtk.MenuButton">
+  <Fragment slot="preview">
+    ```html
+    <adw-menu-button
+      icon-name="open-menu"
+      menu-title="Document"
+      menu='[{"label":"Save as…"},{"label":"Export"},{"label":"Print"}]'
+    ></adw-menu-button>
+    ```
+  </Fragment>
+  <Fragment slot="gjs">
+    ```ts
+    import Gio from '@girs/gio-2.0';
+    import Gtk from '@girs/gtk-4.0';
+
+    const menu = new Gio.Menu();
+    menu.append('Save as…', 'app.save-as');
+    menu.append('Export', 'app.export');
+    menu.append('Print', 'app.print');
+
+    const button = new Gtk.MenuButton({
+        iconName: 'open-menu-symbolic',
+        menuModel: menu,
+        primary: true, // opens on F10, the way an app menu should
+    });
+    button.add_css_class('flat');
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+
+    Gtk.MenuButton {
+      icon-name: "open-menu-symbolic";
+      primary: true;
+      menu-model: primary-menu;
+
+      styles ["flat"]
+    }
+
+    menu primary-menu {
+      section {
+        item {
+          label: _("Save as…");
+          action: "app.save-as";
+        }
+
+        item {
+          label: _("Export");
+          action: "app.export";
+        }
+
+        item {
+          label: _("Print");
+          action: "app.print";
+        }
+      }
+    }
+    ```
+  </Fragment>
+  <Fragment slot="nativescript">
+    ```ts
+    import { AdwMenuButton } from '@gjsify/adwaita-nativescript';
+    import { openMenuSymbolic } from '@gjsify/adwaita-icons/actions';
+
+    const button = new AdwMenuButton();
+    button.icon = openMenuSymbolic; // an Adwaita symbolic icon (SVG string)
+    button.menuTitle = 'Document';
+    button.menuItems = [{ label: 'Save as…' }, { label: 'Export' }, { label: 'Print' }];
+    // NativeScript has no popover, so the menu opens as the platform action sheet.
+    ```
+  </Fragment>
+</AdwWidget>
+
+## Related
+
+- [Controls](../controls/): the entry and the drop down, the other two GTK
+  widgets the Adwaita stylesheet paints.
+- [Adwaita Buttons](/gjsify/adwaita/buttons/): button content, the split button
+  and the toggle group.
+- [Adwaita Storybook](/gjsify/showcases/adwaita-storybook/): the same widgets in
+  a live component browser you can poke at.

--- a/website/src/content/docs/gtk/controls.mdx
+++ b/website/src/content/docs/gtk/controls.mdx
@@ -1,20 +1,19 @@
 ---
 title: Controls
-description: "Adwaita's standalone controls: the text entry and the drop down. A live preview with its markup, plus the TypeScript, Blueprint and NativeScript code."
+description: "GTK's standalone controls, the text entry and the drop down. A live preview with its markup, plus the TypeScript, Blueprint and NativeScript code."
 ---
 
 import AdwWidget from '../../../components/AdwWidget.astro';
 
-Two controls on this page stand on their own rather than inside a boxed list: a
-single-line **entry** for typed text, and a **drop down** for picking one value
-out of a list. Both have a boxed-list twin — `Adw.EntryRow` and `Adw.ComboRow` —
-and which one you want is a question about the surrounding layout, not about the
-control: a preferences page uses the rows, a toolbar or a dialog uses these.
+Two controls on this page stand on their own rather than inside a boxed list. A
+single-line **entry** takes typed text, and a **drop down** picks one value out
+of a list. Both belong to GTK. They are `Gtk.Entry` and `Gtk.DropDown`,
+libadwaita ships neither, and the Adwaita stylesheet gives them their GNOME look.
 
-Neither carries an `Adw` prefix, and that is the point worth knowing about them:
-Libadwaita ships no entry and no drop down of its own. They are `Gtk.Entry` and
-`Gtk.DropDown`, and what makes them look Adwaita is the stylesheet. The widgets
-with an `Adw` prefix are the row variants built on top.
+Each has a boxed-list twin, `Adw.EntryRow` and `Adw.ComboRow`, documented under
+[Boxed Lists](/gjsify/adwaita/boxed-lists/). Which one you want is a question
+about the surrounding layout rather than about the control. A preferences page
+uses the rows, a toolbar or a dialog uses these.
 
 Each block below is a stack of windows. The first one RUNS the widget: the preview
 is the live browser port, so it follows the light and dark toggle the way a real
@@ -28,11 +27,12 @@ than declared, the recorded reason it has no such snippet — and **NativeScript
 the port that runs on a phone. That last window splits the way the first one does. An
 XML template holds the tree, and the TypeScript beside it is the loader.
 
-Libadwaita is the reference here, typed by
-[`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
-[`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web)
-and [`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita)
-follow its naming, and where one of them differs, its own window says so.
+GTK 4 is the reference here, typed by
+[`@girs/gtk-4.0`](https://www.npmjs.com/package/@girs/gtk-4.0). The browser and
+NativeScript ports spell both controls with an `adw` prefix, `<adw-entry>` and
+`<adw-drop-down>` in the browser, `AdwEntry` and `AdwDropDown` on NativeScript.
+Each ships one Adwaita-styled widget set and does not divide it by owning
+library. Where a port behaves differently, its own window says so.
 
 :::note
 The previews run the browser port, so behaviour the toolkits drive natively can
@@ -47,8 +47,8 @@ which has no search field.
 A single-line text field. Give it a **placeholder** to say what belongs in it
 while it is empty, a **value** for the text itself, and `disabled` when it should
 be read-only. For a field that belongs in a preferences group, use
-[Entry Row](../boxed-lists/#entry-row) instead — same control, row presentation,
-and the label doubles as the row title.
+[Entry Row](/gjsify/adwaita/boxed-lists/#entry-row) instead. It is the same
+control in row presentation, and the label doubles as the row title.
 
 <AdwWidget title="Gtk.Entry">
   <Fragment slot="preview">
@@ -104,7 +104,8 @@ and the label doubles as the row title.
 Pick one value from a list. The button shows the current selection and the list
 opens in a popover; **selected** is the zero-based index of the chosen option,
 and `enable-search` adds a filter field for a long list. For the same choice
-presented as a boxed-list row, use [Combo Row](../boxed-lists/#combo-row).
+presented as a boxed-list row, use
+[Combo Row](/gjsify/adwaita/boxed-lists/#combo-row).
 
 <AdwWidget title="Gtk.DropDown">
   <Fragment slot="preview">
@@ -154,9 +155,9 @@ presented as a boxed-list row, use [Combo Row](../boxed-lists/#combo-row).
 
 ## Related
 
-- [Boxed Lists](../boxed-lists/): the row twins of both controls — entry row,
-  password entry row, combo row and spin row.
-- [Buttons](../buttons/): the menu button and split button, the other two
-  controls that open a popover.
-- [Adwaita Storybook](../../showcases/adwaita-storybook/): the same widgets in a
-  live component browser you can poke at.
+- [Buttons](../buttons/): the plain button, its style classes and the menu
+  button.
+- [Boxed Lists](/gjsify/adwaita/boxed-lists/): the row twins of both controls,
+  entry row, password entry row, combo row and spin row.
+- [Adwaita Storybook](/gjsify/showcases/adwaita-storybook/): the same widgets in
+  a live component browser you can poke at.

--- a/website/src/content/docs/gtk/index.mdx
+++ b/website/src/content/docs/gtk/index.mdx
@@ -1,0 +1,93 @@
+---
+title: Gtk
+description: The GTK 4 widgets a GNOME app uses and libadwaita does not ship, one page per family, with a live preview and the TypeScript, Blueprint and NativeScript code.
+---
+
+import AdwGalleryCard from '../../../components/AdwGalleryCard.astro';
+
+Your app is a GTK 4 program. Libadwaita adds a design system on top of GTK
+instead of replacing it, so a GNOME app draws widgets from both libraries. There
+is no `Adw.Entry`, no `Adw.DropDown` and no `Adw.MenuButton`. An app that needs
+one of those uses GTK's own widget, and the Adwaita stylesheet paints it.
+
+This section holds those widgets. A widget is documented under the library that
+owns its GType, which is the rule
+[`@gjsify/gtk-host`](https://github.com/gjsify/gjsify/tree/main/packages/framework/gtk-host)
+already uses to name its tags. So `Gtk.Entry` is here and `Adw.EntryRow` is under
+[Adwaita](/gjsify/adwaita/), and the two are different widgets one namespace
+apart.
+
+Pick a category below. Every widget on those pages runs live in your browser, in a
+window whose second tab holds the markup that paints it, followed by one window per
+kind of implementation: **Native TypeScript**, the `@girs` program that runs
+unchanged on GJS, Node, Bun and Deno, with a Blueprint declaration beside it, **UI
+frameworks**, the same widget written in Solid, Vue and React through
+`@gjsify/gtk-host`, and **NativeScript**, the port that runs on a phone, whose XML
+template holds the tree with the TypeScript beside it as the loader. Choose a tab once
+and every widget block on the site follows it.
+
+## Get the widgets
+
+On the desktop the widgets come from the GTK 4 library already installed on the
+machine. `@girs/gtk-4.0` is the type package for it, and nothing else is needed:
+
+```ts
+import Gtk from '@girs/gtk-4.0';
+
+const entry = new Gtk.Entry({ placeholderText: 'Search files…' });
+```
+
+For the browser, install the Adwaita port and import it once. That registers
+every element and applies the stylesheet, so from there you write HTML:
+
+```bash
+gjsify install @gjsify/adwaita-web
+```
+
+```ts
+import '@gjsify/adwaita-web';
+```
+
+```html
+<adw-entry placeholder="Search files…"></adw-entry>
+```
+
+One package carries the whole Adwaita-styled widget set, so every element it
+registers is spelled `adw-`, whatever library owns the GType. `Gtk.Entry` is
+`<adw-entry>` and `Gtk.MenuButton` is `<adw-menu-button>`. The same holds for
+[`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita),
+where they are `AdwEntry` and `AdwMenuButton`.
+
+## Browse the widgets
+
+<div class="adw-gallery-grid">
+  <AdwGalleryCard title="Controls" href="/gjsify/gtk/controls/" description="The standalone entry and drop down, whose row twins are in the Adwaita boxed lists.">
+    <Fragment slot="preview">
+      <div style="display:flex;flex-direction:column;gap:8px;align-items:center;width:100%;max-width:240px;">
+        <adw-entry placeholder="Search files…" style="width:100%;"></adw-entry>
+        <adw-drop-down options='["Automatic","Always","Never"]' selected="0"></adw-drop-down>
+      </div>
+    </Fragment>
+  </AdwGalleryCard>
+  <AdwGalleryCard title="Buttons" href="/gjsify/gtk/buttons/" description="The plain button, the style classes that shape it, and the menu button that opens a popover.">
+    <Fragment slot="preview">
+      <div style="display:flex;flex-wrap:wrap;gap:8px;justify-content:center;align-items:center;">
+        <adw-button label="Suggested" suggested></adw-button>
+        <adw-button label="Delete" destructive></adw-button>
+        <adw-button icon="list-add" circular></adw-button>
+        <adw-menu-button icon-name="open-menu" menu-title="Document" menu='[{"label":"Save as…"},{"label":"Export"}]'></adw-menu-button>
+      </div>
+    </Fragment>
+  </AdwGalleryCard>
+</div>
+
+## Where the Adwaita widgets are
+
+Everything libadwaita ships has its own section: boxed lists and their rows,
+header bars and clamps, split views, view switchers, avatars, banners and
+dialogs. Start at [Adwaita](/gjsify/adwaita/).
+
+The [Adwaita Storybook](/gjsify/showcases/adwaita-storybook/) carries both sets
+in one component browser, so you can change a widget's properties from a controls
+panel and watch it update. Run it as a native window with `gjsify storybook`, or
+use the version embedded on that page.


### PR DESCRIPTION
## The problem

The site had one top-level widget section, `Adwaita`, and no `Gtk` one, while four
of the blocks inside it documented GTK widgets. Measured on the merge-base
(`b919db36e`):

```sh
for f in website/src/content/docs/adwaita/*.mdx; do
  printf '%-22s Adw=%s Gtk=%s\n' "$(basename $f)" \
    "$(grep -c '<AdwWidget title="Adw\.' $f)" "$(grep -c '<AdwWidget title="Gtk\.' $f)"
done
```

| page | `Adw.*` | `Gtk.*` |
|---|---:|---:|
| `controls.mdx` | **0** | **2** (`Gtk.Entry`, `Gtk.DropDown`) |
| `buttons.mdx` | 3 | 2 (`Gtk.Button`, `Gtk.MenuButton`) |
| the other six | 33 | 0 |

`controls.mdx` carried no Adwaita widget at all. And the split is not a rounding
error in the toolkit either: of the 168 tags `@gjsify/gtk-host` generates from the
GIR, 105 are GTK's and 63 libadwaita's.

```sh
grep -oE "gtype: '(Gtk|Adw)[A-Za-z]+'" packages/framework/gtk-host/src/generated/widgets.ts \
  | sed -E "s/gtype: '(Gtk|Adw).*/\1/" | sort | uniq -c
#      63 Adw
#     105 Gtk
```

A reader looking for `Gtk.Entry` had no heading that would lead them there.

## The argument is already in the repository

The comment above `redirects` in `website/astro.config.mjs` records why `/widgets/*`
became `/adwaita/*`:

> `/widgets/*` became `/adwaita/*`: the section only ever covered Adwaita, and naming
> it after the design system leaves room for a second one (Material, say) **beside**
> it rather than **under** it.

That was right when it was written and its premise has since stopped holding. The
correction is not to undo the rename. It is to apply the same sentence a second time.
ADR 0034 § 1 states the rule the split follows, that a widget belongs to the library
that owns its GType, read from the GIR and never chosen per surface. ADR 0034 lists
this as stage 5.

## What moved

- `adwaita/controls.mdx` → `gtk/controls.mdx`, whole. It had 0 Adwaita blocks.
- The `Gtk.Button` and `Gtk.MenuButton` blocks left `adwaita/buttons.mdx` for a new
  `gtk/buttons.mdx`. `adwaita/buttons.mdx` keeps `Adw.ButtonContent`,
  `Adw.SplitButton` and `Adw.ToggleGroup`, and its second paragraph says where the
  other two went.
- `gtk/index.mdx` introduces the section and states the split rule once.
- A `Gtk` sidebar group sits beside `Adwaita`.

After the move every page is single-library:

```
adwaita/boxed-lists.mdx      Adw=9 Gtk=0      gtk/buttons.mdx     Adw=0 Gtk=2
adwaita/buttons.mdx          Adw=3 Gtk=0      gtk/controls.mdx    Adw=0 Gtk=2
adwaita/feedback.mdx         Adw=4 Gtk=0
adwaita/layout.mdx           Adw=4 Gtk=0
adwaita/navigation.mdx       Adw=5 Gtk=0
adwaita/presentation.mdx     Adw=6 Gtk=0
adwaita/view-switching.mdx   Adw=5 Gtk=0
```

## Redirects

`/adwaita/controls` → `/gjsify/gtk/controls/`, the way the `/widgets/*` rename
already does it. Verified in the built output:

```
$ cat website/dist/adwaita/controls/index.html
<!doctype html><title>Redirecting to: /gjsify/gtk/controls/">…
```

There is no `/widgets/controls` entry, because that page was created after the
rename and the URL never existed:
`git log --diff-filter=A -- website/src/content/docs/adwaita/controls.mdx` is #1244
(2026-08-21); the rename is #1228 (2026-08-18).

One limit, stated rather than papered over: `/adwaita/buttons/#button-styles` and
`#menu-button` are fragments on a page that still exists, and Astro's `redirects`
cannot route a fragment. Both anchors exist unchanged at `/gjsify/gtk/buttons/`, and
the second paragraph of `adwaita/buttons.mdx` links there. This is how the repo
already handled `/guides/ui-frameworks`, which became a whole section.

## The mechanism

Four gates hardcoded `website/src/content/docs/adwaita`. A single-directory scan
would have gone green over a set four blocks short of the site's, so
`check-doc-fences`, `check-generated-website-data` and `check-website-attr-samples`
now read both sections. Their counts are unchanged where they should be (40 gallery
blocks, 39 attribute tables, 190 cells) and up where they should be (12 sources → 14,
83 ts fences → 85).

`check-website-adwaita-gallery.mjs` gets **arm 11**, which holds a block to the
library that owns its GType in both places the filing is written down:

1. the section directory the page sits in, and
2. the sidebar **group** the page's slug is listed in.

The second half is the one worth having. Arm 4 already checks that every gallery page
is in the sidebar, but it reads Starlight's groups as **one flat set of slugs**, so a
`gtk/*` page listed inside the `Adwaita` group satisfies it completely while the
reader meets a GTK page under an Adwaita heading. That is the same blindness as arm
10's known limit, which holds window *titles* and therefore cannot see a new *tab*
inside a window whose title is already named, and it is the reason this PR adds a
mechanism rather than only moving files.

The section table is one declaration carrying all three joins (directory, GIR
namespace, sidebar group), so a third section is three strings and nothing else.

**Measured against five ways it can be wrong, each restored afterwards:**

| probe | result |
|---|---|
| a `Gtk.MenuButton` block filed under `adwaita/` | exit 1 |
| `gtk/controls` listed in the `Adwaita` sidebar group (arm 4 stays green) | exit 1, 2 failures |
| no `Gtk` sidebar group at all | exit 1 |
| the group reader broken (`items:` → `entries:`) | exit 1 on the vacuity guard, not green |
| a declared section with no `<AdwWidget>` block in it | exit 1 |
| a section whose declared namespace `bareName()` does not accept | exit 1, before any data is read |

The last one is the arm guarding itself. The section table declares a GIR namespace
and `bareName()` decides which titles the gallery accepts at all, so if the two drift
the drift is silent in the expensive direction: arm 1 rejects every block of the new
section as a malformed title, the section looks empty rather than misfiled, and arm 11
has nothing to file. Arm 11's own namespace pattern is built from the table for the
same reason, so a literal list cannot fall behind it.

Arm 10 also becomes per-section: a section index must name the union over **its own**
pages, so `gtk/index.mdx` cannot describe a window only the Adwaita pages draw.

## Build and gates

Page count, from `gjsify run docs:build`:

| | pages built | dist HTML files |
|---|---:|---:|
| before (`b919db36e`) | 64 | 79 |
| after | 66 | 82 |

`+2`: `gtk/index` and `gtk/buttons` are new, `gtk/controls` is the moved page, and
the extra HTML file is the redirect.

Every website gate, in its gating mode, exit 0:

```
check-website-adwaita-gallery: 41 story metas — 40 documented by 40 <AdwWidget> blocks across 12 pages, all of them in the sidebar, 1 ledgered with a reason.
check-website-adwaita-gallery: 2 section(s) — Adwaita [36 Adw.* block(s), 9 sidebar slug(s)], Gtk [4 Gtk.* block(s), 3 sidebar slug(s)] — every block under the library that owns its GType, and every page in the sidebar group its section is named by.
check-website-adwaita-gallery: 4 window(s) in website/src/components/AdwWidget.astro — preview [preview], native [gjs blueprint], frameworks [react-native], nativescript [nativescript] — each with a tab at least one of 40 blocks provides, …
check-generated-website-data: 40 gallery block(s), 39 rendering a generated attribute table, 65 registered element(s), 1 exemption(s)
check-generated-website-data: OK.
check-doc-fences: 40 blueprint fence(s) compiled with blueprint-compiler
check-doc-fences: 85 ts fence(s) resolved against 644 glyph exports in 9 subpaths (all round-tripping camel <-> kebab)
check-doc-fences: OK across 14 source(s).
check-website-attr-samples: 11 fixtures and 190 cells across 39 gallery blocks — ok
check-website-package-names: every @gjsify/* name the website quotes resolves.
check-website-preview-not-content: every Adwaita element the website mounts is under `not-content`.
check-storybook-category-order: 9 categories declared, all 9 in use placed — leading with "Overview".
check-storybook-widget-coverage: 44 widgets on both renderers — 38 with a story, 6 ledgered with a reason; 23 on one renderer — 18 a decision, 5 an open gap.
check-comment-budget: exit 0 (scripts 0.572 against a 0.592 ceiling)
check-agent-context-size --check: every agent context file is within its committed ceiling.
gjsify format --check: exit 0
oxlint scripts/ website/astro.config.mjs: exit 0
```

## Links

Every internal link and fragment in the built site, resolved against `dist/`:

```
linkcheck: 82 page(s), 5226 internal link(s) resolved, 71 with a fragment.
linkcheck: no broken internal link or anchor.
```

The checker was probed against a broken href and a missing anchor before being
trusted, and reported both (exit 1).

## Not touched

`scripts/check-vocabulary-alignment.mjs` and `packages/framework/AGENTS.md`, which
belong to the sibling vocabulary PRs. ADR 0034 itself is left alone too: its § Context
records the state at decision time, and this repo does not annotate ADR stages as they
land (ADR 0032 was not edited when its stage 1 shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptuk3enuQKoCy9akasnMfB
