### PR TITLE
fix(react-native): router.push takes the object form

### DIFF
--- a/packages/framework/react-native/README.md
+++ b/packages/framework/react-native/README.md
@@ -313,7 +313,7 @@ refusals. The plugin walks a directory and emits what it found.
 
 | export | tier | GTK | why |
 |---|---|---|---|
-| `router` | P1 | Adw.NavigationView (push/pop) via React Navigation’s StackActions | push, back, replace and navigate — the four methods the measured application calls, 19 of the 27 calls being push. |
+| `router` | P1 | Adw.NavigationView (push/pop) via React Navigation’s StackActions | push, back, replace, navigate and canGoBack. Every href-taking method accepts BOTH argument shapes — a path string and expo-router’s { pathname, params } object. |
 | `useLocalSearchParams` | P1 | — | The current route’s params — the [param] values and the query string — read through React Navigation’s own useRoute(). |
 | `usePathname` | P1 | — | The current URL without its query string, from React Navigation’s getPathFromState over the published root state. |
 | `Stack` | P1 | Adw.NavigationView + Adw.NavigationPage | The stack navigator: React declares which pages exist, the widget owns their order, and the route key is the tag that joins the two. |

--- a/packages/framework/react-native/src/router/href.spec.ts
+++ b/packages/framework/react-native/src/router/href.spec.ts
@@ -1,0 +1,176 @@
+// `{ pathname, params }` in, the same params out — the property that would have
+// caught this before an application did.
+//
+// The defect: `router.push` took a string only, so an object interpolated as
+// `[object Object]`, matched no route, and landed on `+not-found`. No build error, no
+// throw, 10 call sites in one application, every one a detail screen reached with a
+// parameter.
+//
+// WHAT MAKES THAT A PROPERTY RATHER THAN A LIST OF CASES. `hrefFrom` writes params
+// INTO a pattern and `useLocalSearchParams` reads them back OUT, and the two share
+// one definition of what a param is (`paramsSeenBy`). So the check is not "does
+// `/detail/[id]` with `{id:'7'}` give `/detail/7`" — it is that for EVERY shape, what
+// goes in comes out. A writer and a reader that drift apart is the whole failure, and
+// this is the assertion that notices.
+//
+// PURE, deliberately: nothing here imports React Navigation, React or `gi://`, so the
+// property runs with no container mounted and no widget realized. `router.spec.ts`
+// carries the same round trip through the REAL navigator, which is the half this
+// cannot prove.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { RouterError } from './errors.js';
+import { hrefFrom, paramsInHref, paramsSeenBy, patternParams, type HrefObject } from './href.js';
+
+/** A param record as a comparable string, with its keys in a fixed order. */
+const stable = (record: Record<string, string>): string =>
+    JSON.stringify(Object.fromEntries(Object.entries(record).sort(([a], [b]) => (a < b ? -1 : 1))));
+
+const threw = (run: () => unknown): RouterError => {
+    try {
+        run();
+    } catch (error) {
+        if (error instanceof RouterError) return error;
+        throw error;
+    }
+    throw new Error('expected a refusal, and nothing was thrown');
+};
+
+/**
+ * The shapes the round trip is asserted over.
+ *
+ * Chosen for the ways a URL can lose a value rather than for coverage: a segment that
+ * needs encoding, a value that is not a string, a param the pattern has no slot for,
+ * and a pattern with more than one slot — which is where an implementation that
+ * substituted by ORDER instead of by NAME comes apart.
+ */
+const ROUND_TRIP: readonly (readonly [string, HrefObject])[] = [
+    ['one segment', { pathname: '/detail/[id]', params: { id: '7' } }],
+    ['two segments, not in pattern order', { pathname: '/a/[first]/b/[second]', params: { second: 'y', first: 'x' } }],
+    ['a number', { pathname: '/detail/[id]', params: { id: 42 } }],
+    ['a boolean', { pathname: '/detail/[id]', params: { id: true } }],
+    ['a slash in the value', { pathname: '/detail/[id]', params: { id: 'a/b' } }],
+    ['an ampersand and a space', { pathname: '/detail/[id]', params: { id: 'a & b' } }],
+    ['non-ASCII', { pathname: '/detail/[id]', params: { id: 'Grüße' } }],
+    ['a leftover param, which becomes a query', { pathname: '/detail/[id]', params: { id: '7', tab: 'reviews' } }],
+    ['only leftovers', { pathname: '/search', params: { q: 'a b', page: 2 } }],
+    ['no params at all', { pathname: '/settings' }],
+];
+
+export default async () => {
+    await describe('an href, in both directions', async () => {
+        await it('round-trips every shape — what goes in comes out', async () => {
+            // THE VECTOR THIS FILE EXISTS FOR. `paramsSeenBy` is what
+            // `useLocalSearchParams` will hand a screen; `paramsInHref` is what the URL
+            // carries. If those disagree the application navigates somewhere that looks
+            // right and reads back something else.
+            const wrong: string[] = [];
+            for (const [label, href] of ROUND_TRIP) {
+                const url = hrefFrom('push', href);
+                const readBack = paramsInHref(href.pathname, url);
+                const expected = paramsSeenBy(href.params);
+                // SORTED, because a param record has no meaningful key order and
+                // `JSON.stringify` has one: the pattern fills its slots left to right
+                // while the author's object is in whatever order they wrote it, so an
+                // order-sensitive comparison reports a difference that is not one.
+                if (stable(readBack) !== stable(expected)) {
+                    wrong.push(`${label}: ${url} → ${stable(readBack)} ≠ ${stable(expected)}`);
+                }
+            }
+            expect(wrong).toStrictEqual([]);
+            // Not vacuous: an empty case list satisfies an empty problem list, and a
+            // case with no params satisfies any writer at all.
+            expect(ROUND_TRIP.length > 8).toBe(true);
+            expect(Object.keys(paramsSeenBy(ROUND_TRIP[0]?.[1].params)).length).toBe(1);
+        });
+
+        await it('substitutes by NAME, not by position', async () => {
+            // The case the round trip covers and no single example makes obvious: the
+            // params object is unordered, so an implementation that walked the pattern
+            // and the values in parallel would pass every one-param test.
+            expect(hrefFrom('push', { pathname: '/a/[first]/b/[second]', params: { second: 'y', first: 'x' } })).toBe(
+                '/a/x/b/y',
+            );
+        });
+
+        await it('leaves a string href untouched, query and all', async () => {
+            // Not laziness: expo-router's string form is already a URL, and
+            // re-encoding one would double-escape a query an author wrote by hand.
+            expect(hrefFrom('push', '/detail/7?tab=reviews')).toBe('/detail/7?tab=reviews');
+            expect(hrefFrom('push', '/a%20b')).toBe('/a%20b');
+        });
+
+        await it('puts what the pattern has no slot for into the query', async () => {
+            expect(hrefFrom('push', { pathname: '/detail/[id]', params: { id: '7', tab: 'reviews' } })).toBe(
+                '/detail/7?tab=reviews',
+            );
+        });
+
+        await it('reports the param names a pattern carries', async () => {
+            expect(patternParams('/a/[first]/b/[second]')).toStrictEqual(['first', 'second']);
+            expect(patternParams('/settings')).toStrictEqual([]);
+        });
+    });
+
+    await describe('what an href refuses, and why each one is not a silent drop', async () => {
+        await it('names the object form when something else arrives', async () => {
+            // The message carries the defect's own symptom, because that is what a
+            // reader searching for "[object Object]" will have in front of them.
+            const error = threw(() => hrefFrom('push', 42 as never));
+            expect(error.message).toContain('[object Object]');
+            expect(error.message).toContain('+not-found');
+        });
+
+        await it('refuses a pattern slot with no param, rather than sending the literal', async () => {
+            const error = threw(() => hrefFrom('push', { pathname: '/detail/[id]', params: { other: '1' } }));
+            expect(error.message).toContain('"id"');
+            expect(error.message).toContain('other');
+            // The alternative is what the old code did by accident: send something the
+            // router cannot match and let the user land on +not-found.
+            expect(error.message).toContain('matches no route');
+        });
+
+        await it('refuses a structural value on BOTH sides of the pattern', async () => {
+            // A URL segment is a string and so is a query value, so an object could not
+            // survive the trip in either direction — which is the same sentence
+            // `useLocalSearchParams` has always used for dropping one.
+            expect(threw(() => hrefFrom('push', { pathname: '/d/[id]', params: { id: { a: 1 } } })).message).toContain(
+                'a URL segment is a string',
+            );
+            expect(threw(() => hrefFrom('push', { pathname: '/d', params: { q: [1, 2] } })).message).toContain(
+                'an array',
+            );
+        });
+
+        await it('refuses one of React Navigation’s nesting keys as a param name', async () => {
+            // `screen`, `params`, `initial`, `state`, `path`, `pop`, `merge`: the filter
+            // on the READ side drops them, so sending one is a param that never arrives.
+            const error = threw(() => hrefFrom('push', { pathname: '/d', params: { screen: 'x' } }));
+            expect(error.message).toContain('nesting keys');
+            expect(error.message).toContain('never arrives');
+        });
+
+        await it('refuses a catch-all pathname with the file-tree parser’s own answer', async () => {
+            const error = threw(() => hrefFrom('push', { pathname: '/blog/[...slug]', params: { slug: 'a' } }));
+            expect(error.code).toBe('deep-dynamic-unsupported');
+            expect(error.message).toContain('one [param] per segment');
+        });
+
+        await it('refuses a pathname that is not a non-empty string', async () => {
+            expect(threw(() => hrefFrom('push', { pathname: '' } as never)).message).toContain('non-empty string');
+        });
+    });
+
+    await describe('the one rule both directions share', async () => {
+        await it('stringifies a scalar and drops what a URL cannot carry', async () => {
+            expect(paramsSeenBy({ a: 'x', b: 2, c: false })).toStrictEqual({ a: 'x', b: '2', c: 'false' });
+            expect(paramsSeenBy({ a: { deep: 1 }, b: [1], c: undefined, d: null })).toStrictEqual({});
+            expect(paramsSeenBy(undefined)).toStrictEqual({});
+        });
+
+        await it('filters React Navigation’s nesting keys, which are not the author’s', async () => {
+            expect(paramsSeenBy({ id: '7', screen: 'x', params: {}, initial: true })).toStrictEqual({ id: '7' });
+        });
+    });
+};

--- a/packages/framework/react-native/src/router/href.ts
+++ b/packages/framework/react-native/src/router/href.ts
@@ -1,0 +1,216 @@
+// `{ pathname, params }` → the URL, and the same table read back out.
+//
+// THE DEFECT THIS FILE EXISTS FOR DID NOT THROW. `expo-router`'s `router.push`
+// accepts `string | { pathname, params }`; this layer accepted the string only, and
+// an object handed to it was interpolated — so the push SUCCEEDED, the URL was
+// `[object Object]`, no route matched, and every parameterised navigation landed on
+// `+not-found`. Measured: 10 call sites in one application, every one of them a
+// detail screen reached with a parameter. Nothing reported it, at build time or at
+// run time, which makes it worse than the silent no-ops this layer refuses
+// everywhere — it navigated somewhere wrong.
+//
+// TWO DIRECTIONS, ONE DEFINITION, and that is the whole design. `hrefFrom` writes
+// params INTO a pattern and `paramsSeenBy` says what `useLocalSearchParams` will hand
+// back OUT of it. They are the same rule about what a param is — a scalar becomes a
+// string, anything structural is not a URL segment — so a disagreement between them
+// is a defect this layer can detect in itself rather than one an application finds.
+// `router.spec.ts` drives the round trip; `navigation.ts`' `useLocalSearchParams`
+// calls `paramsSeenBy` rather than repeating the filter.
+//
+// NOTHING HERE IMPORTS REACT NAVIGATION OR REACT. That is what lets the round-trip
+// property be asserted with no container mounted and no widget realized.
+
+import { RouterError } from './errors.js';
+
+/** What `router.push` and its siblings accept, as `expo-router` spells it. */
+export type Href = string | HrefObject;
+
+export interface HrefObject {
+    /** A route pattern — `/detail/[id]` — or a plain path. */
+    readonly pathname: string;
+    /** Values for the pattern's `[name]` segments; the rest become a query string. */
+    readonly params?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * React Navigation's own nesting keys, which are not the author's params.
+ *
+ * `screen`, `params`, `initial`, `state`, `path`, `pop` and `merge` are how a nested
+ * NAVIGATE addresses a child navigator. Handing them back as though the author had
+ * written them makes those seven param names silently unusable, which is why
+ * `useLocalSearchParams` has always filtered them — and why `hrefFrom` refuses to
+ * SEND one: a param this layer would not read back is a param that vanishes.
+ */
+export const INTERNAL_PARAMS: ReadonlySet<string> = new Set([
+    'screen',
+    'params',
+    'initial',
+    'state',
+    'path',
+    'pop',
+    'merge',
+]);
+
+/**
+ * A param value → the string a URL can carry, or `null` for one it cannot.
+ *
+ * `null` rather than a throw, because the two callers want different things from the
+ * same answer: `paramsSeenBy` DROPS what it cannot represent (a route really can
+ * arrive carrying a dispatched object, and `useLocalSearchParams` has always left it
+ * out), while `hrefFrom` REFUSES it by name (an author writing one meant it to
+ * survive the trip).
+ */
+export const scalar = (value: unknown): string | null => {
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+    return null;
+};
+
+/**
+ * What `useLocalSearchParams` will hand back for a route carrying `params`.
+ *
+ * The OUT direction of this file's one rule. Shared with `useLocalSearchParams`
+ * itself rather than reimplemented there: two copies of "what counts as a param"
+ * would be exactly the mismatch the round-trip test exists to catch, sitting on both
+ * sides of it.
+ */
+export function paramsSeenBy(params: Readonly<Record<string, unknown>> | undefined): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(params ?? {})) {
+        if (INTERNAL_PARAMS.has(key)) continue;
+        const text = scalar(value);
+        if (text !== null) out[key] = text;
+    }
+    return out;
+}
+
+/** `/detail/[id]` → the param names it carries, in order. */
+export function patternParams(pathname: string): readonly string[] {
+    const names: string[] = [];
+    for (const segment of pathname.split('/')) {
+        if (segment.startsWith('[') && segment.endsWith(']')) names.push(segment.slice(1, -1));
+    }
+    return names;
+}
+
+/**
+ * An `Href` → the URL string the router resolves.
+ *
+ * A STRING PASSES THROUGH UNTOUCHED, which is not laziness: expo-router's string
+ * form is already a URL, params and all, and re-encoding one would double-escape a
+ * query string an author wrote by hand.
+ */
+export function hrefFrom(call: string, href: Href): string {
+    if (typeof href === 'string') return href;
+    if (typeof href !== 'object' || href === null) {
+        throw new RouterError(
+            'unresolved-href',
+            `router.${call}()`,
+            `takes a path or a { pathname, params } object, and received ${href === null ? 'null' : typeof href}. ` +
+                'This used to accept the string form only, and an object reached the router as "[object Object]" — ' +
+                'which matched no route and landed on +not-found without a word',
+        );
+    }
+    const { pathname, params } = href;
+    if (typeof pathname !== 'string' || pathname === '') {
+        throw new RouterError(
+            'unresolved-href',
+            `router.${call}()`,
+            `takes a { pathname } that is a non-empty string, and received ${typeof pathname}`,
+        );
+    }
+
+    const supplied = new Map<string, unknown>(Object.entries(params ?? {}));
+    const segments = pathname.split('/').map((segment) => {
+        if (!segment.startsWith('[') || !segment.endsWith(']')) return segment;
+        const name = segment.slice(1, -1);
+        if (name.startsWith('...')) {
+            // The route parser refuses a catch-all when it READS the file tree, for a
+            // stated reason (React Navigation's path config has no multi-segment
+            // wildcard that also carries its parts as a param). Refusing it here too
+            // keeps one answer rather than letting a pathname reach a route that
+            // cannot exist.
+            throw new RouterError(
+                'deep-dynamic-unsupported',
+                `router.${call}()`,
+                `the pathname "${pathname}" has a catch-all segment "${segment}", and this layer does not answer ` +
+                    'for catch-all routes — the file-tree parser refuses one too. Use one [param] per segment',
+            );
+        }
+        if (!supplied.has(name)) {
+            throw new RouterError(
+                'unresolved-href',
+                `router.${call}()`,
+                `the pathname "${pathname}" needs a param "${name}" and params carries ${
+                    supplied.size === 0 ? 'none' : Object.keys(params ?? {}).join(', ')
+                }. Leaving it unfilled would send the literal "${segment}" to the router, which matches no route`,
+            );
+        }
+        const value = supplied.get(name);
+        supplied.delete(name);
+        const text = scalar(value);
+        if (text === null) {
+            throw new RouterError(
+                'unresolved-href',
+                `router.${call}()`,
+                `the param "${name}" is ${Array.isArray(value) ? 'an array' : typeof value}, and a URL segment is ` +
+                    'a string. useLocalSearchParams() reads segments back as strings, so a structural value could ' +
+                    'not survive the trip in either direction',
+            );
+        }
+        return encodeURIComponent(text);
+    });
+
+    // WHAT IS LEFT OVER BECOMES A QUERY STRING, which is expo-router's own behaviour
+    // and also what makes the round trip total: `useLocalSearchParams` answers for
+    // the query half as well as the segments, so a param that did not fit the pattern
+    // still comes back.
+    const query = new URLSearchParams();
+    for (const [key, value] of supplied) {
+        if (INTERNAL_PARAMS.has(key)) {
+            throw new RouterError(
+                'unresolved-href',
+                `router.${call}()`,
+                `"${key}" is one of React Navigation's own nesting keys (${[...INTERNAL_PARAMS].join(', ')}), so ` +
+                    'useLocalSearchParams() filters it out — sending it would be a param that silently never arrives',
+            );
+        }
+        const text = scalar(value);
+        if (text === null) {
+            throw new RouterError(
+                'unresolved-href',
+                `router.${call}()`,
+                `the param "${key}" is ${Array.isArray(value) ? 'an array' : typeof value}, and a query value is ` +
+                    'a string. Serialise it, or put it in a store rather than in the URL',
+            );
+        }
+        query.append(key, text);
+    }
+    const search = query.toString();
+    return search === '' ? segments.join('/') : `${segments.join('/')}?${search}`;
+}
+
+/**
+ * The inverse: the params a URL built from `pathname` carries.
+ *
+ * Pure, and it exists for the round-trip property rather than for the runtime — the
+ * real read-back goes through React Navigation's own state. What this gives is a
+ * check the layer can run on ITSELF: whatever `hrefFrom` writes into a pattern, this
+ * reads out, and the two must agree with `paramsSeenBy`. A drift between the writer
+ * and the reader is the defect that produced this file, so it is the one thing here
+ * that is asserted rather than argued.
+ */
+export function paramsInHref(pathname: string, url: string): Record<string, string> {
+    const [path, search = ''] = url.split('?');
+    const patternSegments = pathname.split('/');
+    const urlSegments = (path ?? '').split('/');
+    const out: Record<string, string> = {};
+    for (const [index, segment] of patternSegments.entries()) {
+        if (!segment.startsWith('[') || !segment.endsWith(']')) continue;
+        const value = urlSegments[index];
+        if (value === undefined) continue;
+        out[segment.slice(1, -1)] = decodeURIComponent(value);
+    }
+    for (const [key, value] of new URLSearchParams(search)) out[key] = value;
+    return out;
+}

--- a/packages/framework/react-native/src/router/index.ts
+++ b/packages/framework/react-native/src/router/index.ts
@@ -20,6 +20,9 @@
 // cannot know: which GTK operation a stack diff is, what the widget's own `popped`
 // means, and how long a closing page has to stay mounted.
 
+export { hrefFrom, paramsInHref, paramsSeenBy, patternParams } from './href.js';
+export type { Href, HrefObject } from './href.js';
+
 export { router, usePathname, useLocalSearchParams, navigationRef } from './navigation.js';
 export { Stack, type StackProps, type StackScreenOptions } from './stack.js';
 export { Tabs, type TabsProps, type TabScreenOptions } from './tabs.js';

--- a/packages/framework/react-native/src/router/navigation.ts
+++ b/packages/framework/react-native/src/router/navigation.ts
@@ -45,6 +45,7 @@ import type { NavigationState, PartialState } from '@react-navigation/core';
 import { useSyncExternalStore } from 'react';
 
 import { RouterError } from './errors.js';
+import { hrefFrom, paramsSeenBy, type Href } from './href.js';
 import { pathConfigOf, screenUrls, type PathConfigTree, type RouteNode } from './routes.js';
 
 /** The container ref every navigator in the tree hangs under. */
@@ -207,17 +208,18 @@ function targetFor(
 }
 
 /** `push` and `replace` differ in one action name and nothing else. */
-function pushOrReplace(call: 'push' | 'replace', href: string): void {
+function pushOrReplace(call: 'push' | 'replace', target: Href): void {
+    const href = hrefFrom(call, target);
     const container = readyContainer(call);
     const { config } = required(call);
     const state = resolve(call, href);
     const chain = focusChain(state);
     const leaf = chain[chain.length - 1];
-    const target = targetFor(chain);
-    if (leaf !== undefined && target !== null && target.type === 'stack') {
+    const owner = targetFor(chain);
+    if (leaf !== undefined && owner !== null && owner.type === 'stack') {
         const action =
             call === 'push' ? StackActions.push(leaf.name, leaf.params) : StackActions.replace(leaf.name, leaf.params);
-        container.dispatch({ ...action, target: target.key });
+        container.dispatch({ ...action, target: owner.key });
         return;
     }
     // The owning navigator is not mounted, or is not a stack — PUSH and REPLACE are
@@ -230,28 +232,41 @@ function pushOrReplace(call: 'push' | 'replace', href: string): void {
 }
 
 /**
- * `expo-router`'s `router`: four methods, and every argument a URL.
+ * `expo-router`'s `router`.
  *
  * ADR 0032 measured the calls — `push` 19 times, `back` and `replace` a handful
- * each, `navigate` where a screen must not stack up. That is the whole object.
+ * each, `navigate` where a screen must not stack up.
+ *
+ * EVERY ARGUMENT IS AN `Href`, which is `string | { pathname, params }`, and the
+ * second half of that used to be missing: an object reached the router interpolated
+ * as `[object Object]`, matched no route, and landed on `+not-found` — silently, on
+ * 10 measured call sites. `href.ts` holds the resolution and the rule it shares with
+ * `useLocalSearchParams`.
+ *
+ * AND THE THREE NAMES THIS OBJECT REFUSES ARE PRESENT. The support table already
+ * called `dismiss`, `dismissAll`, `dismissTo`, `setParams` and `canGoBack` "a named
+ * refusal rather than an undefined property read" — and they were absent, so reaching
+ * for one was `router.dismissTo is not a function`, which names nothing. `canGoBack`
+ * is now answered for real, because a back button calls it before deciding whether to
+ * render at all.
  */
 export const router = {
     /** Go to `href`, adding a history entry even when that screen is already showing. */
-    push(href: string): void {
+    push(href: Href): void {
         pushOrReplace('push', href);
     },
 
     /** Go to `href`, reusing the screen when it is already the current one. */
-    navigate(href: string): void {
+    navigate(href: Href): void {
         const container = readyContainer('navigate');
         const { config } = required('navigate');
-        const state = resolve('navigate', href);
+        const state = resolve('navigate', hrefFrom('navigate', href));
         const action = getActionFromState(state, upstream(config));
         container.dispatch(action ?? CommonActions.reset(state));
     },
 
     /** Replace the current screen with `href`, leaving the history length alone. */
-    replace(href: string): void {
+    replace(href: Href): void {
         pushOrReplace('replace', href);
     },
 
@@ -275,7 +290,65 @@ export const router = {
         }
         container.dispatch(CommonActions.goBack());
     },
+
+    /**
+     * Is there anywhere to go back to?
+     *
+     * The question `back()` refuses to answer for you, and the reason it has to exist:
+     * a screen calls this to decide whether to render a back affordance AT ALL, so a
+     * missing method is a `router.canGoBack is not a function` the moment anything
+     * asks — latent until the first screen that guards its own back button.
+     *
+     * `false` BEFORE THE CONTAINER IS READY, and that is an answer rather than a
+     * placeholder: nothing has been navigated to yet, so there is genuinely nowhere to
+     * go back to. `usePathname` answers `/` in the same window for the same reason.
+     * Refusing here instead would make the guard need a guard.
+     */
+    canGoBack(): boolean {
+        if (runtime === null || !navigationRef.isReady()) return false;
+        return navigationRef.canGoBack();
+    },
+
+    /** A modal stack this layer does not have. */
+    dismiss(): never {
+        throw dismissRefusal('dismiss');
+    },
+    dismissAll(): never {
+        throw dismissRefusal('dismissAll');
+    },
+    dismissTo(): never {
+        throw dismissRefusal('dismissTo');
+    },
+
+    /**
+     * Change the current route's params without navigating.
+     *
+     * Refused rather than built, and the reason is this file's own rule: params travel
+     * INTO a route through the pattern (`href.ts`) and back OUT through
+     * `useLocalSearchParams`. `setParams` writes them at neither end — it edits the
+     * route object in place — so the URL and the params would stop agreeing, and
+     * `usePathname` would answer for a URL that no longer describes the screen.
+     */
+    setParams(): never {
+        throw new RouterError(
+            'unresolved-href',
+            'router.setParams()',
+            'edits the current route’s params in place, so the URL stops describing the screen — `usePathname()` ' +
+                'would answer for a path whose params are no longer the route’s. Navigate with ' +
+                '`router.replace({ pathname, params })` instead, which changes both together',
+        );
+    },
 } as const;
+
+/** One sentence for the three `dismiss*` names, because they have one reason. */
+const dismissRefusal = (call: string): RouterError =>
+    new RouterError(
+        'unresolved-href',
+        `router.${call}()`,
+        'dismisses a MODAL, and this layer has no modal stack to dismiss from: `<Modal>` is `planned` in the ' +
+            'support table because an `Adw.Dialog` is PRESENTED against a parent rather than parented by it, which ' +
+            'needs a portal seam the host does not have. `router.back()` pops the navigation stack',
+    );
 
 // ---------------------------------------------------------------------------
 // The two hooks
@@ -291,9 +364,6 @@ const subscribe = (onStoreChange: () => void): (() => void) => {
         listeners.delete(onStoreChange);
     };
 };
-
-/** React Navigation's own nesting keys, which are not the author's params. */
-const INTERNAL_PARAMS: ReadonlySet<string> = new Set(['screen', 'params', 'initial', 'state', 'path', 'pop', 'merge']);
 
 const currentPathname = (): string => {
     const state = liveRootState();
@@ -340,12 +410,9 @@ export function usePathname(): string {
  */
 export function useLocalSearchParams<T extends Record<string, string> = Record<string, string>>(): Partial<T> {
     const route = useRoute();
-    const params = (route.params ?? {}) as Record<string, unknown>;
-    const out: Record<string, string> = {};
-    for (const [key, value] of Object.entries(params)) {
-        if (INTERNAL_PARAMS.has(key)) continue;
-        if (typeof value === 'string') out[key] = value;
-        else if (typeof value === 'number' || typeof value === 'boolean') out[key] = String(value);
-    }
-    return out as Partial<T>;
+    // `paramsSeenBy` and NOT a filter written here: it is the same rule `hrefFrom`
+    // applies when it writes params INTO a pattern, and two copies of "what counts as
+    // a param" on opposite sides of a round trip is precisely the mismatch that round
+    // trip exists to catch.
+    return paramsSeenBy(route.params as Record<string, unknown> | undefined) as Partial<T>;
 }

--- a/packages/framework/react-native/src/router/router.spec.ts
+++ b/packages/framework/react-native/src/router/router.spec.ts
@@ -571,6 +571,87 @@ export default async () => {
                 });
             });
 
+            await it('pushes the OBJECT form, and the params reach the screen', async () => {
+                // THE DEFECT, end to end. `router.push({ pathname, params })` used to
+                // interpolate as "[object Object]", match no route and land on
+                // +not-found — no build error, no throw, 10 measured call sites. This
+                // is the round trip `href.spec.ts` asserts in the pure half, driven
+                // through React Navigation and the widget instead.
+                await mounted(app(), async (container) => {
+                    const view = find(container, 'AdwNavigationView') as Adw.NavigationView;
+                    router.push({ pathname: '/detail/[id]', params: { id: '7' } });
+                    const turns = await settle(() => stackTitles(view).length === 2);
+                    expect(turns >= 0).toBe(true);
+                    expect(stackTitles(view)).toStrictEqual(['Home', 'Detail']);
+                    expect(observed.params).toStrictEqual({ id: '7' });
+                    expect(observed.pathname).toBe('/detail/7');
+                });
+            });
+
+            await it('carries a leftover param through the query string', async () => {
+                // The half a segment cannot hold. `useLocalSearchParams` answers for
+                // the query as well, so the round trip stays total: what the pattern
+                // has no slot for still arrives.
+                await mounted(app(), async (container) => {
+                    const view = find(container, 'AdwNavigationView') as Adw.NavigationView;
+                    router.push({ pathname: '/detail/[id]', params: { id: '7', tab: 'reviews' } });
+                    await settle(() => stackTitles(view).length === 2);
+                    expect(observed.params).toStrictEqual({ id: '7', tab: 'reviews' });
+                    // The PATH is the path — expo-router splits the query off, and so
+                    // does `usePathname`.
+                    expect(observed.pathname).toBe('/detail/7');
+                });
+            });
+
+            await it('takes the object form on replace and navigate too', async () => {
+                await mounted(app(), async (container) => {
+                    const view = find(container, 'AdwNavigationView') as Adw.NavigationView;
+                    router.push({ pathname: '/detail/[id]', params: { id: '7' } });
+                    await settle(() => stackTitles(view).length === 2);
+                    router.replace({ pathname: '/detail/[id]', params: { id: '8' } });
+                    await settle(() => observed.params.id === '8');
+                    expect(stackTitles(view)).toStrictEqual(['Home', 'Detail']);
+                    router.navigate({ pathname: '/' });
+                    await settle(() => observed.pathname === '/');
+                    expect(observed.pathname).toBe('/');
+                });
+            });
+
+            await it('answers canGoBack, which is how a back button decides to exist', async () => {
+                // Absent until now, so a consumer's `goBack` helper carried a latent
+                // `router.canGoBack is not a function` — reached the moment anything
+                // asked before popping.
+                await mounted(app(), async (container) => {
+                    const view = find(container, 'AdwNavigationView') as Adw.NavigationView;
+                    expect(router.canGoBack()).toBe(false);
+                    router.push('/detail/7');
+                    await settle(() => stackTitles(view).length === 2);
+                    expect(router.canGoBack()).toBe(true);
+                    router.back();
+                    await settle(() => stackTitles(view).length === 1);
+                    expect(router.canGoBack()).toBe(false);
+                });
+            });
+
+            await it('refuses the dismiss family and setParams BY NAME, as the table says', async () => {
+                // The table already called these "a named refusal rather than an
+                // undefined property read" — and they were absent, so reaching for one
+                // was `router.dismissTo is not a function`, which names nothing.
+                await mounted(app(), () => {
+                    for (const call of ['dismiss', 'dismissAll', 'dismissTo', 'setParams'] as const) {
+                        const member = (router as unknown as Record<string, () => void>)[call];
+                        expect(typeof member).toBe('function');
+                        let message = '';
+                        try {
+                            member();
+                        } catch (error) {
+                            message = (error as Error).message;
+                        }
+                        expect(message).toContain(`router.${call}()`);
+                    }
+                });
+            });
+
             await it('uses the ROUTE KEY as the widget tag, which is the join', async () => {
                 await mounted(app(), async (container) => {
                     const view = find(container, 'AdwNavigationView') as Adw.NavigationView;

--- a/packages/framework/react-native/src/support-table.ts
+++ b/packages/framework/react-native/src/support-table.ts
@@ -680,12 +680,14 @@ export const ROUTER_SUPPORT_TABLE: Readonly<Record<string, SupportEntry>> = {
         status: 'partial',
         tier: 'P1',
         gtk: 'Adw.NavigationView (push/pop) via React Navigation’s StackActions',
-        reason: 'push, back, replace and navigate — the four methods the measured application calls, 19 of the 27 calls being push.',
+        reason: 'push, back, replace, navigate and canGoBack. Every href-taking method accepts BOTH argument shapes — a path string and expo-router’s { pathname, params } object.',
         limits: [
+            'ARGUMENT SHAPES, because naming only the methods is the half that let a defect through: push/navigate/replace take `string | { pathname, params }`; back() and canGoBack() take nothing. A params value is a string, a number or a boolean — anything structural is refused by name, because a URL segment is a string and useLocalSearchParams reads it back as one. Params the pattern has no slot for become a query string, which useLocalSearchParams also answers for, so the round trip is total.',
+            'The object form used to be missing and it did NOT throw: it interpolated as "[object Object]", so the push succeeded, no route matched, and every parameterised navigation landed on +not-found — 10 call sites in one measured application. `hrefFrom` and `useLocalSearchParams` now share one definition of what a param is, so a drift between writing and reading is a defect the layer detects in itself.',
             'push falls back to NAVIGATE when the navigator that owns the target is not mounted yet. StackActions.push is dispatched at ONE navigator and an href can name a screen several navigators down; for an unmounted navigator, arriving there IS the new entry, so the fallback is correct rather than approximate — but a push into a mounted navigator that is not a stack cannot add an entry, because PUSH is the stack router’s action and no other router answers it.',
-            'back() THROWS when there is nothing to go back to, where expo-router and React Navigation both return quietly. A quiet return is a back button that does nothing with no message, which is the silent drop this layer refuses everywhere else.',
-            'setParams, dismiss, dismissAll, dismissTo and canGoBack are not implemented. They are not in the measured surface, and each is a named refusal rather than an undefined property read.',
-            'An href is a path. expo-router also accepts an object form ({ pathname, params }); this layer takes the string, which is what all 27 measured calls pass.',
+            'back() THROWS when there is nothing to go back to, where expo-router and React Navigation both return quietly. A quiet return is a back button that does nothing with no message, which is the silent drop this layer refuses everywhere else. canGoBack() is the question that lets a caller avoid it, and it answers false before the container is ready — nothing has been navigated to yet, so there is genuinely nowhere to go back to.',
+            'setParams, dismiss, dismissAll and dismissTo are present functions that THROW with their reason. The dismiss family needs a modal stack this layer has no portal seam for (see Modal); setParams edits the current route’s params in place, so the URL would stop describing the screen and usePathname would answer for a path that is no longer the route’s — replace({ pathname, params }) changes both together.',
+            'A catch-all pathname ([...rest]) is refused, with the file-tree parser’s own reason: React Navigation’s path config has no multi-segment wildcard that also carries its parts as a param.',
         ],
     },
     useLocalSearchParams: {

--- a/packages/framework/react-native/src/test.mts
+++ b/packages/framework/react-native/src/test.mts
@@ -6,6 +6,7 @@ import listsSuite from './lists/lists.spec.js';
 import classesSuite from './primitives/classes.spec.js';
 import primitivesSuite from './primitives/primitives.spec.js';
 import widgetsSuite from './primitives/widgets.spec.js';
+import hrefSuite from './router/href.spec.js';
 import routerWidgetsSuite from './router/router.spec.js';
 import routesSuite from './router/routes.spec.js';
 import solidSuite from './solid/solid.spec.js';
@@ -24,6 +25,7 @@ run({
     widgetsSuite,
     listsSuite,
     solidSuite,
+    hrefSuite,
     routesSuite,
     routerWidgetsSuite,
 });

--- a/scripts/posix-path-slice-exceptions.mjs
+++ b/scripts/posix-path-slice-exceptions.mjs
@@ -29,6 +29,12 @@ export const POSIX_PATH_SLICE_EXCEPTIONS = {
         'Module SPECIFIERS as written in import statements. ESM specifiers are `/`-separated by ' +
         'the resolution spec regardless of host, which is why a Windows import still reads ' +
         '`@gjsify/fs`, never `@gjsify\\fs`.',
+    'packages/framework/react-native/src/router/href.ts':
+        'An expo-router ROUTE PATTERN (`/detail/[id]`) and the URL built from it. Both are URL ' +
+        'pathname grammar — `/`-separated by RFC 3986 on every host — and the pattern half is ' +
+        'additionally expo-router’s own file-convention spelling, which is `/` even when the ' +
+        'route files sit in a Windows directory tree. Nothing here ever reaches a filesystem: ' +
+        'the segments become React Navigation path-config keys.',
     'packages/infra/npm-registry/src/auth.ts':
         'A `URL.pathname`, already normalised to `/` by the URL parser before this code sees it.',
     'packages/node/fs/src/browser/opfs.ts':


### PR DESCRIPTION
Closes #1452.

`expo-router`'s `router.push` accepts `string | { pathname, params }`. This layer
accepted the string only — and the object form was **not** a build error and **not** a
throw. It interpolated as `[object Object]`, so the push succeeded, no route matched,
and **every parameterised navigation landed on `+not-found`**. Measured: 10 call sites
in one application, every one a detail screen reached with a parameter.

That is worse than the silent no-ops this layer is built to refuse: it navigated
somewhere wrong.

## The fix is written so the layer can catch this class in itself

`hrefFrom` writes params **into** a pattern; `useLocalSearchParams` reads them back
**out**. They are the same rule about what a param is, so they now go through one
definition (`paramsSeenBy`) instead of two — because two copies of that rule sitting
on opposite sides of a round trip is exactly the mismatch the round trip exists to
catch.

- a scalar becomes a string; anything structural is refused **by name on both sides**,
  because a URL segment is a string and the reader hands one back
- params the pattern has no slot for become a **query string**, which the reader also
  answers for, so the trip is total
- one of React Navigation's seven nesting keys (`screen`, `params`, `initial`, …) is
  refused as a param name — the read side filters them, so sending one is a param that
  silently never arrives

`href.spec.ts` asserts the property over ten shapes rather than a list of examples:
numbers, booleans, a slash in the value, an ampersand, non-ASCII, leftovers, no params
at all — and **two patterns filled out of order**, which is where an implementation
that substituted by position instead of by name comes apart while passing every
one-param test. `router.spec.ts` drives the same trip through React Navigation and the
`Adw.NavigationView`, which is the half a pure test cannot prove.

The pure half imports no React Navigation, no React and no `gi://`, so the property
runs with nothing mounted.

## `canGoBack()`

It is how a screen decides whether to render a back affordance **at all**, so its
absence was a latent `router.canGoBack is not a function` in every consumer's `goBack`
helper — reached the moment anything asked before popping.

It answers `false` before the container is ready, and that is an answer rather than a
placeholder: nothing has been navigated to yet, so there is genuinely nowhere to go
back to. `usePathname` answers `/` in the same window for the same reason. Refusing
there would make the guard need a guard.

## The table's claim about the dismiss family is now true

It already said `setParams`, `dismiss`, `dismissAll`, `dismissTo` and `canGoBack` were
"a named refusal rather than an undefined property read". **They were absent**, so
reaching for one was `router.dismissTo is not a function`, which names nothing. All
four are now present functions that throw with their own reason — the dismiss family
because there is no modal stack to dismiss from (`<Modal>` is `planned` for the portal
reason), `setParams` because it edits the route's params in place, so the URL would
stop describing the screen and `usePathname` would answer for a path that is no longer
the route's.

## The table entry describes ARGUMENT SHAPES now

That is the half that would have caught this before an application did. The old entry
said "push, back, replace and navigate — the four methods the measured application
calls", which is true about the method **names** and silent about what they accept.

## Broken to watch it go red

Restoring the original defect — `hrefFrom` returning `String(href)` — turns **seven**
vectors red, including the round trip and every named refusal. The by-name
substitution vector fails on its own if the implementation walks pattern and values in
parallel.

## Measurements

gjs **941/941 green**; node leg **2 of 937**, both the named #1438 baseline failures
(`Gtk.ListItem` `list_properties`, `Adw.NavigationView` `popped`) — this branch adds
none. `check-rn-surface` green, `gjsify lint` exit 0. Branched from `254eb9ce4`.

Not in scope, and left as the issue describes them: `dismissTo` stays a refusal
because it presumes a modal stack, and catch-all pathnames (`[...rest]`) are refused
with the file-tree parser's own reason rather than half-implemented.
