### PR TITLE
feat(style): flex-wrap becomes a Gtk.FlowBox intent

### DIFF
--- a/packages/framework/gtk-host/src/style/gtk-props.ts
+++ b/packages/framework/gtk-host/src/style/gtk-props.ts
@@ -58,6 +58,15 @@ export const GTK_WIDGET_PROPERTY_PROBES: ReadonlyArray<readonly [gtype: string, 
         ['GtkBox', 'spacing', 'gint'],
         ['GtkLabel', 'xalign', 'gfloat'],
         ['GtkLabel', 'justify', 'GtkJustification'],
+        // The wrapping widget. `flex-wrap` is a widget swap rather than a property
+        // (`layout.ts`), and these four are what the swapped-in class takes instead
+        // of the box's single `spacing`. `guint`, not `gint`: a negative row spacing
+        // is out of range rather than merely odd, and `max-children-per-line` has a
+        // ceiling — writing G_MAXUINT to it stores 65535 (measured).
+        ['GtkFlowBox', 'row-spacing', 'guint'],
+        ['GtkFlowBox', 'column-spacing', 'guint'],
+        ['GtkFlowBox', 'max-children-per-line', 'guint'],
+        ['GtkFlowBox', 'selection-mode', 'GtkSelectionMode'],
     ];
 
 /**
@@ -86,6 +95,10 @@ export const NOT_GTK_WIDGET_PROPERTIES: ReadonlyArray<readonly [gtype: string, p
     ['GtkLabel', 'orientation'],
     ['GtkLabel', 'spacing'],
     ['GtkCenterBox', 'spacing'],
+    // The absence `flex-wrap` is built on: a wrapping element becomes a
+    // `Gtk.FlowBox`, which has a row spacing and a column spacing and NO `spacing`
+    // — so a gap that took the box's route would be applied to a widget that
+    // refuses it, at attach time, in a consumer's window.
     ['GtkFlowBox', 'spacing'],
     // Only a text widget aligns text, which is why `text-center` is an intent.
     ['GtkWidget', 'xalign'],

--- a/packages/framework/gtk-host/src/style/index.ts
+++ b/packages/framework/gtk-host/src/style/index.ts
@@ -29,6 +29,7 @@ export type {
     LayoutPartition,
     LayoutProps,
     OverlayIntent,
+    WrapIntent,
 } from './layout.js';
 export { partition, resolveUtilities, resolveUtility } from './resolve.js';
 export type { Partitioned, StyleProps } from './resolve.js';

--- a/packages/framework/gtk-host/src/style/layout.spec.ts
+++ b/packages/framework/gtk-host/src/style/layout.spec.ts
@@ -109,13 +109,48 @@ export default async () => {
             expect(of('flex-1').css).toStrictEqual([]);
         });
 
-        await it('names the widget a wrap would need, instead of approximating one', async () => {
-            const error = threw(() => resolveUtility('flex-wrap', TOKENS));
-            expect(error.message).toContain('Gtk.FlowBox');
-            // `Gtk.Box` never wraps, so the no-wrap spelling restates the platform.
-            // Declared and empty is not the same as unrecognised, and the difference
-            // is exactly what this assertion pins.
-            expect(resolveLayoutUtility('flex-nowrap', TOKENS)).toStrictEqual({});
+        await it('makes a wrap an intent, because wrapping is a different WIDGET', async () => {
+            // The same shape as `justify-between`: a `Gtk.Box` has no second line to
+            // put anything on, and the answer is `Gtk.FlowBox` — another class, not
+            // another property. L1 names it and L2 swaps it.
+            expect(of('flex-wrap').intent).toStrictEqual({ wrap: { lines: 'multi' } });
+            expect(of('flex-wrap').props).toStrictEqual({});
+            expect(of('flex-wrap').css).toStrictEqual([]);
+            // A `Gtk.Box` is already one line, so the no-wrap spelling restates the
+            // platform — and is still CARRIED, because L2 refuses a wrap utility on
+            // a widget that cannot wrap and needs the spelling to name the element.
+            expect(of('flex-nowrap').intent).toStrictEqual({ wrap: { lines: 'single' } });
+            expect(resolveLayoutUtility('flex-nowrap', TOKENS)).toStrictEqual({ flexWrap: 'nowrap' });
+            // Reversal has no property behind it on either widget.
+            expect(threw(() => resolveUtility('flex-wrap-reverse', TOKENS)).message).toContain('Gtk.FlowBox');
+        });
+
+        await it('sends a wrapping element’s gap to the two spacings a FlowBox has', async () => {
+            // `Gtk.FlowBox` installs NO `spacing` (measured, gtk-props.ts). A gap
+            // that took the box's route would be a property the widget refuses at
+            // attach time, in a consumer's window — so the wrap carries it instead,
+            // and an unqualified gap is both spacings at once.
+            expect(of('flex-wrap', 'gap-xs').intent).toStrictEqual({
+                wrap: { lines: 'multi', rowSpacing: 8, columnSpacing: 8 },
+            });
+            expect(of('flex-wrap', 'gap-xs').props).toStrictEqual({});
+            // The axis-qualified spellings stop being an orientation question: both
+            // spacings are real on a FlowBox, whichever way the lines run.
+            expect(of('flex-wrap', 'gap-x-xs', 'gap-y-s').intent).toStrictEqual({
+                wrap: { lines: 'multi', columnSpacing: 8, rowSpacing: 12 },
+            });
+            // …which is also why the two-spellings refusal stops applying, and only
+            // then: without the wrap it is still one `Gtk.Box:spacing` being asked
+            // for twice.
+            expect(of('flex-wrap', 'gap-xs', 'gap-y-s').intent).toStrictEqual({
+                wrap: { lines: 'multi', rowSpacing: 12, columnSpacing: 8 },
+            });
+            expect(threw(() => of('gap-xs', 'gap-y-s')).message).toContain('ONE `spacing`');
+            // The class order does not decide it: the route table is iterated in its
+            // own declaration order, with `flexWrap` ahead of the gaps.
+            expect(of('gap-xs', 'flex-wrap').intent).toStrictEqual({
+                wrap: { lines: 'multi', rowSpacing: 8, columnSpacing: 8 },
+            });
         });
 
         await it('defers both axes of alignment to the shadow tree', async () => {
@@ -250,6 +285,7 @@ export default async () => {
             paddingBottom: '8px',
             paddingLeft: '8px',
             flexDirection: 'row',
+            flexWrap: 'nowrap',
             flexGrow: '1',
             alignItems: 'center',
             justifyContent: 'center',

--- a/packages/framework/gtk-host/src/style/layout.ts
+++ b/packages/framework/gtk-host/src/style/layout.ts
@@ -69,6 +69,7 @@ export interface LayoutProps {
     paddingBottom?: string;
     paddingLeft?: string;
     flexDirection?: 'row' | 'column';
+    flexWrap?: 'nowrap' | 'wrap';
     flexGrow?: string;
     alignItems?: AlignValue;
     justifyContent?: JustifyValue;
@@ -155,6 +156,25 @@ export interface LayoutIntent {
      */
     readonly overlay?: OverlayIntent;
     /**
+     * `flex-wrap` — the element becomes a DIFFERENT WIDGET.
+     *
+     * A `Gtk.Box` lays its children on one line and has no second line to put
+     * anything on. Wrapping on GTK is `Gtk.FlowBox`, which is not another property
+     * on the box but another class — so this is the same shape as
+     * {@link LayoutIntent.distribute}'s `space-between`: L1 names the widget the
+     * answer needs and L2 swaps it, because L1 resolves properties for an element
+     * and has no say in what the element becomes.
+     *
+     * The SPACINGS travel with it, and that is the reason this field carries values
+     * at all rather than being a flag. `Gtk.FlowBox` has NO `spacing` (measured,
+     * `gtk-props.ts`) — it has `row-spacing` and `column-spacing`, both real at once
+     * — so a gap on a wrapping element cannot take the `Gtk.Box:spacing` route the
+     * gap routes below use, and the axis-qualified spellings stop being an
+     * orientation question. Routing them here is what keeps `gap-*` from emitting a
+     * property the widget does not install.
+     */
+    readonly wrap?: WrapIntent;
+    /**
      * `text-*` — only a text widget aligns text.
      *
      * `xalign` and `justify` are `Gtk.Label`'s; `Gtk.Box` has neither (measured).
@@ -164,6 +184,17 @@ export interface LayoutIntent {
      */
     readonly textAlign?: 'left' | 'center' | 'right' | 'justify';
 }
+
+/**
+ * `flex-nowrap` / `flex-wrap`, with the spacings a wrapping widget needs.
+ *
+ * `single` is carried rather than dropped for the reason `relative` is: it is the
+ * half L2 can hold the other half against, and a resolution that never sees it
+ * cannot tell "this element does not wrap" from "nobody asked".
+ */
+export type WrapIntent =
+    | { readonly lines: 'single' }
+    | { readonly lines: 'multi'; readonly rowSpacing?: number; readonly columnSpacing?: number };
 
 export type OverlayIntent =
     | { readonly role: 'context' }
@@ -191,6 +222,8 @@ const NO_LOGICAL_PADDING =
     'GTK has no logical padding in either mechanism — `padding-start` is not a CSS property (measured) and no GTK class installs a padding property at all — so it cannot be expressed even approximately. Use `pl-*`/`pr-*`';
 const NO_LOGICAL_TEXT_ALIGN =
     'GTK aligns text PHYSICALLY: `Gtk.Label:xalign` is 0 = left, and `GtkJustification` has exactly LEFT, RIGHT, CENTER and FILL (measured). There is no start/end spelling to map onto. Use `text-left`/`text-right`';
+const NO_REVERSED_WRAP =
+    '`Gtk.FlowBox` — the widget a wrap becomes — lays its lines out in one direction only: it installs `orientation`, `homogeneous`, `row-spacing`, `column-spacing`, `min-children-per-line`, `max-children-per-line` and `selection-mode`, and nothing that reverses the line order (measured). Reverse the children instead — the shadow tree is the order. `flex-wrap` is the spelling that maps';
 const NO_PERCENTAGE_SIZE =
     'GTK has no percentage size: a widget requests a MINIMUM in pixels (`width-request`) or expands to fill what it is given (`hexpand`). `w-full`/`h-full` are the only fractions with an exact GTK meaning';
 
@@ -288,17 +321,15 @@ export function resolveLayoutUtility(utility: string, tokens: StyleTokens): Layo
         case 'flex-col':
             return { flexDirection: 'column' };
         case 'flex-nowrap':
-            // `Gtk.Box` never wraps, so this restates the platform. The empty record
-            // is not a dropped utility: the name is DECLARED here and asserted empty
-            // in the spec, which is what separates "means nothing on GTK" from "was
-            // never recognised".
-            return {};
+            // A `Gtk.Box` is already one line, so this restates the platform — and
+            // it is still a VALUE rather than an empty record, because L2 refuses a
+            // wrap utility on a widget that cannot wrap and needs to see the
+            // no-wrap spelling to say so about the right element.
+            return { flexWrap: 'nowrap' };
         case 'flex-wrap':
+            return { flexWrap: 'wrap' };
         case 'flex-wrap-reverse':
-            throw new UnknownUtilityError(
-                utility,
-                'a `Gtk.Box` cannot wrap. Wrapping is a different widget — `Gtk.FlowBox` — and swapping the widget under an element is L2 widget selection, not a style property',
-            );
+            throw new UnknownUtilityError(utility, NO_REVERSED_WRAP);
         case 'flex-row-reverse':
         case 'flex-col-reverse':
             throw new UnknownUtilityError(
@@ -423,6 +454,7 @@ const unknownToken = (utility: string, token: string, table: Readonly<Record<str
 
 interface MutableIntent {
     expand?: 'main-axis';
+    wrap?: { lines: 'single' } | { lines: 'multi'; rowSpacing?: number; columnSpacing?: number };
     alignChildren?: AlignValue;
     distribute?: JustifyValue;
     alignSelf?: AlignValue;
@@ -491,6 +523,9 @@ function oneOf<T extends string>(value: string, allowed: readonly T[], property:
 
 type Route = (value: string, sink: Sink) => void;
 
+/** Has this element already declared that its children wrap? */
+const multiLine = (sink: Sink): boolean => sink.intent.wrap?.lines === 'multi';
+
 const edgeRoute =
     (edge: Edge): Route =>
     (value, sink) => {
@@ -554,6 +589,14 @@ const ROUTES: Readonly<Record<keyof LayoutProps, Route>> = {
             'orientation',
             oneOf(value, ['row', 'column'], 'flexDirection') === 'row' ? 'horizontal' : 'vertical',
         ),
+    // BEFORE the three gap routes below, by the declaration order this table is
+    // iterated in: a gap on a wrapping element goes to `Gtk.FlowBox`'s two spacings
+    // and not to `Gtk.Box:spacing`, and the routes can only see that if the wrap has
+    // already landed in the intent. Same reason `position` sits before the edges.
+    flexWrap: (value, sink) => {
+        sink.intent.wrap =
+            oneOf(value, ['nowrap', 'wrap'], 'flexWrap') === 'wrap' ? { lines: 'multi' } : { lines: 'single' };
+    },
     flexGrow: (value, sink) => {
         if (value !== '1') throw new UnknownUtilityError('flexGrow', NO_FLEX_FACTOR);
         sink.intent.expand = 'main-axis';
@@ -577,12 +620,27 @@ const ROUTES: Readonly<Record<keyof LayoutProps, Route>> = {
     alignSelf: (value, sink) => {
         sink.intent.alignSelf = oneOf(value, ['flex-start', 'flex-end', 'center', 'stretch', 'baseline'], 'alignSelf');
     },
-    gap: (value, sink) => emitProp(sink, 'spacing', pixels(value, 'spacing')),
+    gap: (value, sink) => {
+        const px = pixels(value, 'spacing');
+        // A wrapping element is a `Gtk.FlowBox`, which installs no `spacing` at all
+        // (measured, `gtk-props.ts`) — so emitting one here would be a property the
+        // widget refuses at attach time, in a consumer's window. Its two spacings
+        // are BOTH real, and an unqualified gap is both.
+        if (multiLine(sink)) sink.intent.wrap = { lines: 'multi', rowSpacing: px, columnSpacing: px };
+        else emitProp(sink, 'spacing', px);
+    },
     columnGap: (value, sink) => {
-        sink.intent.axisSpacing = { axis: 'horizontal', pixels: pixels(value, 'spacing') };
+        const px = pixels(value, 'spacing');
+        // On a `Gtk.Box` an axis-qualified gap is an orientation question L1 cannot
+        // answer. On a `Gtk.FlowBox` it is not a question at all: `column-spacing`
+        // is the gap between children in a line whichever way the lines run.
+        if (multiLine(sink)) sink.intent.wrap = { ...sink.intent.wrap, lines: 'multi', columnSpacing: px };
+        else sink.intent.axisSpacing = { axis: 'horizontal', pixels: px };
     },
     rowGap: (value, sink) => {
-        sink.intent.axisSpacing = { axis: 'vertical', pixels: pixels(value, 'spacing') };
+        const px = pixels(value, 'spacing');
+        if (multiLine(sink)) sink.intent.wrap = { ...sink.intent.wrap, lines: 'multi', rowSpacing: px };
+        else sink.intent.axisSpacing = { axis: 'vertical', pixels: px };
     },
     // `100%` is the ONLY fraction with an exact GTK meaning, and it is not a size at
     // all: `hexpand` says "take what is going", where `width-request` says "never
@@ -650,11 +708,15 @@ export function partitionLayout(props: LayoutProps): LayoutPartition {
         );
     }
 
+    // The two-spacings refusal is a fact about `Gtk.Box`, so it stops applying the
+    // moment the element declares that it wraps: `Gtk.FlowBox` has `row-spacing` AND
+    // `column-spacing` (measured), and `gap-4 gap-x-2` on a wrapping element is
+    // ordinary authoring that lands on exactly two properties.
     const gaps = ['gap', 'columnGap', 'rowGap'].filter((key) => props[key as keyof LayoutProps] !== undefined);
-    if (gaps.length > 1) {
+    if (gaps.length > 1 && props.flexWrap !== 'wrap') {
         throw new UnknownUtilityError(
             gaps.join(' + '),
-            'a `Gtk.Box` has ONE `spacing` (measured), so two gap spellings on one element ask for two spacings. Keep one',
+            'a `Gtk.Box` has ONE `spacing` (measured), so two gap spellings on one element ask for two spacings. Keep one, or add `flex-wrap` — a `Gtk.FlowBox` has a row spacing and a column spacing and can carry both',
         );
     }
 

--- a/packages/framework/react-native/src/primitives/intents.ts
+++ b/packages/framework/react-native/src/primitives/intents.ts
@@ -22,6 +22,11 @@
 //                  `gtk-props.ts`), so on a non-text widget the value travels
 //                  down to the first descendant that can take it.
 //   overlay(child) the PARENT's identity, which the caller supplies as context.
+//   wrap           WHICH WIDGET the element is. `flex-wrap` is not a property on
+//                  any GTK class — a `Gtk.Box` has one line — so it is answered by
+//                  swapping in `Gtk.FlowBox`, and only a layer holding the widget
+//                  table can do that. The spacings come with it, because the two
+//                  classes spell a gap differently.
 //
 // WHAT IS PASSED UP, and why no amount of local cleverness closes it:
 //
@@ -84,12 +89,34 @@ export interface ChildFacts {
     readonly text: boolean;
 }
 
+/**
+ * The widget an element becomes when its children WRAP, and what that class needs.
+ *
+ * Data rather than code because it is a fact about GTK's class hierarchy, the same
+ * way `overlayOnAbsoluteChild` is: a `Gtk.Box` has one line and a `Gtk.FlowBox` has
+ * as many as it needs, and neither is reachable from the other by setting a
+ * property. `null` is a primitive whose widget has no wrapping counterpart at all.
+ */
+export interface WrapsInto {
+    /** GType name of the wrapping class. */
+    readonly tag: string;
+    /**
+     * Properties the swapped-in class needs before a single utility is read.
+     *
+     * Not cosmetic: `Gtk.FlowBox` ships two defaults that make it something other
+     * than a wrapping box (measured, gtk 4.22.4), and both are corrected here.
+     */
+    readonly widgetProps: Readonly<Record<string, unknown>>;
+}
+
 /** What the element's own widget can take. Declared per primitive, measured in the spec. */
 export interface WidgetFacts {
     /** Installs `orientation` and `spacing` — a `Gtk.Box`. */
     readonly box: boolean;
     /** Installs `xalign` and `justify` — a `Gtk.Label`. */
     readonly alignsText: boolean;
+    /** What this element becomes when its children wrap, or `null` when nothing can. */
+    readonly wrapsInto: WrapsInto | null;
 }
 
 export interface IntentInput {
@@ -104,6 +131,14 @@ export interface IntentInput {
     readonly emittedProps: Readonly<Record<string, unknown>>;
 }
 
+/** The widget swap a wrap asks for, for the caller that owns the plan's tags. */
+export interface WrapResolution {
+    /** GType name the node the children go into takes instead of its own. */
+    readonly tag: string;
+    /** Properties that belong to the swapped-in class, the spacings included. */
+    readonly props: Readonly<Record<string, unknown>>;
+}
+
 export interface IntentResolution {
     /** Widget properties this resolution adds, GTK spelling. */
     readonly props: Readonly<Record<string, unknown>>;
@@ -113,6 +148,14 @@ export interface IntentResolution {
     readonly childContext: ChildContext;
     /** The `slot` this element declares to its parent, or null. */
     readonly slot: string | null;
+    /**
+     * The tag the node holding the children takes instead of its own, or null.
+     *
+     * Returned rather than applied because this function answers for PROPERTIES and
+     * the plan's tags belong to `resolve.ts` — the same division that keeps
+     * `overlayOnAbsoluteChild` out of here.
+     */
+    readonly wrapping: WrapResolution | null;
     /** What is still unresolved, for a caller that knows more. */
     readonly remaining: LayoutIntent;
 }
@@ -165,6 +208,9 @@ const main = (orientation: Orientation): 'halign' | 'valign' => (orientation ===
 const NO_CENTER_BOX =
     "GTK's box has no main-axis justification, and ADR 0032 § 6's mapping for this one is `Gtk.CenterBox` — a different WIDGET, not another property on this one. The host's `slotted` policy used to be what blocked it, because it named a `remove` that gtk 4.22.4's `Gtk.CenterBox` does not install (it clears a slot with `set_center_widget(null)`); that block is gone, since `children.remove` is optional for a policy whose slots are all setters. What is missing is the CHILD COUNT — two or three children pick the widget, and this layer resolves properties for the widget it was handed, with no children to count. Spell the distribution with a spacer child (`flex-1`) or with `gap-*`";
 
+const NO_WRAPPING_WIDGET =
+    'wraps CHILDREN onto a second line, and the widget this primitive becomes has no wrapping counterpart: `Gtk.FlowBox` is a box that wraps, and there is no wrapping `Gtk.Label`, `Gtk.Button` or `Gtk.ScrolledWindow` to swap in. Move the utility to the container — on a `ScrollView` that is `contentContainerClassName`, which lands on a real box';
+
 export function resolveIntent(input: IntentInput): IntentResolution {
     const { primitive, intent, orientation, widget, parent } = input;
     const props: Record<string, unknown> = {};
@@ -172,6 +218,7 @@ export function resolveIntent(input: IntentInput): IntentResolution {
     const childProps: Record<string, unknown> = {};
     const remaining: Record<string, unknown> = {};
     let slot: string | null = null;
+    let wrapping: WrapResolution | null = null;
     let childTextAlign = parent?.textAlign;
 
     // --- resolved: the element's own orientation is enough ---------------------
@@ -215,6 +262,29 @@ export function resolveIntent(input: IntentInput): IntentResolution {
         // it would reject `gap-x-2` written defensively beside a `flex-row` that a
         // breakpoint later turns into a column.
         if (intent.axisSpacing.axis === orientation) props.spacing = intent.axisSpacing.pixels;
+    }
+
+    if (intent.wrap !== undefined) {
+        // ONE guard for both halves of the refusal: a primitive whose widget cannot
+        // wrap has no wrapping counterpart either, so `wrapsInto === null` is the
+        // whole test and the message names the fact rather than the class.
+        const into = widget.wrapsInto;
+        if (into === null) throw new PrimitiveError(primitive, 'flex-wrap/flex-nowrap', NO_WRAPPING_WIDGET);
+        // `single` is RESOLVED here, by there being nothing to do: the element's own
+        // widget is already one line. Consumed rather than passed up, because no
+        // caller knowing more could answer it differently — which is exactly the
+        // difference between this and `expand`.
+        if (intent.wrap.lines === 'multi') {
+            const { rowSpacing, columnSpacing } = intent.wrap;
+            wrapping = {
+                tag: into.tag,
+                props: {
+                    ...into.widgetProps,
+                    ...(rowSpacing === undefined ? {} : { 'row-spacing': rowSpacing }),
+                    ...(columnSpacing === undefined ? {} : { 'column-spacing': columnSpacing }),
+                },
+            };
+        }
     }
 
     if (intent.textAlign !== undefined) childTextAlign = intent.textAlign;
@@ -276,6 +346,7 @@ export function resolveIntent(input: IntentInput): IntentResolution {
             ...(childTextAlign === undefined ? {} : { textAlign: childTextAlign }),
         },
         slot,
+        wrapping,
         remaining: remaining as LayoutIntent,
     };
 }

--- a/packages/framework/react-native/src/primitives/primitives.spec.ts
+++ b/packages/framework/react-native/src/primitives/primitives.spec.ts
@@ -246,6 +246,87 @@ export default async () => {
         await it('refuses items-* on a primitive with no children to align', async () => {
             expect(threw(() => plan('Text', { className: 'items-center' })).message).toContain('not a box');
         });
+
+        await it('swaps the WIDGET for a wrap, because no property makes a box wrap', async () => {
+            // The second widget-changing intent, and the one ADR 0032 § 6's
+            // `justify-between` precedent is about: L1 names the class, L2 owns the
+            // tag. A `Gtk.Box` has one line and nothing to set to give it two.
+            const p = plan('View', { className: 'flex-wrap' }).plan;
+            expect(p.node.tag).toBe('GtkFlowBox');
+            // …and the element keeps everything that describes it AS an element: the
+            // orientation means the same thing on both classes (measured), so
+            // `flex-row` still selects rows and `flex-col` still selects columns.
+            expect(plan('View', { className: 'flex-wrap' }).plan.node.props.orientation).toBe('vertical');
+            expect(plan('View', { className: 'flex-row flex-wrap' }).plan.node.props.orientation).toBe('horizontal');
+        });
+
+        await it('corrects the two GtkFlowBox defaults that would make it not a flex container', async () => {
+            // Both silent. `max-children-per-line` defaults to 7, so a wrap would cap
+            // a line at seven children however much room was left; `selection-mode`
+            // defaults to SINGLE, so a click would select a child and draw a focus
+            // ring a flexbox container never draws. 65535 is not a round number
+            // picked for looks — it is what GTK stores when handed G_MAXUINT, and `0`
+            // is out of range for the `guint` rather than meaning "no limit".
+            const p = plan('View', { className: 'flex-wrap' }).plan;
+            expect(p.node.props['max-children-per-line']).toBe(65535);
+            expect(p.node.props['selection-mode']).toBe('none');
+        });
+
+        await it('sends a wrapping element’s gap to the two spacings, never to `spacing`', async () => {
+            // `Gtk.FlowBox` installs NO `spacing` (measured). Emitting one would be a
+            // property the host refuses at attach time, in a consumer's window.
+            const both = plan('View', { className: 'flex-wrap gap-2' }).plan;
+            expect(both.node.props.spacing).toBeUndefined();
+            expect(both.node.props['row-spacing']).toBe(8);
+            expect(both.node.props['column-spacing']).toBe(8);
+            // And the axis-qualified gaps stop being an orientation question: both
+            // spacings are real, whichever way the lines run.
+            const axes = plan('View', { className: 'flex-wrap gap-x-1 gap-y-4' }).plan;
+            expect(axes.node.props['column-spacing']).toBe(4);
+            expect(axes.node.props['row-spacing']).toBe(16);
+        });
+
+        await it('consumes flex-nowrap instead of dropping it or refusing it', async () => {
+            // A `Gtk.Box` is already one line, so the resolution is "nothing to do" —
+            // and it is a RESOLUTION rather than a pass-up, because no caller knowing
+            // more could answer it differently. The tag is the proof it was consumed.
+            const p = plan('View', { className: 'flex-nowrap' }).plan;
+            expect(p.node.tag).toBe('GtkBox');
+            expect(p.intent).toStrictEqual({});
+        });
+
+        await it('refuses a wrap on a primitive whose widget has no wrapping counterpart', async () => {
+            // There is no wrapping `Gtk.Label` and no wrapping `Gtk.ScrolledWindow`,
+            // so the refusal points at the node that IS a box — which on a
+            // `ScrollView` is reached through `contentContainerClassName`.
+            expect(threw(() => plan('Text', { className: 'flex-wrap' })).message).toContain('no wrapping counterpart');
+            const scroller = threw(() => plan('ScrollView', { className: 'flex-wrap' }));
+            expect(scroller.message).toContain('contentContainerClassName');
+        });
+
+        await it('wraps a ScrollView’s CONTENT box, which is the node that holds children', async () => {
+            const p = plan('ScrollView', { contentContainerClassName: 'flex-wrap gap-2' }).plan;
+            expect(p.node.tag).toBe('GtkScrolledWindow');
+            expect(p.content?.tag).toBe('GtkFlowBox');
+            expect(p.content?.props['row-spacing']).toBe(8);
+        });
+
+        await it('wraps the INNER box when an absolute child made the element an overlay', async () => {
+            // Two widget swaps on one element, and they do not collide: the outer
+            // node becomes the overlay the absolute child needs, and the node the
+            // ordinary children go into becomes the one that wraps.
+            const p = plan(
+                'View',
+                { className: 'flex-wrap gap-1' },
+                { children: { absolute: 1, count: 2, text: false } },
+            ).plan;
+            expect(p.node.tag).toBe('GtkOverlay');
+            expect(p.content?.tag).toBe('GtkFlowBox');
+            expect(p.content?.props['column-spacing']).toBe(4);
+            // The spacings belong to the inner class and must not be left on the
+            // overlay, which installs neither (measured: 37 properties, no spacing).
+            expect(p.node.props['column-spacing']).toBeUndefined();
+        });
     });
 
     await describe('the intents L2 passes up', async () => {

--- a/packages/framework/react-native/src/primitives/resolve.ts
+++ b/packages/framework/react-native/src/primitives/resolve.ts
@@ -17,6 +17,12 @@
 //   4. derive the effective orientation            — from step 3, not from the spec
 //   5. resolve the intents                         — needs step 4's answer
 //   6. mint the class                              — needs step 5's extra declarations
+//   7. apply the wrap swap                         — step 5 says WHICH widget, not this
+//
+// Step 7 is the second widget swap in this function and the opposite trigger to step
+// 1's: `switchOn` reads one React Native PROP, while a wrap is decided by the STYLE
+// and can therefore only be known after step 3. The class is minted before it (step
+// 6) because a generated class name travels with the element and not with the tag.
 //
 // Steps 3 and 4 are the pair that cannot be reordered: `flex-row` becomes the
 // widget property `orientation`, and `items-center` becomes `halign` or `valign`
@@ -28,7 +34,14 @@ import type { LayoutIntent, StyleProps, StyleTokens } from '@gjsify/gtk-host/sty
 
 import type { ClassNameInput } from './classes.js';
 import { PrimitiveError } from './errors.js';
-import { resolveIntent, type ChildContext, type ChildFacts, type Orientation, type WidgetFacts } from './intents.js';
+import {
+    resolveIntent,
+    type ChildContext,
+    type ChildFacts,
+    type Orientation,
+    type WidgetFacts,
+    type WrapResolution,
+} from './intents.js';
 import { mintClass, normalise, partition, variantDeclarations, type ClassNameSink, type StyleInput } from './style.js';
 import {
     FRAMEWORK_PROPS,
@@ -77,6 +90,29 @@ const withOrientationClass = (
     if (classes.length === 0) return classes;
     const orientation = props.orientation;
     return typeof orientation === 'string' ? [orientation, ...classes] : classes;
+};
+
+/**
+ * The node the children go into, after a wrap has changed which widget that is.
+ *
+ * ONE function for the three places a plan can put the children — the element's own
+ * node, the inner box of an overlay, and a `ScrollView`'s content box — because the
+ * swap is the same operation on all three and a second copy is the one that would
+ * miss `contentContainerClassName="flex-wrap"`.
+ */
+const wrapped = (
+    tag: string,
+    props: Record<string, unknown>,
+    wrapping: WrapResolution | null,
+): { readonly tag: string; readonly props: Record<string, unknown> } => {
+    if (wrapping === null) return { tag, props };
+    // `spacing` is `Gtk.Box`'s and the swapped-in class does not install it (measured,
+    // gtk-props.ts). L1 already routes a wrapping element's gap into the intent, so
+    // there is normally nothing here — this is the line that keeps that true if a
+    // spec ever carries a `spacing` of its own, rather than letting the host refuse
+    // the property at attach time in a consumer's window.
+    const { spacing: _dropped, ...rest } = props;
+    return { tag: wrapping.tag, props: { ...rest, ...wrapping.props } };
 };
 
 /** Everything L2 needs that is not the primitive and not its props. */
@@ -324,10 +360,11 @@ export function resolvePrimitive(primitive: string, props: PrimitiveProps, conte
             inner[name] = outerProps[name];
             delete outerProps[name];
         }
+        const innerNode = wrapped(spec.tag, inner, resolved.wrapping);
         return {
             primitive,
             node: { tag: overlay.tag, props: outerProps, cssClasses: withOrientationClass(outerProps, cssClasses) },
-            content: { tag: spec.tag, props: inner, cssClasses: [] },
+            content: { tag: innerNode.tag, props: innerNode.props, cssClasses: [] },
             backdrop: null,
             backdropSlot: null,
             contentSlot: null,
@@ -347,9 +384,19 @@ export function resolvePrimitive(primitive: string, props: PrimitiveProps, conte
     const backdropResolved =
         spec.backdrop === undefined ? null : resolveNode(spec.backdrop, props, backdropProps, context, primitive);
 
+    // A primitive WITH a content node styles the scroller with its own class list, so
+    // a wrap written there belongs to the scroller — which cannot wrap, and
+    // `resolveIntent` has already refused it by then (`ScrollView`'s widget facts say
+    // `wrapsInto: null`). So this swap only ever fires on a primitive that holds its
+    // own children.
+    const ownNode = wrapped(spec.tag, outerProps, resolved.wrapping);
     return {
         primitive,
-        node: { tag: spec.tag, props: outerProps, cssClasses: withOrientationClass(outerProps, cssClasses) },
+        node: {
+            tag: ownNode.tag,
+            props: ownNode.props,
+            cssClasses: withOrientationClass(ownNode.props, cssClasses),
+        },
         content: contentResolved === null ? null : contentResolved.node,
         backdrop: backdropResolved === null ? null : backdropResolved.node,
         backdropSlot: spec.backdrop?.slot ?? null,
@@ -432,11 +479,12 @@ function resolveNode(
         variantDeclarations(authored.groups, context.tokens, label),
     );
     Object.assign(contentProps, partitioned.props, resolved.props);
+    const node = wrapped(content.tag, contentProps, resolved.wrapping);
     return {
         node: {
-            tag: content.tag,
-            props: contentProps,
-            cssClasses: withOrientationClass(contentProps, generated === null ? [] : [generated]),
+            tag: node.tag,
+            props: node.props,
+            cssClasses: withOrientationClass(node.props, generated === null ? [] : [generated]),
         },
         childContext: { ...resolved.childContext, orientation },
     };

--- a/packages/framework/react-native/src/primitives/table.ts
+++ b/packages/framework/react-native/src/primitives/table.ts
@@ -33,7 +33,7 @@
 // generated refusing export is the honest answer — strictly better than a `partial`
 // that aborts the process the first time somebody renders one.
 
-import type { Orientation, WidgetFacts } from './intents.js';
+import type { Orientation, WidgetFacts, WrapsInto } from './intents.js';
 
 /** How a prop's value becomes a GTK value. */
 export type Coercion =
@@ -241,9 +241,37 @@ export interface PrimitiveSpec {
     readonly refusesStyle?: string;
 }
 
-const BOX: WidgetFacts = { box: true, alignsText: false };
-const LEAF: WidgetFacts = { box: false, alignsText: false };
-const TEXT: WidgetFacts = { box: false, alignsText: true };
+/**
+ * A wrapping box, and the two defaults that stop `Gtk.FlowBox` from being one.
+ *
+ * MEASURED on gtk 4.22.4, and both are the silent kind:
+ *
+ *   `max-children-per-line` defaults to **7**. A `flex-wrap` container would put
+ *   seven children on a line and wrap the eighth however much room was left — a
+ *   layout that is plausible on screen and wrong. There is no "no limit" spelling:
+ *   `0` is OUT OF RANGE for the `guint` (a GLib-GObject-CRITICAL, and the property
+ *   keeps its old value), and writing G_MAXUINT stores 65535. So 65535 IS GTK's
+ *   spelling of "as many as fit", and the natural width is unaffected by it — it
+ *   tracks the child count, measured identical for 12 children at 12, 1024 and
+ *   65535.
+ *
+ *   `selection-mode` defaults to SINGLE. A `Gtk.FlowBox` is a selection widget
+ *   before it is a layout one, so a plain `<View>` would gain a focus ring and a
+ *   selected row from a click that a flexbox container ignores.
+ *
+ * `orientation` needs no correction and is not listed: it means the same thing on
+ * both classes (measured — HORIZONTAL fills along x and wraps into rows, VERTICAL
+ * fills along y and wraps into columns), so `flex-row`/`flex-col` survive the swap
+ * through the ordinary property route.
+ */
+const WRAPS_INTO_FLOW_BOX: WrapsInto = {
+    tag: 'GtkFlowBox',
+    widgetProps: { 'max-children-per-line': 65535, 'selection-mode': 'none' },
+};
+
+const BOX: WidgetFacts = { box: true, alignsText: false, wrapsInto: WRAPS_INTO_FLOW_BOX };
+const LEAF: WidgetFacts = { box: false, alignsText: false, wrapsInto: null };
+const TEXT: WidgetFacts = { box: false, alignsText: true, wrapsInto: null };
 
 const NO_ACCESSIBILITY_PROP =
     'GTK carries accessibility through `Gtk.Accessible.update_property()`, an imperative call, not through a widget property — so there is nothing for this layer to set as data. `AccessibilityInfo` (tier P3) is the entry that owns this, and GTK’s model maps onto the props well once it exists';

--- a/packages/framework/react-native/src/primitives/widgets.spec.ts
+++ b/packages/framework/react-native/src/primitives/widgets.spec.ts
@@ -140,6 +140,19 @@ function propertyClaims(): Claim[] {
             // on `spec.tag` either way — which is exactly what `BOX_ONLY_PROPS` moves.
             for (const property of ['orientation', 'spacing']) add(spec.tag, property, `${name} (box intent)`);
         }
+        // The wrap swap's node. Its properties are NOT the box's: a `Gtk.FlowBox`
+        // installs no `spacing` at all, so the two spacings the resolver emits are
+        // the exact claim this gate exists to hold — a misspelling here resolves
+        // perfectly and is refused at attach time, in a consumer's window.
+        for (const facts of [spec.widget, content?.widget, backdrop?.widget]) {
+            const into = facts?.wrapsInto ?? null;
+            if (into === null) continue;
+            for (const property of Object.keys(into.widgetProps)) add(into.tag, property, `${name} (wrap)`);
+            for (const property of ['orientation', 'row-spacing', 'column-spacing']) {
+                add(into.tag, property, `${name} (wrap spacing)`);
+            }
+            for (const property of UNIVERSAL) add(into.tag, property, `${name} (wrap, universal)`);
+        }
         if (content?.widget.box === true) {
             for (const property of ['orientation', 'spacing'])
                 add(content.tag, property, `${name}.content (box intent)`);
@@ -240,6 +253,8 @@ export default async () => {
                         spec.content?.tag,
                         spec.backdrop?.tag,
                         spec.overlayOnAbsoluteChild?.tag,
+                        spec.widget.wrapsInto?.tag,
+                        spec.content?.widget.wrapsInto?.tag,
                     ]) {
                         if (gtype === undefined) continue;
                         expect(typeof lookupWidget(gtype).ctor()).toBe('function');
@@ -387,6 +402,40 @@ export default async () => {
                         // overlay child positioned against the padding box.
                         expect(generatedClasses(overlay).length).toBe(1);
                         expect(generatedClasses(box)).toStrictEqual([]);
+                    },
+                );
+            });
+
+            await it('becomes a Gtk.FlowBox for a wrap, and puts its children INSIDE it', async () => {
+                // The tag is half the claim. The other half is that the host can
+                // actually place children in the swapped-in class — a `Gtk.FlowBox`
+                // wraps each child in a `Gtk.FlowBoxChild`, so a plan naming the tag
+                // without a curated placement rule builds and then refuses at insert
+                // time. This reads the REAL tree, through the wrapper row.
+                mounted(
+                    createElement(
+                        View,
+                        { className: 'flex-row flex-wrap gap-2' },
+                        createElement(Text, { key: 'a' }, 'a'),
+                        createElement(Text, { key: 'b' }, 'b'),
+                    ),
+                    (container) => {
+                        const flow = gtkChildren(container)[0] as Gtk.FlowBox;
+                        expect(typeOf(flow)).toBe('GtkFlowBox');
+                        expect(flow.orientation).toBe(Gtk.Orientation.HORIZONTAL);
+                        // The two corrected defaults, read back off the widget rather
+                        // than off the plan: 7 children per line and a SINGLE
+                        // selection are what a `Gtk.FlowBox` is without them.
+                        expect(flow.maxChildrenPerLine).toBe(65535);
+                        expect(flow.selectionMode).toBe(Gtk.SelectionMode.NONE);
+                        // `gap-2` reached the two spacings, and NOT `Gtk.Box:spacing`
+                        // — a property this class does not install at all.
+                        expect(flow.rowSpacing).toBe(8);
+                        expect(flow.columnSpacing).toBe(8);
+                        // Each child sits in the wrapper row the host adds.
+                        const rows = gtkChildren(flow);
+                        expect(rows.map(typeOf)).toStrictEqual(['GtkFlowBoxChild', 'GtkFlowBoxChild']);
+                        expect(rows.map((row) => (gtkChildren(row)[0] as Gtk.Label).label)).toStrictEqual(['a', 'b']);
                     },
                 );
             });

--- a/website/src/content/docs/frameworks/styling.mdx
+++ b/website/src/content/docs/frameworks/styling.mdx
@@ -25,7 +25,7 @@ A property is answered in exactly one of three ways:
 |---|---|---|
 | **GTK CSS** | GTK's CSS parser accepts the property name | `padding-left`, `background-color`, `margin-left` |
 | **widget property** | some GTK class installs a property by that name | `margin-start`, `hexpand`, `overflow`, `width-request` |
-| **intent** | neither can answer it *here*, because the answer needs the parent, the children, or the widget this element becomes | `flex-1`, `items-center`, `gap-x-2`, `text-center` |
+| **intent** | neither can answer it *here*, because the answer needs the parent, the children, or the widget this element becomes | `flex-1`, `items-center`, `gap-x-2`, `text-center`, `flex-wrap` |
 
 Which one a property takes is a **measurement**, not a preference. Two committed tables hold it:
 one loads every accepted CSS property name into a real `Gtk.CssProvider` and asserts it parses,
@@ -160,6 +160,46 @@ child as `halign` / `valign`, so resolving it means walking children. And *which
 depends on the element's own orientation — where the defaults disagree, since a `Gtk.Box` is
 horizontal and a React Native `View` is a column. There is not even a safe fallback to guess with.
 
+## `flex-wrap` is a different widget, not a property
+
+A `Gtk.Box` lays its children on one line and installs nothing that gives it a
+second one. Wrapping on GTK is `Gtk.FlowBox` — another class, reached by swapping the
+widget rather than by setting anything — so `flex-wrap` is an **intent** for the same
+reason `justify-between` is: the partition answers for an element's properties and
+has no say in what the element becomes. The layer above swaps the tag, and
+`flex-nowrap` is *resolved* by there being nothing to do, since a box is already one
+line.
+
+`flex-wrap-reverse` stays a refusal. `Gtk.FlowBox` installs `orientation`,
+`homogeneous`, `row-spacing`, `column-spacing`, `min-children-per-line`,
+`max-children-per-line` and `selection-mode`, and nothing that reverses the line
+order — so reverse the children instead, which is what the tree is for.
+
+Two `Gtk.FlowBox` defaults are corrected on the way in, and both are the silent kind:
+
+| Default | What it would do to a `flex-wrap` container |
+|---|---|
+| `max-children-per-line: 7` | seven children per line however much room is left — a layout that is plausible on screen and wrong |
+| `selection-mode: SINGLE` | a click selects a child and draws a focus ring, which a flex container never does |
+
+There is **no "no limit" spelling** for the first. `0` is out of range for the
+`guint` — a `GLib-GObject-CRITICAL`, and the property keeps its old value — and
+writing `G_MAXUINT` stores **65535**, which is therefore GTK's own way to say "as
+many as fit". It costs nothing: the natural width tracks the child count, measured
+identical for twelve children at `12`, `1024` and `65535`.
+
+**A gap changes channel when an element wraps.** `Gtk.FlowBox` has *no* `spacing` at
+all; it has `row-spacing` and `column-spacing`, and both are real at once. So on a
+wrapping element `gap-*` becomes both spacings instead of the box's single one, and
+the axis-qualified spellings stop being an orientation question — `gap-x-*` is the
+gap between children in a line whichever way the lines run. That is also the one
+place the two-gap-spellings refusal lifts: `gap-4 gap-x-2` asks a `Gtk.Box` for two
+spacings it does not have, and asks a `Gtk.FlowBox` for exactly the two it does.
+
+`orientation` needs no translation and keeps working across the swap, measured on
+both classes: `HORIZONTAL` fills along x and wraps into rows, `VERTICAL` fills along
+y and wraps into columns — the same meaning `flex-row` and `flex-col` already had.
+
 ## The generated stylesheet
 
 A widget takes `css-classes`, a string array. So something has to turn a set of declarations into
@@ -187,6 +227,8 @@ a **name** and keep a document that defines it.
 | `w-1/2` and other fractions | refused: a widget requests a *minimum* in pixels or expands to fill. `w-full` / `h-full` are the only fractions with an exact GTK meaning |
 | `overflow-scroll`, `overflow-auto` | refused: scrolling is a **widget** on GTK, not an overflow mode — wrap the element in a `Gtk.ScrolledWindow`. `Gtk.Overflow` has exactly `VISIBLE` and `HIDDEN` |
 | `flex-2`, `grow-2`, `shrink-*`, `basis-*` | refused: GTK expresses main-axis growth as the boolean `hexpand` / `vexpand`, so there is no growth factor, shrink factor or flex basis to carry. `flex-1` is the only spelling with a GTK meaning |
+| `flex-wrap-reverse` | refused: `Gtk.FlowBox` runs its lines in one direction only and installs nothing that reverses them. Reverse the children |
+| `flex-wrap` on a `<Text>`, or on a `ScrollView`'s own class list | refused at attach time: there is no wrapping `Gtk.Label` and no wrapping `Gtk.ScrolledWindow` to swap in. On a `ScrollView` the box that holds the children is reached through `contentContainerClassName` |
 | a name no family claims | `UnknownUtilityError`, naming the utility — never a silent drop |
 
 The first two rows refuse at different moments, and it is worth knowing why. **No child count


### PR DESCRIPTION
`flex-wrap` was a named refusal in the layout half, and the refusal's own text said what should happen instead: *"wrapping is a different widget — `Gtk.FlowBox` — and swapping the widget under an element is L2 widget selection"*. That is not a reason to refuse the vocabulary, it is a description of the intent mechanism ADR 0032 § 6 already established for `justify-between` → `Gtk.CenterBox`. So it becomes one.

L1 emits `wrap: { lines: 'multi' | 'single' }`, L2 swaps the tag of the node the children go into, and `flex-wrap-reverse` stays refused. `flex-nowrap` is **resolved** rather than dropped: a `Gtk.Box` is already one line, and no caller knowing more could answer it differently — which is what separates it from `expand`.

## Four measurements on gtk 4.22.4, three of them traps

**`Gtk.FlowBox` installs no `spacing` at all.** It has `row-spacing` and `column-spacing`, both real at once. A gap on a wrapping element therefore cannot take the `Gtk.Box:spacing` route — emitting one would be a property the host refuses at attach time, in a consumer's window — so the intent carries the spacings instead. Two consequences fall out:

- the axis-qualified spellings stop being an orientation question, since `column-spacing` is the gap between children in a line whichever way the lines run;
- the cross-key *"a `Gtk.Box` has ONE `spacing`"* refusal lifts for a wrapping element **only**, because `gap-4 gap-x-2` asks a FlowBox for exactly the two properties it has.

`flexWrap` is routed **before** the three gaps by the route table's declaration order, the same way `position` sits before the four edges.

**`max-children-per-line` defaults to 7.** A wrap would cap a line at seven children however much room was left — plausible on screen and wrong. There is no "no limit" spelling: `0` is **out of range** for the `guint` (a `GLib-GObject-CRITICAL`, and the property keeps its old value) and writing `G_MAXUINT` stores **65535**. So 65535 is GTK's own way to say "as many as fit", and it costs nothing: the natural width tracks the child count, measured identical for twelve children at `12`, `1024` and `65535`.

**`selection-mode` defaults to SINGLE.** A `Gtk.FlowBox` is a selection widget before it is a layout one, so a plain wrapping `<View>` would gain a focus ring and a selected row from a click a flex container ignores. Both defaults are corrected in the widget-facts data, where the other widget facts live.

**`orientation` needs no translation**, measured both ways: `HORIZONTAL` fills along x and wraps into rows, `VERTICAL` fills along y and wraps into columns — the meaning `flex-row`/`flex-col` already had. It survives the swap through the ordinary property route, which is why the swap is a tag change and not a re-routing.

## Where the swap happens

At all three places a plan can put children — the element's own node, the inner box of an overlay, and a `ScrollView`'s content box — through **one** function, because a second copy is the one that would miss `contentContainerClassName`. Two widget swaps on one element do not collide: the outer node becomes the overlay the absolute child needs and the inner one becomes the FlowBox. A primitive whose widget has no wrapping counterpart is a named refusal pointing at the node that *is* a box.

## What holds it

- `propertyClaims()` in the widget spec now covers the swapped-in tag, so the two spacings are held against the installed typelib rather than against a hand-written vector; the placement-rule gate covers it too, since a tag with no curated rule builds a plan and then refuses at insert time.
- A real-tree mount vector reads the `Gtk.FlowBoxChild` wrappers the host adds and the four properties off the widget, not off the plan.
- Every new vector was A/B checked against the branch it names: restoring the old refusal reddens the L1 pair, forcing `multiLine()` false reddens the gap vector, and `max-children-per-line: 7` reddens both the plan vector and the mount vector.

`gjsify run test` green in `@gjsify/gtk-host` (2284) and `@gjsify/react-native` (897); `gjsify run check` clean in both.