### PR TITLE
fix(scripts): pin every gi:// import to a version

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -185,6 +185,16 @@ jobs:
       - name: Check the CLI reads its own version through one resolver
         run: node scripts/check-cli-own-version-read.mjs
 
+      # `import Gtk from 'gi://Gtk'` asks the loader for whichever Gtk it finds first.
+      # The tree already pinned almost everywhere — 83 GLib, 83 Gio, 72 Gtk — and held
+      # nothing, so 52 unpinned ones sat among them. For Gio/GObject/Pango exactly one
+      # version is installed and they resolved correctly; the case that is not
+      # hypothetical is WebKit2-4.1 beside WebKit-6.0, where the wrong pick loads a
+      # second toolkit into the same address space. A rule that covers only the
+      # namespace someone was already bitten by covers the wrong set.
+      - name: Check every gi:// import states its version
+        run: node scripts/check-gi-import-versions.mjs
+
       # Comment volume has no natural limit, so nothing failed while `cli-fail.ts` grew
       # a 47-line yargs research diary above a 3-line function (ratio 9.3), while
       # `rolldown-plugin-gjsify` reached one comment line per code line, or while

--- a/docs/code-anti-patterns.md
+++ b/docs/code-anti-patterns.md
@@ -23,7 +23,7 @@ Recurring shapes LLM-written code gets wrong (cf. GNOME reviewers' list, 2026-07
 |**try/catch around a call that cannot throw.** Before wrapping, answer: *can this block throw at all?* For GI calls read the GIR — only `throws="1"` functions raise a GError→JS exception; a method that reports failure via a return code cannot throw, and "best-effort" is ignoring a return value, not wrapping a non-throwing call. A kept catch must STATE ITS REASON. Measured (#880, the `eslint/no-empty` sweep): the empty catch around the http2 teardown GOAWAY flush hid that the flush never wrote (the flag it was called after made it early-return — the peer only ever saw a bare FIN); try/catches around `GLib.Source.destroy` (no throw path) and around SessionBridge calls that report via return codes were deleted; the legitimate swallows (Gio close/shutdown on an already-dead peer, temp-cert cleanup, spec teardown) now say why. `eslint/no-empty` is `error` — a bare `catch {}` does not land. The worst variant swallows a `ReferenceError` from a missing binding into a silent wrong answer (see the `crypto` `Math.random()` incident above and § CJS-ESM rule 1).
 |**paranoid probes for what the workspace guarantees.** Redundant `x?.m?.()` / `typeof x.m === 'function'` on our own classes or lockfile-pinned deps is written to span versions that don't coexist here, and it hides real bugs as silent no-calls. The SANCTIONED probes are the documented ones: register existence guards (§ Tree-shakeable globals rule 2), host-runtime detection (`isGjs()`/`isNode()` single source § Build; the `globalThis.imports?.gi` probe shape; NS `typeof java !== 'undefined'`), optional native-bridge loads (`imports.gi.GjsifyX` in try/catch — the typelib genuinely may be absent), `isNativeStreamUsable` before replacing a native stream. Each guards a REAL per-runtime/per-install variance and says so at the site. Everything else: import it and call it.
 |**comments that restate the code.** Comment WHY, never WHAT — a restating comment is a second copy the reviewer must diff against the code, and their drift reads as documentation while being a bug. JSDoc for public APIs; trivial/internal code stays bare.
-|**duplication instead of a helper.** The SECOND copy is where you lift a helper — copies drift, and the drifted copy fails in a CONSUMER while the owning package's tests stay green. Measured (#869): the root-relative-URL rewrite existed hand-written in three packages, and the drifted one (`fetch`) broke every root-relative fetch on node while its siblings worked; the entropy chain was two locally-defensible copies wrong in composition (webcrypto row). The literal line `app.runAsync([imports.system.programInvocationName, ...ARGV])` is currently triplicated across `storybook`/`devtools-browser`/`adwaita-app` — a consolidation target, not a pattern to extend. The lift targets exist and are the pattern: `@gjsify/utils/core`, `storybook-core`, `adwaita-app` are each "the helper the copies forced".
+|**duplication instead of a helper.** The SECOND copy is where you lift a helper — copies drift, and the drifted copy fails in a CONSUMER while the owning package's tests stay green. Measured (#869): the root-relative-URL rewrite existed hand-written in three packages, and the drifted one (`fetch`) broke every root-relative fetch on node while its siblings worked; the entropy chain was two locally-defensible copies wrong in composition (webcrypto row). The literal line `app.runAsync([imports.system.programInvocationName, ...ARGV])` is currently triplicated across `storybook`/`devtools-browser`/`adwaita-app` — a consolidation target, not a pattern to extend. The lift targets exist and are the pattern: `@gjsify/utils/core`, `storybook-core`, `adwaita-app` are each "the helper the copies forced". The eight-copy comment stripper below is the same story with a reader instead of a rewriter.
 |**scattered lifecycle.** Init and teardown live together: cleanup beside creation, ownership in ONE place, wired to the exit the host actually HAS — and teardown must not assume the process lives long enough. Measured: the GStreamer pipeline registry (webaudio row) exists because per-call-site `set_state(NULL)` could not fix teardown spread over sites with process-lifetime assumptions; `decodeAudioDataSync` tears down in `finally` so a throw cannot leak a PLAYING pipeline. No `_destroyed`/`_enabled` boolean flags where nulling the reference says the same and cannot desync; release children BEFORE chaining up to the parent's destroy, never after.
 |**shelling out where an API exists.** A spawned command line is an injection surface and a quoting-bug factory. Standing in-repo counter-example (fix at next touch, never copy): `@gjsify/fs`'s GJS `linkSync`/`link` run ``GLib.spawn_command_line_sync(`ln ${existing} ${new}`)`` — unquoted interpolation, so a path with a space or shell metachar breaks or injects (`packages/node/fs/src/{sync,callback}.ts`). When a subprocess IS the job, pass an argv array (`Gio.Subprocess`), never an interpolated command line.
 |**monolithic entry points.** `index.ts` = barrel re-exports only; commands/views/features are modules composed by a thin entry. A class owning bootstrap AND business logic AND IO is three classes.
@@ -218,3 +218,44 @@ the one a user installs.
 The resolver's own doc comment already said "deliberately NOT a fixed
 `../../package.json` read", and a fourth copy grew beside it regardless. Prose
 does not fail a PR; the check does.
+
+## A comment stripper written as two regexes
+
+Every static check that reads source has to blank comments first, or it reports a
+name that appears only in prose. The obvious implementation is two passes —
+`.replace(/\/\*[\s\S]*?\*\//g, '')` and `.replace(/\/\/[^\n]*/g, '')` — and nine
+readers in this repository each wrote their own.
+
+Neither regex can tell a comment from a string, so the ORDER of the two decides
+which half of the tree goes invisible, and BOTH orders are wrong:
+
+- **block comments first** lets a line comment ending in `/*` — `@girs/*`,
+  `packages/*`, `src/*`, all common here — pair with the next `*/` anywhere below,
+  usually the opening of the following JSDoc. Everything between is blanked.
+- **line comments first** lets a block comment CONTAINING a `//` lose its
+  terminator, after which the `/*` pairs with the next `*/` instead and swallows
+  the declaration under it. `packages/infra/npm-registry/src/types.ts` documents a
+  field as keyed by a `//host/path/:` prefix; under that order its `authTokens`
+  declaration disappears.
+
+Neither can see a glob pattern in a string either: `globSync('**/*.ts')` opens a
+fake block comment in `packages/node/fs/src/glob.spec.ts` whichever way round the
+passes go, and the two orders simply blank different halves of the file.
+
+Measured 2026-09-01 over the 3642 tracked JS/TS sources, against the stateful
+scanner as ground truth: **block-first hid 7780 code lines in 226 files;
+line-first hid 3503 in 104.** Swapping the order halves a class it cannot close.
+
+A reader that sees nothing reports nothing, and that is indistinguishable from a
+clean tree — the whole class is a green run that checked nothing. It had
+already been paid for once: `check-adapter-import-direction.mjs` rewrote its
+stripper as a stateful scanner after a regex read `const re = /[/*]/;` as an open
+block comment that ran to EOF, and the run printed
+"1 adapter(s) carry no widget knowledge", exit 0, over a live violation.
+
+**The one implementation is
+[`packages/infra/manifest-conformance/lib/strip-comments.mjs`](../packages/infra/manifest-conformance/lib/strip-comments.mjs)** —
+a lexical scanner that knows strings, template holes and regex literals, keeps
+every non-comment byte and every line boundary, and hides 0 code lines. Its
+self-test runs on IMPORT, with one vector per shape, so every consumer inherits
+the proof. Do not write a ninth copy; import it.

--- a/docs/poc/tla-microtask-draining.gjs.mjs
+++ b/docs/poc/tla-microtask-draining.gjs.mjs
@@ -16,8 +16,8 @@
 // Exit code 0 = every scenario behaved as documented on this GJS; non-zero =
 // a scenario regressed (the expectation no longer holds on this runtime).
 
-import GLib from 'gi://GLib';
-import Gio from 'gi://Gio';
+import GLib from 'gi://GLib?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
 
 const system = imports.system;
 

--- a/install.mjs
+++ b/install.mjs
@@ -18,8 +18,8 @@
  * GJSIFY_INSTALL_BOOTSTRAP_CACHE.
  */
 
-import GLib from 'gi://GLib';
-import Gio from 'gi://Gio';
+import GLib from 'gi://GLib?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
 import system, { exit } from 'system';
 
 /**

--- a/packages/dom/canvas2d-core/src/canvas-rendering-context-2d.ts
+++ b/packages/dom/canvas2d-core/src/canvas-rendering-context-2d.ts
@@ -9,8 +9,8 @@
 import Cairo from 'cairo';
 // `gi://`, not the legacy `imports.gi` global: the portable spelling also resolves on the
 // `--app node` reverse bridge (AGENTS.md § The legacy imports.* object is NOT an API).
-import Gio from 'gi://Gio';
-import GLib from 'gi://GLib';
+import Gio from 'gi://Gio?version=2.0';
+import GLib from 'gi://GLib?version=2.0';
 
 // Bare side-effect import so the method groups' `declare module` augmentations survive into the
 // emitted .d.ts — tsc keeps bare imports but strips the value-only one at the bottom, and without

--- a/packages/dom/canvas2d-core/src/context/text-rendering.ts
+++ b/packages/dom/canvas2d-core/src/context/text-rendering.ts
@@ -5,8 +5,8 @@
 // Original: see canvas-rendering-context-2d.ts pre-split.
 
 import Cairo from 'cairo';
-import Pango from 'gi://Pango';
-import PangoCairo from 'gi://PangoCairo';
+import Pango from 'gi://Pango?version=1.0';
+import PangoCairo from 'gi://PangoCairo?version=1.0';
 
 import type { CanvasRenderingContext2D } from '../canvas-rendering-context-2d.js';
 import { parseColor } from '../color.js';

--- a/packages/dom/canvas2d-core/src/gdk-pixel-bridge.ts
+++ b/packages/dom/canvas2d-core/src/gdk-pixel-bridge.ts
@@ -5,7 +5,7 @@
 // `package.json#sideEffects` (AGENTS.md § Tree-shakeable globals).
 
 import Gdk from 'gi://Gdk?version=4.0';
-import GdkPixbuf from 'gi://GdkPixbuf';
+import GdkPixbuf from 'gi://GdkPixbuf?version=2.0';
 import type Cairo from 'cairo';
 
 import { type CanvasImageHandle, type CanvasPixelBridge, setCanvasPixelBridge } from './pixel-bridge.js';

--- a/packages/framework/adwaita-react-native/src/widgets/clamp.gtk.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/clamp.gtk.spec.tsx
@@ -36,7 +36,7 @@
 import Adw from 'gi://Adw?version=1';
 import Gdk from 'gi://Gdk?version=4.0';
 import GLib from 'gi://GLib?version=2.0';
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 import { afterEach, beforeEach, describe, expect, it, on, type Runtime } from '@gjsify/unit';
 import { registerBuiltinWidgets, shotEvidence, blankReason, type CaptureWidget } from '@gjsify/gtk-host';

--- a/packages/framework/canvas2d/src/canvas2d-bridge.ts
+++ b/packages/framework/canvas2d/src/canvas2d-bridge.ts
@@ -1,6 +1,6 @@
 // A Gtk.DrawingArea subclass carrying the Canvas 2D bootstrapping, Cairo-backed.
 
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import type Gdk from 'gi://Gdk?version=4.0';
 import GLib from 'gi://GLib?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';

--- a/packages/framework/gtk-host/src/adapters/react.spec.ts
+++ b/packages/framework/gtk-host/src/adapters/react.spec.ts
@@ -25,7 +25,7 @@
 
 import { expect, it, on } from '@gjsify/unit';
 
-import GLib from 'gi://GLib';
+import GLib from 'gi://GLib?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 import Reconciler from 'react-reconciler';
 import { ConcurrentRoot } from 'react-reconciler/constants.js';

--- a/packages/framework/gtk-host/src/conformance/diagnostics.ts
+++ b/packages/framework/gtk-host/src/conformance/diagnostics.ts
@@ -9,7 +9,7 @@
 // Every adapter's vectors should install this. A renderer that emits a critical
 // has not "worked with a warning"; it has produced a tree GTK refused.
 
-import GLib from 'gi://GLib';
+import GLib from 'gi://GLib?version=2.0';
 
 /**
  * Declared locally, deliberately: this module is GJS-only, and `console.error`

--- a/packages/framework/gtk-host/src/conformance/index.ts
+++ b/packages/framework/gtk-host/src/conformance/index.ts
@@ -11,7 +11,7 @@ export {
 // describe the GTK that is actually installed, and a vector must read the REAL
 // widget tree — never our shadow tree, which would happily agree with itself.
 
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import type Gtk from '@girs/gtk-4.0';
 
 import { BUILTIN_DESCRIPTORS } from '../descriptors/index.js';

--- a/packages/framework/gtk-host/src/generated.spec.ts
+++ b/packages/framework/gtk-host/src/generated.spec.ts
@@ -15,7 +15,7 @@
 import { expect, it, on } from '@gjsify/unit';
 
 import Adw from 'gi://Adw?version=1';
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 
 import { installDiagnosticsGate } from './conformance/index.js';

--- a/packages/framework/gtk-host/src/generator/main.mts
+++ b/packages/framework/gtk-host/src/generator/main.mts
@@ -21,8 +21,8 @@
  * whether every generated name is real.
  */
 
-import Gio from 'gi://Gio';
-import GLib from 'gi://GLib';
+import Gio from 'gi://Gio?version=2.0';
+import GLib from 'gi://GLib?version=2.0';
 import system from 'system';
 
 import { methodsOf } from '../conformance/index.js';

--- a/packages/framework/gtk-host/src/host.spec.ts
+++ b/packages/framework/gtk-host/src/host.spec.ts
@@ -8,7 +8,7 @@
 import { expect, it, on } from '@gjsify/unit';
 
 import Adw from 'gi://Adw?version=1';
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 
 import { dumpTree, gtkChildTypes, gtkChildren, installDiagnosticsGate } from './conformance/index.js';

--- a/packages/framework/gtk-host/src/host.ts
+++ b/packages/framework/gtk-host/src/host.ts
@@ -6,7 +6,7 @@
 // and the Svelte custom-renderer PR's 19 attribute-shaped methods. Anything an
 // adapter needs beyond these is that framework's own tax and lives in its file.
 
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import type Gtk from '@girs/gtk-4.0';
 
 import { err, GtkHostError } from './errors.js';

--- a/packages/framework/gtk-host/src/list/controller.ts
+++ b/packages/framework/gtk-host/src/list/controller.ts
@@ -49,8 +49,8 @@
 //
 // Values through `gi://`, types through `@girs/*`.
 
-import Gio from 'gi://Gio';
-import GObject from 'gi://GObject';
+import Gio from 'gi://Gio?version=2.0';
+import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 
 /**

--- a/packages/framework/gtk-host/src/list/list.spec.ts
+++ b/packages/framework/gtk-host/src/list/list.spec.ts
@@ -20,7 +20,7 @@
 // whichever of the two a dialect takes; a spec that reached for a flush seam would be
 // testing a shortcut and would go green against either.
 
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 import { expect, it, on } from '@gjsify/unit';
 

--- a/packages/framework/gtk-host/src/probe.ts
+++ b/packages/framework/gtk-host/src/probe.ts
@@ -24,7 +24,7 @@
 // waits) otherwise proves nothing beyond "it started".
 
 import Adw from 'gi://Adw?version=1';
-import GLib from 'gi://GLib';
+import GLib from 'gi://GLib?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 import system from 'system';
 

--- a/packages/framework/gtk-host/src/props.spec.ts
+++ b/packages/framework/gtk-host/src/props.spec.ts
@@ -2,7 +2,7 @@
 
 import { expect, it, on } from '@gjsify/unit';
 
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 // Type position only — the descriptors pull Adw in for value use themselves.
 import type Adw from 'gi://Adw?version=1';

--- a/packages/framework/gtk-host/src/props.ts
+++ b/packages/framework/gtk-host/src/props.ts
@@ -4,11 +4,11 @@
 // runtime says what a value must look like. That split is deliberate: the table
 // travels with the package, the coercion travels with the user's GTK.
 
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 import Adw from 'gi://Adw?version=1';
 import Gdk from 'gi://Gdk?version=4.0';
-import Pango from 'gi://Pango';
+import Pango from 'gi://Pango?version=1.0';
 
 import { err } from './errors.js';
 import type { WidgetDescriptor } from './types.js';

--- a/packages/framework/gtk-host/src/registry.ts
+++ b/packages/framework/gtk-host/src/registry.ts
@@ -9,7 +9,7 @@
 // with nothing to scan would have reported green while proving nothing, which is the
 // failure class this repo pays most for.
 
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 
 import { err } from './errors.js';
 import { tagOf } from './tags.js';

--- a/packages/framework/gtk-host/src/style/gtk-props.spec.ts
+++ b/packages/framework/gtk-host/src/style/gtk-props.spec.ts
@@ -13,7 +13,7 @@
 // universal one because `orientation` is not on `Gtk.Widget`. A table that only
 // asserted presences would agree with a GTK in which all three were false.
 
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 import { expect, it, on } from '@gjsify/unit';
 

--- a/packages/framework/gtk-host/src/style/theme.spec.ts
+++ b/packages/framework/gtk-host/src/style/theme.spec.ts
@@ -16,7 +16,7 @@
 // resolved value is the truth, the pixel is a picture of a cache.
 
 import Gdk from 'gi://Gdk?version=4.0';
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import Adw from 'gi://Adw?version=1';
 import Gtk from 'gi://Gtk?version=4.0';
 import { expect, it, on } from '@gjsify/unit';

--- a/packages/framework/iframe/src/iframe-bridge.ts
+++ b/packages/framework/iframe/src/iframe-bridge.ts
@@ -1,7 +1,7 @@
 // A WebKit.WebView subclass carrying the bootstrapping for HTMLIFrameElement.
 
 import GLib from 'gi://GLib?version=2.0';
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import WebKit from 'gi://WebKit?version=6.0';
 
 import { Document, notifyElementResize } from '@gjsify/dom-elements';

--- a/packages/framework/react-native/src/animated/animated.spec.ts
+++ b/packages/framework/react-native/src/animated/animated.spec.ts
@@ -23,7 +23,7 @@
 // behaviour a desktop actually shows when animations are switched off.
 
 import Gtk from 'gi://Gtk?version=4.0';
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import { afterEach, beforeEach, describe, expect, it, on, type Runtime } from '@gjsify/unit';
 import { registerBuiltinWidgets } from '@gjsify/gtk-host';
 import { gtkChildren, installDiagnosticsGate } from '@gjsify/gtk-host/conformance';

--- a/packages/framework/react-native/src/components.ts
+++ b/packages/framework/react-native/src/components.ts
@@ -29,7 +29,7 @@
 // signal arguments at all. L2 says WHICH widget property holds the value
 // (`ResolvedEvent.read`); this file reads it off the widget its ref holds.
 
-import Gio from 'gi://Gio';
+import Gio from 'gi://Gio?version=2.0';
 import {
     Children,
     createElement,

--- a/packages/framework/react-native/src/lists/lists.spec.ts
+++ b/packages/framework/react-native/src/lists/lists.spec.ts
@@ -20,7 +20,7 @@
 // a nested root cannot flush). Awaiting a freshly queued microtask is what makes the
 // real path observable — not a synchronous flush seam, which would test a shortcut.
 
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 import { afterEach, beforeEach, describe, expect, it, on, type Runtime } from '@gjsify/unit';
 import { lookupWidget, paramSpecs, registerBuiltinWidgets } from '@gjsify/gtk-host';

--- a/packages/framework/react-native/src/primitives/defaults.spec.ts
+++ b/packages/framework/react-native/src/primitives/defaults.spec.ts
@@ -11,7 +11,7 @@
 // a `widgetProps` entry with no row fails, and a row that stops being true fails.
 
 import Gtk from 'gi://Gtk?version=4.0';
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import { afterEach, beforeEach, describe, expect, it, on, type Runtime } from '@gjsify/unit';
 import { lookupEnumNick, registerBuiltinWidgets } from '@gjsify/gtk-host';
 import { gtkChildren, installDiagnosticsGate } from '@gjsify/gtk-host/conformance';

--- a/packages/framework/react-native/src/primitives/widgets.spec.ts
+++ b/packages/framework/react-native/src/primitives/widgets.spec.ts
@@ -25,7 +25,7 @@
 // the blame surfaced twelve tests later on an innocent neighbour.
 
 import Gdk from 'gi://Gdk?version=4.0';
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 import { afterEach, beforeEach, describe, expect, it, on, type Runtime } from '@gjsify/unit';
 import { lookupWidget, paramSpecs, registerBuiltinWidgets } from '@gjsify/gtk-host';

--- a/packages/framework/react-native/src/router/router.spec.ts
+++ b/packages/framework/react-native/src/router/router.spec.ts
@@ -21,8 +21,8 @@
 // describe #15 printed to stderr, the case still reported a tick, and the blame
 // surfaced twelve tests later on an innocent neighbour.
 
-import GLib from 'gi://GLib';
-import GObject from 'gi://GObject';
+import GLib from 'gi://GLib?version=2.0';
+import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 import { afterEach, beforeEach, describe, expect, it, on, type Runtime } from '@gjsify/unit';
 import { lookupWidget, registerBuiltinWidgets } from '@gjsify/gtk-host';

--- a/packages/framework/react-native/src/solid/solid.spec.ts
+++ b/packages/framework/react-native/src/solid/solid.spec.ts
@@ -29,7 +29,7 @@
 // renders a perfect initial tree and then has no reactivity at all, with no error.
 // A render-only smoke test passes against it; only an update can tell the two apart.
 
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 import { afterEach, beforeEach, describe, expect, it, on, type Runtime } from '@gjsify/unit';
 import { registerBuiltinWidgets } from '@gjsify/gtk-host';

--- a/packages/framework/react-native/src/surfaces/async-storage.ts
+++ b/packages/framework/react-native/src/surfaces/async-storage.ts
@@ -36,8 +36,8 @@
 // application exists — so a read before the application is constructed throws by name
 // rather than writing to a directory called `gjs`.
 
-import GLib from 'gi://GLib';
-import Gio from 'gi://Gio';
+import GLib from 'gi://GLib?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
 
 import { PrimitiveError } from '../primitives/errors.js';
 

--- a/packages/framework/react-native/src/surfaces/surfaces.spec.ts
+++ b/packages/framework/react-native/src/surfaces/surfaces.spec.ts
@@ -20,9 +20,9 @@
 
 import Gdk from 'gi://Gdk?version=4.0';
 import Gtk from 'gi://Gtk?version=4.0';
-import GLib from 'gi://GLib';
-import Gio from 'gi://Gio';
-import GObject from 'gi://GObject';
+import GLib from 'gi://GLib?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
+import GObject from 'gi://GObject?version=2.0';
 import PangoCairo from 'gi://PangoCairo?version=1.0';
 import { afterEach, beforeEach, describe, expect, it, on, type Runtime } from '@gjsify/unit';
 import { registerBuiltinWidgets } from '@gjsify/gtk-host';

--- a/packages/framework/video/src/video-bridge.ts
+++ b/packages/framework/video/src/video-bridge.ts
@@ -6,7 +6,7 @@
 // Reference: refs/showtime/showtime/play.py (gtk4paintablesink + glsinkbin).
 // Pattern follows packages/dom/canvas2d/src/canvas-drawing-area.ts.
 
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import GLib from 'gi://GLib?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 import type Gst from 'gi://Gst?version=1.0';

--- a/packages/framework/webgl/src/ts/webgl-bridge.ts
+++ b/packages/framework/webgl/src/ts/webgl-bridge.ts
@@ -1,7 +1,7 @@
 // A Gtk.GLArea subclass that carries the WebGL bootstrapping for
 // HTMLCanvasElement.
 
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 // Value import: `Gdk.GLAPI` is read at construction (see `set_allowed_apis`).
 import Gdk from 'gi://Gdk?version=4.0';
 import GLib from 'gi://GLib?version=2.0';

--- a/packages/infra/manifest-conformance/lib/source-graph.mjs
+++ b/packages/infra/manifest-conformance/lib/source-graph.mjs
@@ -22,6 +22,7 @@ import { readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 
 import { TS_SOURCE_EXTENSIONS, isDeclarationFile, sourceExtensionRe } from './source-extensions.mjs';
+import { stripComments } from './strip-comments.mjs';
 
 /** A VALUE import of a `@girs/*` type package — it resolves to a `gi://` body. */
 export const GIRS_VALUE_RE = /^\s*import\s+(?!type\b)[^;]*from\s+['"]@girs\//m;
@@ -212,7 +213,7 @@ export async function collectValueExports(file, seen = new Set()) {
     // (`@gjsify/fs` alone produced five). That only surfaces once a slot is
     // flipped to `polyfill` — i.e. exactly when someone reads the list.
     for (const m of text.matchAll(/^export\s*\{([^}]*)\}\s*(?:from\s*['"][^'"]+['"]\s*)?;?/gm)) {
-        const members = m[1].replace(/\/\/[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+        const members = stripComments(m[1]);
         for (const raw of members.split(',')) {
             const t = raw.trim();
             if (!t || /^type\s/.test(t)) continue;

--- a/packages/infra/manifest-conformance/lib/source-graph.mjs
+++ b/packages/infra/manifest-conformance/lib/source-graph.mjs
@@ -212,7 +212,7 @@ export async function collectValueExports(file, seen = new Set()) {
     // (`@gjsify/fs` alone produced five). That only surfaces once a slot is
     // flipped to `polyfill` — i.e. exactly when someone reads the list.
     for (const m of text.matchAll(/^export\s*\{([^}]*)\}\s*(?:from\s*['"][^'"]+['"]\s*)?;?/gm)) {
-        const members = m[1].replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+        const members = m[1].replace(/\/\/[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
         for (const raw of members.split(',')) {
             const t = raw.trim();
             if (!t || /^type\s/.test(t)) continue;

--- a/packages/infra/manifest-conformance/lib/strip-comments.mjs
+++ b/packages/infra/manifest-conformance/lib/strip-comments.mjs
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: MIT
+// The ONE comment stripper every whole-file check reads through.
+//
+// THE INCIDENT
+//
+// Eleven readers, eleven implementations. Nine were the same two regexes — remove
+// `/* … */`, remove `//…` — and neither regex can tell a comment from a string, so the
+// ORDER of the two decided which half of the tree went invisible. Block-first let a line
+// comment ending in `/*` — `@girs/*`, `packages/*`, `src/*` — pair with the next `*/`
+// below, usually the following JSDoc. Line-first let a block comment CONTAINING a `//`
+// lose its terminator and swallow the declaration under it, which is a live shape:
+// `npm-registry/src/types.ts` documents its field as keyed by a `//host/path/:` prefix.
+// Neither sees a glob pattern in a string: `globSync('**/*.ts')` opens a fake block
+// comment either way round, and the two orders blank different halves of the file.
+//
+// Measured against this scanner over the 3642 tracked JS/TS sources: block-first hid 7780
+// code lines in 226 files, line-first hid 3503 in 104. Swapping the order halves a class
+// it cannot close — and the closed version already existed in this repository.
+// `check-adapter-import-direction.mjs` rewrote its stripper as a stateful scanner after a
+// regex read `const re = /[/*]/;` as an open block comment and reported a live violation
+// as exit 0. This module is that scanner, lifted so the other ten inherit it: measured
+// the same way it hides 0 code lines and keeps 0 comment lines.
+//
+// Strings and regex bodies are KEPT — a quoted widget name, a `gi://` specifier or a glob
+// pattern is usually the thing being looked for. Line boundaries are kept too, so a
+// reported line number still points at the source line it came from.
+
+/** A character that ENDS an expression, so a `/` after it is division and never a regex. */
+const ENDS_EXPRESSION = /[\w$)\]'"`<>]/;
+
+/** Identifier characters, for the keyword lookback below. */
+const IDENTIFIER = /[\w$]/;
+
+/**
+ * Keywords a `/` may FOLLOW and still open a regex. The previous character alone cannot tell
+ * `return /x/` from `total / x`: both end in an identifier character.
+ */
+const REGEX_AFTER_KEYWORD = new Set([
+    'await',
+    'case',
+    'delete',
+    'do',
+    'else',
+    'in',
+    'instanceof',
+    'new',
+    'of',
+    'return',
+    'throw',
+    'typeof',
+    'void',
+    'yield',
+]);
+
+/**
+ * The index just past a regex literal starting at `start`, or -1 if it does not close on its
+ * line — in which case the `/` was division, or JSX, and reading it as a regex is what would
+ * cost the rest of the line. Character classes are a region where `/` is literal, which is the
+ * whole of `/[/*]/`; a backslash escapes the next character.
+ */
+function regexLiteralEnd(source, start) {
+    let i = start + 1;
+    let inClass = false;
+    while (i < source.length) {
+        const ch = source[i];
+        if (ch === '\n') return -1;
+        if (ch === '\\') {
+            if (source[i + 1] === undefined || source[i + 1] === '\n') return -1;
+            i += 2;
+            continue;
+        }
+        if (inClass) {
+            if (ch === ']') inClass = false;
+        } else if (ch === '[') {
+            inClass = true;
+        } else if (ch === '/') {
+            return i + 1;
+        }
+        i += 1;
+    }
+    return -1;
+}
+
+/**
+ * Strip comments, keeping every other byte and every line boundary.
+ *
+ * Stateful because the four shapes a line-regex cannot decide are the ones that were wrong:
+ * a `//` inside a string literal is not a comment, a `/* … *\/` block runs across lines whether
+ * or not the continuation lines are decorated, a `${…}` inside a template literal is code
+ * again, and a `/` may open a REGEX LITERAL. Strings are KEPT — a quoted widget name is the
+ * violation being looked for — and so is a regex body.
+ *
+ * The note that used to stand here called the untracked regex "a false negative on a line".
+ * It was measured, and it costs the FILE. `const re = /[/*]/;` is valid JS; read as code, its
+ * `/*` opened block-comment state that ran to EOF, so the `'GtkBox'` and the `.append()` under
+ * it vanished and the run printed "1 adapter(s) carry no widget knowledge", exit 0 — a
+ * violation the PRE-rewrite script caught, lost as GREEN. The mirror image was loud rather than
+ * dangerous: `/'/` left string state open, after which `//` stopped being a comment and prose
+ * was reported as a placement method. `//` costs a line; `/*` costs the file.
+ *
+ * So a `/` opens a regex only when the previous significant character cannot END an expression
+ * (or the word before it is a keyword like `return`) AND the literal CLOSES on its line — the
+ * second half is not a heuristic, ECMAScript forbids a LineTerminator in a
+ * RegularExpressionLiteral. Together they bound a miscall to the rest of ONE line.
+ *
+ * Still lexical, not a parser: `a < /re/.test(b)` reads as division, because `<` and `>` count
+ * as ending an expression. That is what keeps a `.tsx` file's `</div>` out of regex state.
+ */
+export function stripCommentLines(source) {
+    const lines = [];
+    let current = '';
+    const endLine = () => {
+        lines.push(current);
+        current = '';
+    };
+
+    /** `code` (top level, or a `${…}` expression) | `single` | `double` | `template`. */
+    const stack = ['code'];
+    /** Brace depth per `code` frame, so a `}` knows whether it closes a `${…}`. */
+    const depth = [0];
+    /** Whether a `/` here would open a regex, and the identifier before it for the keyword case. */
+    let regexAllowed = true;
+    let word = '';
+
+    let i = 0;
+    while (i < source.length) {
+        const ch = source[i];
+        const next = source[i + 1];
+        const top = stack[stack.length - 1];
+
+        // Line accounting is state-independent: every reported line number depends on it.
+        if (ch === '\n') {
+            endLine();
+            i += 1;
+            continue;
+        }
+
+        if (top === 'code') {
+            if (ch === '/' && next === '/') {
+                while (i < source.length && source[i] !== '\n') i += 1;
+                continue;
+            }
+            if (ch === '/' && next === '*') {
+                i += 2;
+                while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) {
+                    if (source[i] === '\n') endLine();
+                    i += 1;
+                }
+                i += 2;
+                continue;
+            }
+            // A regex literal, kept whole. Tested only HERE — after `//` and `/*`, exactly the
+            // order JS lexes them in — so `/[/*]/` is a regex and `/* … */` is still a comment.
+            if (ch === '/' && (regexAllowed || REGEX_AFTER_KEYWORD.has(word))) {
+                const end = regexLiteralEnd(source, i);
+                if (end !== -1) {
+                    current += source.slice(i, end);
+                    regexAllowed = false;
+                    word = '';
+                    i = end;
+                    continue;
+                }
+            }
+            if (ch === "'" || ch === '"' || ch === '`') {
+                stack.push(ch === "'" ? 'single' : ch === '"' ? 'double' : 'template');
+            } else if (ch === '{') {
+                depth[depth.length - 1] += 1;
+            } else if (ch === '}') {
+                if (depth[depth.length - 1] === 0 && stack.length > 1) {
+                    depth.pop();
+                    stack.pop();
+                } else if (depth[depth.length - 1] > 0) {
+                    depth[depth.length - 1] -= 1;
+                }
+            }
+            if (!/\s/.test(ch)) {
+                word = IDENTIFIER.test(ch) ? word + ch : '';
+                regexAllowed = !ENDS_EXPRESSION.test(ch);
+            }
+            current += ch;
+            i += 1;
+            continue;
+        }
+
+        // Inside a string or a template literal.
+        if (ch === '\\') {
+            current += ch;
+            if (next === '\n') {
+                endLine();
+            } else if (next !== undefined) {
+                current += next;
+            }
+            i += 2;
+            continue;
+        }
+        if (
+            (top === 'single' && ch === "'") ||
+            (top === 'double' && ch === '"') ||
+            (top === 'template' && ch === '`')
+        ) {
+            stack.pop();
+            regexAllowed = false;
+            word = '';
+            current += ch;
+            i += 1;
+            continue;
+        }
+        if (top === 'template' && ch === '$' && next === '{') {
+            stack.push('code');
+            depth.push(0);
+            regexAllowed = true;
+            word = '';
+            current += '${';
+            i += 2;
+            continue;
+        }
+        current += ch;
+        i += 1;
+    }
+    endLine();
+    return lines;
+}
+
+/** The same text with comment bodies removed, as one string. */
+export function stripComments(source) {
+    return stripCommentLines(source).join('\n');
+}
+
+// ------------------------------------------------------------------ the self-test
+//
+// One vector per shape a two-regex stripper gets wrong, each measured in this tree. It runs
+// on IMPORT, so every consumer inherits the proof instead of trusting that someone ran it.
+const VECTORS = [
+    // The two ORDERING shapes. Neither order gets both: block-first loses the first,
+    // line-first loses the second, and each blanks everything down to the next `*/`.
+    ['// types live under `@girs/*`\nconst a = 1;\n/** doc */\nconst b = 2;', '\nconst a = 1;\n\nconst b = 2;'],
+    // The trailing `/** … */` is load-bearing in both: with no later `*/` the lazy block
+    // regex finds no match and neither bug reproduces, so a vector without it is green
+    // under every ordering and proves nothing.
+    ['/** keyed by `//host/path/:` */\nconst c = 3;\n/** doc */\nconst d = 4;', '\nconst c = 3;\n\nconst d = 4;'],
+    // A string is not a comment, in either delimiter.
+    ["const u = 'https://x'; f();", "const u = 'https://x'; f();"],
+    ["const g = '**/*.ts';\nconst h = 4;", "const g = '**/*.ts';\nconst h = 4;"],
+    ["import Gtk from 'gi://Gtk?version=4.0';", "import Gtk from 'gi://Gtk?version=4.0';"],
+    // A regex literal is not a comment either — `/[/*]/` read as code opened block state
+    // that ran to EOF, and `/\'/` left string state open. Both were measured as exit 0.
+    ['const re = /[/*]/;\nconst i = 5;', 'const re = /[/*]/;\nconst i = 5;'],
+    ["const q = /'/;\nconst j = 6; // gone", "const q = /'/;\nconst j = 6; "],
+    // A `${…}` hole is code again, so a comment inside one is still a comment.
+    ['const t = `a${b /* x */}c`;', 'const t = `a${b }c`;'],
+    // Line boundaries survive, so a reported line number still points at its source line.
+    ['/* one\n   two */\nconst k = 7;', '\n\nconst k = 7;'],
+];
+
+const failures = VECTORS.filter(([source, want]) => stripComments(source) !== want).map(
+    ([source, want]) =>
+        `  ${JSON.stringify(source)}\n    wanted ${JSON.stringify(want)}\n    got    ${JSON.stringify(stripComments(source))}`,
+);
+if (failures.length > 0) {
+    throw new Error(
+        `scripts/strip-comments.mjs: SELF-TEST failed — every check reading through it is unsound:\n${failures.join('\n')}`,
+    );
+}

--- a/packages/node-gi/node-gi/test/glib-overrides.test.mjs
+++ b/packages/node-gi/node-gi/test/glib-overrides.test.mjs
@@ -56,7 +56,7 @@ function logStderr(runtime) {
         if (runtime === 'gjs') {
             writeFileSync(
                 script,
-                `import GLib from 'gi://GLib';\n` +
+                `import GLib from 'gi://GLib?version=2.0';\n` +
                     `GLib.log_structured('nodegi-parity', GLib.LogLevelFlags.LEVEL_MESSAGE, { MESSAGE: 'structured-gold' });\n`,
             );
             const res = spawnSync('gjs', ['-m', script], { encoding: 'utf8' });

--- a/packages/node-gi/node-gi/test/gobject-overrides.test.mjs
+++ b/packages/node-gi/node-gi/test/gobject-overrides.test.mjs
@@ -98,7 +98,7 @@ test(
         const ours = signalsByFuncProbe(GObject, Gio).join('\n');
         const theirs = gjsProbeLines(
             signalsByFuncProbe,
-            `import GObject from 'gi://GObject';\nimport Gio from 'gi://Gio';\nconst __args = [GObject, Gio];`,
+            `import GObject from 'gi://GObject?version=2.0';\nimport Gio from 'gi://Gio?version=2.0';\nconst __args = [GObject, Gio];`,
         ).join('\n');
         assert.equal(ours, theirs, 'node-gi and gjs by-func signal ops agree line-for-line');
     },
@@ -192,9 +192,10 @@ test('GObject.Value: new/init/set_*/get_*/copy + the 2-arg convenience', () => {
 
 test('GObject.Value is byte-identical to gjs (gold standard)', { skip: hasGjs ? false : 'gjs not on PATH' }, () => {
     const ours = valueProbe(GObject).join('\n');
-    const theirs = gjsProbeLines(valueProbe, `import GObject from 'gi://GObject';\nconst __args = [GObject];`).join(
-        '\n',
-    );
+    const theirs = gjsProbeLines(
+        valueProbe,
+        `import GObject from 'gi://GObject?version=2.0';\nconst __args = [GObject];`,
+    ).join('\n');
     assert.equal(ours, theirs, 'node-gi and gjs GObject.Value agree line-for-line');
 });
 

--- a/packages/node/worker_threads/src/worker-bootstrap.ts
+++ b/packages/node/worker_threads/src/worker-bootstrap.ts
@@ -30,8 +30,8 @@
 // dormant and any incoming __sab placeholder will fail loudly when
 // resolveTag throws.
 export const BOOTSTRAP_CODE = `\
-import GLib from 'gi://GLib';
-import Gio from 'gi://Gio';
+import GLib from 'gi://GLib?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
 import System from 'system';
 
 const loop = new GLib.MainLoop(null, false);

--- a/packages/web/gamepad/src/backend.ts
+++ b/packages/web/gamepad/src/backend.ts
@@ -225,7 +225,8 @@ async function probeGamepadBackend(options: LoadGamepadBackendOptions): Promise<
     // `gi://*` (`gjsGiNodePlugin`, `gjsImportsEmptyPlugin`, the `--app gjs` externals
     // predicate) matches the resolved specifier at BUILD time, so a template literal
     // would leave the import unclaimed on all four targets.
-    const importer = options.importer ?? (() => import('gi://Manette') as Promise<{ default: typeof Manette }>);
+    const importer =
+        options.importer ?? (() => import('gi://Manette?version=0.2') as Promise<{ default: typeof Manette }>);
 
     let module: typeof Manette;
     try {

--- a/packages/web/gamepad/src/register.spec.ts
+++ b/packages/web/gamepad/src/register.spec.ts
@@ -66,7 +66,7 @@ export default async () => {
             // export ever stops reflecting reality.
             let liveBackend = true;
             try {
-                await import('gi://Manette');
+                await import('gi://Manette?version=0.2');
             } catch {
                 liveBackend = false;
             }

--- a/scripts/adapter-import-direction-fixtures.mjs
+++ b/scripts/adapter-import-direction-fixtures.mjs
@@ -423,7 +423,7 @@ export const ADAPTER_IMPORT_DIRECTION_FIXTURES = [
         name: 'framework-free-clean',
         files: {
             'src/adapters/toy.ts': CLEAN_ADAPTER,
-            'src/list/index.ts': `import Gio from 'gi://Gio';\n\nexport const store = () => Gio.ListStore;\n`,
+            'src/list/index.ts': `import Gio from 'gi://Gio?version=2.0';\n\nexport const store = () => Gio.ListStore;\n`,
         },
         frameworkFree: ['./list'],
         expect: { files: 1, problems: [], blockers: [] },

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -37,6 +37,7 @@ import {
     sourceExtensionRe,
     toPosixPath,
 } from '../packages/infra/manifest-conformance/lib/index.mjs';
+import { stripComments } from '../packages/infra/manifest-conformance/lib/strip-comments.mjs';
 
 /** Repo-relative source roots, so callers can name them in their own messages. */
 export const ADWAITA_WEB_SRC = 'packages/web/adwaita-web/src';
@@ -246,16 +247,13 @@ function bindsOnlyTypes(clause) {
 }
 
 /**
- * A source with its comments blanked out, so a static reader claims only what the
- * module RUNS. `[^:]` before `//` keeps a `https://` inside a string intact. Shared,
- * because #1123 is what a reader without it costs: `.osd` and `.linked` read as
- * implemented off a comment while the code spelled something else.
- *
- * @param {string} text
+ * A source with its comments removed, so a static reader claims only what the module
+ * RUNS — #1123 is what a reader without it costs: `.osd` and `.linked` read as
+ * implemented off a comment while the code spelled something else. Re-exported rather
+ * than reimplemented: the two-regex version this replaced could not tell a `//` inside
+ * a string from a comment, and no ordering of its two passes fixes that.
  */
-export function stripComments(text) {
-    return text.replaceAll(/(^|[^:])\/\/[^\n]*/g, '$1').replaceAll(/\/\*[\s\S]*?\*\//g, '');
-}
+export { stripComments };
 
 /**
  * `observedAttributes` per CLASS, from the returned array literal.

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -254,7 +254,7 @@ function bindsOnlyTypes(clause) {
  * @param {string} text
  */
 export function stripComments(text) {
-    return text.replaceAll(/\/\*[\s\S]*?\*\//g, '').replaceAll(/(^|[^:])\/\/[^\n]*/g, '$1');
+    return text.replaceAll(/(^|[^:])\/\/[^\n]*/g, '$1').replaceAll(/\/\*[\s\S]*?\*\//g, '');
 }
 
 /**

--- a/scripts/check-adapter-import-direction.mjs
+++ b/scripts/check-adapter-import-direction.mjs
@@ -23,17 +23,9 @@
 // globs `src/**/*.{ts,js}`, and `status/status.json` names "No React adapter" as next work,
 // so `react.tsx` is the file that plausibly arrives.
 //
-// The comment stripper is a STATEFUL scanner, not three regexes. `/\/\/.*$/` truncated a line
-// at a `//` inside a string literal (`const u = 'https://x'; w.append(c);` passed), and a
-// `/* … */` block whose continuation lines carry no leading `*` was scanned as code, so
-// ordinary prose quoting a widget name FAILED the check. Prose may name a widget; code may not.
-//
-// It also lexes REGEX LITERALS, which the first stateful version did not — and that omission
-// cost a violation as GREEN. `const re = /[/*]/;` is valid JS; read as code its `/*` opened
-// block-comment state that ran to EOF, so a widget name and a placement call under it were
-// swallowed and the run printed "1 adapter(s) carry no widget knowledge", exit 0, on a file the
-// version this one replaced had failed. `/'/` was the loud twin: it left string state open,
-// after which `//` stopped being a comment and PROSE was reported as a placement method.
+// The comment stripper is a STATEFUL scanner, not three regexes — `scripts/strip-comments.mjs`,
+// which grew here and now serves every whole-file check. Prose may name a widget; code may not,
+// and each shape a line-regex decided wrongly is a vector in that module.
 //
 // The two UNQUOTED patterns landed later, and each was a live violation at the time. `new
 // Gtk.Box()` in the Vue adapter was the one concrete widget class in the whole adapter set and
@@ -71,6 +63,7 @@ import {
     sourceExtensionRe,
 } from '../packages/infra/manifest-conformance/lib/source-extensions.mjs';
 import { ADAPTER_IMPORT_DIRECTION_FIXTURES, materializeFixture } from './adapter-import-direction-fixtures.mjs';
+import { stripCommentLines, stripComments } from '../packages/infra/manifest-conformance/lib/strip-comments.mjs';
 
 /** The package that owns the host, its table and its adapters. */
 const PKG = 'packages/framework/gtk-host';
@@ -220,203 +213,6 @@ const RUNTIME_GI = /^gi:\/\//;
  */
 const SPECIFIER_SOURCE = String.raw`(?:\bfrom|\bimport|\brequire)\s*\(?\s*(['"\x60])([^'"\x60\n]+)\1`;
 
-/** A character that ENDS an expression, so a `/` after it is division and never a regex. */
-const ENDS_EXPRESSION = /[\w$)\]'"`<>]/;
-
-/** Identifier characters, for the keyword lookback below. */
-const IDENTIFIER = /[\w$]/;
-
-/**
- * Keywords a `/` may FOLLOW and still open a regex. The previous character alone cannot tell
- * `return /x/` from `total / x`: both end in an identifier character.
- */
-const REGEX_AFTER_KEYWORD = new Set([
-    'await',
-    'case',
-    'delete',
-    'do',
-    'else',
-    'in',
-    'instanceof',
-    'new',
-    'of',
-    'return',
-    'throw',
-    'typeof',
-    'void',
-    'yield',
-]);
-
-/**
- * The index just past a regex literal starting at `start`, or -1 if it does not close on its
- * line — in which case the `/` was division, or JSX, and reading it as a regex is what would
- * cost the rest of the line. Character classes are a region where `/` is literal, which is the
- * whole of `/[/*]/`; a backslash escapes the next character.
- */
-function regexLiteralEnd(source, start) {
-    let i = start + 1;
-    let inClass = false;
-    while (i < source.length) {
-        const ch = source[i];
-        if (ch === '\n') return -1;
-        if (ch === '\\') {
-            if (source[i + 1] === undefined || source[i + 1] === '\n') return -1;
-            i += 2;
-            continue;
-        }
-        if (inClass) {
-            if (ch === ']') inClass = false;
-        } else if (ch === '[') {
-            inClass = true;
-        } else if (ch === '/') {
-            return i + 1;
-        }
-        i += 1;
-    }
-    return -1;
-}
-
-/**
- * Strip comments, keeping every other byte and every line boundary.
- *
- * Stateful because the four shapes a line-regex cannot decide are the ones that were wrong:
- * a `//` inside a string literal is not a comment, a `/* … *\/` block runs across lines whether
- * or not the continuation lines are decorated, a `${…}` inside a template literal is code
- * again, and a `/` may open a REGEX LITERAL. Strings are KEPT — a quoted widget name is the
- * violation being looked for — and so is a regex body.
- *
- * The note that used to stand here called the untracked regex "a false negative on a line".
- * It was measured, and it costs the FILE. `const re = /[/*]/;` is valid JS; read as code, its
- * `/*` opened block-comment state that ran to EOF, so the `'GtkBox'` and the `.append()` under
- * it vanished and the run printed "1 adapter(s) carry no widget knowledge", exit 0 — a
- * violation the PRE-rewrite script caught, lost as GREEN. The mirror image was loud rather than
- * dangerous: `/'/` left string state open, after which `//` stopped being a comment and prose
- * was reported as a placement method. `//` costs a line; `/*` costs the file.
- *
- * So a `/` opens a regex only when the previous significant character cannot END an expression
- * (or the word before it is a keyword like `return`) AND the literal CLOSES on its line — the
- * second half is not a heuristic, ECMAScript forbids a LineTerminator in a
- * RegularExpressionLiteral. Together they bound a miscall to the rest of ONE line.
- *
- * Still lexical, not a parser: `a < /re/.test(b)` reads as division, because `<` and `>` count
- * as ending an expression. That is what keeps a `.tsx` adapter's `</div>` out of regex state,
- * and `.tsx` is in SOURCE_EXT.
- */
-function stripComments(source) {
-    const lines = [];
-    let current = '';
-    const endLine = () => {
-        lines.push(current);
-        current = '';
-    };
-
-    /** `code` (top level, or a `${…}` expression) | `single` | `double` | `template`. */
-    const stack = ['code'];
-    /** Brace depth per `code` frame, so a `}` knows whether it closes a `${…}`. */
-    const depth = [0];
-    /** Whether a `/` here would open a regex, and the identifier before it for the keyword case. */
-    let regexAllowed = true;
-    let word = '';
-
-    let i = 0;
-    while (i < source.length) {
-        const ch = source[i];
-        const next = source[i + 1];
-        const top = stack[stack.length - 1];
-
-        // Line accounting is state-independent: every reported line number depends on it.
-        if (ch === '\n') {
-            endLine();
-            i += 1;
-            continue;
-        }
-
-        if (top === 'code') {
-            if (ch === '/' && next === '/') {
-                while (i < source.length && source[i] !== '\n') i += 1;
-                continue;
-            }
-            if (ch === '/' && next === '*') {
-                i += 2;
-                while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) {
-                    if (source[i] === '\n') endLine();
-                    i += 1;
-                }
-                i += 2;
-                continue;
-            }
-            // A regex literal, kept whole. Tested only HERE — after `//` and `/*`, exactly the
-            // order JS lexes them in — so `/[/*]/` is a regex and `/* … */` is still a comment.
-            if (ch === '/' && (regexAllowed || REGEX_AFTER_KEYWORD.has(word))) {
-                const end = regexLiteralEnd(source, i);
-                if (end !== -1) {
-                    current += source.slice(i, end);
-                    regexAllowed = false;
-                    word = '';
-                    i = end;
-                    continue;
-                }
-            }
-            if (ch === "'" || ch === '"' || ch === '`') {
-                stack.push(ch === "'" ? 'single' : ch === '"' ? 'double' : 'template');
-            } else if (ch === '{') {
-                depth[depth.length - 1] += 1;
-            } else if (ch === '}') {
-                if (depth[depth.length - 1] === 0 && stack.length > 1) {
-                    depth.pop();
-                    stack.pop();
-                } else if (depth[depth.length - 1] > 0) {
-                    depth[depth.length - 1] -= 1;
-                }
-            }
-            if (!/\s/.test(ch)) {
-                word = IDENTIFIER.test(ch) ? word + ch : '';
-                regexAllowed = !ENDS_EXPRESSION.test(ch);
-            }
-            current += ch;
-            i += 1;
-            continue;
-        }
-
-        // Inside a string or a template literal.
-        if (ch === '\\') {
-            current += ch;
-            if (next === '\n') {
-                endLine();
-            } else if (next !== undefined) {
-                current += next;
-            }
-            i += 2;
-            continue;
-        }
-        if (
-            (top === 'single' && ch === "'") ||
-            (top === 'double' && ch === '"') ||
-            (top === 'template' && ch === '`')
-        ) {
-            stack.pop();
-            regexAllowed = false;
-            word = '';
-            current += ch;
-            i += 1;
-            continue;
-        }
-        if (top === 'template' && ch === '$' && next === '{') {
-            stack.push('code');
-            depth.push(0);
-            regexAllowed = true;
-            word = '';
-            current += '${';
-            i += 2;
-            continue;
-        }
-        current += ch;
-        i += 1;
-    }
-    endLine();
-    return lines;
-}
-
 /** Specifiers an adapter may not bind, with the offset each was found at. */
 function importProblems(code) {
     const found = [];
@@ -532,7 +328,7 @@ function publishedAdapters(manifestPath) {
 
 function scanFile(path) {
     const found = [];
-    const lines = stripComments(readFileSync(path, 'utf8'));
+    const lines = stripCommentLines(readFileSync(path, 'utf8'));
     lines.forEach((line, index) => {
         if (WIDGET_NAME.test(line)) {
             found.push({ kind: 'widget-name', line: index + 1, path, message: `names a widget type: ${line.trim()}` });
@@ -570,7 +366,7 @@ function scanFile(path) {
 
 /** One framework-free source file: no framework import, by value or by type. */
 function scanFrameworkFree(path) {
-    const code = stripComments(readFileSync(path, 'utf8')).join('\n');
+    const code = stripComments(readFileSync(path, 'utf8'));
     return frameworkImports(code)
         .map((hit) => ({
             kind: hit.kind,

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -112,6 +112,7 @@ import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { toPosixPath } from '../packages/infra/manifest-conformance/lib/index.mjs';
+import { stripComments } from '../packages/infra/manifest-conformance/lib/strip-comments.mjs';
 import { readSuiteRegistration, walk as walkFiles } from './suite-registration.mjs';
 import {
     TS_SOURCE_EXTENSIONS,
@@ -239,8 +240,8 @@ function tablesIn(file) {
     return found;
 }
 
-/** Comment bodies, blanked; `[^:]` keeps `https://` out of it. */
-const withoutComments = (source) => source.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, ' ');
+/** Comment bodies, removed by the shared lexical scanner. */
+const withoutComments = stripComments;
 
 /**
  * Which of `names` each `*.spec.ts` under `dir` NAMES, outside a comment.

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -240,7 +240,7 @@ function tablesIn(file) {
 }
 
 /** Comment bodies, blanked; `[^:]` keeps `https://` out of it. */
-const withoutComments = (source) => source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/.*$/gm, '$1');
+const withoutComments = (source) => source.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, ' ');
 
 /**
  * Which of `names` each `*.spec.ts` under `dir` NAMES, outside a comment.

--- a/scripts/check-adwaita-icon-masks.mjs
+++ b/scripts/check-adwaita-icon-masks.mjs
@@ -51,10 +51,11 @@
 //     `adw-button-content.spec.ts` and `split-button.spec.ts` compare the computed
 //     `mask-image` with `--icon-image-missing`.
 //
-// COMMENTS ARE STRIPPED FIRST, and only whole-line `//` ones — a bare `//` mid-line is
-// a URL far more often than a comment. A name that appears only in prose is not
-// emitted; before the strip, `gtk-image.spec.ts`' own explanation of the bug (a comment
-// spelling `adw-icon--a b`) registered `a` as an emitted icon.
+// COMMENTS ARE STRIPPED FIRST, by the shared lexical scanner. A name that appears only
+// in prose is not emitted; before the strip, `gtk-image.spec.ts`' own explanation of the
+// bug (a comment spelling `adw-icon--a b`) registered `a` as an emitted icon. Mid-line
+// `//` used to be left alone here because it is a URL more often than a comment — the
+// scanner knows which, so a trailing comment is stripped and a `https://` is not.
 //
 // STILL BLIND to a name assembled at runtime — `icon.iconName = someRecord.icon`, with
 // no literal in the tree; `_icon.scss` covers that by falling back to `image-missing`.
@@ -72,6 +73,7 @@ import { fileURLToPath } from 'node:url';
 import { CODE_SOURCE_EXTENSIONS } from '../packages/infra/manifest-conformance/lib/source-extensions.mjs';
 
 import { toPosixPath } from '../packages/infra/manifest-conformance/lib/index.mjs';
+import { stripComments } from '../packages/infra/manifest-conformance/lib/strip-comments.mjs';
 
 const args = process.argv.slice(2);
 const rootFlag = args.indexOf('--root');
@@ -243,11 +245,6 @@ function metaControlNames(code) {
         for (const value of code.slice(open, end).matchAll(CONTROL_VALUE)) names.push(value[2]);
     }
     return names;
-}
-
-/** Whole-line `//` and every `/* *\/` — see the header on why not mid-line `//`. */
-function stripComments(code) {
-    return code.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
 function filesUnder(source) {

--- a/scripts/check-adwaita-icon-masks.mjs
+++ b/scripts/check-adwaita-icon-masks.mjs
@@ -247,7 +247,7 @@ function metaControlNames(code) {
 
 /** Whole-line `//` and every `/* *\/` — see the header on why not mid-line `//`. */
 function stripComments(code) {
-    return code.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    return code.replace(/^\s*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
 function filesUnder(source) {

--- a/scripts/check-adwaita-tag-vs-class.mjs
+++ b/scripts/check-adwaita-tag-vs-class.mjs
@@ -261,6 +261,20 @@ const VECTORS = [
         false,
         { tags: [], classes: [] },
     ],
+    // A LINE COMMENT ENDING IN `/*` MUST NOT SWALLOW THE CODE BELOW IT. `@girs/*`,
+    // `packages/*` and `src/*` all put those two characters at the end of a line comment,
+    // and the shared `stripComments` removed BLOCK comments first — so that `/*` paired
+    // with the next `*/` anywhere below, usually the opening of the following JSDoc.
+    // Everything between vanished, and a reader that sees nothing reports nothing.
+    // Measured repo-wide before the ordering was swapped: 8243 code lines across 307 of
+    // 3641 tracked sources. The trailing `/** … */` is load-bearing in this vector — with
+    // no later `*/` the lazy regex finds no match at all and the bug does not reproduce.
+    [
+        'a line comment ending in `/*` does not open a block comment',
+        '// tags live under `packages/*`\n<gtk-entry></gtk-entry>\n/** doc */\nconst x = 1;',
+        false,
+        { tags: ['gtk-entry'], classes: [] },
+    ],
 ];
 
 const selfTestFailures = [];

--- a/scripts/check-adwaita-tag-vs-class.mjs
+++ b/scripts/check-adwaita-tag-vs-class.mjs
@@ -266,9 +266,9 @@ const VECTORS = [
     // and the shared `stripComments` removed BLOCK comments first — so that `/*` paired
     // with the next `*/` anywhere below, usually the opening of the following JSDoc.
     // Everything between vanished, and a reader that sees nothing reports nothing.
-    // Measured repo-wide before the ordering was swapped: 8243 code lines across 307 of
-    // 3641 tracked sources. The trailing `/** … */` is load-bearing in this vector — with
-    // no later `*/` the lazy regex finds no match at all and the bug does not reproduce.
+    // Measured repo-wide: that ordering hid 7780 code lines across 226 of 3642 tracked
+    // JS/TS sources. The trailing `/** … */` is load-bearing in this vector — with no
+    // later `*/` the lazy regex finds no match at all and the bug does not reproduce.
     [
         'a line comment ending in `/*` does not open a block comment',
         '// tags live under `packages/*`\n<gtk-entry></gtk-entry>\n/** doc */\nconst x = 1;',

--- a/scripts/check-cli-own-version-read.mjs
+++ b/scripts/check-cli-own-version-read.mjs
@@ -132,10 +132,17 @@ if (files.length === 0) {
 // enforces is precisely the kind a comment needs to QUOTE in order to explain
 // itself, and a guard that fires on its own rationale trains people to delete
 // the rationale.
+//
+// LINE COMMENTS FIRST, and the order is load-bearing. A line comment ending in `/*` —
+// `@gjsify/*`, `packages/*`, `src/*`, all common here — otherwise pairs with the next
+// `*/` anywhere below, usually the opening of the following JSDoc, and everything
+// between is blanked. Measured over this check's own corpus before the swap: 2446 code
+// lines across 46 of its 285 files were invisible to it. A guard that cannot see two
+// thousand lines of what it guards is not a weak guard, it is a decoration.
 function stripComments(text) {
     return text
-        .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
-        .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) => lead + ' '.repeat(m.length - lead.length));
+        .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) => lead + ' '.repeat(m.length - lead.length))
+        .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
 }
 
 const offenders = [];

--- a/scripts/check-cli-own-version-read.mjs
+++ b/scripts/check-cli-own-version-read.mjs
@@ -64,6 +64,7 @@ import {
     TS_SOURCE_EXTENSIONS,
     sourceExtensionRe,
 } from '../packages/infra/manifest-conformance/lib/source-extensions.mjs';
+import { stripComments } from '../packages/infra/manifest-conformance/lib/strip-comments.mjs';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const CLI_SRC = join(REPO_ROOT, 'packages/infra/cli/src');
@@ -128,22 +129,18 @@ if (files.length === 0) {
     process.exit(1);
 }
 
-// Blank out comment bodies while preserving line numbering: the rule this check
-// enforces is precisely the kind a comment needs to QUOTE in order to explain
-// itself, and a guard that fires on its own rationale trains people to delete
-// the rationale.
+// Comments are removed, line numbering intact: the rule this check enforces is precisely
+// the kind a comment needs to QUOTE in order to explain itself, and a guard that fires on
+// its own rationale trains people to delete the rationale.
 //
-// LINE COMMENTS FIRST, and the order is load-bearing. A line comment ending in `/*` —
-// `@gjsify/*`, `packages/*`, `src/*`, all common here — otherwise pairs with the next
-// `*/` anywhere below, usually the opening of the following JSDoc, and everything
-// between is blanked. Measured over this check's own corpus before the swap: 2446 code
-// lines across 46 of its 285 files were invisible to it. A guard that cannot see two
-// thousand lines of what it guards is not a weak guard, it is a decoration.
-function stripComments(text) {
-    return text
-        .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) => lead + ' '.repeat(m.length - lead.length))
-        .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
-}
+// The reader is `scripts/strip-comments.mjs`, a lexical scanner, because no PAIR of
+// regexes can do this. Removing block comments first let a line comment ending in `/*` —
+// `@gjsify/*`, `packages/*`, `src/*`, all common here — pair with the next `*/` below and
+// blank everything between; removing line comments first let a block comment containing a
+// `//` lose its terminator and swallow the declaration under it instead. Measured over
+// this check's own corpus, block-first hid 2448 code lines across 47 of its 285 files. A
+// guard that cannot see two thousand lines of what it guards is not a weak guard, it is a
+// decoration.
 
 const offenders = [];
 for (const file of files) {

--- a/scripts/check-gi-import-versions.mjs
+++ b/scripts/check-gi-import-versions.mjs
@@ -44,8 +44,15 @@ import { readFileSync } from 'node:fs';
 import { stripComments } from '../packages/infra/manifest-conformance/lib/strip-comments.mjs';
 import { GI_IMPORT_VERSION_VECTORS } from './gi-import-version-fixtures.mjs';
 
-/** Sources a `gi://` import can appear in, plus the docs that teach the spelling. */
-const SCANNED = /\.(ts|tsx|mts|cts|js|mjs|cjs|jsx|md|mdx)$/;
+/**
+ * Sources a `gi://` import can appear in, plus the docs that teach the spelling.
+ *
+ * `.astro`/`.vue`/`.svelte` carry a script block like any other source, and
+ * `website/src/components/ShowcaseSlideshow.astro` holds five `gi://` imports the first
+ * list did not reach: seed one unpinned there and the check goes red with these
+ * extensions and green without.
+ */
+const SCANNED = /\.(ts|tsx|mts|cts|js|mjs|cjs|jsx|astro|vue|svelte|md|mdx)$/;
 
 /** Markdown has no `//` comments to confuse, and a doc example teaches the form. */
 const MARKDOWN = /\.mdx?$/;

--- a/scripts/check-gi-import-versions.mjs
+++ b/scripts/check-gi-import-versions.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// Every `gi://` import states the typelib version it wants.
+//
+// WHAT THIS PROTECTS
+//
+// `import Gtk from 'gi://Gtk'` asks the loader for whatever `Gtk` it finds first. On a
+// machine with one Gtk that is the right one; on a machine with two it is a coin toss
+// resolved at load time, and the failure is not an import error — it is a widget that
+// behaves differently, or two toolkits in one address space. The repository already
+// treats the version as part of the request almost everywhere: at the time this landed,
+// 83 `gi://GLib?version=2.0`, 83 `gi://Gio?version=2.0`, 72 `gi://Gtk?version=4.0`. What
+// it did not have was anything holding the remaining 52.
+//
+// THE HONEST SCOPE. For `Gio`, `GObject` and `Pango` exactly one version is installed on
+// every machine this runs on, so those unpinned imports were not resolving wrongly — the
+// value here is the RULE, stated the same way everywhere, and the machines where it stops
+// being true are the ones nobody tests on. The case that is not hypothetical is the one
+// the WebKit shim warns about in capitals: `WebKit2-4.1` (GTK3) and `WebKit-6.0` (GTK4)
+// are routinely installed side by side, and picking the wrong one loads a second toolkit.
+// A rule that only covers the namespace someone has already been bitten by covers the
+// wrong set.
+//
+// WHAT IT DOES NOT CHECK: whether the stated version is the RIGHT one. That is a claim
+// about the machine, not about the source, and a gate that asserted it would be
+// [[tests-that-measure-the-runner]] — green or red depending on what is installed on the
+// runner rather than on what the diff changed.
+//
+// COMMENTS ARE BLANKED FIRST, and the ORDER of the two strippers is load-bearing. A line
+// comment ending in `/*` — `@girs/*`, `packages/*`, `src/*`, all common — pairs with the
+// next `*/` anywhere below if block comments are removed first, and everything between
+// disappears. Measured across this repository at the time this landed: 8243 code lines in
+// 307 of 3641 tracked sources went invisible that way, to every check that shares the
+// idiom. Line comments first, then block comments.
+//
+// FAILURE POLICY: hard, and a scan that finds nothing is itself a failure — a check that
+// cannot find what it checks has stopped checking.
+//
+// Usage: node scripts/check-gi-import-versions.mjs
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+/** Sources a `gi://` import can appear in, plus the docs that teach the spelling. */
+const SCANNED = /\.(ts|tsx|mts|cts|js|mjs|cjs|jsx|md|mdx)$/;
+
+/** Markdown has no `//` comments to confuse, and a doc example teaches the form. */
+const MARKDOWN = /\.mdx?$/;
+
+/**
+ * `import <anything> from 'gi://<Ns>'` with no query string.
+ *
+ * Anchored at `import` so a specifier quoted in prose or built at runtime is not an
+ * import — the check must not fire on the sentence that explains it.
+ */
+const UNPINNED = /^[ \t]*import\b[^\n]*\bfrom\s*(['"])gi:\/\/([A-Za-z0-9_]+)\1/;
+
+/** Any `gi://` import, pinned or not — used to prove the scan actually found some. */
+const ANY_GI_IMPORT = /^[ \t]*import\b[^\n]*\bfrom\s*['"]gi:\/\//;
+
+/**
+ * Blank comment bodies, preserving line numbering.
+ *
+ * `[^:]` before `//` keeps `gi://` and `https://` inside a string intact. Line comments
+ * go first; see the header for what the other order costs.
+ */
+export function stripComments(text) {
+    return text
+        .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) => lead + ' '.repeat(m.length - lead.length))
+        .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
+}
+
+/** Every unpinned `gi://` import in one source, as `{ line, namespace, text }`. */
+export function unpinnedImports(source, isMarkdown = false) {
+    const lines = (isMarkdown ? source : stripComments(source)).split('\n');
+    const original = source.split('\n');
+    const found = [];
+    lines.forEach((line, i) => {
+        const m = line.match(UNPINNED);
+        if (m) found.push({ line: i + 1, namespace: m[2], text: original[i].trim() });
+    });
+    return found;
+}
+
+// ------------------------------------------------------------------ the self-test
+//
+// Each vector is a source fragment and the namespaces the reader must report. The two
+// that matter are the ones a regex gets wrong in the SAFE-LOOKING direction: prose that
+// quotes the defect, and a line comment that ends in `/*`.
+const VECTORS = [
+    ["import Gtk from 'gi://Gtk';", ['Gtk']],
+    ['import Gtk from "gi://Gtk";', ['Gtk']],
+    ["import Gtk from 'gi://Gtk?version=4.0';", []],
+    ["import { foo } from 'gi://Gio';", ['Gio']],
+    ["    import GLib from 'gi://GLib';", ['GLib']],
+    // Prose is not an import. A gate that fires on its own rationale gets the rationale
+    // deleted, and the rationale is the half that survives a rewrite.
+    ["// `import Gtk from 'gi://Gtk'` is what this forbids\nconst x = 1;", []],
+    ["/* import Gtk from 'gi://Gtk' */\nconst x = 1;", []],
+    // The ordering case. The trailing `/** … */` is part of the vector: with no later
+    // `*/` the lazy block regex finds no match and the bug does not reproduce, so a
+    // version of this without it passed under BOTH orderings and proved nothing.
+    ["// types live under `@girs/*`\nimport Gtk from 'gi://Gtk';\n/** doc */\nconst x = 1;", ['Gtk']],
+    // Not an import at all: a runtime require, and a string that merely contains one.
+    ["const Gtk = require('gi://Gtk');", []],
+    ["const spec = 'gi://Gtk';", []],
+];
+
+const selfTestFailures = [];
+for (const [source, expected] of VECTORS) {
+    const got = unpinnedImports(source).map((f) => f.namespace);
+    if (got.join(',') !== expected.join(',')) {
+        selfTestFailures.push(`  ${JSON.stringify(source)}\n    expected [${expected}], got [${got}]`);
+    }
+}
+if (selfTestFailures.length > 0) {
+    process.stderr.write('check-gi-import-versions: SELF-TEST failed — the check itself is broken:\n');
+    for (const failure of selfTestFailures) process.stderr.write(`${failure}\n`);
+    process.exit(2);
+}
+
+// ------------------------------------------------------------------ the scan
+
+const files = execFileSync('git', ['ls-files', '-z'], { encoding: 'utf8', maxBuffer: 1 << 28 })
+    .split('\0')
+    .filter(Boolean)
+    .filter((f) => SCANNED.test(f));
+
+const offenders = [];
+let pinned = 0;
+let scanned = 0;
+for (const file of files) {
+    let source;
+    try {
+        source = readFileSync(file, 'utf8');
+    } catch {
+        continue; // a tracked path that is not readable here (submodule gitlink, symlink)
+    }
+    if (!source.includes('gi://')) continue;
+    scanned++;
+    const isMarkdown = MARKDOWN.test(file);
+    const lines = (isMarkdown ? source : stripComments(source)).split('\n');
+    for (const line of lines) if (ANY_GI_IMPORT.test(line)) pinned++;
+    for (const found of unpinnedImports(source, isMarkdown)) {
+        offenders.push(`${file}:${found.line}: ${found.text}`);
+        pinned--;
+    }
+}
+
+if (scanned === 0) {
+    process.stderr.write('check-gi-import-versions: no file mentions `gi://` — the scan found nothing to check.\n');
+    process.exit(1);
+}
+
+if (offenders.length > 0) {
+    process.stderr.write(`check-gi-import-versions: ${offenders.length} unpinned \`gi://\` import(s):\n\n`);
+    for (const o of offenders) process.stderr.write(`  ${o}\n`);
+    process.stderr.write(
+        '\nAdd the version the code actually wants, the way the rest of the tree spells it:\n' +
+            "  import Gtk from 'gi://Gtk?version=4.0';\n" +
+            "  import Adw from 'gi://Adw?version=1';\n" +
+            "  import GLib from 'gi://GLib?version=2.0';\n\n" +
+            'Unversioned, the loader takes whichever typelib it finds first. Where two are\n' +
+            'installed side by side — WebKit2-4.1 and WebKit-6.0 is the standing example —\n' +
+            'that is a second toolkit in the same address space, decided at load time.\n',
+    );
+    process.exit(1);
+}
+
+process.stdout.write(
+    `check-gi-import-versions: OK — ${VECTORS.length} self-test vector(s); ` +
+        `${pinned} \`gi://\` import(s) across ${scanned} file(s), every one of them versioned.\n`,
+);

--- a/scripts/check-gi-import-versions.mjs
+++ b/scripts/check-gi-import-versions.mjs
@@ -26,12 +26,12 @@
 // [[tests-that-measure-the-runner]] — green or red depending on what is installed on the
 // runner rather than on what the diff changed.
 //
-// COMMENTS ARE BLANKED FIRST, and the ORDER of the two strippers is load-bearing. A line
-// comment ending in `/*` — `@girs/*`, `packages/*`, `src/*`, all common — pairs with the
-// next `*/` anywhere below if block comments are removed first, and everything between
-// disappears. Measured across this repository at the time this landed: 8243 code lines in
-// 307 of 3641 tracked sources went invisible that way, to every check that shares the
-// idiom. Line comments first, then block comments.
+// COMMENTS ARE REMOVED FIRST, by `manifest-conformance/lib/strip-comments.mjs`, which is a
+// lexical scanner rather than a pair of regexes. Neither ORDER of two regexes is right: a
+// line comment ending in `/*` — `@girs/*`, `packages/*`, `src/*` — pairs with the next `*/`
+// below if block comments go first, and a block comment containing a `//` loses its
+// terminator if line comments do. Measured against the scanner over the 3642 tracked JS/TS
+// sources, block-first hid 7780 code lines in 226 files and line-first 3503 in 104.
 //
 // FAILURE POLICY: hard, and a scan that finds nothing is itself a failure — a check that
 // cannot find what it checks has stopped checking.
@@ -41,74 +41,92 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
+import { stripComments } from '../packages/infra/manifest-conformance/lib/strip-comments.mjs';
+import { GI_IMPORT_VERSION_VECTORS } from './gi-import-version-fixtures.mjs';
+
 /** Sources a `gi://` import can appear in, plus the docs that teach the spelling. */
 const SCANNED = /\.(ts|tsx|mts|cts|js|mjs|cjs|jsx|md|mdx)$/;
 
 /** Markdown has no `//` comments to confuse, and a doc example teaches the form. */
 const MARKDOWN = /\.mdx?$/;
 
-/**
- * `import <anything> from 'gi://<Ns>'` with no query string.
- *
- * Anchored at `import` so a specifier quoted in prose or built at runtime is not an
- * import — the check must not fire on the sentence that explains it.
- */
-const UNPINNED = /^[ \t]*import\b[^\n]*\bfrom\s*(['"])gi:\/\/([A-Za-z0-9_]+)\1/;
-
-/** Any `gi://` import, pinned or not — used to prove the scan actually found some. */
-const ANY_GI_IMPORT = /^[ \t]*import\b[^\n]*\bfrom\s*['"]gi:\/\//;
+/** The vectors, which are unpinned specifiers on purpose. */
+const FIXTURES = 'scripts/gi-import-version-fixtures.mjs';
 
 /**
- * Blank comment bodies, preserving line numbering.
+ * An import statement binding `gi://<Ns>[?query]`, in every spelling that binds one:
+ * `import Ns from`, `import { x } from`, a clause wrapped over lines, and a bare
+ * side-effect `import 'gi://Ns'`.
  *
- * `[^:]` before `//` keeps `gi://` and `https://` inside a string intact. Line comments
- * go first; see the header for what the other order costs.
+ * Anchored at the start of a line, at the backtick that opens a template literal, or at
+ * an escaped `\n` inside one, and bounded by the `;` that ends the statement. The two
+ * extra arms are not decoration: the GJS programs this repository hands to `gjs -m` — the
+ * e2e runners, the node-gi gold-standard probes — are written as template literals, and
+ * eight real unpinned imports sat in them while a line-anchored reader called the tree
+ * clean. Prose quoting a specifier is still not an import; in a code file the scanner has
+ * removed it, and in markdown only the line-anchored arm runs.
  */
-export function stripComments(text) {
-    return text
-        .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) => lead + ' '.repeat(m.length - lead.length))
-        .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
+const CODE_IMPORT = /(?:^|`|\\n)[ \t]*import\b[^;`]*?(['"])gi:\/\/([A-Za-z0-9_]+)([^'"\n]*)\1/gm;
+
+/**
+ * The same, line-anchored, for markdown.
+ *
+ * Markdown is not comment-stripped and is mostly prose: an ADR quotes
+ * `import … from 'gi://Ns'` inline, after a backtick, in the middle of a sentence. Only a
+ * line that STARTS with `import` is a code example here.
+ */
+const MARKDOWN_IMPORT = /^[ \t]*import\b[^;`]*?(['"])gi:\/\/([A-Za-z0-9_]+)([^'"\n]*)\1/gm;
+
+/**
+ * `import('gi://<Ns>[?query]')`, the loader's other spelling.
+ *
+ * Read only in code files, where comments are gone: markdown prose explains dynamic
+ * imports in exactly this shape. `@gjsify/gamepad` loads its whole backend through one.
+ */
+const DYNAMIC_IMPORT = /\bimport\s*\(\s*(['"])gi:\/\/([A-Za-z0-9_]+)([^'"\n]*)\1/g;
+
+/**
+ * Whether a specifier's query states a version.
+ *
+ * A query is not a pin: `gi://Gtk?theme=dark` names no version and the loader still
+ * takes whichever typelib it finds first. Only `version=<something>` counts, wherever
+ * it sits among the parameters.
+ */
+const statesVersion = (query) => /(?:^\?|&)version=[^&]+/.test(query);
+
+/** Every `gi://` import in one source, as `{ line, namespace, pinned, text }`. */
+export function giImports(source, isMarkdown = false) {
+    const code = isMarkdown ? source : stripComments(source);
+    const original = source.split('\n');
+    const lineAt = (index) => code.slice(0, index).split('\n').length;
+    const found = [];
+    for (const pattern of isMarkdown ? [MARKDOWN_IMPORT] : [CODE_IMPORT, DYNAMIC_IMPORT]) {
+        pattern.lastIndex = 0;
+        for (const m of code.matchAll(pattern)) {
+            const line = lineAt(m.index + m[0].length);
+            found.push({
+                line,
+                namespace: m[2],
+                pinned: statesVersion(m[3]),
+                text: (original[line - 1] ?? '').trim(),
+            });
+        }
+    }
+    return found.sort((a, b) => a.line - b.line);
 }
 
-/** Every unpinned `gi://` import in one source, as `{ line, namespace, text }`. */
+/** Only the ones that state no version. */
 export function unpinnedImports(source, isMarkdown = false) {
-    const lines = (isMarkdown ? source : stripComments(source)).split('\n');
-    const original = source.split('\n');
-    const found = [];
-    lines.forEach((line, i) => {
-        const m = line.match(UNPINNED);
-        if (m) found.push({ line: i + 1, namespace: m[2], text: original[i].trim() });
-    });
-    return found;
+    return giImports(source, isMarkdown).filter((found) => !found.pinned);
 }
 
 // ------------------------------------------------------------------ the self-test
 //
-// Each vector is a source fragment and the namespaces the reader must report. The two
-// that matter are the ones a regex gets wrong in the SAFE-LOOKING direction: prose that
-// quotes the defect, and a line comment that ends in `/*`.
-const VECTORS = [
-    ["import Gtk from 'gi://Gtk';", ['Gtk']],
-    ['import Gtk from "gi://Gtk";', ['Gtk']],
-    ["import Gtk from 'gi://Gtk?version=4.0';", []],
-    ["import { foo } from 'gi://Gio';", ['Gio']],
-    ["    import GLib from 'gi://GLib';", ['GLib']],
-    // Prose is not an import. A gate that fires on its own rationale gets the rationale
-    // deleted, and the rationale is the half that survives a rewrite.
-    ["// `import Gtk from 'gi://Gtk'` is what this forbids\nconst x = 1;", []],
-    ["/* import Gtk from 'gi://Gtk' */\nconst x = 1;", []],
-    // The ordering case. The trailing `/** … */` is part of the vector: with no later
-    // `*/` the lazy block regex finds no match and the bug does not reproduce, so a
-    // version of this without it passed under BOTH orderings and proved nothing.
-    ["// types live under `@girs/*`\nimport Gtk from 'gi://Gtk';\n/** doc */\nconst x = 1;", ['Gtk']],
-    // Not an import at all: a runtime require, and a string that merely contains one.
-    ["const Gtk = require('gi://Gtk');", []],
-    ["const spec = 'gi://Gtk';", []],
-];
-
+// The vectors live in `gi-import-version-fixtures.mjs`, which the scan below skips —
+// see the note there for why a reader of this shape cannot carry them as data.
 const selfTestFailures = [];
-for (const [source, expected] of VECTORS) {
-    const got = unpinnedImports(source).map((f) => f.namespace);
+for (const [source, expected, markdown = false] of GI_IMPORT_VERSION_VECTORS) {
+    const got = unpinnedImports(source, markdown).map((f) => f.namespace);
     if (got.join(',') !== expected.join(',')) {
         selfTestFailures.push(`  ${JSON.stringify(source)}\n    expected [${expected}], got [${got}]`);
     }
@@ -124,10 +142,11 @@ if (selfTestFailures.length > 0) {
 const files = execFileSync('git', ['ls-files', '-z'], { encoding: 'utf8', maxBuffer: 1 << 28 })
     .split('\0')
     .filter(Boolean)
-    .filter((f) => SCANNED.test(f));
+    .filter((f) => SCANNED.test(f))
+    .filter((f) => f !== FIXTURES);
 
 const offenders = [];
-let pinned = 0;
+let imports = 0;
 let scanned = 0;
 for (const file of files) {
     let source;
@@ -139,16 +158,19 @@ for (const file of files) {
     if (!source.includes('gi://')) continue;
     scanned++;
     const isMarkdown = MARKDOWN.test(file);
-    const lines = (isMarkdown ? source : stripComments(source)).split('\n');
-    for (const line of lines) if (ANY_GI_IMPORT.test(line)) pinned++;
-    for (const found of unpinnedImports(source, isMarkdown)) {
-        offenders.push(`${file}:${found.line}: ${found.text}`);
-        pinned--;
+    for (const found of giImports(source, isMarkdown)) {
+        imports++;
+        if (!found.pinned) offenders.push(`${file}:${found.line}: ${found.text}`);
     }
 }
 
-if (scanned === 0) {
-    process.stderr.write('check-gi-import-versions: no file mentions `gi://` — the scan found nothing to check.\n');
+// The guard counts IMPORTS, not files that mention `gi://`. Mentions are mostly prose, so
+// a reader whose pattern had stopped matching would still have found 600-odd of them and
+// printed OK over zero imports — a green run that checked nothing.
+if (imports === 0) {
+    process.stderr.write(
+        `check-gi-import-versions: ${scanned} file(s) mention \`gi://\` and the reader found no import in any of them — it has stopped checking.\n`,
+    );
     process.exit(1);
 }
 
@@ -168,6 +190,6 @@ if (offenders.length > 0) {
 }
 
 process.stdout.write(
-    `check-gi-import-versions: OK — ${VECTORS.length} self-test vector(s); ` +
-        `${pinned} \`gi://\` import(s) across ${scanned} file(s), every one of them versioned.\n`,
+    `check-gi-import-versions: OK — ${GI_IMPORT_VERSION_VECTORS.length} self-test vector(s); ` +
+        `${imports} \`gi://\` import(s) across ${scanned} file(s), every one of them versioned.\n`,
 );

--- a/scripts/check-vocabulary-alignment.mjs
+++ b/scripts/check-vocabulary-alignment.mjs
@@ -624,7 +624,7 @@ const WEB_SURFACE = '@gjsify/adwaita-web';
  * A naive match reports the explanation as the violation — measured on the sibling check
  * for the generated surface, whose first run failed on a word inside its own header.
  */
-const stripComments = (text) => text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+const stripComments = (text) => text.replace(/^[ \t]*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 
 /** The body of `export interface <name> { … }`, or null. */
 function interfaceBody(text, name) {
@@ -1803,6 +1803,24 @@ const READER_VECTORS = [
     ["throw new Error('GtkWidget expected here');", [], []],
     ["// 'gtk-box' in a comment is prose, not a table\nconst x = 1;", [], []],
     ['let w: Gtk.Widget | null = null;', [], []],
+    // A LINE COMMENT CONTAINING `/*` MUST NOT OPEN A BLOCK COMMENT. `@girs/*`,
+    // `packages/*` and `src/*` all end a line comment with those two characters, and a
+    // stripper that removes block comments FIRST then pairs that `/*` with the next `*/`
+    // anywhere below — usually the opening of the next JSDoc, often hundreds of lines
+    // down. Everything between goes invisible, and a reader that sees nothing reports
+    // nothing, which is indistinguishable from a file that contains nothing.
+    //
+    // Measured repo-wide with the old ordering: 8243 code lines across 307 of 3641
+    // tracked sources were blanked for every check that shares this idiom. In THIS
+    // reader's own corpus the numbers did not move — which is why it needs a vector
+    // rather than a diff, since nothing in the real tree makes it go red.
+    // The `*/` that closes the fake block comment is part of the vector, not decoration:
+    // without a later `*/` the lazy block regex simply finds no match and the bug does not
+    // reproduce. A first draft of these two omitted it and passed under BOTH orderings —
+    // an assertion that cannot go red, which is the thing the rest of this file exists to
+    // prevent. Here the next JSDoc supplies it, exactly as a real source file does.
+    ["// types through `@girs/*`\nimport type { A } from './generated/props.js';\n/** doc */\nconst x = 1;", ['A'], []],
+    ["// see `packages/*` for the rest\nconst t = 'gtk-box';\n/** doc */\nconst y = 2;", [], ["'gtk-box'"]],
 ];
 
 function readerSelfTest() {

--- a/scripts/check-vocabulary-alignment.mjs
+++ b/scripts/check-vocabulary-alignment.mjs
@@ -156,6 +156,11 @@ import {
     settablePropertiesOfClass,
     widgetClass,
 } from './adwaita-elements.mjs';
+// `stripComments`, so a rule about DECLARATIONS is not answered by prose: these files
+// explain what they deliberately do not contain, and they name those things. A naive match
+// reports the explanation as the violation — measured on the sibling check for the
+// generated surface, whose first run failed on a word inside its own header.
+import { stripComments } from '../packages/infra/manifest-conformance/lib/strip-comments.mjs';
 import { WIDGET_SURFACE_READERS, declaredWidgetSurfaces, enrolmentProblems } from './widget-surfaces.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -616,15 +621,6 @@ const RENDERER_TABLES = {
 const WEB_SURFACE = '@gjsify/adwaita-web';
 
 // ------------------------------------------------------------------ readers
-
-/**
- * Strip comments so a rule about DECLARATIONS is not answered by prose.
- *
- * These files explain what they deliberately do not contain, and they name those things.
- * A naive match reports the explanation as the violation — measured on the sibling check
- * for the generated surface, whose first run failed on a word inside its own header.
- */
-const stripComments = (text) => text.replace(/^[ \t]*\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
 
 /** The body of `export interface <name> { … }`, or null. */
 function interfaceBody(text, name) {
@@ -1810,10 +1806,10 @@ const READER_VECTORS = [
     // down. Everything between goes invisible, and a reader that sees nothing reports
     // nothing, which is indistinguishable from a file that contains nothing.
     //
-    // Measured repo-wide with the old ordering: 8243 code lines across 307 of 3641
-    // tracked sources were blanked for every check that shares this idiom. In THIS
-    // reader's own corpus the numbers did not move — which is why it needs a vector
-    // rather than a diff, since nothing in the real tree makes it go red.
+    // Measured repo-wide: that ordering hid 7780 code lines across 226 of 3642 tracked
+    // JS/TS sources, for every check that shared the idiom. In THIS reader's own corpus
+    // the numbers did not move — which is why it needs a vector rather than a diff, since
+    // nothing in the real tree makes it go red.
     // The `*/` that closes the fake block comment is part of the vector, not decoration:
     // without a later `*/` the lazy block regex simply finds no match and the bug does not
     // reproduce. A first draft of these two omitted it and passed under BOTH orderings —

--- a/scripts/check-website-adwaita-gallery.mjs
+++ b/scripts/check-website-adwaita-gallery.mjs
@@ -118,6 +118,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { ADWAITA_STORY_SRC, adwaitaStoryMetas } from './adwaita-elements.mjs';
+import { stripComments } from '../packages/infra/manifest-conformance/lib/strip-comments.mjs';
 
 const args = process.argv.slice(2);
 const rootFlag = args.indexOf('--root');
@@ -256,7 +257,7 @@ const TAB_MAP = 'tabs.map(';
  * Line comments are anchored to the start of a line so that a `https://` inside an
  * attribute is not read as one.
  */
-const withoutComments = (text) => text.replaceAll(/^[ \t]*\/\/.*$/gm, '').replaceAll(/\/\*[\s\S]*?\*\//g, '');
+const withoutComments = stripComments;
 
 /**
  * Arm 9: the live preview is emitted BEFORE the code tabs, inside the tab view, and

--- a/scripts/check-website-adwaita-gallery.mjs
+++ b/scripts/check-website-adwaita-gallery.mjs
@@ -256,7 +256,7 @@ const TAB_MAP = 'tabs.map(';
  * Line comments are anchored to the start of a line so that a `https://` inside an
  * attribute is not read as one.
  */
-const withoutComments = (text) => text.replaceAll(/\/\*[\s\S]*?\*\//g, '').replaceAll(/^[ \t]*\/\/.*$/gm, '');
+const withoutComments = (text) => text.replaceAll(/^[ \t]*\/\/.*$/gm, '').replaceAll(/\/\*[\s\S]*?\*\//g, '');
 
 /**
  * Arm 9: the live preview is emitted BEFORE the code tabs, inside the tab view, and

--- a/scripts/gi-import-version-fixtures.mjs
+++ b/scripts/gi-import-version-fixtures.mjs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+// Vectors for `check-gi-import-versions.mjs`: a source fragment, the namespaces the
+// reader must report as unversioned, and whether to read it as markdown.
+//
+// SEPARATE FILE, and the scan SKIPS it, because a reader that looks for
+// `import … 'gi://Ns'` anywhere in a file cannot also carry unpinned specifiers as data:
+// it would report its own vectors and the fix would be to delete them. Nothing but
+// vectors lives here, so the exclusion cannot hide a real import — and the self-test
+// still proves the reader sees every shape in the list.
+
+/** @type {[source: string, unversioned: string[], markdown?: boolean][]} */
+export const GI_IMPORT_VERSION_VECTORS = [
+    ["import Gtk from 'gi://Gtk';", ['Gtk']],
+    ['import Gtk from "gi://Gtk";', ['Gtk']],
+    ["import Gtk from 'gi://Gtk?version=4.0';", []],
+    ["import { foo } from 'gi://Gio';", ['Gio']],
+    ["    import GLib from 'gi://GLib';", ['GLib']],
+    // Prose is not an import. A gate that fires on its own rationale gets the rationale
+    // deleted, and the rationale is the half that survives a rewrite.
+    // Both quote the specifier after a BACKTICK, which is the template-literal arm's
+    // anchor — so each one goes red the moment its half of the comment scanner stops
+    // working, instead of passing on the line anchor alone.
+    ["// `import Gtk from 'gi://Gtk'` is what this forbids\nconst x = 1;", []],
+    ["/* `import Gtk from 'gi://Gtk'` */\nconst x = 1;", []],
+    // The ordering case the shared stripper exists for. The trailing `/** … */` is part of
+    // the vector: with no later `*/` the lazy block regex finds no match and the bug does
+    // not reproduce, so a version of this without it passed under BOTH orderings.
+    ["// types live under `@girs/*`\nimport Gtk from 'gi://Gtk';\n/** doc */\nconst x = 1;", ['Gtk']],
+    // Not an import at all: a runtime require, and a string that merely contains one.
+    ["const Gtk = require('gi://Gtk');", []],
+    ["const spec = 'gi://Gtk';", []],
+
+    // A QUERY IS NOT A PIN. Only `version=<something>` answers the question the loader
+    // asks; anything else leaves it picking whichever typelib it finds first, and the
+    // first reader here reported all three of these as versioned.
+    ["import Gtk from 'gi://Gtk?theme=dark';", ['Gtk']],
+    ["import Gtk from 'gi://Gtk?version=';", ['Gtk']],
+    ["import Gtk from 'gi://Gtk?lang=de&version=4.0';", []],
+
+    // THE SHAPES A LINE-ANCHORED `import … from` READER MISSED, each one measured in this
+    // tree at the time these landed. A GJS program written as a template literal and
+    // handed to `gjs -m` is an import; so is a side-effect import with no clause, a
+    // dynamic one, and one whose clause is wrapped across lines.
+    ["const p = `import GLib from 'gi://GLib';`;", ['GLib']],
+    ["import 'gi://Gtk';", ['Gtk']],
+    ["const importer = () => import('gi://Manette');", ['Manette']],
+    ["import {\n    Widget,\n} from 'gi://Gtk';", ['Gtk']],
+    // A program written as ONE template literal joined by escaped newlines — the shape
+    // `node-gi`'s gold-standard probes and `tests/e2e/gi-runtime-prologue` use. Only the
+    // first import of such a line sits after the backtick; the rest sit after a `\n`.
+    ["const p = `import GLib from 'gi://GLib';\\nimport Gio from 'gi://Gio';`;", ['GLib', 'Gio']],
+    ["const p = `x();\\nimport 'gi://Gtk';`;", ['Gtk']],
+
+    // Markdown is read as prose with code in it: line-anchored only, because an ADR
+    // explaining the rule quotes the shape inline and a doc example teaches it.
+    ["import Gtk from 'gi://Gtk';", ['Gtk'], true],
+    ["so every STATIC `import … from 'gi://Ns'` in a bundle has loaded its typelib", [], true],
+    ["A doc may quote `import Gtk from 'gi://Gtk'` mid-sentence.", [], true],
+];

--- a/scripts/nativescript-xml-doors.mjs
+++ b/scripts/nativescript-xml-doors.mjs
@@ -19,6 +19,8 @@
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { stripComments } from '../packages/infra/manifest-conformance/lib/strip-comments.mjs';
+
 /** Where the widget classes live, relative to the repo root. */
 export const NS_WIDGETS_DIR = 'packages/nativescript-bridge/adwaita/src/widgets';
 
@@ -83,7 +85,7 @@ export const SETTER_ONLY_ON_BASE = {
 };
 
 /** Strip comments, so a coercer NAMED in prose is not mistaken for one that runs. */
-export const executable = (text) => text.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
+export const executable = stripComments;
 
 /**
  * Every source a type alias might be declared in — the widgets plus the headless core.

--- a/scripts/nativescript-xml-doors.mjs
+++ b/scripts/nativescript-xml-doors.mjs
@@ -83,7 +83,7 @@ export const SETTER_ONLY_ON_BASE = {
 };
 
 /** Strip comments, so a coercer NAMED in prose is not mistaken for one that runs. */
-export const executable = (text) => text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+export const executable = (text) => text.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
 
 /**
  * Every source a type alias might be declared in — the widgets plus the headless core.

--- a/scripts/suite-registration.mjs
+++ b/scripts/suite-registration.mjs
@@ -35,6 +35,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 
 import { TS_SOURCE_EXTENSIONS } from '../packages/infra/manifest-conformance/lib/source-extensions.mjs';
+import { stripComments } from '../packages/infra/manifest-conformance/lib/strip-comments.mjs';
 
 /** Directories that never hold first-party sources. */
 export const SKIP = new Set(['node_modules', 'dist', 'lib', '.git', 'refs', 'tmp']);
@@ -104,30 +105,13 @@ export function isTestEntry(name) {
  * A regex pair would be shorter and WRONG: `packages/node/url/src/test.browser.mts` is
  * built out of `'http://example.com/…'` literals, and a `//`-to-end-of-line strip eats
  * the rest of every line one of them sits on — measured, it deletes real code from that
- * entry today. So this walks the source and skips quoted runs, because a check that
- * reads the file differently from the engine that runs it is the bug, not the guard.
+ * entry today. So the reader walks the source and skips quoted runs, because a check that
+ * reads the file differently from the engine that runs it is the bug, not the guard. It is
+ * `manifest-conformance/lib/strip-comments.mjs`, and it also lexes regex literals — the
+ * local copy this re-export replaced did not, so a `/'/` left string state open for the
+ * rest of it.
  */
-export function stripComments(source) {
-    let out = '';
-    let i = 0;
-    while (i < source.length) {
-        const c = source[i];
-        if (c === '/' && source[i + 1] === '/') {
-            while (i < source.length && source[i] !== '\n') i++;
-        } else if (c === '/' && source[i + 1] === '*') {
-            const end = source.indexOf('*/', i + 2);
-            i = end === -1 ? source.length : end + 2;
-        } else if (c === "'" || c === '"' || c === '`') {
-            const start = i++;
-            while (i < source.length && source[i] !== c) i += source[i] === '\\' ? 2 : 1;
-            out += source.slice(start, ++i);
-        } else {
-            out += c;
-            i++;
-        }
-    }
-    return out;
-}
+export { stripComments };
 
 /**
  * A relative specifier as the file on disk.

--- a/showcases/gtk/adwaita-storybook/tools/shoot-stories.js
+++ b/showcases/gtk/adwaita-storybook/tools/shoot-stories.js
@@ -8,8 +8,8 @@
 // <out-dir> directory to write <slug>.png screenshots into
 // [title]   optional single "Category/Name" to shoot (default: all stories)
 
-import Gio from 'gi://Gio';
-import GLib from 'gi://GLib';
+import Gio from 'gi://Gio?version=2.0';
+import GLib from 'gi://GLib?version=2.0';
 
 const IFACE = 'org.gjsify.Devtools';
 

--- a/showcases/gtk/node-gi-window/tools/shoot.js
+++ b/showcases/gtk/node-gi-window/tools/shoot.js
@@ -7,8 +7,8 @@
 //
 // <app-id>  eu.jumplink.NodeGiWindow (the devtools object path is derived from it)
 // <out.png> file to write the PNG into
-import Gio from 'gi://Gio';
-import GLib from 'gi://GLib';
+import Gio from 'gi://Gio?version=2.0';
+import GLib from 'gi://GLib?version=2.0';
 
 const IFACE = 'org.gjsify.Devtools';
 const [appId, outPath] = ARGV;

--- a/showcases/gtk/rn-design-system/src/app.tsx
+++ b/showcases/gtk/rn-design-system/src/app.tsx
@@ -44,7 +44,7 @@
 
 import Adw from 'gi://Adw?version=1';
 import GLib from 'gi://GLib?version=2.0';
-import GObject from 'gi://GObject';
+import GObject from 'gi://GObject?version=2.0';
 import Pango from 'gi://Pango?version=1.0';
 import Gtk from 'gi://Gtk?version=4.0';
 

--- a/tests/e2e/gi-runtime-prologue/run.mjs
+++ b/tests/e2e/gi-runtime-prologue/run.mjs
@@ -242,7 +242,7 @@ describe('the GI runtime-path prologue in a --app gjs bundle', { timeout: 5 * 60
             try {
                 writeFileSync(
                     join(dir, 'entry.js'),
-                    `(function(){globalThis.print('BANNER RAN')})();\nimport 'gi://NoSuchNamespaceForThisTest';\n`,
+                    `(function(){globalThis.print('BANNER RAN')})();\nimport 'gi://NoSuchNamespaceForThisTest?version=1.0';\n`,
                 );
                 const run = spawnSync('gjs', ['-m', join(dir, 'entry.js')], { encoding: 'utf-8', timeout: 60 * 1000 });
                 assert.match(
@@ -266,7 +266,7 @@ describe('the GI runtime-path prologue in a --app gjs bundle', { timeout: 5 * 60
             try {
                 writeFileSync(
                     join(dir, 'entry.js'),
-                    `(function(){globalThis.print('BANNER RAN')})();\nawait import('gi://NoSuchNamespaceForThisTest');\n`,
+                    `(function(){globalThis.print('BANNER RAN')})();\nawait import('gi://NoSuchNamespaceForThisTest?version=1.0');\n`,
                 );
                 const run = spawnSync('gjs', ['-m', join(dir, 'entry.js')], { encoding: 'utf-8', timeout: 60 * 1000 });
                 assert.ok(

--- a/tests/e2e/oxc-plugin/run.mjs
+++ b/tests/e2e/oxc-plugin/run.mjs
@@ -590,7 +590,7 @@ describe('oxlint plugin gjsify/no-css-side-effect-import E2E', { timeout: 5 * 60
 // is invisible to a line-based grep, which reported the tree clean while two live
 // sites stood in it. The direct form and an unrelated borrow must stay silent — a
 // rule that flagged `Array.prototype.slice.call` would be turned off within a day.
-const BORROW_FIXTURE = `import GObject from 'gi://GObject';
+const BORROW_FIXTURE = `import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 
 const one = GObject.Object.list_properties.call(Gtk.ListItem);
@@ -602,7 +602,7 @@ const four = GObject.Object.prototype.find_property.call(Gtk.ListItem, 'child');
 export const all = [one, two, three, four];
 `;
 
-const DIRECT_FIXTURE = `import GObject from 'gi://GObject';
+const DIRECT_FIXTURE = `import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 
 // The repair the rule's message names, in both spellings.

--- a/tests/e2e/process-exit-terminates/run.mjs
+++ b/tests/e2e/process-exit-terminates/run.mjs
@@ -112,7 +112,7 @@ print('AFTER');
     it('exits from a microtask with a main-loop hook armed', () => {
         // The shape every CLI reaches after `await parseAsync()`, and the one a
         // direct `system.exit()` hangs on — see the last case.
-        const run = runGjs(`import GLib from 'gi://GLib';
+        const run = runGjs(`import GLib from 'gi://GLib?version=2.0';
 ${IMPORT_EXIT}
 const loop = new GLib.MainLoop(null, false);
 loop.runAsync().catch(() => {});
@@ -128,7 +128,7 @@ print('AFTER');
     });
 
     it('exits from inside a callback someone else dispatched', () => {
-        const run = runGjs(`import GLib from 'gi://GLib';
+        const run = runGjs(`import GLib from 'gi://GLib?version=2.0';
 ${IMPORT_EXIT}
 const loop = new GLib.MainLoop(null, false);
 GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
@@ -169,7 +169,7 @@ print('AFTER');
         // the working cases above finish in about a tenth of a second, so five
         // seconds separates "hung" from "slow runner" with room to spare.
         const run = runGjs(
-            `import GLib from 'gi://GLib';
+            `import GLib from 'gi://GLib?version=2.0';
 import system from 'system';
 const loop = new GLib.MainLoop(null, false);
 loop.runAsync().catch(() => {});

--- a/website/src/content/docs/packages/dom.md
+++ b/website/src/content/docs/packages/dom.md
@@ -8,7 +8,7 @@ These packages let you draw with the browser APIs inside a real GTK window. You 
 ## Draw on a canvas
 
 ```typescript
-import Adw from 'gi://Adw';
+import Adw from 'gi://Adw?version=1';
 import { Canvas2DBridge } from '@gjsify/canvas2d';
 
 const bridge = new Canvas2DBridge();
@@ -35,7 +35,7 @@ win.present();
 ## Render with WebGL
 
 ```typescript
-import Adw from 'gi://Adw';
+import Adw from 'gi://Adw?version=1';
 import { WebGLBridge } from '@gjsify/webgl';
 
 const bridge = new WebGLBridge();


### PR DESCRIPTION
Every `gi://` import states the typelib version it wants, and one shared lexer replaces thirteen hand-rolled comment strippers.

**This description was wrong twice and is corrected below.** An independent review re-measured every claim in it; three of its commits are the result, and the numbers here are that review's, not my first pass's.

## The pins

`import Gtk from 'gi://Gtk'` asks the loader for whichever typelib it finds first. The tree already pinned almost everywhere — 83 `gi://GLib?version=2.0`, 83 Gio, 72 Gtk — and held nothing.

**66 imports were unpinned, not 52.** My reader saw exactly one shape: a line beginning `import … from 'gi://Ns'`. It missed eight imports inside template-literal GJS programs handed to `gjs -m`, two dynamic `import('gi://Manette')` calls (one of them the whole gamepad backend), a bare `import 'gi://Ns'`, a clause wrapped over lines, and a query that is not a version — `gi://Gtk?theme=dark` and `gi://Gtk?version=` both read as pinned. My commit message said the e2e runners were pinned; **the first diff never touched `tests/` at all.**

All 66 are pinned now and verified against the live loader rather than by eye: each resolves under `gjs -m`, and `gi://NoSuchNamespaceForThisTest?version=1.0` still fails naming the namespace, which two e2e cases assert.

Every version is one the tree already uses and one installed under `/usr/lib64/girepository-1.0`. Nothing guessed.

`scripts/check-gi-import-versions.mjs` holds it, with **22** self-test vectors. It does not check that the stated version is the RIGHT one — that is a claim about the machine, and a gate asserting it would go red on a runner rather than on a diff.

Honest about the value: for Gio, GObject and Pango exactly one version is installed on every machine this runs on. The case that is not hypothetical is `WebKit2-4.1` (GTK3) beside `WebKit-6.0` (GTK4), where the wrong pick loads a second toolkit into one address space.

## The comment strippers — a lexer, not a reordering

The first version of this PR swapped the order of two regexes in seven strippers. **That was not a fix.** Measured against a stateful lexer over 3642 tracked JS/TS sources:

| stripper | code lines hidden | files |
|---|---|---|
| block-first (before) | 7780 | 226 |
| line-first (my swap) | 3503 | 104 |
| **lexer** | **0** | **0** |

Line-first halves the class and opens a new one: a block comment *containing* a `//` loses its terminator, and `[^:]` does not help when the `//` follows a backtick. `packages/infra/npm-registry/src/types.ts` documents a `//host/path/:` prefix, and under my order its `authTokens` declaration disappeared. Line-level A/B: my shape gains 4347 lines and **loses 84 in 18 files**. The old description reported only the gain — netting, in a PR about a blindness.

Neither order sees `globSync('**/*.ts')`, which opens a fake block comment either way.

**The closed version already existed in this repo.** `scripts/check-adapter-import-direction.mjs` had rewritten its stripper as a stateful scanner after a regex read `const re = /[/*]/;` as an open block comment and reported a live violation at exit 0 — its header documents this exact class. I had classified that file as "character scanner, immune" without asking why it was a scanner. It is now lifted to `packages/infra/manifest-conformance/lib/strip-comments.mjs` and **ten readers share it**, including `suite-registration` (a third implementation that did not lex regex literals) and `source-graph`. Self-test runs on import. The incident is written up in `docs/code-anti-patterns.md`.

## Four of my ten vectors could not go red

Mutation-tested against ten single-fault mutants: the two prose vectors, `require('gi://Gtk')` and `const spec = 'gi://Gtk'` all stayed green **with the comment stripper removed entirely** — none begins a line with `import`, so the anchor alone rejected them. They asserted nothing about what they were written for. 18 of 22 now die to a single fault; the four that do not are the baseline "does it match at all" shapes.

The "scan found nothing" guard had the same shape of hole: it fired only when no file *mentioned* `gi://`, and mentions are mostly prose. A reader whose pattern stopped matching would still have counted 607 files and printed OK over zero imports. It counts imports now.

## Corrected numbers

| earlier claim | measured |
|---|---|
| 3641 tracked sources | 3642 |
| 8243 code lines in 307 files | 7780 code lines in 226 files — magnitude right, "code lines" overstated it; most of a swallowed span is comment text |
| cli-own-version-read: 2446 over 46 of 285 | 2448 over 47 of 285. Still exit 0 afterwards, output byte-identical — the blindness was real, what it hid was clean |
| 468 imports across 605 files | 512 across 606 (`CLAUDE.md` is a symlink to `AGENTS.md`; `git grep` skips it, `readFileSync` follows it). Now **517 across 608** |
| `audit-runtimes --strict` byte-identical with source-graph reverted | confirmed by `cmp` |

## Checked and fine

All 66 pins mechanically verified: every namespace/version pair exists under `/usr/lib64/girepository-1.0`, matches the tree's dominant spelling, and sits on a real import line outside a comment per the lexer. No changed line was a non-import. No `export … from 'gi://'`, no template-built specifier, no `.blp` import in the tree. `.astro`/`.vue`/`.svelte` were unscanned and now are — `ShowcaseSlideshow.astro` alone holds five.

All 65 `scripts/check-*.mjs` at baseline exit codes. `gjsify lint` 0, proved live. `gjsify format --check` 0 over 3512 files. `@gjsify/gamepad` 139; `process-exit-terminates` 5/5; `gi-runtime-prologue` 11/11; `oxc-plugin` 17/17.