### PR TITLE
fix(react-native): a label centres where React Native does not

### DIFF
--- a/packages/framework/react-native/README.md
+++ b/packages/framework/react-native/README.md
@@ -200,7 +200,7 @@ refusals. The plugin walks a directory and emits what it found.
 | export | tier | GTK | why |
 |---|---|---|---|
 | `View` | P1 | Gtk.Box, or Gtk.Overlay when a child is absolutely positioned | The container primitive. Which widget it becomes depends on its children, not on the element. |
-| `Text` | P1 | Gtk.Label | Wrapping is ON by default in React Native and OFF on a Gtk.Label, so the default is set explicitly. |
+| `Text` | P1 | Gtk.Label | THREE Gtk.Label defaults disagree with React Native’s and are set explicitly — wrap, xalign and yalign. The whole set of default divergences, including the ones that agree, is enumerated in primitives/defaults.ts. |
 | `Pressable` | P1 | Gtk.Button (flat) | Press state is a GTK CSS :active pseudo-class; children-as-a-function is implemented over the state flag, and costs nothing when it is unused. |
 | `ScrollView` | P1 | Gtk.ScrolledWindow + an implicit content box | contentContainerStyle styles the inner box, which is a second styleable node. |
 | `ActivityIndicator` | P1 | Adw.Spinner | Direct counterpart. |

--- a/packages/framework/react-native/src/primitives/defaults.spec.ts
+++ b/packages/framework/react-native/src/primitives/defaults.spec.ts
@@ -1,0 +1,266 @@
+// The default-divergence ledger, held against the installed GTK and against the table.
+//
+// `defaults.ts` claims two things a comment cannot: that GTK really gives a fresh
+// widget the value the row records, and that the set is CLOSED — every default this
+// layer overrides has a row, and every row that says `normalised` is really written.
+//
+// The second half is the one that matters. Four divergences were normalised one at a
+// time before anybody wrote them down, and the fifth (`Gtk.Label:xalign`) survived
+// every pass and was found by porting an application: all of its text rendered
+// centred, on every screen. The vectors below are what stops a sixth doing the same —
+// a `widgetProps` entry with no row fails, and a row that stops being true fails.
+
+import Gtk from 'gi://Gtk?version=4.0';
+import GObject from 'gi://GObject';
+import { afterEach, beforeEach, describe, expect, it, on, type Runtime } from '@gjsify/unit';
+import { lookupEnumNick, registerBuiltinWidgets } from '@gjsify/gtk-host';
+import { gtkChildren, installDiagnosticsGate } from '@gjsify/gtk-host/conformance';
+import { MINIMAL_TOKENS, type StyleTokens } from '@gjsify/gtk-host/style';
+import { createRoot } from '@gjsify/gtk-host/react';
+import { createElement } from 'react';
+
+import { Text, View } from '../components.js';
+import { configureStyle, resetStyleConfig } from '../style-config.js';
+import { DEFAULT_ROWS, NORMALISED_DEFAULTS, defaultRowFor } from './defaults.js';
+import { PRIMITIVES, type PrimitiveSpec } from './table.js';
+
+const GTK_HOSTS: Runtime[] = ['Gjs', 'Node.js', 'Bun', 'Deno'];
+const TOKENS: StyleTokens = { ...MINIMAL_TOKENS };
+
+/** `max-length` → `maxLength`: the spelling GJS installs the JS accessor under. */
+const accessor = (name: string): string => name.replace(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+
+/**
+ * A freshly constructed widget of `gtype`, for reading a default off.
+ *
+ * CONSTRUCTED, not read off the class: under node-gi a GObject class's properties are
+ * not visible until something realizes it (gjsify#1438), so a vector that only touched
+ * the constructor would be red on one leg of ADR 0030's one corpus and green on the
+ * other for a reason that has nothing to do with this ledger.
+ */
+function freshWidget(gtype: string): Gtk.Widget {
+    const ctor = (Gtk as unknown as Record<string, new () => Gtk.Widget>)[gtype.replace(/^Gtk/, '')];
+    if (typeof ctor !== 'function') throw new Error(`no Gtk constructor for ${gtype}`);
+    return new ctor();
+}
+
+/** Every `(gtype, property)` the primitive table writes as a widget default. */
+function tableOverrides(): readonly {
+    readonly gtype: string;
+    readonly property: string;
+    readonly value: unknown;
+    readonly where: string;
+}[] {
+    const out: { gtype: string; property: string; value: unknown; where: string }[] = [];
+    const visit = (name: string, spec: PrimitiveSpec): void => {
+        const nodes: readonly [string | undefined, Readonly<Record<string, unknown>> | undefined, string][] = [
+            [spec.tag, spec.widgetProps, name],
+            [spec.content?.tag, spec.content?.widgetProps, `${name}.content`],
+            [spec.backdrop?.tag, spec.backdrop?.widgetProps, `${name}.backdrop`],
+        ];
+        for (const [gtype, props, where] of nodes) {
+            if (gtype === undefined || props === undefined) continue;
+            for (const [property, value] of Object.entries(props)) out.push({ gtype, property, value, where });
+        }
+        if (spec.switchOn !== undefined) visit(`${name}[${spec.switchOn.prop}]`, spec.switchOn.whenTrue);
+    };
+    for (const [name, spec] of Object.entries(PRIMITIVES)) visit(name, spec);
+    return out;
+}
+
+export default async () => {
+    await on(GTK_HOSTS, async () => {
+        Gtk.init();
+        registerBuiltinWidgets();
+        const diagnostics = installDiagnosticsGate();
+        const gated = (name: string, run: () => Promise<void>): Promise<void> =>
+            describe(name, async () => {
+                beforeEach(() => {
+                    diagnostics.reset();
+                    configureStyle({ tokens: TOKENS });
+                });
+                afterEach(() => {
+                    resetStyleConfig();
+                    diagnostics.assertQuiet();
+                });
+                await run();
+            }) as Promise<void>;
+
+        await gated('the ledger, against the GTK that is installed', async () => {
+            await it('records the value a FRESH widget really reports, for every row', async () => {
+                // The GTK half of every row, re-measured. A row that recorded a value
+                // GTK stopped giving would otherwise sit here reading true for ever —
+                // and the whole point of the ledger is that it is the thing a reader
+                // trusts instead of looking.
+                const wrong: string[] = [];
+                for (const row of DEFAULT_ROWS) {
+                    // `GtkWidget` is abstract; its properties are read off any widget.
+                    const widget = freshWidget(row.gtype === 'GtkWidget' ? 'GtkBox' : row.gtype);
+                    const actual = (widget as unknown as Record<string, unknown>)[accessor(row.property)];
+                    const expected = row.gtk;
+                    // An enum comes back as a NUMBER; the ledger spells the nick,
+                    // because a number in a document nobody can read is not a record.
+                    // AN ENUM COMES BACK AS A NUMBER and the ledger spells the NICK,
+                    // because a number in a document nobody can read is not a record.
+                    // The nick is resolved to a number rather than the other way
+                    // round, through `@gjsify/gtk-host`'s own `lookupEnumNick` — the
+                    // host already owns that mapping and a second one here would be
+                    // the copy that drifts.
+                    const matches =
+                        typeof expected === 'string' && typeof actual === 'number'
+                            ? enumValue(widget, row.property, expected) === actual
+                            : actual === expected;
+                    if (!matches)
+                        wrong.push(`${row.gtype}.${row.property}: ledger ${String(expected)}, GTK ${String(actual)}`);
+                }
+                expect(wrong).toStrictEqual([]);
+                expect(DEFAULT_ROWS.length > 15).toBe(true);
+            });
+
+            await it('names a property the widget really installs, for every row', async () => {
+                const missing: string[] = [];
+                for (const row of DEFAULT_ROWS) {
+                    const gtype = row.gtype === 'GtkWidget' ? 'GtkBox' : row.gtype;
+                    const widget = freshWidget(gtype);
+                    const specs = (
+                        widget.constructor as unknown as { list_properties(): GObject.ParamSpec[] }
+                    ).list_properties();
+                    if (!specs.some((spec) => spec.get_name() === row.property)) {
+                        missing.push(`${row.gtype}.${row.property}`);
+                    }
+                }
+                expect(missing).toStrictEqual([]);
+            });
+        });
+
+        await gated('the ledger, against the primitive table', async () => {
+            await it('has a row for EVERY default the table overrides', async () => {
+                // THE VECTOR THIS FILE EXISTS FOR. A sixth normalisation written into
+                // `widgetProps` without a row here is a divergence nobody enumerated —
+                // which is exactly how the fifth one reached a shipped screen.
+                const unrecorded = tableOverrides()
+                    .filter(({ gtype, property }) => defaultRowFor(gtype, property) === undefined)
+                    .map(({ gtype, property, where }) => `${where}: ${gtype}.${property}`);
+                expect(unrecorded).toStrictEqual([]);
+                expect(tableOverrides().length > 5).toBe(true);
+            });
+
+            await it('is really written by the table, for every row that says `normalised`', async () => {
+                // The other direction: a row can claim a normalisation the table does
+                // not perform, and it would read as covered.
+                const overrides = tableOverrides();
+                const unperformed = NORMALISED_DEFAULTS.filter(
+                    (row) => !overrides.some((o) => o.gtype === row.gtype && o.property === row.property),
+                ).map((row) => `${row.gtype}.${row.property}`);
+                expect(unperformed).toStrictEqual([]);
+                // AND THE VALUE, not only the fact of an override: a ledger that said
+                // `xalign: 0` beside a table that wrote 0.5 would read as covered and
+                // be exactly as wrong as no ledger at all.
+                const disagreeing = NORMALISED_DEFAULTS.filter((row) =>
+                    overrides.some(
+                        (o) => o.gtype === row.gtype && o.property === row.property && o.value !== row.normalisedTo,
+                    ),
+                ).map((row) => `${row.gtype}.${row.property}`);
+                expect(disagreeing).toStrictEqual([]);
+                // Not vacuous — an empty ledger satisfies both lists above.
+                expect(NORMALISED_DEFAULTS.length > 5).toBe(true);
+            });
+
+            await it('gives every row a reason and a source, and a value exactly when it normalises', async () => {
+                const bad: string[] = [];
+                for (const row of DEFAULT_ROWS) {
+                    const where = `${row.gtype}.${row.property}`;
+                    if (row.reason.trim() === '') bad.push(`${where}: no reason`);
+                    if (row.source.trim() === '') bad.push(`${where}: no source`);
+                    if (row.verdict === 'normalised' && row.normalisedTo === undefined) {
+                        bad.push(`${where}: normalised with no value`);
+                    }
+                    if (row.verdict !== 'normalised' && row.normalisedTo !== undefined) {
+                        bad.push(`${where}: a value on a ${row.verdict} row`);
+                    }
+                }
+                expect(bad).toStrictEqual([]);
+            });
+        });
+
+        await gated('the text a reader actually sees', async () => {
+            await it('draws text at the START corner, not centred', async () => {
+                // THE MEASUREMENT, and it is a POSITION rather than a property: reading
+                // back `xalign === 0` would pass just as well if the label were never
+                // allocated any spare room, which is the case every unit test creates.
+                // `get_layout_offsets()` is where Pango actually put the glyphs.
+                //
+                // MEASURED on gtk 4.22.4 with GTK's own defaults, for the record this
+                // vector protects: a label allocated 400×100 reports (193, 41).
+                const container = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL });
+                const root = createRoot(container);
+                try {
+                    root.render(
+                        createElement(View, null, createElement(Text, { style: { width: 400, height: 100 } }, 'hi')),
+                    );
+                    const label = find(container, 'GtkLabel') as Gtk.Label;
+                    expect(label.xalign).toBe(0);
+                    expect(label.yalign).toBe(0);
+                    // The label has to be given the room for the offsets to mean
+                    // anything, so the size request is asserted rather than assumed.
+                    expect(label.widthRequest).toBe(400);
+                    expect(label.heightRequest).toBe(100);
+                    const [x, y] = label.get_layout_offsets();
+                    expect(x).toBe(0);
+                    expect(y).toBe(0);
+                } finally {
+                    root.unmount();
+                }
+            });
+
+            await it('still centres when the author ASKS, so the default is a default', async () => {
+                // The control. Without it the vector above passes just as well for a
+                // layer that hard-wired left alignment and dropped `text-center` —
+                // which would be the same defect facing the other way.
+                const container = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL });
+                const root = createRoot(container);
+                try {
+                    root.render(createElement(View, null, createElement(Text, { className: 'text-center' }, 'hi')));
+                    const label = find(container, 'GtkLabel') as Gtk.Label;
+                    expect(label.xalign).toBe(0.5);
+                } finally {
+                    root.unmount();
+                }
+            });
+
+            await it('keeps wrapping on, which is the divergence that was already known', async () => {
+                const container = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL });
+                const root = createRoot(container);
+                try {
+                    root.render(createElement(Text, null, 'hi'));
+                    expect((gtkChildren(container)[0] as Gtk.Label).wrap).toBe(true);
+                } finally {
+                    root.unmount();
+                }
+            });
+        });
+    });
+};
+
+/** The number a nick names on `property`'s enum type, through the host's own mapping. */
+function enumValue(widget: Gtk.Widget, property: string, nick: string): number | undefined {
+    const spec = (widget.constructor as unknown as { list_properties(): GObject.ParamSpec[] })
+        .list_properties()
+        .find((candidate) => candidate.get_name() === property);
+    if (spec === undefined) return undefined;
+    return lookupEnumNick(GObject.type_name(spec.value_type) ?? '', nick);
+}
+
+/** First strict descendant of a GType, breadth-first over the REAL tree. */
+function find(root: Gtk.Widget, gtype: string): Gtk.Widget {
+    const queue: Gtk.Widget[] = [...gtkChildren(root)];
+    while (queue.length > 0) {
+        const widget = queue.shift() as Gtk.Widget;
+        const name = GObject.type_name(
+            (widget as unknown as { constructor: { $gtype: GObject.GType } }).constructor.$gtype,
+        );
+        if (name === gtype) return widget;
+        queue.push(...gtkChildren(widget));
+    }
+    throw new Error(`no ${gtype} in the tree`);
+}

--- a/packages/framework/react-native/src/primitives/defaults.ts
+++ b/packages/framework/react-native/src/primitives/defaults.ts
@@ -1,0 +1,328 @@
+// Where GTK's default and React Native's disagree — the whole set, as data.
+//
+// WHY THIS FILE EXISTS AT ALL. This layer is built on named refusals: a prop it
+// cannot answer says so. A DEFAULT that disagrees arrives through the other door and
+// says nothing — the element renders, the build is green, every test passes, and the
+// window is wrong. It is the same failure the refusals exist to prevent, minus the
+// error message.
+//
+// AND IT WAS FOUND BY RUNNING, NOT BY READING. Four of these were normalised one at a
+// time, each in the PR that happened to trip over it. The fifth — `Gtk.Label:xalign` —
+// survived every one of those passes and was found by porting a 25-route application
+// and looking at it: ALL of its text rendered centred, on every screen, and one line
+// fixed all of them. That is what a set nobody enumerated looks like, so this is the
+// enumeration.
+//
+// MEASURED ON BOTH SIDES, and the two halves have different provenance, so each row
+// says which:
+//
+//   * the GTK column is read from a FRESH WIDGET on the installed GTK, and
+//     `defaults.spec.ts` re-reads every row rather than trusting it;
+//   * the React Native column cites the file in React Native's own tree that fixes
+//     it — Yoga's `Style.h` for layout, `ReactCommon/react/renderer/attributedstring`
+//     for text — or, where the default lives in a platform text engine rather than in
+//     the tree, the OBSERVATION from the port.
+//
+// THE LEDGER IS CLOSED IN BOTH DIRECTIONS, which is what makes it a mechanism instead
+// of a list. Every `widgetProps` entry in `table.ts` overrides a GTK default, so
+// `defaults.spec.ts` asserts that each one has a row here AND that each row marked
+// `normalised` is really written by the table. A sixth normalisation added without a
+// row fails; a row that stops being true fails.
+
+/** What this layer does about one divergence. */
+export type DefaultVerdict =
+    /** The two disagree and the primitive writes React Native's value. */
+    | 'normalised'
+    /** Checked, and the two already agree. Recorded so the sweep is a sweep. */
+    | 'agrees'
+    /** They disagree and GTK's is KEPT on purpose — the reason says why. */
+    | 'kept'
+    /**
+     * Not a default question at all: the table writes this for ONE primitive's own
+     * layout.
+     *
+     * The distinction is worth a verdict because the closure check below cannot make
+     * it — every `widgetProps` entry looks the same from there — and conflating the
+     * two would let a real divergence hide behind "well, some primitive wanted it".
+     */
+    | 'primitive';
+
+export interface DefaultRow {
+    /** The GType a primitive names. */
+    readonly gtype: string;
+    /** The property, in GTK's own kebab spelling. */
+    readonly property: string;
+    /** What a freshly constructed widget reports. Re-measured by the spec. */
+    readonly gtk: string | number | boolean;
+    /** React Native's own default, in words. */
+    readonly reactNative: string;
+    /** Where that is written down, or how it was observed. */
+    readonly source: string;
+    readonly verdict: DefaultVerdict;
+    /** The value the primitive writes. Present exactly when the verdict is `normalised`. */
+    readonly normalisedTo?: string | number | boolean;
+    readonly reason: string;
+}
+
+/**
+ * Every (widget, property) pair whose default this layer has looked at.
+ *
+ * ORDERED BY WIDGET, and the `agrees` rows are not padding: "we checked and they
+ * match" and "nobody has looked" are different states, and only one of them is safe.
+ * A property absent from this file is in the second state.
+ */
+export const DEFAULT_ROWS: readonly DefaultRow[] = [
+    // --- Gtk.Box -------------------------------------------------------------
+    {
+        gtype: 'GtkBox',
+        property: 'orientation',
+        gtk: 'horizontal',
+        reactNative: 'column',
+        source: 'Yoga’s own default — `ReactCommon/yoga/yoga/style/Style.h`: `FlexDirection::Column`. CSS defaults to `row`; React Native deliberately does not.',
+        verdict: 'normalised',
+        normalisedTo: 'vertical',
+        reason: 'The first inversion this layer met, and the loudest: a screen written as a column would have come out as a row.',
+    },
+    {
+        gtype: 'GtkBox',
+        property: 'spacing',
+        gtk: 0,
+        reactNative: '0 (`gap` is unset)',
+        source: 'Yoga: an unset gap is 0.',
+        verdict: 'agrees',
+        reason: 'Nothing to do.',
+    },
+    {
+        gtype: 'GtkBox',
+        property: 'homogeneous',
+        gtk: false,
+        reactNative: 'no counterpart — children are sized by flex',
+        source: 'Yoga has no "all children equal" mode.',
+        verdict: 'agrees',
+        reason: 'GTK’s `false` is what a flex container does, so the absent concept and the default coincide.',
+    },
+
+    // --- Gtk.Label -----------------------------------------------------------
+    {
+        gtype: 'GtkLabel',
+        property: 'wrap',
+        gtk: false,
+        reactNative: 'text wraps',
+        source: 'React Native’s `<Text>` wraps unless `numberOfLines` says otherwise.',
+        verdict: 'normalised',
+        normalisedTo: true,
+        reason: 'Without it a long line forces the window wider instead of wrapping — which reads as a layout bug anywhere but here.',
+    },
+    {
+        gtype: 'GtkLabel',
+        property: 'xalign',
+        gtk: 0.5,
+        reactNative: 'the script’s natural alignment — start, i.e. left in LTR',
+        source: '`ReactCommon/react/renderer/attributedstring/TextAttributes.h`: `std::optional<TextAlignment> alignment{}` is UNSET by default, and `primitives.h` documents `TextAlignment::Natural` as "the default alignment for script". Observed in a 25-route port: every string on every screen rendered centred.',
+        verdict: 'normalised',
+        normalisedTo: 0,
+        reason: 'MEASURED as a position, not as a property: a `Gtk.Label` allocated 400×100 reports `get_layout_offsets()` = (193, 41) with GTK’s defaults and (0, 0) with xalign/yalign 0. Nothing anywhere reports the difference.',
+    },
+    {
+        gtype: 'GtkLabel',
+        property: 'yalign',
+        gtk: 0.5,
+        reactNative: 'the top of the text’s box',
+        source: 'The same unset `alignment`; vertical centring is `textAlignVertical`/`verticalAlign`, which is also unset. Same layout-offset measurement as `xalign` — the 41 in (193, 41) is this one.',
+        verdict: 'normalised',
+        normalisedTo: 0,
+        reason: 'Only visible when the label is given more height than its text — a `flex-1` or an explicit height — which is exactly when it is hardest to attribute.',
+    },
+    {
+        gtype: 'GtkLabel',
+        property: 'justify',
+        gtk: 'left',
+        reactNative: 'natural, i.e. left in LTR',
+        source: 'As `xalign`: unset means natural.',
+        verdict: 'agrees',
+        reason: 'GTK’s enum default already is the LTR answer. It is `xalign` that positions the BLOCK and this that positions the lines within it, which is why only one of the pair was wrong.',
+    },
+    {
+        gtype: 'GtkLabel',
+        property: 'ellipsize',
+        gtk: 'none',
+        reactNative: 'no truncation until `numberOfLines` is set',
+        source: 'React Native applies `ellipsizeMode` only together with `numberOfLines`.',
+        verdict: 'agrees',
+        reason: 'Both truncate nothing until asked.',
+    },
+    {
+        gtype: 'GtkLabel',
+        property: 'selectable',
+        gtk: false,
+        reactNative: '`selectable` defaults to false',
+        source: 'React Native’s `TextProps`.',
+        verdict: 'agrees',
+        reason: 'Nothing to do.',
+    },
+
+    // --- Gtk.TextView --------------------------------------------------------
+    {
+        gtype: 'GtkTextView',
+        property: 'wrap-mode',
+        gtk: 'none',
+        reactNative: 'a multiline input wraps',
+        source: 'React Native’s multiline `TextInput` wraps, as `<Text>` does.',
+        verdict: 'normalised',
+        normalisedTo: 'word-char',
+        reason: 'The same disagreement as `Gtk.Label:wrap`, one widget over: without it the field scrolls sideways for ever.',
+    },
+    {
+        gtype: 'GtkTextView',
+        property: 'editable',
+        gtk: true,
+        reactNative: '`editable` defaults to true',
+        source: 'React Native’s `TextInputProps`.',
+        verdict: 'agrees',
+        reason: 'Nothing to do.',
+    },
+
+    // --- Gtk.Picture ---------------------------------------------------------
+    {
+        gtype: 'GtkPicture',
+        property: 'content-fit',
+        gtk: 'contain',
+        reactNative: 'cover',
+        source: 'React Native’s `Image` defaults `resizeMode` to `cover`.',
+        verdict: 'normalised',
+        normalisedTo: 'cover',
+        reason: 'Inverted between the two platforms, and an image that fits where it should fill looks deliberate.',
+    },
+
+    // --- Gtk.ScrolledWindow --------------------------------------------------
+    {
+        gtype: 'GtkScrolledWindow',
+        property: 'hscrollbar-policy',
+        gtk: 'automatic',
+        reactNative: 'vertical only — `horizontal` defaults to false',
+        source: 'React Native’s `ScrollViewProps`.',
+        verdict: 'normalised',
+        normalisedTo: 'never',
+        reason: 'GTK would scroll sideways as well, which is a second scroll axis the author did not ask for.',
+    },
+    {
+        gtype: 'GtkScrolledWindow',
+        property: 'vexpand',
+        gtk: false,
+        reactNative: '`flexGrow` 0, as for any widget',
+        source: 'Yoga: an unset `flexGrow` is 0.',
+        verdict: 'primitive',
+        reason: '`FlatList` writes it on its scroller, and it is a layout decision rather than a default: the scroller is one of up to three children of the outer box and it is the one that takes the leftover space, because a header and a footer are their own natural height.',
+    },
+    {
+        gtype: 'GtkScrolledWindow',
+        property: 'hexpand',
+        gtk: false,
+        reactNative: '`flexGrow` 0, as for any widget',
+        source: 'Yoga: an unset `flexGrow` is 0.',
+        verdict: 'primitive',
+        reason: 'As `vexpand`, one axis over — `FlatList`’s scroller fills its box.',
+    },
+    {
+        gtype: 'GtkScrolledWindow',
+        property: 'kinetic-scrolling',
+        gtk: true,
+        reactNative: 'no counterpart on a desktop',
+        source: '—',
+        verdict: 'kept',
+        reason: 'Touch-and-flick scrolling is GTK’s own behaviour on a touchscreen and costs nothing with a mouse. Turning it off would remove a desktop affordance to match a phone API that does not describe it.',
+    },
+
+    // --- Gtk.Entry -----------------------------------------------------------
+    {
+        gtype: 'GtkEntry',
+        property: 'has-frame',
+        gtk: true,
+        reactNative: 'unstyled — a bare text field with no border',
+        source: 'React Native’s `TextInput` draws no chrome of its own on either platform.',
+        verdict: 'kept',
+        reason: 'DELIBERATE, and the one row here that is a design choice rather than a match: an Adwaita entry without its frame is not a text field a desktop user recognises. The divergence is visible, which is what separates it from the silent ones — an author sees the frame immediately and can remove it from the stylesheet.',
+    },
+    {
+        gtype: 'GtkEntry',
+        property: 'visibility',
+        gtk: true,
+        reactNative: '`secureTextEntry` defaults to false',
+        source: 'React Native’s `TextInputProps`.',
+        verdict: 'agrees',
+        reason: 'Nothing to do.',
+    },
+
+    // --- Gtk.Switch ----------------------------------------------------------
+    {
+        gtype: 'GtkSwitch',
+        property: 'active',
+        gtk: false,
+        reactNative: '`value` defaults to false',
+        source: 'React Native’s `SwitchProps`.',
+        verdict: 'agrees',
+        reason: 'Nothing to do.',
+    },
+
+    // --- Gtk.Widget, which every primitive inherits --------------------------
+    {
+        gtype: 'GtkWidget',
+        property: 'halign',
+        gtk: 'fill',
+        reactNative: 'stretch',
+        source: 'Yoga’s own default — `ReactCommon/yoga/yoga/style/Style.h`: `Align alignItems_ = Align::Stretch`.',
+        verdict: 'agrees',
+        reason: 'GTK’s `fill` and CSS’s `stretch` are the same instruction under different words — `intents.ts` maps them to each other for the explicit case too.',
+    },
+    {
+        gtype: 'GtkWidget',
+        property: 'hexpand',
+        gtk: false,
+        reactNative: '`flexGrow` 0',
+        source: 'Yoga: an unset `flexGrow` is 0.',
+        verdict: 'agrees',
+        reason: 'Neither grows until asked. `flex-1` is what asks, and `intents.ts` resolves it against the PARENT’s axis.',
+    },
+    {
+        gtype: 'GtkWidget',
+        property: 'opacity',
+        gtk: 1,
+        reactNative: '1',
+        source: 'React Native’s style default.',
+        verdict: 'agrees',
+        reason: 'Nothing to do. `Animated.View` writes this property, which is why it is worth having checked.',
+    },
+    {
+        gtype: 'GtkWidget',
+        property: 'overflow',
+        gtk: 'visible',
+        reactNative: 'visible',
+        source: 'React Native’s `overflow` style default.',
+        verdict: 'agrees',
+        reason: 'Nothing to do.',
+    },
+    {
+        gtype: 'GtkWidget',
+        property: 'can-target',
+        gtk: true,
+        reactNative: '`pointerEvents` defaults to `auto`',
+        source: 'React Native’s `ViewProps`.',
+        verdict: 'agrees',
+        reason: 'Nothing to do.',
+    },
+];
+
+/** Every row this layer writes a value for, as `(gtype, property)`. Read by the spec. */
+export const NORMALISED_DEFAULTS: readonly DefaultRow[] = DEFAULT_ROWS.filter((row) => row.verdict === 'normalised');
+
+/**
+ * The row for one `(gtype, property)`, or undefined.
+ *
+ * FALLS BACK TO `GtkWidget`, and that is not a convenience: `hexpand`, `opacity` and
+ * `halign` are `Gtk.Widget`'s properties, so a primitive writing one on a
+ * `Gtk.ScrolledWindow` is writing the same property this ledger records once. Keying
+ * a row per widget that inherits them would be twenty copies of one fact.
+ */
+export const defaultRowFor = (gtype: string, property: string): DefaultRow | undefined =>
+    DEFAULT_ROWS.find((row) => row.gtype === gtype && row.property === property) ??
+    DEFAULT_ROWS.find((row) => row.gtype === 'GtkWidget' && row.property === property);

--- a/packages/framework/react-native/src/primitives/index.ts
+++ b/packages/framework/react-native/src/primitives/index.ts
@@ -8,6 +8,8 @@
 // stopped being true.
 
 export { splitVariants } from './classes.js';
+export { DEFAULT_ROWS, NORMALISED_DEFAULTS, defaultRowFor } from './defaults.js';
+export type { DefaultRow, DefaultVerdict } from './defaults.js';
 export type { ClassGroups, ClassNameInput } from './classes.js';
 export { PrimitiveError } from './errors.js';
 export { resolveIntent } from './intents.js';

--- a/packages/framework/react-native/src/primitives/primitives.spec.ts
+++ b/packages/framework/react-native/src/primitives/primitives.spec.ts
@@ -460,8 +460,11 @@ export default async () => {
         });
 
         await it('contributes nothing for a declared no-op', async () => {
+            // The three are `Gtk.Label` defaults this layer normalises to React
+            // Native's, enumerated with the rest of the set in `defaults.ts`; a
+            // declared no-op adds nothing to them.
             const p = plan('Text', { allowFontScaling: true, maxFontSizeMultiplier: 2 }).plan;
-            expect(p.node.props).toStrictEqual({ wrap: true });
+            expect(p.node.props).toStrictEqual({ wrap: true, xalign: 0, yalign: 0 });
         });
     });
 

--- a/packages/framework/react-native/src/primitives/table.ts
+++ b/packages/framework/react-native/src/primitives/table.ts
@@ -520,10 +520,23 @@ export const PRIMITIVES: Readonly<Record<string, PrimitiveSpec>> = {
 
     Text: {
         tag: 'GtkLabel',
-        // THE SECOND INVERSION. React Native's `Text` wraps; `Gtk.Label` does not
-        // (`wrap` defaults to false), and a long line simply forces the window
-        // wider — which reads as a layout bug anywhere but here.
-        widgetProps: { wrap: true },
+        // THREE DEFAULTS `Gtk.Label` disagrees with React Native about, and the whole
+        // set — including the ones that AGREE — is enumerated in `defaults.ts`, which
+        // a spec holds against the installed GTK in both directions.
+        //
+        //   wrap    React Native's `Text` wraps; a `Gtk.Label` does not, and a long
+        //           line forces the window wider instead.
+        //   xalign  `Gtk.Label` CENTRES. React Native's text alignment is unset by
+        //           default, which means the script's natural edge — left in LTR.
+        //   yalign  the same, one axis over: it centres vertically wherever the label
+        //           is given more height than its text.
+        //
+        // MEASURED as a position rather than as a property, because a property read
+        // does not say what a reader sees: a label allocated 400×100 reports
+        // `get_layout_offsets()` = (193, 41) with GTK's defaults and (0, 0) with these
+        // two. Found by porting a 25-route application and looking at it — every
+        // string on every screen was centred, and nothing reported it.
+        widgetProps: { wrap: true, xalign: 0, yalign: 0 },
         cssClasses: [],
         orientation: 'vertical',
         widget: TEXT,

--- a/packages/framework/react-native/src/support-table.ts
+++ b/packages/framework/react-native/src/support-table.ts
@@ -87,8 +87,9 @@ export const SUPPORT_TABLE: Readonly<Record<string, SupportEntry>> = {
         status: 'partial',
         tier: 'P1',
         gtk: 'Gtk.Label',
-        reason: 'Wrapping is ON by default in React Native and OFF on a Gtk.Label, so the default is set explicitly.',
+        reason: 'THREE Gtk.Label defaults disagree with React Native’s and are set explicitly — wrap, xalign and yalign. The whole set of default divergences, including the ones that agree, is enumerated in primitives/defaults.ts.',
         limits: [
+            'Gtk.Label CENTRES by default and React Native’s text alignment is unset, which means the script’s natural edge — left in LTR. MEASURED as a position rather than a property: a label allocated 400×100 reports get_layout_offsets() = (193, 41) with GTK’s defaults and (0, 0) with xalign/yalign 0. Found by porting a 25-route application, where every string on every screen rendered centred and nothing reported it; text-center still works, because widgetProps is the base the style partition overrides.',
             'A nested <Text> is refused by the host naming the tag: Gtk.Label takes no children (measured), so React Native’s inline-styling idiom has no counterpart. Use Pango markup through a ref, or separate labels.',
             'ellipsizeMode="clip" is refused: PangoEllipsizeMode is NONE, START, MIDDLE, END (measured) and has no clip member, so honouring it would add an ellipsis the author asked not to have.',
             'onPress is refused: a Gtk.Label emits no clicked signal (measured). Wrap it in a <Pressable>.',

--- a/packages/framework/react-native/src/test.mts
+++ b/packages/framework/react-native/src/test.mts
@@ -4,6 +4,7 @@ import apisSuite from './apis/apis.spec.js';
 import eventEmitterSuite from './event-emitter.spec.js';
 import listsSuite from './lists/lists.spec.js';
 import classesSuite from './primitives/classes.spec.js';
+import defaultsSuite from './primitives/defaults.spec.js';
 import primitivesSuite from './primitives/primitives.spec.js';
 import widgetsSuite from './primitives/widgets.spec.js';
 import routerWidgetsSuite from './router/router.spec.js';
@@ -18,6 +19,7 @@ run({
     unsupportedSuite,
     eventEmitterSuite,
     classesSuite,
+    defaultsSuite,
     stylesheetSuite,
     primitivesSuite,
     apisSuite,


### PR DESCRIPTION
Closes #1450.

Porting a 25-route application onto this layer and **looking at it** found that all
of its text rendered centred — every headline, every list row, every badge, on every
screen — and nothing anywhere reported a problem. `Gtk.Label:xalign` and `:yalign`
default to `0.5`; React Native's text alignment is unset, which means the script's
natural edge.

## Measured as a position, not as a property

A property read does not say what a reader sees. `get_layout_offsets()` is where
Pango actually put the glyphs:

| label, allocated 400×100 | `xalign` | `yalign` | glyphs at |
|---|---|---|---|
| GTK's own defaults | 0.5 | 0.5 | **(193, 41)** |
| this PR | 0 | 0 | **(0, 0)** |

The rendering vector asserts the offsets, not the properties — reading back
`xalign === 0` would pass just as well on a label that was never given any spare
room, which is every label a unit test creates.

## The argument was already in the file

`Text`'s own support-table entry has said this for a different property since the
primitive landed:

> Wrapping is ON by default in React Native and OFF on a `Gtk.Label`, so the default
> is set explicitly.

Same shape, same widget, second property. **That it survived every pass which wrote
that sentence is the actual finding**: four divergences had been normalised one at a
time, each in the PR that happened to trip over it, and nobody had ever enumerated
the set. So the fix is the enumeration.

## `primitives/defaults.ts` — the set, with a verdict per row

| verdict | rows |
|---|---|
| `normalised` | `Gtk.Box:orientation`, `Gtk.Label:wrap`, **`Gtk.Label:xalign`**, **`Gtk.Label:yalign`**, `Gtk.TextView:wrap-mode`, `Gtk.Picture:content-fit`, `Gtk.ScrolledWindow:hscrollbar-policy` |
| `agrees` | `halign`/`hexpand`/`opacity`/`overflow`/`can-target`, `Gtk.Label:justify`/`ellipsize`/`selectable`, `Gtk.Box:spacing`/`homogeneous`, `Gtk.Entry:visibility`, `Gtk.TextView:editable`, `Gtk.Switch:active` |
| `kept` | `Gtk.Entry:has-frame` (an Adwaita entry without its frame is not a text field a desktop user recognises — and the divergence is *visible*, which is what separates it from the silent ones), `Gtk.ScrolledWindow:kinetic-scrolling` |
| `primitive` | `Gtk.ScrolledWindow:hexpand`/`vexpand` — `FlatList`'s scroller taking the leftover space, which is a layout decision and not a default question |

The `agrees` rows are not padding: **"we checked and they match" and "nobody has
looked" are different states, and only one of them is safe.** A property absent from
the file is in the second one.

Both halves are measured and each row says which:

- the **GTK** column is read off a freshly constructed widget, and the spec re-reads
  every row rather than trusting it;
- the **React Native** column cites the file in React Native's own tree that settles
  it — Yoga's `ReactCommon/yoga/yoga/style/Style.h` (`FlexDirection::Column`,
  `Align::Stretch`) for layout, `ReactCommon/react/renderer/attributedstring`
  (`std::optional<TextAlignment> alignment{}` unset, `TextAlignment::Natural`
  documented as "the default alignment for script") for text — or the observation
  from the port, where the default lives in a platform text engine rather than in the
  tree.

## The ledger is closed in both directions

That is what makes it a mechanism rather than a list, and it is the part that stops
an eighth divergence repeating this one:

- every `widgetProps` entry in the primitive table **must have a row** — and writing
  one without a row fails a test;
- every row that says `normalised` **must really be written by the table, with the
  value it records** — a ledger claiming `xalign: 0` beside a table writing `0.5`
  would read as covered and be exactly as wrong as no ledger at all.

The closure check earned its place immediately: it found two overrides nobody had
written down (`FlatList`'s scroller `hexpand`/`vexpand`), which is why the
`primitive` verdict exists at all.

## Broken to watch it go red

- remove `xalign`/`yalign` from the table → the layout-offset vector fails **and** the
  ledger's "is really written" check fails
- add an unenumerated override (`'single-line-mode': false`) → the closure check fails
- the control vector: `className="text-center"` still yields `xalign === 0.5`, so the
  default is a default and not a hard-wire — without it this PR would pass just as
  well for a layer that dropped `text-align` entirely

## Measurements

gjs **914/914 green**; node leg **2 of 910**, and both are the named #1438 baseline
failures (`Gtk.ListItem` `list_properties`, `Adw.NavigationView` `popped`) — this
branch adds none. `check-rn-surface` green, `gjsify lint` exit 0. Rebased on
`254eb9ce4`, with `@gjsify/gtk-host` rebuilt for #1439's `LayoutIntent.wrap`.
