### PR TITLE
docs(poc): the WebView2 loop probe, written not run

### DIFF
--- a/.github/workflows/webview2-probe.yml
+++ b/.github/workflows/webview2-probe.yml
@@ -1,0 +1,64 @@
+# ADR 0035's spike, on demand.
+#
+# This is NOT a gate and deliberately has no `push`/`pull_request` trigger. It
+# answers three questions about a platform we do not yet support, and the answers
+# change an ADR rather than a build: whether WebView2 delivers its callbacks
+# without the Win32 message queue being dispatched (the win32 counterpart of the
+# finding that cost ADR 0022 a release), what a `CapturePreviewAsync` frame
+# costs against darwin's 15.8 ms `takeSnapshot`, and whether the Evergreen
+# runtime is present on a stock image.
+#
+# WHAT IT PROVES, AND WHAT IT DOES NOT. It runs a NON-BUNDLED console process,
+# which is the process shape a `gjs` or a `node` host is — no WinMain, no
+# application message loop — because that is the shape the finding has to hold
+# in. It links no GLib: the probe compares a non-pumping wait against a pumping
+# one, which is the one property of `g_main_loop_run()` that decides the design,
+# and `@gjsify/gtk-runtime-win32-x64` ships DLLs and typelibs rather than
+# headers, so a translation unit could not include the bundle's own GLib anyway.
+# It makes NO claim about a visible window: a hosted runner's window station is
+# not an interactive session, and `EnumWindows` from a non-interactive context
+# returns an empty list while a window is on screen.
+#
+# The probe exits non-zero on outcomes that INVALIDATE something written down —
+# 10 when no loop bridge turns out to be needed, 11 when no frame is captured —
+# so a red run here is a result to read, not a build to fix.
+
+name: WebView2 probe (ADR 0035)
+
+on:
+  workflow_dispatch:
+    inputs:
+      webview2-version:
+        description: 'Microsoft.Web.WebView2 NuGet version to pin'
+        required: false
+        default: '1.0.2903.40'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: webview2-probe-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    name: WebView2 in a non-pumping console process (win32-x64)
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Report the host this run measured
+        shell: pwsh
+        run: |
+          Write-Host "OS       : $([System.Environment]::OSVersion.VersionString)"
+          Write-Host "Edge     : $((Get-AppxPackage -Name 'Microsoft.MicrosoftEdge.Stable' -ErrorAction SilentlyContinue).Version)"
+          $key = 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}'
+          $pv = (Get-ItemProperty -Path $key -Name pv -ErrorAction SilentlyContinue).pv
+          Write-Host "WebView2 : $(if ($pv) { $pv } else { '(not registered under the Evergreen client GUID)' })"
+
+      - name: Build and run the probe
+        shell: pwsh
+        run: |
+          pwsh -File docs/poc/webview2-win32-probe.ps1 `
+            -WebView2Version '${{ inputs.webview2-version || '1.0.2903.40' }}'

--- a/docs/adr/0035-web-view-on-win32.md
+++ b/docs/adr/0035-web-view-on-win32.md
@@ -200,10 +200,19 @@ or be replaced by an assertion that does not need one.
 
 ## Implementation
 
-Nothing is implemented. The order, once the spike answers:
+Nothing of the backend is implemented. The order, once the spike answers:
 
-1. `docs/poc/webview2-win32-probe.cpp` + the invocation that runs it, answering
-   questions 1, 3 and 5 — the three that do not need a widget.
+1. **The probe is WRITTEN and has NOT been run** — `docs/poc/webview2-win32-probe.cpp`,
+   built and run by `docs/poc/webview2-win32-probe.ps1`, dispatchable as the
+   `WebView2 probe (ADR 0035)` workflow. It answers questions 1, 3 and 5, the three
+   that need no widget, and it links no GLib on purpose: what decides the design is
+   the one property `g_main_loop_run()` has — it does not dispatch Win32 window
+   messages — and a `Sleep()` loop has that property while a second GLib pulled from
+   MSYS2 or gvsbuild would measure a library the shipped bundle is not. It exits
+   non-zero on the outcomes that invalidate this ADR (10: no loop bridge needed;
+   11: no frame captured), so a red run is a result rather than a build to fix.
+   **Until it has run on a Windows host, every number in this ADR about win32 is a
+   question, not a measurement.**
 2. The GObject shim: a C header with every GIR annotation and a C++/WinRT
    implementation, producing the DLL plus `WebKit-6.0.{gir,typelib}` for the
    subset in decision 4, staged into `prebuilds/win32-x64/` per ADR 0017.

--- a/docs/poc/webview2-win32-probe.cpp
+++ b/docs/poc/webview2-win32-probe.cpp
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: MIT
+//
+// ADR 0035 spike, questions 1, 3 and 5: can WebView2 back `gi://WebKit` 6.0 on
+// win32, and what does the loop bridge cost?
+//
+// This is the win32 counterpart of `webkit-runloop-darwin.m`, and it asks the
+// question that one answered the hard way. There, `WKWebView`'s callbacks are
+// CFRunLoop sources, a `GMainContext` never looks at them, and a bare
+// `g_main_loop_run()` did not reach `didFinishNavigation` at all — case [1] did
+// not run slowly, it did not run. Every API row in that ADR was unreachable
+// until a drain source existed.
+//
+// WHY THIS PROBE LINKS NO GLIB. The tempting shape is "run a real GMainLoop and
+// see". It is the wrong shape twice over: `@gjsify/gtk-runtime-win32-x64` ships
+// DLLs and typelibs, not headers, so a C++ translation unit cannot include
+// glib.h from the bundle a shipped app actually carries — and pulling a second
+// GLib from MSYS2 or gvsbuild would measure a different library than the one
+// that ships. What matters about `g_main_loop_run()` here is one property:
+// **it does not dispatch Win32 window messages.** A loop of `Sleep()` has
+// exactly that property, links nothing, and cannot drift from the bundle. So
+// the probe compares "no pump" against "pump" and reports which operations
+// need which — which is the fact the binding has to be designed around.
+//
+// It is also written to RETIRE itself. If the no-pump case succeeds, the loop
+// bridge is dead weight and the probe says so in as many words instead of
+// printing a green line; if the pump case fails, WebView2 is not reachable
+// from a console process at all and stage 1 of the ADR needs rethinking. Both
+// outcomes exit non-zero, because both invalidate something written down.
+//
+// BUILD + RUN: docs/poc/webview2-win32-probe.ps1
+
+#include <windows.h>
+
+#include <wrl.h>
+#include <objbase.h>
+#include <shlwapi.h>
+
+#include <WebView2.h>
+
+#include <cstdio>
+#include <cwchar>
+
+using namespace Microsoft::WRL;
+
+namespace {
+
+constexpr int kCaptureWidth = 1024;
+constexpr int kCaptureHeight = 768;
+constexpr DWORD kWaitMs = 8000;   // the darwin probe's timeout, kept identical
+constexpr int kCaptureRuns = 10;
+
+// The page is handed over with NavigateToString rather than a data: URL on
+// purpose: Chromium blocks a TOP-LEVEL navigation to data:, so a probe built on
+// one would measure that block and report it as "navigation never completed".
+const wchar_t* kPage =
+    L"<!doctype html><html><head><meta charset='utf-8'><title>probe</title>"
+    L"<style>body{margin:0;background:#1c71d8;color:#fff;font:16px sans-serif}"
+    L"h1{margin:0;padding:24px}</style></head>"
+    L"<body><h1>gjsify webview2 probe</h1></body></html>";
+
+struct Probe {
+    HWND hwnd = nullptr;
+    ComPtr<ICoreWebView2Controller> controller;
+    ComPtr<ICoreWebView2> webview;
+
+    bool environmentReady = false;
+    bool controllerReady = false;
+    bool navigationCompleted = false;
+    HRESULT navigationStatus = S_OK;
+    HRESULT lastError = S_OK;
+};
+
+Probe g_probe;
+
+// Two ways to wait, and the whole probe is the difference between them.
+//
+// `WaitPumping` is what an ordinary Win32 app's message loop does.
+// `WaitWithoutPumping` has the one property of `g_main_loop_run()` that matters
+// here: the thread is alive, it is not blocked on a WebView2 handle, and it
+// never calls DispatchMessage.
+
+bool WaitPumping(bool* flag, DWORD timeoutMs) {
+    const ULONGLONG deadline = GetTickCount64() + timeoutMs;
+    MSG msg;
+    while (!*flag && GetTickCount64() < deadline) {
+        while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+            TranslateMessage(&msg);
+            DispatchMessageW(&msg);
+        }
+        Sleep(1);
+    }
+    return *flag;
+}
+
+bool WaitWithoutPumping(bool* flag, DWORD timeoutMs) {
+    const ULONGLONG deadline = GetTickCount64() + timeoutMs;
+    while (!*flag && GetTickCount64() < deadline) {
+        Sleep(10);
+    }
+    return *flag;
+}
+
+LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp) {
+    if (msg == WM_DESTROY) {
+        PostQuitMessage(0);
+        return 0;
+    }
+    return DefWindowProcW(hwnd, msg, wp, lp);
+}
+
+HWND CreateHostWindow() {
+    WNDCLASSEXW wc = {};
+    wc.cbSize = sizeof(wc);
+    wc.lpfnWndProc = WndProc;
+    wc.hInstance = GetModuleHandleW(nullptr);
+    wc.lpszClassName = L"GjsifyWebView2Probe";
+    RegisterClassExW(&wc);
+
+    // A real top-level window, not HWND_MESSAGE: WebView2's windowed hosting
+    // mode parents a child HWND, and a message-only window has no client area
+    // for it to occupy. This is the stage-1 shape from the ADR — the window a
+    // GTK toplevel would be on win32 (`gdk_win32_surface_get_handle`).
+    return CreateWindowExW(0, wc.lpszClassName, L"gjsify webview2 probe",
+                           WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT,
+                           kCaptureWidth, kCaptureHeight, nullptr, nullptr,
+                           wc.hInstance, nullptr);
+}
+
+void ReportHr(const char* what, HRESULT hr) {
+    std::printf("  [--] %s -> HRESULT 0x%08lX\n", what, static_cast<unsigned long>(hr));
+}
+
+}  // namespace
+
+int main() {
+    std::setvbuf(stdout, nullptr, _IONBF, 0);
+    HRESULT hrInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    if (FAILED(hrInit)) {
+        ReportHr("CoInitializeEx", hrInit);
+        return 2;
+    }
+
+    std::printf("ADR 0035 spike — WebView2 in a NON-PUMPING console process\n");
+    std::printf("(the process shape a gjs/node host is: no WinMain, no app message loop)\n\n");
+
+    // ---------------------------------------------------------------- Q5
+    // Is the Evergreen runtime present, and what answers when it is not?
+    std::printf("Q5 — the Evergreen runtime\n");
+    LPWSTR version = nullptr;
+    HRESULT hrVersion = GetAvailableCoreWebView2BrowserVersionString(nullptr, &version);
+    if (SUCCEEDED(hrVersion) && version != nullptr) {
+        std::printf("  [ok] runtime present: %ls\n", version);
+        CoTaskMemFree(version);
+    } else {
+        // This is the answer a stranger's machine may give, and ADR 0035
+        // decision 5 turns it into a declared dependency of the .msi rather
+        // than an assumption. HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND) is the
+        // documented "not installed".
+        ReportHr("GetAvailableCoreWebView2BrowserVersionString (NOT INSTALLED)", hrVersion);
+        std::printf("\nverdict: no WebView2 runtime on this host — nothing below is measurable.\n");
+        CoUninitialize();
+        return 3;
+    }
+
+    g_probe.hwnd = CreateHostWindow();
+    if (g_probe.hwnd == nullptr) {
+        std::printf("  [--] CreateWindowExW failed, GetLastError=%lu\n", GetLastError());
+        CoUninitialize();
+        return 2;
+    }
+    ShowWindow(g_probe.hwnd, SW_SHOW);
+
+    // ---------------------------------------------------------------- Q1, setup half
+    // Environment and controller creation are themselves completion-handler
+    // APIs, so "does creation need the queue pumped" is as load-bearing as the
+    // navigation question and has to be asked first.
+    std::printf("\nQ1a — does CreateCoreWebView2Environment complete with NO pump?\n");
+    HRESULT hrEnv = CreateCoreWebView2EnvironmentWithOptions(
+        nullptr, nullptr, nullptr,
+        Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(
+            [](HRESULT result, ICoreWebView2Environment* env) -> HRESULT {
+                g_probe.lastError = result;
+                if (SUCCEEDED(result) && env != nullptr) {
+                    HRESULT hr = env->CreateCoreWebView2Controller(
+                        g_probe.hwnd,
+                        Callback<ICoreWebView2CreateCoreWebView2ControllerCompletedHandler>(
+                            [](HRESULT r, ICoreWebView2Controller* c) -> HRESULT {
+                                g_probe.lastError = r;
+                                if (SUCCEEDED(r) && c != nullptr) {
+                                    g_probe.controller = c;
+                                    g_probe.controller->get_CoreWebView2(&g_probe.webview);
+                                }
+                                g_probe.controllerReady = true;
+                                return S_OK;
+                            })
+                            .Get());
+                    if (FAILED(hr)) {
+                        g_probe.lastError = hr;
+                        g_probe.controllerReady = true;
+                    }
+                }
+                g_probe.environmentReady = true;
+                return S_OK;
+            })
+            .Get());
+    if (FAILED(hrEnv)) {
+        ReportHr("CreateCoreWebView2EnvironmentWithOptions returned", hrEnv);
+        CoUninitialize();
+        return 2;
+    }
+
+    const bool envNoPump = WaitWithoutPumping(&g_probe.environmentReady, kWaitMs);
+    std::printf(envNoPump ? "  [ok] environment callback arrived with NO pump\n"
+                          : "  [!!] TIMED OUT after %lu ms with no pump — the callback needs the queue\n",
+                static_cast<unsigned long>(kWaitMs));
+
+    if (!envNoPump) {
+        std::printf("\nQ1b — the same wait, pumping the Win32 message queue\n");
+        if (!WaitPumping(&g_probe.environmentReady, kWaitMs)) {
+            std::printf("  [--] TIMED OUT pumping as well — WebView2 is not reachable here at all\n");
+            CoUninitialize();
+            return 4;
+        }
+        std::printf("  [ok] environment callback arrived while pumping\n");
+    }
+
+    if (!WaitPumping(&g_probe.controllerReady, kWaitMs)) {
+        std::printf("  [--] controller creation never completed\n");
+        CoUninitialize();
+        return 4;
+    }
+    if (g_probe.webview == nullptr) {
+        ReportHr("controller/CoreWebView2 unavailable", g_probe.lastError);
+        CoUninitialize();
+        return 4;
+    }
+    std::printf("  [ok] controller + CoreWebView2 obtained\n");
+
+    RECT bounds = {0, 0, kCaptureWidth, kCaptureHeight};
+    g_probe.controller->put_Bounds(bounds);
+    g_probe.controller->put_IsVisible(TRUE);
+
+    // ---------------------------------------------------------------- Q1, navigation half
+    EventRegistrationToken token = {};
+    g_probe.webview->add_NavigationCompleted(
+        Callback<ICoreWebView2NavigationCompletedEventHandler>(
+            [](ICoreWebView2*, ICoreWebView2NavigationCompletedEventArgs* args) -> HRESULT {
+                BOOL ok = FALSE;
+                if (args != nullptr) {
+                    args->get_IsSuccess(&ok);
+                }
+                g_probe.navigationStatus = ok ? S_OK : E_FAIL;
+                g_probe.navigationCompleted = true;
+                return S_OK;
+            })
+            .Get(),
+        &token);
+
+    std::printf("\nQ1c — does NavigationCompleted fire with NO pump?\n");
+    HRESULT hrNav = g_probe.webview->NavigateToString(kPage);
+    if (FAILED(hrNav)) {
+        ReportHr("NavigateToString", hrNav);
+        CoUninitialize();
+        return 4;
+    }
+    const bool navNoPump = WaitWithoutPumping(&g_probe.navigationCompleted, kWaitMs);
+    bool navPumped = navNoPump;
+    if (navNoPump) {
+        std::printf("  [ok] NavigationCompleted arrived with NO pump\n");
+    } else {
+        std::printf("  [!!] TIMED OUT after %lu ms with no pump\n", static_cast<unsigned long>(kWaitMs));
+        std::printf("\nQ1d — the same navigation, pumping\n");
+        navPumped = WaitPumping(&g_probe.navigationCompleted, kWaitMs);
+        std::printf(navPumped ? "  [ok] NavigationCompleted arrived while pumping\n"
+                              : "  [--] TIMED OUT pumping as well\n");
+    }
+    if (!navPumped) {
+        std::printf("\nverdict: navigation never completes in this process shape.\n");
+        CoUninitialize();
+        return 4;
+    }
+
+    // ---------------------------------------------------------------- Q3
+    // The number ADR 0035 needs beside darwin's 15.8 ms per takeSnapshot at
+    // 1024x768. CapturePreview is a PNG/JPEG encoder, so this is expected to be
+    // far worse — the point is to know by how much before stage 2 is scheduled.
+    std::printf("\nQ3 — CapturePreviewAsync at %dx%d, %d runs\n", kCaptureWidth, kCaptureHeight,
+                kCaptureRuns);
+    LARGE_INTEGER freq;
+    QueryPerformanceFrequency(&freq);
+    double totalMs = 0.0;
+    int captured = 0;
+    for (int i = 0; i < kCaptureRuns; ++i) {
+        ComPtr<IStream> stream;
+        if (FAILED(CreateStreamOnHGlobal(nullptr, TRUE, &stream))) {
+            continue;
+        }
+        bool done = false;
+        HRESULT captureResult = S_OK;
+        LARGE_INTEGER start;
+        QueryPerformanceCounter(&start);
+        HRESULT hrCap = g_probe.webview->CapturePreview(
+            COREWEBVIEW2_CAPTURE_PREVIEW_IMAGE_FORMAT_PNG, stream.Get(),
+            Callback<ICoreWebView2CapturePreviewCompletedHandler>(
+                [&done, &captureResult](HRESULT result) -> HRESULT {
+                    captureResult = result;
+                    done = true;
+                    return S_OK;
+                })
+                .Get());
+        if (FAILED(hrCap)) {
+            ReportHr("CapturePreview returned", hrCap);
+            break;
+        }
+        if (!WaitPumping(&done, kWaitMs)) {
+            std::printf("  [--] capture %d never completed\n", i);
+            break;
+        }
+        LARGE_INTEGER end;
+        QueryPerformanceCounter(&end);
+        if (FAILED(captureResult)) {
+            ReportHr("capture completed with", captureResult);
+            break;
+        }
+        STATSTG stat = {};
+        stream->Stat(&stat, STATFLAG_NONAME);
+        const double ms =
+            static_cast<double>(end.QuadPart - start.QuadPart) * 1000.0 / static_cast<double>(freq.QuadPart);
+        totalMs += ms;
+        ++captured;
+        if (i == 0) {
+            std::printf("  [ok] first capture: %.1f ms, %llu bytes of PNG\n", ms,
+                        static_cast<unsigned long long>(stat.cbSize.QuadPart));
+        }
+    }
+    if (captured > 0) {
+        std::printf("  [ok] %d captures, mean %.1f ms  (darwin takeSnapshot: 15.8 ms at the same size)\n",
+                    captured, totalMs / captured);
+    }
+
+    // ---------------------------------------------------------------- verdict
+    std::printf("\n---- verdict ----\n");
+    std::printf("evergreen runtime : present\n");
+    std::printf("env callback      : %s\n", envNoPump ? "NO pump needed" : "needs the queue pumped");
+    std::printf("navigation        : %s\n", navNoPump ? "NO pump needed" : "needs the queue pumped");
+    std::printf("capture           : %s\n", captured > 0 ? "works" : "FAILED");
+
+    // The self-retiring half. Each branch invalidates something that is
+    // currently written down, so each one exits non-zero and says which.
+    int rc = 0;
+    if (navNoPump && envNoPump) {
+        std::printf("\nFINDING: no loop bridge is needed on win32. ADR 0035's premise that the\n");
+        std::printf("darwin drain source has a win32 counterpart is WRONG and the ADR must say so.\n");
+        rc = 10;
+    } else {
+        std::printf("\nFINDING: WebView2 needs the Win32 message queue dispatched, so the win32\n");
+        std::printf("backend owes the same kind of loop bridge ADR 0022 built for CFRunLoop —\n");
+        std::printf("a GSource that pumps the queue while at least one view is alive.\n");
+    }
+    if (captured == 0) {
+        std::printf("\nFINDING: CapturePreview did not produce a frame in this process shape.\n");
+        std::printf("Stage 2's frame transport cannot be budgeted from this host.\n");
+        rc = rc == 0 ? 11 : rc;
+    }
+
+    if (g_probe.controller) {
+        g_probe.controller->Close();
+    }
+    DestroyWindow(g_probe.hwnd);
+    CoUninitialize();
+    return rc;
+}

--- a/docs/poc/webview2-win32-probe.ps1
+++ b/docs/poc/webview2-win32-probe.ps1
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: MIT
+#
+# Builds and runs `webview2-win32-probe.cpp` — ADR 0035's spike.
+#
+# Runs on a stock `windows-latest` runner and on a Windows workstation with
+# Visual Studio (or the Build Tools) installed. It resolves the toolchain rather
+# than assuming a shell has already been initialised, because the two hosts
+# differ there and a probe that only works inside a Developer Prompt is a probe
+# nobody runs twice.
+#
+#   pwsh -File docs/poc/webview2-win32-probe.ps1
+#
+# Exit codes are the probe's own (see the tail of the .cpp): 0 = the expected
+# shape, 10 = no loop bridge needed (which invalidates part of ADR 0035), 11 =
+# no frame captured, 2/3/4 = the probe could not measure.
+
+[CmdletBinding()]
+param(
+    # A probe input, pinned like every other version in this repo: an unpinned
+    # SDK makes two runs of the same probe two different measurements.
+    [string]$WebView2Version = '1.0.2903.40',
+    [string]$OutDir = (Join-Path ([IO.Path]::GetTempPath()) 'gjsify-webview2-probe')
+)
+
+$ErrorActionPreference = 'Stop'
+$probeSource = Join-Path $PSScriptRoot 'webview2-win32-probe.cpp'
+if (-not (Test-Path $probeSource)) {
+    throw "probe source not found beside this script: $probeSource"
+}
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+# ---------------------------------------------------------------- 1. the SDK
+# The WebView2 SDK is a NuGet package and nothing else — there is no system
+# location for it, so the probe fetches its own copy. `nuget.exe` is present on
+# GitHub's windows images; on a workstation it may not be.
+$nuget = (Get-Command nuget.exe -ErrorAction SilentlyContinue)?.Source
+if (-not $nuget) {
+    $nuget = Join-Path $OutDir 'nuget.exe'
+    if (-not (Test-Path $nuget)) {
+        Write-Host 'fetching nuget.exe'
+        Invoke-WebRequest -UseBasicParsing `
+            -Uri 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' `
+            -OutFile $nuget
+    }
+}
+
+$packages = Join-Path $OutDir 'packages'
+$sdk = Join-Path $packages "Microsoft.Web.WebView2.$WebView2Version"
+if (-not (Test-Path $sdk)) {
+    Write-Host "installing Microsoft.Web.WebView2 $WebView2Version"
+    & $nuget install Microsoft.Web.WebView2 -Version $WebView2Version `
+        -OutputDirectory $packages -NonInteractive | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "nuget install failed ($LASTEXITCODE)" }
+}
+$include = Join-Path $sdk 'build\native\include'
+$libDir = Join-Path $sdk 'build\native\x64'
+foreach ($p in @($include, $libDir)) {
+    if (-not (Test-Path $p)) { throw "the SDK layout is not what this script expects: $p is absent" }
+}
+
+# ---------------------------------------------------------------- 2. the toolchain
+# `cl.exe` only works with the environment `vcvars64.bat` sets, and that is a
+# batch file: the portable way to get it into PowerShell is to run it and read
+# the resulting environment back out. vswhere ships with VS since 2017 and is at
+# a fixed location.
+if (-not (Get-Command cl.exe -ErrorAction SilentlyContinue)) {
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+    if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found — is Visual Studio (or the Build Tools) installed?" }
+    $vsRoot = & $vswhere -latest -products '*' `
+        -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+        -property installationPath
+    if (-not $vsRoot) { throw 'vswhere found no installation carrying the x64 C++ toolset' }
+    $vcvars = Join-Path $vsRoot 'VC\Auxiliary\Build\vcvars64.bat'
+    if (-not (Test-Path $vcvars)) { throw "vcvars64.bat missing under $vsRoot" }
+
+    Write-Host "importing the MSVC environment from $vsRoot"
+    & cmd.exe /c "call `"$vcvars`" >nul 2>&1 && set" | ForEach-Object {
+        if ($_ -match '^([^=]+)=(.*)$') {
+            Set-Item -Path "env:$($matches[1])" -Value $matches[2] -ErrorAction SilentlyContinue
+        }
+    }
+}
+if (-not (Get-Command cl.exe -ErrorAction SilentlyContinue)) {
+    throw 'cl.exe is still not on PATH after importing the MSVC environment'
+}
+
+# ---------------------------------------------------------------- 3. compile
+# WebView2LoaderStatic.lib is chosen over the DLL deliberately: the probe is one
+# file that a reader copies to a machine and runs, and a loader DLL beside it is
+# one more thing to get wrong. `version.lib` is what the static loader needs to
+# read the runtime's version, and it is the link error people hit first.
+$exe = Join-Path $OutDir 'webview2-win32-probe.exe'
+Push-Location $OutDir
+try {
+    & cl.exe /nologo /std:c++17 /EHsc /W3 /MD `
+        "/I$include" $probeSource `
+        "/Fe:$exe" `
+        /link "/LIBPATH:$libDir" `
+        WebView2LoaderStatic.lib ole32.lib oleaut32.lib user32.lib shlwapi.lib version.lib advapi32.lib | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "cl.exe failed ($LASTEXITCODE)" }
+}
+finally {
+    Pop-Location
+}
+
+# ---------------------------------------------------------------- 4. run
+# No redirection: the probe's stdout IS the measurement, and a `| Tee-Object`
+# here would make $LASTEXITCODE the pipeline's rather than the probe's — the
+# same class of mistake as reading a shell pipeline's exit code as the program's.
+Write-Host ''
+& $exe
+$rc = $LASTEXITCODE
+Write-Host ''
+Write-Host "probe exit code: $rc"
+exit $rc


### PR DESCRIPTION
## What

ADR 0035's spike, written. One C++ translation unit, a PowerShell build/run script beside it, and a `workflow_dispatch`-only workflow so it can be run on a hosted Windows runner.

**It has not been run.** No Windows host is available in the environment this was written in, so the ADR now says outright that every win32 number in it is a question until the probe answers. That is the honest state, and it is the state ADR 0022's Proposed draft was in when two of its decisions were still wrong.

## The question it exists for

ADR 0022's most expensive finding was one its draft did not know about: `WKWebView` delivers its callbacks as CFRunLoop sources, a `GMainContext` never looks at them, and a bare `g_main_loop_run()` did not reach `didFinishNavigation` **at all** — case [1] of `webkit-runloop-darwin.m` did not run slowly, it did not run. Every API row in that ADR was unreachable until a drain source existed.

The win32 version of that assumption is "WebView2 delivers through the thread's message queue, and GTK4's Windows backend already pumps it, so the loop bridge is free." Plausible, load-bearing, unmeasured. This probe measures it.

## Why it links no GLib

The tempting shape is to run a real `GMainLoop`. It is wrong twice:

- `@gjsify/gtk-runtime-win32-x64` ships **DLLs and typelibs, not headers**, so a translation unit cannot include the GLib that a shipped `.msi` actually carries.
- Pulling a second GLib from MSYS2 or gvsbuild would measure a library the bundle is not.

What decides the design is one property of `g_main_loop_run()`: **it does not dispatch Win32 window messages.** A `Sleep()` loop has exactly that property, links nothing, and cannot drift from the bundle. So the probe compares a non-pumping wait against a pumping one — for the environment callback, the controller callback and the navigation separately, because "does creation need the queue" is as load-bearing as the navigation question and has to be asked first.

## What it reports

| question | measurement |
|---|---|
| 5 | is the Evergreen runtime present, and what HRESULT answers when it is not |
| 1 | which of environment / controller / navigation complete with **no** pump, and which need one |
| 3 | `CapturePreviewAsync` at 1024×768 over 10 runs, mean ms — the number to put beside darwin's 15.8 ms `takeSnapshot` |

It runs in a **non-bundled console process** — no WinMain, no application message loop — because that is the shape a `gjs` or `node` host is, and the finding has to hold in that shape.

## It retires itself

Both probes in ADR 0022 fail if their own finding stops holding, so they cannot decay into comments. This one does the same, and the exit codes carry it:

- **10** — the no-pump case succeeded, so no loop bridge is needed and this ADR's premise that darwin's drain source has a win32 counterpart is **wrong and must say so**.
- **11** — no frame was captured, so stage 2's transport cannot be budgeted from this host.
- **4/3/2** — the probe could not measure (navigation never completed even pumping; no runtime; setup failed).

A red run here is a result to read, not a build to fix — which is also why the workflow has no `push` or `pull_request` trigger and is not a gate.

## Two details that would otherwise be discovered the slow way

- The page is handed over with `NavigateToString`, not a `data:` URL: **Chromium blocks top-level navigation to `data:`**, so a probe built on one would measure that block and report it as "navigation never completed".
- It links `WebView2LoaderStatic.lib` rather than the loader DLL, and therefore needs `version.lib` — the link error people hit first.

## Scope

Docs + one dispatch-only workflow. No package changes, no backend, nothing on any existing gate. `check-adr-index` and `check-doc-fences` pass.
