### PR TITLE
docs(adr): repoint a citation the section split moved

### DIFF
--- a/docs/adr/0034-widget-vocabulary-convergence.md
+++ b/docs/adr/0034-widget-vocabulary-convergence.md
@@ -49,7 +49,7 @@ Anything unmeasured is marked UNVERIFIED.
 
 ### The same widget, four spellings, on one documentation page
 
-`website/src/content/docs/adwaita/controls.mdx:52-98` renders one gallery block whose
+`website/src/content/docs/gtk/controls.mdx:52-98` renders one gallery block whose
 title is `Gtk.Entry`. Inside it:
 
 | fence | how the widget is named |
@@ -71,7 +71,11 @@ titled `Adw.*` and 4 titled `Gtk.*` — and the four are exactly `Gtk.Button`,
 `Gtk.DropDown`, `Gtk.Entry`, `Gtk.MenuButton`.
 
 ```sh
-grep -rhoE '<AdwWidget title="[A-Za-z.]+"' website/src/content/docs/adwaita/ \
+# The gallery lived in one directory when this was measured. #1433 split it,
+# so the glob names both -- the totals are unchanged, because nothing was added
+# or removed, only moved.
+grep -rhoE '<AdwWidget title="[A-Za-z.]+"' \
+    website/src/content/docs/adwaita/ website/src/content/docs/gtk/ \
   | sed 's/.*title="//;s/"//' | sed 's/\..*//' | sort | uniq -c
 ```
 
@@ -269,7 +273,7 @@ gallery pages that carry widget blocks:
 | the other six | 33 | 0 |
 
 ```sh
-for f in website/src/content/docs/adwaita/*.mdx; do
+for f in website/src/content/docs/adwaita/*.mdx website/src/content/docs/gtk/*.mdx; do
   printf '%-22s Adw=%s Gtk=%s\n' "$(basename $f)" \
     "$(grep -c '<AdwWidget title="Adw\.' $f)" "$(grep -c '<AdwWidget title="Gtk\.' $f)"
 done

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -3987,3 +3987,20 @@ The repair is one line: count sites on the published-and-declared branch too, be
 `continue`. Left open rather than applied for the same reason as the entry above, and
 because #1427 emptied the ledger, so the control is dormant until the next bootstrap —
 which is precisely when someone will meet it cold.
+
+### An in-repo `path:line` citation is checked by nothing
+
+`scripts/check-refs-citations.mjs` holds every `refs/<submodule>/<path>` cited as provenance
+against the filesystem. A citation of a path **inside this repository** is covered by no gate at
+all, and #1433 proved it costs something: moving `website/src/content/docs/adwaita/controls.mdx`
+to `gtk/` left ADR 0034 § Context pointing at a file that no longer exists, plus two reproduction
+commands whose glob had silently narrowed. Nothing failed; the ADR simply stopped being
+re-runnable, which is the failure this repository cares about most.
+
+Both were repaired by hand (the glob now names both directories and reproduces the same `36 Adw`
+/ `4 Gtk`). The gate was NOT written, deliberately: it was found during a release window, and a
+new check landing hours before a cut is the change nobody can price. The shape is already
+available — `check-refs-citations` resolves with `statSync` and would extend to repo-relative
+paths cheaply — and the harder half is the same one it already declines: it asks whether the FILE
+exists, never whether the LINE says what the citation claims. A moved file is caught by the cheap
+half; a moved line is not, and that is the case that bit `stage.ts:35` three times.


### PR DESCRIPTION
#1433 moved `website/src/content/docs/adwaita/controls.mdx` to `gtk/`. ADR 0034 § Context cites
that path, and two of its reproduction commands glob the old directory alone. Nothing failed —
the ADR simply stopped being re-runnable, which is the thing it exists to be.

## What was wrong

| | |
|---|---|
| § Context, line 52 | cited `adwaita/controls.mdx:52-98`, a path that no longer exists |
| line 74 | `grep -rhoE … website/src/content/docs/adwaita/` |
| line 272 | `for f in website/src/content/docs/adwaita/*.mdx` |

The two commands are the evidence for *"36 blocks titled `Adw.*` and 4 titled `Gtk.*`"*. After the
split they see one of the two directories, so they return a smaller set than the sentence above
them claims.

## What changed

The path is repointed, and both globs name **both** directories. The line range holds because the
file moved whole; verified, not assumed — line 53 of the new file still opens
`&lt;AdwWidget title="Gtk.Entry"&gt;`.

The widened command reproduces the ADR's own numbers exactly:

```
$ grep -rhoE '<AdwWidget title="[A-Za-z.]+"' \
      website/src/content/docs/adwaita/ website/src/content/docs/gtk/ \
    | sed 's/.*title="//;s/"//' | sed 's/\..*//' | sort | uniq -c
     36 Adw
      4 Gtk
```

Nothing was added or removed by #1433, only moved, which is why the totals are unchanged. A
comment above the command says so, because a reader who runs it after the split would otherwise
wonder why a one-directory measurement is written as two.

## The gap, ledgered rather than closed

`scripts/check-refs-citations.mjs` holds every `refs/<submodule>/<path>` citation against the
filesystem. **A citation of a path inside this repository is covered by nothing**, which is why
this went unnoticed until someone read the ADR.

I did not write that gate. It was found during a release window, and a new check landing hours
before a cut is the change nobody can price. The entry in `status/open-todos.md` records the shape
it would take and, more usefully, the half it would still not cover: `check-refs-citations`
resolves with `statSync`, so it asks whether the FILE exists and never whether the LINE says what
the citation claims. A moved file is the cheap case. A moved line is the one that bit
`stage.ts:35` three times.

## Checks

`check-doc-fences` (OK across 14 sources), `check-adr-index` (34 ADRs, statuses agree),
`check-doc-revert` (nothing resurrected) — all exit 0.