### PR TITLE
feat(style): an opt-in for the Tailwind defaults

### DIFF
--- a/packages/framework/gtk-host/src/style/index.ts
+++ b/packages/framework/gtk-host/src/style/index.ts
@@ -15,7 +15,14 @@
 
 export { GTK_CSS_PROBES, GTK_CSS_PROPERTIES, NOT_GTK_CSS } from './gtk-css.js';
 export { GTK_WIDGET_PROPERTIES, GTK_WIDGET_PROPERTY_PROBES, NOT_GTK_WIDGET_PROPERTIES } from './gtk-props.js';
-export { MINIMAL_TOKENS, lookupToken, requireToken } from './tokens.js';
+export {
+    MINIMAL_TOKENS,
+    TAILWIND_DEFAULT_TOKENS,
+    lookupToken,
+    mergeTokens,
+    requireToken,
+    tailwindDefaultHint,
+} from './tokens.js';
 export type { Scale, StyleTokens } from './tokens.js';
 export { UnknownUtilityError } from './errors.js';
 export { PAINT_PROPERTIES, partitionPaint, resolvePaintUtility } from './paint.js';

--- a/packages/framework/gtk-host/src/style/layout.ts
+++ b/packages/framework/gtk-host/src/style/layout.ts
@@ -38,7 +38,7 @@
 import { UnknownUtilityError } from './errors.js';
 import { GTK_CSS_PROPERTIES } from './gtk-css.js';
 import { GTK_WIDGET_PROPERTIES } from './gtk-props.js';
-import { requireToken, type Scale, type StyleTokens } from './tokens.js';
+import { requireToken, tailwindDefaultHint, type Scale, type StyleTokens } from './tokens.js';
 
 /** React Native's own `alignItems`/`alignSelf` vocabulary. */
 export type AlignValue = 'flex-start' | 'flex-end' | 'center' | 'stretch' | 'baseline';
@@ -299,7 +299,10 @@ function requireSize(tokens: StyleTokens, kind: 'width' | 'height', token: strin
     const known = [...new Set([...Object.keys(own ?? {}), ...Object.keys(tokens.spacing ?? {})])].sort().join(', ');
     throw new UnknownUtilityError(
         utility,
-        `"${token}" is in neither the ${kind} nor the spacing scale. Known: ${known === '' ? '(neither scale is configured)' : known}`,
+        `"${token}" is in neither the ${kind} nor the spacing scale. Known: ${known === '' ? '(neither scale is configured)' : known}` +
+            // Both scales, because `w-*` reads both — and the hint is only ever a
+            // sentence when one of them would have answered.
+            (tailwindDefaultHint(kind, token) || tailwindDefaultHint('spacing', token)),
     );
 }
 

--- a/packages/framework/gtk-host/src/style/paint.ts
+++ b/packages/framework/gtk-host/src/style/paint.ts
@@ -24,7 +24,7 @@
 
 import { UnknownUtilityError } from './errors.js';
 import { GTK_CSS_PROPERTIES } from './gtk-css.js';
-import { lookupToken, requireToken, type StyleTokens } from './tokens.js';
+import { lookupToken, requireToken, tailwindDefaultHint, type StyleTokens } from './tokens.js';
 
 /** The properties the paint half understands, in React Native's spelling. */
 export interface PaintProps {
@@ -210,7 +210,11 @@ export function resolvePaintUtility(utility: string, tokens: StyleTokens): Paint
                 return { borderWidth: width };
             }
             if (tint !== undefined) return { borderColor: colour(tint) };
-            throw new UnknownUtilityError(utility, `"${token}" is in neither the borderWidth nor the colors scale`);
+            throw new UnknownUtilityError(
+                utility,
+                `"${token}" is in neither the borderWidth nor the colors scale` +
+                    (tailwindDefaultHint('borderWidth', token) || tailwindDefaultHint('colors', token)),
+            );
         }
         case 'text': {
             // The genuinely ambiguous family, and the scales settle it: `text-sm` is
@@ -234,7 +238,11 @@ export function resolvePaintUtility(utility: string, tokens: StyleTokens): Paint
                 return { fontSize: size };
             }
             if (tint !== undefined) return { color: colour(tint) };
-            throw new UnknownUtilityError(utility, `"${token}" is in neither the fontSize nor the colors scale`);
+            throw new UnknownUtilityError(
+                utility,
+                `"${token}" is in neither the fontSize nor the colors scale` +
+                    (tailwindDefaultHint('fontSize', token) || tailwindDefaultHint('colors', token)),
+            );
         }
         case 'font': {
             noAlpha();

--- a/packages/framework/gtk-host/src/style/tokens.spec.ts
+++ b/packages/framework/gtk-host/src/style/tokens.spec.ts
@@ -1,0 +1,165 @@
+// The token scales — pure TypeScript, so this runs without a display or a widget.
+//
+// The module used to be two lookups and a constant, and needed no spec of its own.
+// It now holds three DECISIONS, and each of them is the kind that is invisible when
+// it is wrong: an opt-in set whose whole value is what it deliberately does NOT
+// carry, a merge whose depth is the difference between working and silently losing a
+// token, and an error hint that is only useful when it stays out of the way.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { UnknownUtilityError } from './errors.js';
+import { resolveUtility } from './resolve.js';
+import {
+    MINIMAL_TOKENS,
+    TAILWIND_DEFAULT_TOKENS,
+    mergeTokens,
+    requireToken,
+    tailwindDefaultHint,
+    type StyleTokens,
+} from './tokens.js';
+
+/** A token file's own vocabulary — generated from a design source, Tailwind-free. */
+const PROJECT: StyleTokens = {
+    spacing: { '2xs': '4px', xs: '8px', s: '12px', m: '16px' },
+    colors: { emphasis: 'rgb(17 34 51)', muted: 'rgb(120 120 120)' },
+    borderRadius: { s: '4px', m: '8px', l: '12px' },
+    fontSize: { caption: '11px', body: '14px' },
+};
+
+const threw = (fn: () => unknown): UnknownUtilityError => {
+    try {
+        fn();
+    } catch (error) {
+        if (error instanceof UnknownUtilityError) return error;
+        throw error;
+    }
+    throw new Error('expected an UnknownUtilityError, nothing was thrown');
+};
+
+export default async () => {
+    await describe('the measured gap a project’s own @theme leaves', async () => {
+        await it('is exactly the tokens nobody would declare: 0 and full', async () => {
+            // The five of six measured failures, reproduced as vectors. A project
+            // that declares its whole spacing and radius vocabulary still has no
+            // `full` and no `0`, because neither is a value a designer picks.
+            for (const utility of ['inset-0', 'top-0', 'left-0', 'right-0']) {
+                expect(threw(() => resolveUtility(utility, PROJECT)).message).toContain('not in the spacing scale');
+            }
+            expect(threw(() => resolveUtility('rounded-full', PROJECT)).message).toContain(
+                'not in the borderRadius scale',
+            );
+        });
+
+        await it('closes with the opt-in, merged per TOKEN', async () => {
+            const tokens = mergeTokens(TAILWIND_DEFAULT_TOKENS, PROJECT);
+            expect(resolveUtility('inset-0', tokens)).toStrictEqual({
+                top: '0px',
+                right: '0px',
+                bottom: '0px',
+                left: '0px',
+            });
+            expect(resolveUtility('rounded-full', tokens)).toStrictEqual({ borderRadius: '9999px' });
+            // …without the project losing anything it declared.
+            expect(resolveUtility('mt-m', tokens)).toStrictEqual({ marginTop: '16px' });
+            expect(resolveUtility('rounded-l', tokens)).toStrictEqual({ borderRadius: '12px' });
+        });
+
+        await it('is NOT closed by a spread, which is why mergeTokens exists', async () => {
+            // The bug the helper answers, asserted rather than described. An object
+            // spread replaces whole SCALES, so a project declaring any `spacing`
+            // loses `0` again — and finds out at `inset-0`, far from the line that
+            // did it.
+            const spread: StyleTokens = { ...TAILWIND_DEFAULT_TOKENS, ...PROJECT };
+            expect(threw(() => resolveUtility('inset-0', spread)).message).toContain('not in the spacing scale');
+        });
+
+        await it('lets the project override a default token rather than being shadowed by it', async () => {
+            // Later sets win token by token, which is what "my values on top of the
+            // defaults" means. A project whose hairline is 2px keeps it.
+            const tokens = mergeTokens(TAILWIND_DEFAULT_TOKENS, { spacing: { px: '2px' } });
+            expect(resolveUtility('mt-px', tokens)).toStrictEqual({ marginTop: '2px' });
+            expect(resolveUtility('mt-0', tokens)).toStrictEqual({ marginTop: '0px' });
+        });
+    });
+
+    await describe('what the opt-in deliberately does not carry', async () => {
+        await it('ships no numeric ladder, because that IS the project’s decision', async () => {
+            // Shipping `spacing-4` … `spacing-96` would ship a design decision the
+            // project has already made differently. `4` staying unknown under the
+            // opt-in is the behaviour, not an omission.
+            expect(Object.keys(TAILWIND_DEFAULT_TOKENS.spacing ?? {}).sort()).toStrictEqual(['0', 'px']);
+            expect(threw(() => resolveUtility('mt-4', TAILWIND_DEFAULT_TOKENS)).message).toContain('spacing scale');
+        });
+
+        await it('spells every length in px, because the widget channel stores gint', async () => {
+            // A `rem` token pads and cannot margin — `Gtk.Widget:margin-top` is a
+            // gint of device pixels with no unit conversion behind it. A rem-faithful
+            // copy of Tailwind's defaults would trade "the token is missing" for "the
+            // token throws on half the families".
+            const lengths = [
+                ...Object.values(TAILWIND_DEFAULT_TOKENS.spacing ?? {}),
+                ...Object.values(TAILWIND_DEFAULT_TOKENS.borderRadius ?? {}),
+                ...Object.values(TAILWIND_DEFAULT_TOKENS.borderWidth ?? {}),
+            ];
+            expect(lengths.filter((value) => /r?em|%/.test(value))).toStrictEqual([]);
+        });
+
+        await it('omits the colour keyword whose alpha form GTK refuses', async () => {
+            // `color: inherit` parses and `alpha(inherit, 0.5)` does not (measured),
+            // so `bg-inherit/50` would be a refusal rather than a colour. The other
+            // four keywords survive the modifier and are carried.
+            expect(Object.keys(TAILWIND_DEFAULT_TOKENS.colors ?? {}).sort()).toStrictEqual([
+                'black',
+                'current',
+                'transparent',
+                'white',
+            ]);
+        });
+
+        await it('leaves MINIMAL_TOKENS as small as it was', async () => {
+            // The opt-in is not a retreat from the smallness decision, and this is
+            // the line that would go red if someone widened the default instead.
+            expect(Object.keys(MINIMAL_TOKENS.spacing ?? {}).sort()).toStrictEqual(['0', 'px']);
+            expect(Object.keys(MINIMAL_TOKENS.fontWeight ?? {}).length).toBe(4);
+        });
+    });
+
+    await describe('the hint on a scale miss', async () => {
+        await it('names the opt-in for a token Tailwind’s defaults DO define', async () => {
+            const error = threw(() => resolveUtility('rounded-full', PROJECT));
+            expect(error.message).toContain('TAILWIND_DEFAULT_TOKENS');
+            expect(error.message).toContain('mergeTokens');
+            // The VALUE, so a reader who wants the one token instead of the set can
+            // copy it rather than look it up.
+            expect(error.message).toContain('9999px');
+        });
+
+        await it('stays silent for an ordinary typo, which the opt-in would not fix', async () => {
+            // A remedy offered where it would not have helped is worse than none: it
+            // sends a reader to add a dependency instead of to fix the spelling.
+            const error = threw(() => resolveUtility('mt-nonsuch', PROJECT));
+            expect(error.message).toContain('spacing scale');
+            expect(error.message.includes('TAILWIND_DEFAULT_TOKENS')).toBe(false);
+        });
+
+        await it('reads the scale by NAME, so a caller cannot ask the wrong one', async () => {
+            expect(tailwindDefaultHint('borderRadius', 'full')).toContain('9999px');
+            expect(tailwindDefaultHint('spacing', 'full')).toBe('');
+            expect(tailwindDefaultHint('nonsuch', '0')).toBe('');
+        });
+
+        await it('reaches the w-*/h-* path, which reads two scales', async () => {
+            // `requireSize` builds its own message and would have been the one place
+            // the hint was missing — `w-0` is as ordinary as `inset-0`.
+            const error = threw(() => resolveUtility('w-0', PROJECT));
+            expect(error.message).toContain('TAILWIND_DEFAULT_TOKENS');
+        });
+
+        await it('reaches requireToken directly, for a caller outside the families', async () => {
+            expect(
+                threw(() => requireToken(PROJECT.borderRadius, 'full', 'rounded-full', 'borderRadius')).message,
+            ).toContain('TAILWIND_DEFAULT_TOKENS');
+        });
+    });
+};

--- a/packages/framework/gtk-host/src/style/tokens.ts
+++ b/packages/framework/gtk-host/src/style/tokens.ts
@@ -59,6 +59,12 @@ export interface StyleTokens {
  * scale would let a project's typo resolve against a value nobody chose, which is
  * the failure the declared-vocabulary rule exists to prevent — and it would make
  * "the values come from the project" false in the common case.
+ *
+ * That decision stands, and {@link TAILWIND_DEFAULT_TOKENS} is not a retreat from
+ * it: the measured gap is that a project REPLACING this default with its own
+ * generated scales loses `0` and `full`, which nothing in its `@theme` was ever
+ * going to declare. The answer is an opt-in a reader can see in their own code, not
+ * a wider default nobody chose. This constant stays as small as it is.
  */
 export const MINIMAL_TOKENS: StyleTokens = {
     // Two entries, and both earn their place: `0` is what `inset-0` needs and `px`
@@ -71,6 +77,123 @@ export const MINIMAL_TOKENS: StyleTokens = {
     fontWeight: { normal: '400', medium: '500', semibold: '600', bold: '700' },
     opacity: { '0': '0', '50': '0.5', '60': '0.6', '70': '0.7', '80': '0.8', '90': '0.9', '100': '1' },
 };
+
+/**
+ * The Tailwind defaults a project's own `@theme` does not replace — OPT-IN.
+ *
+ * MEASURED, and this is the highest-frequency finding of the whole exercise. Running
+ * one production-shaped application's real class vocabulary — 87 distinct utilities,
+ * 826 occurrences — through this partition with tokens generated mechanically from
+ * its Tailwind v4 `@theme` resolves **81 of 87 distinct and 803 of 826 occurrences**.
+ * Five of the six failures are one thing: `rounded-full` (11 uses) and
+ * `inset-0`/`left-0`/`right-0`/`top-0` (9 between them). The project's declared
+ * scales simply have no `full` and no `0`.
+ *
+ * They have no reason to. **`0` and `full` are not design decisions.** A token source
+ * emits the values a designer chose; `inset-0` means "flush" and `rounded-full` means
+ * "a pill", and neither is a number anybody picked. A project that declares its whole
+ * palette still leans on Tailwind for the STRUCTURAL tokens, and finds out one class
+ * at a time.
+ *
+ * So this set is deliberately NOT a copy of Tailwind's default theme, and the name
+ * would be a lie if it carried the numeric ladder: shipping `spacing-4` … `spacing-96`
+ * would be shipping a design decision the project has already made differently, which
+ * is the opposite of the point. It carries the structural tokens and the keyword sets
+ * — the ones a `@theme` has no reason to name — and nothing that is a value someone
+ * chose.
+ *
+ * THREE DIVERGENCES FROM TAILWIND'S OWN NUMBERS, each forced and each measured:
+ *
+ *   - **Every length is px, not rem.** Tailwind v4's spacing is rem-based. A `rem`
+ *     token reaches CSS padding unchanged and is a NAMED ERROR the moment the same
+ *     token is asked to become a margin, because `Gtk.Widget:margin-top` is a `gint`
+ *     of device pixels with no unit conversion behind it. A rem scale here would
+ *     therefore trade "the token is missing" for "the token throws on half the
+ *     families", which is worse.
+ *   - **`full` is `9999px`, not `calc(infinity * 1px)`.** GTK's parser has no
+ *     infinity, and a border radius larger than the box is clamped anyway.
+ *   - **`inherit` is absent from the colours.** `color: inherit` parses, but
+ *     `alpha(inherit, 0.5)` does not (measured: *"inherit" is not a valid color
+ *     name*), so `bg-inherit/50` would be a refusal rather than a colour. The other
+ *     four keywords survive the alpha modifier and are carried.
+ *
+ * Opting in is a VISIBLE LINE in the consumer's code, which is the whole design:
+ *
+ * ```ts
+ * configureStyle({ tokens: mergeTokens(TAILWIND_DEFAULT_TOKENS, projectTokens) });
+ * ```
+ *
+ * Use {@link mergeTokens} and not a spread. `{ ...TAILWIND_DEFAULT_TOKENS,
+ * ...projectTokens }` replaces whole SCALES, so a project declaring any `spacing` at
+ * all loses `0` again — which is the exact bug this constant exists to answer.
+ */
+export const TAILWIND_DEFAULT_TOKENS: StyleTokens = {
+    // The two structural lengths. Everything between them is the project's.
+    spacing: { '0': '0px', px: '1px' },
+    colors: {
+        transparent: 'transparent',
+        current: 'currentColor',
+        black: 'rgb(0 0 0)',
+        white: 'rgb(255 255 255)',
+    },
+    borderRadius: { none: '0', DEFAULT: '4px', full: '9999px' },
+    borderWidth: { DEFAULT: '1px', '0': '0', '2': '2px', '4': '4px', '8': '8px' },
+    // Named weights rather than numbers, which is what a `font-*` utility spells and
+    // what a type scale in a `@theme` leaves alone.
+    fontWeight: {
+        thin: '100',
+        extralight: '200',
+        light: '300',
+        normal: '400',
+        medium: '500',
+        semibold: '600',
+        bold: '700',
+        extrabold: '800',
+        black: '900',
+    },
+    // Tailwind's documented ladder. It accepts any integer and a SCALE cannot, so
+    // this is the set the docs promise rather than the set the generator accepts —
+    // an `opacity-63` is a named error listing these, which is the right outcome for
+    // a value nobody put in a design system.
+    opacity: Object.fromEntries(Array.from({ length: 21 }, (_, step) => [`${step * 5}`, `${step / 20}`])) as Readonly<
+        Record<string, string>
+    >,
+};
+
+/**
+ * Several token sets into one, merging PER TOKEN and not per scale.
+ *
+ * The distinction is the whole function. `{ ...defaults, ...project }` is an object
+ * spread over the SCALE names, so a project that declares any `spacing` replaces the
+ * default `spacing` wholesale and loses `0` — silently, and visible only as
+ * `inset-0` throwing much later. Later sets win token by token, which is what a
+ * reader means by "my values on top of the defaults".
+ */
+export function mergeTokens(...sets: readonly StyleTokens[]): StyleTokens {
+    const out: Record<string, Record<string, string>> = {};
+    for (const set of sets) {
+        for (const [scale, values] of Object.entries(set)) {
+            if (values === undefined) continue;
+            out[scale] = { ...out[scale], ...values };
+        }
+    }
+    return out as StyleTokens;
+}
+
+/**
+ * The sentence a scale-miss error adds when Tailwind's defaults DO define the token.
+ *
+ * The measured six failures each become a one-line fix with this and stay a search
+ * without it: "not in the borderRadius scale. Known: l, m, s" sends a reader to
+ * invent a radius, where naming the opt-in sends them to the line that was missing.
+ * Empty for a token nothing would have answered, so an ordinary typo is not offered
+ * a remedy that would not have helped.
+ */
+export function tailwindDefaultHint(scaleName: string, token: string): string {
+    const scale = (TAILWIND_DEFAULT_TOKENS as Readonly<Record<string, Scale | undefined>>)[scaleName];
+    if (scale?.[token] === undefined) return '';
+    return `. Tailwind's own default scale defines "${token}" (${scale[token]}) — a project's \`@theme\` has no reason to declare it, so spread TAILWIND_DEFAULT_TOKENS into your tokens with mergeTokens() if you rely on it`;
+}
 
 /** A token's value, or `undefined` when the scale is absent or does not carry it. */
 export const lookupToken = (scale: Scale | undefined, token: string): string | undefined => scale?.[token];
@@ -87,5 +210,8 @@ export function requireToken(scale: Scale | undefined, token: string, utility: s
     const value = lookupToken(scale, token);
     if (value !== undefined) return value;
     const known = scale === undefined ? '(the scale is not configured)' : Object.keys(scale).sort().join(', ');
-    throw new UnknownUtilityError(utility, `"${token}" is not in the ${scaleName} scale. Known: ${known}`);
+    throw new UnknownUtilityError(
+        utility,
+        `"${token}" is not in the ${scaleName} scale. Known: ${known}${tailwindDefaultHint(scaleName, token)}`,
+    );
 }

--- a/packages/framework/gtk-host/src/test.mts
+++ b/packages/framework/gtk-host/src/test.mts
@@ -16,8 +16,10 @@ import layoutSuite from './style/layout.spec.js';
 import listSuite from './list/list.spec.js';
 import paintSuite from './style/paint.spec.js';
 import sheetSuite from './style/sheet.spec.js';
+import tokensSuite from './style/tokens.spec.js';
 
 run({
+    tokensSuite,
     sheetSuite,
     paintSuite,
     layoutSuite,

--- a/packages/framework/react-native/src/style-config.ts
+++ b/packages/framework/react-native/src/style-config.ts
@@ -18,6 +18,21 @@
 // writes `mt-2xs` — which is the intended outcome, and the reason the default is
 // not a copy of Tailwind's own scales: a large default would let a typo resolve
 // against a value nobody chose.
+//
+// WHAT THIS MODULE REPLACES, and the one thing a caller gets wrong: `tokens` is taken
+// WHOLE. That is right — the values are the project's — and it is also why a project
+// generating its scales from a Tailwind v4 `@theme` loses `0` and `full`, which
+// nothing in a `@theme` was ever going to declare (measured on one production-shaped
+// application: 81 of 87 distinct utilities and 803 of 826 occurrences resolve, and
+// five of the six failures are exactly those two tokens). The remedy is an opt-in the
+// caller can SEE:
+//
+//     configureStyle({ tokens: mergeTokens(TAILWIND_DEFAULT_TOKENS, projectTokens) });
+//
+// `mergeTokens` and NOT a spread — an object spread replaces whole SCALES, so a
+// project declaring any `spacing` loses `0` again. Both are exported from
+// `@gjsify/gtk-host/style`, and a scale miss whose token the defaults define names
+// them in the error rather than leaving a reader to find this comment.
 
 import { MINIMAL_TOKENS, StyleSheet as GeneratedStyleSheet, type StyleTokens } from '@gjsify/gtk-host/style';
 

--- a/website/src/content/docs/frameworks/react-native.mdx
+++ b/website/src/content/docs/frameworks/react-native.mdx
@@ -79,6 +79,20 @@ import { tokens } from './tokens.js';
 configureStyle({ tokens });
 ```
 
+If your tokens are generated from a Tailwind v4 `@theme`, add the structural defaults
+your `@theme` has no reason to declare — measured, a real application's vocabulary
+loses `rounded-full` and `inset-0`/`top-0`/`left-0`/`right-0` without them:
+
+```tsx
+import { TAILWIND_DEFAULT_TOKENS, mergeTokens } from '@gjsify/gtk-host/style';
+
+configureStyle({ tokens: mergeTokens(TAILWIND_DEFAULT_TOKENS, tokens) });
+```
+
+`mergeTokens` and not a spread: a spread replaces whole scales and loses `0` again.
+The [styling page](/gjsify/frameworks/styling/) has the numbers and what the set does
+not carry.
+
 Every snippet on this page uses those two scales. **Skipping this step is not a styling
 difference, it is a blank window**: the first undeclared token throws out of the render, React
 unmounts the tree, and the process goes on to exit 0 with no GTK diagnostic at all — measured, and

--- a/website/src/content/docs/frameworks/styling.mdx
+++ b/website/src/content/docs/frameworks/styling.mdx
@@ -160,6 +160,76 @@ child as `halign` / `valign`, so resolving it means walking children. And *which
 depends on the element's own orientation — where the defaults disagree, since a `Gtk.Box` is
 horizontal and a React Native `View` is a column. There is not even a safe fallback to guess with.
 
+## Your `@theme` will still lean on Tailwind for `0` and `full`
+
+The values behind a class name are your project's — that is the rule the whole
+partition is built on, and the default scale it ships is *deliberately* tiny so that
+a token you never declared is a named error rather than a wrong margin.
+
+Measured, and it is the highest-frequency finding of the whole exercise: a
+production-shaped application whose Tailwind v4 `@theme` declares its own scales
+**still relies on Tailwind's defaults** for a handful of utilities. Running its real
+class vocabulary — **87 distinct utilities, 826 occurrences** — through this partition
+with tokens generated mechanically from that `@theme` resolves **81 of 87 distinct and
+803 of 826 occurrences**. Five of the six failures are one thing:
+
+| Class | Uses | Missing from |
+|---|---:|---|
+| `rounded-full` | 11 | the project's `borderRadius` scale |
+| `inset-0`, `left-0`, `right-0`, `top-0` | 9 between them | the project's `spacing` scale |
+
+The scales have no `full` and no `0`, and there is no reason they should.
+**Neither is a design decision.** A token source emits the values a designer chose;
+`inset-0` means "flush" and `rounded-full` means "a pill". So a project can declare
+its entire palette and type scale and still lean on Tailwind for the *structural*
+tokens — and find that out one class at a time, in a window.
+
+The answer is an **opt-in you can see in your own code**, not a wider default:
+
+```ts
+import { TAILWIND_DEFAULT_TOKENS, mergeTokens } from '@gjsify/gtk-host/style';
+import { configureStyle } from '@gjsify/react-native';
+import { tokens } from './tokens.js';
+
+configureStyle({ tokens: mergeTokens(TAILWIND_DEFAULT_TOKENS, tokens) });
+```
+
+**Use `mergeTokens`, not a spread.** `{ ...TAILWIND_DEFAULT_TOKENS, ...tokens }`
+replaces whole *scales*, so a project that declares any `spacing` at all loses `0`
+again — which is the exact bug the constant exists to answer. `mergeTokens` merges
+token by token, later sets winning, so your `px` overrides the default `px` without
+taking the rest of the scale with it.
+
+`TAILWIND_DEFAULT_TOKENS` is **not** a copy of Tailwind's default theme, and the
+smallness of the built-in default is unchanged. It carries the structural tokens and
+the keyword sets — the ones a `@theme` has no reason to name — and no numeric ladder,
+because shipping `spacing-4` … `spacing-96` would be shipping a design decision your
+project has already made differently. Three divergences from Tailwind's own numbers,
+each forced:
+
+- **every length is px, not rem** — a `rem` token pads and cannot margin, since
+  `Gtk.Widget:margin-top` is a `gint` of device pixels with no unit conversion behind
+  it. A rem-faithful copy would trade "the token is missing" for "the token throws on
+  half the families";
+- **`full` is `9999px`**, not `calc(infinity * 1px)` — GTK's parser has no infinity,
+  and a radius larger than the box is clamped anyway;
+- **`inherit` is absent from the colours** — `color: inherit` parses, but
+  `alpha(inherit, 0.5)` does not (measured), so `bg-inherit/50` would be a refusal
+  rather than a colour. The other four keywords survive the modifier and are carried.
+
+You do not have to find any of this out from a table. A scale miss whose token
+Tailwind's defaults *do* define says so in the error, with the value:
+
+```
+@gjsify/gtk-host/style: "rounded-full" — "full" is not in the borderRadius scale.
+Known: l, m, s. Tailwind's own default scale defines "full" (9999px) — a project's
+`@theme` has no reason to declare it, so spread TAILWIND_DEFAULT_TOKENS into your
+tokens with mergeTokens() if you rely on it
+```
+
+An ordinary typo gets no such sentence, deliberately: a remedy offered where it would
+not have helped sends a reader to add a dependency instead of to fix the spelling.
+
 ## `flex-wrap` is a different widget, not a property
 
 A `Gtk.Box` lays its children on one line and installs nothing that gives it a


### PR DESCRIPTION
> Stacked on #1439. Review the top commit only; the base merges first.

A project's own `@theme` does not replace all of Tailwind, and this is the highest-frequency finding of the whole exercise. Running one production-shaped application's real class vocabulary — **87 distinct utilities, 826 occurrences** — through this partition with tokens generated mechanically from its Tailwind v4 `@theme` resolves **81 of 87 distinct and 803 of 826 occurrences**. Five of the six failures are one thing:

| Class | Uses | Missing from |
|---|---:|---|
| `rounded-full` | 11 | the project's `borderRadius` scale |
| `inset-0`, `left-0`, `right-0`, `top-0` | 9 between them | the project's `spacing` scale |

The declared scales have no `full` and no `0`, and there is no reason they should. **Neither is a design decision.** A token source emits the values a designer chose; `inset-0` means "flush" and `rounded-full` means "a pill". So a project can declare its entire palette and type scale and still lean on Tailwind for the *structural* tokens — and find that out one class at a time, in a window.

## `MINIMAL_TOKENS` is not widened

Its smallness is the decision that makes an undeclared token a named error instead of a wrong margin, and a wider default is exactly the shape that lets a typo resolve against a value nobody chose. The answer is an opt-in the consumer can **see** in their own code:

```ts
configureStyle({ tokens: mergeTokens(TAILWIND_DEFAULT_TOKENS, projectTokens) });
```

**`mergeTokens` and not a spread**, and that is not a style preference: an object spread replaces whole *scales*, so a project declaring any `spacing` at all loses `0` again — the exact bug the constant exists to answer. A spec vector asserts that rather than describing it. The helper merges token by token, later sets winning.

## What the set deliberately does not carry

`TAILWIND_DEFAULT_TOKENS` is not a copy of Tailwind's default theme, and the name would be a lie if it carried the numeric ladder: shipping `spacing-4` … `spacing-96` would be shipping a design decision the project has already made differently. It carries the structural tokens and the keyword sets and nothing that is a value someone chose. Three divergences from Tailwind's own numbers, each forced and each measured:

- **every length is px, not rem** — a `rem` token pads and cannot margin, since `Gtk.Widget:margin-top` is a `gint` of device pixels with no unit conversion behind it. A rem-faithful copy would trade "the token is missing" for "the token throws on half the families";
- **`full` is `9999px`**, not `calc(infinity * 1px)` — GTK's parser has no infinity;
- **`inherit` is absent from the colours** — `color: inherit` parses and `alpha(inherit, 0.5)` does not (measured: *"inherit" is not a valid color name*, and **contained** — the sentinel survives, so it would be a named refusal rather than a poisoned document). The other four keywords survive the modifier and are carried.

## The diagnostic is the part that closes it

A scale miss whose token Tailwind's defaults *do* define now names the opt-in and the value:

```
@gjsify/gtk-host/style: "rounded-full" — "full" is not in the borderRadius scale.
Known: l, m, s. Tailwind's own default scale defines "full" (9999px) — a project's
`@theme` has no reason to declare it, so spread TAILWIND_DEFAULT_TOKENS into your
tokens with mergeTokens() if you rely on it
```

An ordinary typo gets no such sentence, deliberately: a remedy offered where it would not have helped sends a reader to add a dependency instead of to fix the spelling. The hint reaches all three message shapes — `requireToken`, `requireSize`'s two-scale one, and the paint half's ambiguous families.

## What holds it

`tokens.ts` gains a spec — the module used to be two lookups and a constant and now holds three decisions that are invisible when wrong. Every vector was A/B checked: flattening the merge to a spread reddens three, silencing the hint reddens four.

`gjsify run test` green in `@gjsify/gtk-host` (2312) and `@gjsify/react-native` (897); `gjsify run check` clean in both.