### PR TITLE
feat(adwaita-react-native): add the content group

### DIFF
--- a/packages/framework/adwaita-react-native/README.md
+++ b/packages/framework/adwaita-react-native/README.md
@@ -17,10 +17,13 @@ approximation.
 
 ## What this is, honestly
 
-**A walking skeleton, not yet a widget set.** The table below is the whole of it. Every
-row carries the whole vertical — both platform halves, the resolution mechanism, the
-`exports` entry, a gate, and a suite on each side that reads the REAL tree — and the
-widgets that are not in it are repetition against a boundary that has been measured.
+**Not a widget set yet.** The table below is the whole of it, and every row carries the
+whole vertical — both platform halves, the resolution mechanism, the `exports` entry, a
+gate, and a suite on each side that reads the REAL tree. `AdwBin` and `AdwClamp` came
+first and proved that shape; the groups since are where it starts earning its keep, and
+the content-and-feedback widgets are the clearest case — each has a DERIVATION as its
+shared half (an initials hash, a palette index, a queue policy, a ring geometry), so the
+two implementations are held to the same number rather than to the same shape.
 
 **The promise is the Adwaita design language on React Native, not "your app runs".**
 Unlike [`@gjsify/react-native`](../react-native) — the opposite direction, which was
@@ -46,10 +49,15 @@ a GTK-only consumer does not need it installed.
 
 | widget | props | notes |
 |---|---|---|
+| `AdwAvatar` | `size` (**required**), `text`, `showInitials`, `iconName` | Initials and palette entry from one port of `extract_initials_from_text` + `set_class_color`. `size` is required because libadwaita's default is the `-1` "ask the stylesheet" sentinel and neither renderer here has one |
+| `AdwBanner` | `title`, `buttonLabel`, `revealed`, `useMarkup`, `buttonStyle`, `onButtonClicked` | An omitted `useMarkup` is FALSE on both halves — the value the widget reads back, not the TRUE its `GParamSpec` declares |
 | `AdwBin` | `children` | One child, no layout of its own |
+| `AdwButtonContent` | `iconName`, `label`, `useUnderline`, `canShrink` | Four derivations from the core, including the 6px gap that is `border-spacing` and not `GtkBox:spacing` |
 | `AdwClamp` | `children`, `maximumSize` (600), `tighteningThreshold` (400) | Constrain a child's width and centre it, on libadwaita's easing curve |
 | `AdwHeaderBar` | `start`, `titleWidget`, `title`, `subtitle`, `end` | The three slots as PROPS, in draw order. No window controls: a phone has none |
+| `AdwSpinner` | `widthRequest`, `heightRequest` | The BOX and the RING are two numbers: an unbounded box around a ring capped at 64 |
 | `AdwStatusPage` | `children`, `iconName`, `title`, `description` | A centred empty state. The icon draws on GTK only |
+| `AdwToastOverlay` | `children`, `ref` (`addToast`, `dismissAll`) | One toast at a time. A toast is PUSHED through the ref, never declared as a prop — `add_toast` is a call |
 | `AdwToolbarView` | `children` (the content), `topBar`, `bottomBar`, `topBarStyle` (`flat`), `bottomBarStyle` (`flat`), `extendContentToTopEdge` (false), `extendContentToBottomEdge` (false) | Content framed by bars. The two styles reach the real widget on GTK and draw nothing on a phone |
 | `AdwWindowTitle` | `title`, `subtitle` | Two labels; an EMPTY one takes no space, a blank one does |
 | `AdwWrapBox` | `children` plus libadwaita's fourteen: `childSpacing`/`childSpacingUnit`, `lineSpacing`/`lineSpacingUnit`, `align`, `justify`, `justifyLastLine`, `lineHomogeneous`, `naturalLineLength`/`naturalLineLengthUnit`, `packDirection`, `wrapReverse`, `wrapPolicy`, `orientation` | Children flow onto new lines. The line DECISION is `@gjsify/adwaita-core`'s, the line BREAKING is Yoga's |
@@ -122,6 +130,10 @@ nothing:
 | GTK: a slot is the slot it was written into | the style class libadwaita puts on the box it packs into — `start`/`end` on the header bar, `top-bar`/`bottom-bar` on the toolbar view. `pack_start`, `pack_end`, `add_top_bar` and `add_bottom_bar` are all WRITE-ONLY, so an assertion that the child is merely present passes with the child in the wrong slot |
 | both halves agree on the number | two frames, one of them ON the easing curve: 1000 points at `maximumSize` 400 gives width 400 at offset 300, and 700 points at the default 600/400 gives **575 at offset 62**, where a `min()` would give 600 |
 | both halves answer the same for a property value GObject cannot store | `normalizeClampSize` from `@gjsify/adwaita-core`, run by **both** halves — the same call `@gjsify/adwaita-web` and `@gjsify/adwaita-nativescript` make. `400.7` &rarr; 400, `NaN` &rarr; the default 600, `-5` &rarr; the range floor 0, asserted on both sides |
+| both halves pick the same avatar colour, from the same bytes | libadwaita PUBLISHES its answer: `set_class_color` stamps `color{n}` on the avatar's internal gizmo. GTK reads `color11` off the live tree for "Ada Lovelace" and `color6` for "Grace Hopper"; React Native paints `#8c75d9` and `#eba831`, the same two entries flattened. Two names, because one agreeing proves only that both landed in a bucket once — the derivation is `g_str_hash` over UTF-8 BYTES, and a renderer hashing UTF-16 code units agrees for plenty of ASCII names |
+| both halves show ONE toast for two adds | measured on libadwaita 1.9.3 as a single `AdwToastWidget` carrying the first title, and asserted of `@gjsify/adwaita-core`'s `AdwToastQueue` on the other side. Neither half runs the other's queue |
+| the millisecond&rarr;second conversion cannot turn a brief toast into a permanent one | `Adw.Toast:timeout` counts whole seconds and reads back 5 on a default toast; `DEFAULT_TOAST_TIMEOUT` counts 5000 ms. The conversion is `ceil`, asserted against libadwaita's own default rather than against itself — `Math.round(400 / 1000)` is 0, which is "until dismissed" |
+| the spinner's box and its ring are held on the half where each is a node | GTK measures the BOX (`[16, 16]` unrequested, 200 requested, no upper bound); React Native asserts the RING, which on GTK is an `AdwSpinnerPaintable` and not a widget at all — 64 points with an 8-point stroke inside a 200-point box |
 
 **Not proven: Yoga, and the device.** A `width` in a style object is an instruction to a
 layout engine that no test here runs. The React Native half is type-checked and
@@ -164,12 +176,16 @@ than smoothed over.
   an `AdwWindowTitle` centre. This is the same divergence `@gjsify/adwaita-web` and
   `@gjsify/adwaita-nativescript` carry, recorded as `HeaderBarRenderState.derivedSubtitle`
   in `@gjsify/adwaita-core`.
-- **`AdwStatusPage` draws no icon on React Native.** `icon-name` names an entry in an
-  ICON THEME and React Native has none — no `Image` source a GNOME symbolic name resolves
-  to, and no renderer for the SVG `@gjsify/adwaita-nativescript` substituted instead.
-  Drawing the name as text would put the literal `folder-symbolic` on screen. The prop is
-  carried so a GTK consumer's props stay portable, and the ABSENCE of an icon node is
-  asserted, so the day one appears it is a decision and not a drift.
+- **Neither renderer here resolves an icon theme, so `iconName` is accepted and not
+  drawn.** `icon-name` names an entry in an ICON THEME and React Native has none — no
+  `Image` source a GNOME symbolic name resolves to, and no renderer for the SVG
+  `@gjsify/adwaita-nativescript` substituted instead. Drawing the name as text would put
+  the literal `folder-symbolic` on screen. So `AdwStatusPage` shows no icon, `AdwAvatar`'s
+  icon mode is a coloured circle with the initials hidden where GTK draws
+  `adw-avatar-default-symbolic`, and `AdwButtonContent`'s icon slot sits in the row with
+  libadwaita's own `hexpand` and holds no glyph. The props are carried so a GTK consumer's
+  props stay portable, and the ABSENCE of an icon node is asserted in each case, so the
+  day one appears it is a decision and not a drift.
 - **`AdwToolbarView` does not run libadwaita's allocation on React Native, and cannot.**
   `adw_toolbar_view_size_allocate` is two chained CLAMPs over the bars' MINIMUM and
   NATURAL heights — ported as `toolbarViewAllocate` and held to vectors — and React
@@ -201,6 +217,41 @@ than smoothed over.
   `@gjsify/adwaita-core`'s `wrapBoxFlexStyle` rather than in a conformance vector. The
   GTK half runs none of it: `Adw.WrapBox` is `adw-wrap-layout.c` itself, and the suite
   reads the continuum back off the live tree.
+- **`AdwAvatar`'s font size is the CAP, not a measurement.** `update_font_size` scales
+  the label's measured aspect ratio against `avatarMaxFontSize(size)`; React Native
+  reports a text box only through `onLayout`, i.e. after layout — the same missing
+  measure pass that makes `AdwClamp` pass `childMin: 0`. Using the cap alone stays inside
+  libadwaita's bound. The NativeScript port's `size * 0.4` heuristic is deliberately not
+  copied: it is not monotonic in `size` and exceeds the cap above ~54 points.
+- **`AdwButtonContent` cannot stamp `image-text-button`.** `adw_button_content_root` puts
+  the class on the nearest `GtkButton` ancestor, and this package ships no button for it
+  to find. `buttonContentStyleTargetIndex` holds the retarget rule for a renderer that has
+  a tree to walk; when a button lands here, that is the call to make.
+- **`AdwSpinner` draws the track and not the arc.** `AdwSpinnerPaintable`'s segment
+  extends, overlaps, contracts and idles on an ease-in-out-sine while the whole figure
+  turns, and drawing it needs a path renderer that is not a dependency of this package.
+  What is drawn is the circle underneath — `ADW_SPINNER_TRACK_OPACITY` of the current
+  colour, exactly what the browser renderer paints under its arc. The `_spinner.scss`
+  substitute (a fixed 90-degree `border-top-color` chase at 0.8s) is a different animation
+  with a different period, so copying it would put a wrong number where there is an absent
+  one. **The suite asserts the track's opacity and nothing about motion** — there is no
+  animation assertion here, because there is no animation to assert.
+- **`Adw.Toast:timeout` is lossy in the other direction.** GObject stores whole seconds,
+  so 1500 ms is 2 s on GTK and stays 1500 ms on React Native.
+- **A toast's action button has no callback.** `Adw.Toast` expresses its action as
+  `action-name`, a `GAction` this package has no surface for, so pressing the button does
+  what both other renderers do: dismiss the current toast, which advances the queue.
+- **`dismissAll`'s REMOVAL is asserted only on React Native.**
+  `adw_toast_overlay_dismiss_all` animates the strip out over real time, and pumping the
+  main context for ~1.6s leaves the `AdwToastWidget` in place — measured. GTK asserts that
+  the call lands and costs no diagnostic; the removal is asserted where the queue is ours.
+- **`AdwBanner` reduces markup to its plain text.** React Native has no inline-markup
+  layer, and painting `<b>Metered</b>` literally is further from what GTK draws than
+  painting `Metered` is. Unparseable markup keeps the raw string, which is Pango's own
+  fallback.
+- **A press assertion proves the widget ASKS for the press, never that a tap arrives.**
+  The `react-native` double forwards `onPress` verbatim; the real runtime wires it through
+  the press responder. Same class of gap as Yoga, one layer up.
 - **`Adw.ClampScrollable` has no counterpart and will not get one.** It binds its four
   scroll properties onto its child, which is a GTK adoption concern; on React Native
   scrolling belongs to the `ScrollView`, not to the clamp. This is an asymmetry, not a

--- a/packages/framework/adwaita-react-native/package.json
+++ b/packages/framework/adwaita-react-native/package.json
@@ -11,10 +11,25 @@
             "react-native": "./lib/esm/index.native.js",
             "default": "./lib/esm/index.gtk.js"
         },
+        "./widgets/avatar": {
+            "types": "./lib/types/widgets/avatar.d.ts",
+            "react-native": "./lib/esm/widgets/avatar.native.js",
+            "default": "./lib/esm/widgets/avatar.gtk.js"
+        },
+        "./widgets/banner": {
+            "types": "./lib/types/widgets/banner.d.ts",
+            "react-native": "./lib/esm/widgets/banner.native.js",
+            "default": "./lib/esm/widgets/banner.gtk.js"
+        },
         "./widgets/bin": {
             "types": "./lib/types/widgets/bin.d.ts",
             "react-native": "./lib/esm/widgets/bin.native.js",
             "default": "./lib/esm/widgets/bin.gtk.js"
+        },
+        "./widgets/button-content": {
+            "types": "./lib/types/widgets/button-content.d.ts",
+            "react-native": "./lib/esm/widgets/button-content.native.js",
+            "default": "./lib/esm/widgets/button-content.gtk.js"
         },
         "./widgets/clamp": {
             "types": "./lib/types/widgets/clamp.d.ts",
@@ -26,10 +41,20 @@
             "react-native": "./lib/esm/widgets/header-bar.native.js",
             "default": "./lib/esm/widgets/header-bar.gtk.js"
         },
+        "./widgets/spinner": {
+            "types": "./lib/types/widgets/spinner.d.ts",
+            "react-native": "./lib/esm/widgets/spinner.native.js",
+            "default": "./lib/esm/widgets/spinner.gtk.js"
+        },
         "./widgets/status-page": {
             "types": "./lib/types/widgets/status-page.d.ts",
             "react-native": "./lib/esm/widgets/status-page.native.js",
             "default": "./lib/esm/widgets/status-page.gtk.js"
+        },
+        "./widgets/toast-overlay": {
+            "types": "./lib/types/widgets/toast-overlay.d.ts",
+            "react-native": "./lib/esm/widgets/toast-overlay.native.js",
+            "default": "./lib/esm/widgets/toast-overlay.gtk.js"
         },
         "./widgets/toolbar-view": {
             "types": "./lib/types/widgets/toolbar-view.d.ts",

--- a/packages/framework/adwaita-react-native/src/index.gtk.ts
+++ b/packages/framework/adwaita-react-native/src/index.gtk.ts
@@ -8,20 +8,31 @@
 // replacement, `scripts/check-adwaita-rn-platform-split.mjs`.
 
 export type {
+    AdwAvatarProps,
+    AdwBannerProps,
     AdwBinProps,
+    AdwButtonContentProps,
     AdwClampProps,
     AdwHeaderBarProps,
+    AdwSpinnerProps,
     AdwStatusPageProps,
+    AdwToastOverlayHandle,
+    AdwToastOverlayProps,
     AdwToolbarViewProps,
     AdwWidgetProps,
     AdwWindowTitleProps,
     AdwWrapBoxProps,
 } from './props.js';
 
+export { AdwAvatar } from './widgets/avatar.gtk.js';
+export { AdwBanner } from './widgets/banner.gtk.js';
 export { AdwBin } from './widgets/bin.gtk.js';
+export { AdwButtonContent } from './widgets/button-content.gtk.js';
 export { AdwClamp } from './widgets/clamp.gtk.js';
 export { AdwHeaderBar } from './widgets/header-bar.gtk.js';
+export { AdwSpinner } from './widgets/spinner.gtk.js';
 export { AdwStatusPage } from './widgets/status-page.gtk.js';
+export { AdwToastOverlay } from './widgets/toast-overlay.gtk.js';
 export { AdwToolbarView } from './widgets/toolbar-view.gtk.js';
 export { AdwWindowTitle } from './widgets/window-title.gtk.js';
 export { AdwWrapBox } from './widgets/wrap-box.gtk.js';
@@ -37,12 +48,30 @@ export { AdwWrapBox } from './widgets/wrap-box.gtk.js';
 // from drifting is rule 8 of `check-adwaita-rn-platform-split.mjs`, which holds the
 // members of `Adw` against the widgets on disk in both directions.
 
+import { AdwAvatar as Avatar } from './widgets/avatar.gtk.js';
+import { AdwBanner as Banner } from './widgets/banner.gtk.js';
 import { AdwBin as Bin } from './widgets/bin.gtk.js';
+import { AdwButtonContent as ButtonContent } from './widgets/button-content.gtk.js';
 import { AdwClamp as Clamp } from './widgets/clamp.gtk.js';
 import { AdwHeaderBar as HeaderBar } from './widgets/header-bar.gtk.js';
+import { AdwSpinner as Spinner } from './widgets/spinner.gtk.js';
 import { AdwStatusPage as StatusPage } from './widgets/status-page.gtk.js';
+import { AdwToastOverlay as ToastOverlay } from './widgets/toast-overlay.gtk.js';
 import { AdwToolbarView as ToolbarView } from './widgets/toolbar-view.gtk.js';
 import { AdwWindowTitle as WindowTitle } from './widgets/window-title.gtk.js';
 import { AdwWrapBox as WrapBox } from './widgets/wrap-box.gtk.js';
 
-export const Adw = { Bin, Clamp, HeaderBar, StatusPage, ToolbarView, WindowTitle, WrapBox };
+export const Adw = {
+    Avatar,
+    Banner,
+    Bin,
+    ButtonContent,
+    Clamp,
+    HeaderBar,
+    Spinner,
+    StatusPage,
+    ToastOverlay,
+    ToolbarView,
+    WindowTitle,
+    WrapBox,
+};

--- a/packages/framework/adwaita-react-native/src/index.native.ts
+++ b/packages/framework/adwaita-react-native/src/index.native.ts
@@ -6,20 +6,31 @@
 // literal-naming rule the barrel below follows.
 
 export type {
+    AdwAvatarProps,
+    AdwBannerProps,
     AdwBinProps,
+    AdwButtonContentProps,
     AdwClampProps,
     AdwHeaderBarProps,
+    AdwSpinnerProps,
     AdwStatusPageProps,
+    AdwToastOverlayHandle,
+    AdwToastOverlayProps,
     AdwToolbarViewProps,
     AdwWidgetProps,
     AdwWindowTitleProps,
     AdwWrapBoxProps,
 } from './props.js';
 
+export { AdwAvatar } from './widgets/avatar.native.js';
+export { AdwBanner } from './widgets/banner.native.js';
 export { AdwBin } from './widgets/bin.native.js';
+export { AdwButtonContent } from './widgets/button-content.native.js';
 export { AdwClamp } from './widgets/clamp.native.js';
 export { AdwHeaderBar } from './widgets/header-bar.native.js';
+export { AdwSpinner } from './widgets/spinner.native.js';
 export { AdwStatusPage } from './widgets/status-page.native.js';
+export { AdwToastOverlay } from './widgets/toast-overlay.native.js';
 export { AdwToolbarView } from './widgets/toolbar-view.native.js';
 export { AdwWindowTitle } from './widgets/window-title.native.js';
 export { AdwWrapBox } from './widgets/wrap-box.native.js';
@@ -35,12 +46,30 @@ export { AdwWrapBox } from './widgets/wrap-box.native.js';
 // from drifting is rule 8 of `check-adwaita-rn-platform-split.mjs`, which holds the
 // members of `Adw` against the widgets on disk in both directions.
 
+import { AdwAvatar as Avatar } from './widgets/avatar.native.js';
+import { AdwBanner as Banner } from './widgets/banner.native.js';
 import { AdwBin as Bin } from './widgets/bin.native.js';
+import { AdwButtonContent as ButtonContent } from './widgets/button-content.native.js';
 import { AdwClamp as Clamp } from './widgets/clamp.native.js';
 import { AdwHeaderBar as HeaderBar } from './widgets/header-bar.native.js';
+import { AdwSpinner as Spinner } from './widgets/spinner.native.js';
 import { AdwStatusPage as StatusPage } from './widgets/status-page.native.js';
+import { AdwToastOverlay as ToastOverlay } from './widgets/toast-overlay.native.js';
 import { AdwToolbarView as ToolbarView } from './widgets/toolbar-view.native.js';
 import { AdwWindowTitle as WindowTitle } from './widgets/window-title.native.js';
 import { AdwWrapBox as WrapBox } from './widgets/wrap-box.native.js';
 
-export const Adw = { Bin, Clamp, HeaderBar, StatusPage, ToolbarView, WindowTitle, WrapBox };
+export const Adw = {
+    Avatar,
+    Banner,
+    Bin,
+    ButtonContent,
+    Clamp,
+    HeaderBar,
+    Spinner,
+    StatusPage,
+    ToastOverlay,
+    ToolbarView,
+    WindowTitle,
+    WrapBox,
+};

--- a/packages/framework/adwaita-react-native/src/index.ts
+++ b/packages/framework/adwaita-react-native/src/index.ts
@@ -10,20 +10,31 @@
 // is what makes both halves satisfy it.
 
 export type {
+    AdwAvatarProps,
+    AdwBannerProps,
     AdwBinProps,
+    AdwButtonContentProps,
     AdwClampProps,
     AdwHeaderBarProps,
+    AdwSpinnerProps,
     AdwStatusPageProps,
+    AdwToastOverlayHandle,
+    AdwToastOverlayProps,
     AdwToolbarViewProps,
     AdwWidgetProps,
     AdwWindowTitleProps,
     AdwWrapBoxProps,
 } from './props.js';
 
+export { AdwAvatar } from './widgets/avatar.js';
+export { AdwBanner } from './widgets/banner.js';
 export { AdwBin } from './widgets/bin.js';
+export { AdwButtonContent } from './widgets/button-content.js';
 export { AdwClamp } from './widgets/clamp.js';
 export { AdwHeaderBar } from './widgets/header-bar.js';
+export { AdwSpinner } from './widgets/spinner.js';
 export { AdwStatusPage } from './widgets/status-page.js';
+export { AdwToastOverlay } from './widgets/toast-overlay.js';
 export { AdwToolbarView } from './widgets/toolbar-view.js';
 export { AdwWindowTitle } from './widgets/window-title.js';
 export { AdwWrapBox } from './widgets/wrap-box.js';
@@ -39,12 +50,30 @@ export { AdwWrapBox } from './widgets/wrap-box.js';
 // from drifting is rule 8 of `check-adwaita-rn-platform-split.mjs`, which holds the
 // members of `Adw` against the widgets on disk in both directions.
 
+import { AdwAvatar as Avatar } from './widgets/avatar.js';
+import { AdwBanner as Banner } from './widgets/banner.js';
 import { AdwBin as Bin } from './widgets/bin.js';
+import { AdwButtonContent as ButtonContent } from './widgets/button-content.js';
 import { AdwClamp as Clamp } from './widgets/clamp.js';
 import { AdwHeaderBar as HeaderBar } from './widgets/header-bar.js';
+import { AdwSpinner as Spinner } from './widgets/spinner.js';
 import { AdwStatusPage as StatusPage } from './widgets/status-page.js';
+import { AdwToastOverlay as ToastOverlay } from './widgets/toast-overlay.js';
 import { AdwToolbarView as ToolbarView } from './widgets/toolbar-view.js';
 import { AdwWindowTitle as WindowTitle } from './widgets/window-title.js';
 import { AdwWrapBox as WrapBox } from './widgets/wrap-box.js';
 
-export const Adw = { Bin, Clamp, HeaderBar, StatusPage, ToolbarView, WindowTitle, WrapBox };
+export const Adw = {
+    Avatar,
+    Banner,
+    Bin,
+    ButtonContent,
+    Clamp,
+    HeaderBar,
+    Spinner,
+    StatusPage,
+    ToastOverlay,
+    ToolbarView,
+    WindowTitle,
+    WrapBox,
+};

--- a/packages/framework/adwaita-react-native/src/parity.spec.ts
+++ b/packages/framework/adwaita-react-native/src/parity.spec.ts
@@ -36,18 +36,33 @@
 
 import { describe, expect, it } from '@gjsify/unit';
 
+import type * as AvatarBase from './widgets/avatar.js';
+import type * as AvatarGtk from './widgets/avatar.gtk.js';
+import type * as AvatarNative from './widgets/avatar.native.js';
+import type * as BannerBase from './widgets/banner.js';
+import type * as BannerGtk from './widgets/banner.gtk.js';
+import type * as BannerNative from './widgets/banner.native.js';
 import type * as BinBase from './widgets/bin.js';
 import type * as BinGtk from './widgets/bin.gtk.js';
 import type * as BinNative from './widgets/bin.native.js';
+import type * as ButtonContentBase from './widgets/button-content.js';
+import type * as ButtonContentGtk from './widgets/button-content.gtk.js';
+import type * as ButtonContentNative from './widgets/button-content.native.js';
 import type * as ClampBase from './widgets/clamp.js';
 import type * as ClampGtk from './widgets/clamp.gtk.js';
 import type * as ClampNative from './widgets/clamp.native.js';
 import type * as HeaderBarBase from './widgets/header-bar.js';
 import type * as HeaderBarGtk from './widgets/header-bar.gtk.js';
 import type * as HeaderBarNative from './widgets/header-bar.native.js';
+import type * as SpinnerBase from './widgets/spinner.js';
+import type * as SpinnerGtk from './widgets/spinner.gtk.js';
+import type * as SpinnerNative from './widgets/spinner.native.js';
 import type * as StatusPageBase from './widgets/status-page.js';
 import type * as StatusPageGtk from './widgets/status-page.gtk.js';
 import type * as StatusPageNative from './widgets/status-page.native.js';
+import type * as ToastOverlayBase from './widgets/toast-overlay.js';
+import type * as ToastOverlayGtk from './widgets/toast-overlay.gtk.js';
+import type * as ToastOverlayNative from './widgets/toast-overlay.native.js';
 import type * as ToolbarViewBase from './widgets/toolbar-view.js';
 import type * as ToolbarViewGtk from './widgets/toolbar-view.gtk.js';
 import type * as ToolbarViewNative from './widgets/toolbar-view.native.js';
@@ -117,8 +132,18 @@ type SatisfiesBase<Platform, Base, Name extends keyof Base & keyof Platform> = P
     ? SameKeys<PropsOf<Platform[Name]>, PropsOf<Base[Name]>>
     : false;
 
+export type AvatarGtkSatisfiesBase = Assert<SatisfiesBase<typeof AvatarGtk, typeof AvatarBase, 'AdwAvatar'>>;
+export type AvatarNativeSatisfiesBase = Assert<SatisfiesBase<typeof AvatarNative, typeof AvatarBase, 'AdwAvatar'>>;
+export type BannerGtkSatisfiesBase = Assert<SatisfiesBase<typeof BannerGtk, typeof BannerBase, 'AdwBanner'>>;
+export type BannerNativeSatisfiesBase = Assert<SatisfiesBase<typeof BannerNative, typeof BannerBase, 'AdwBanner'>>;
 export type BinGtkSatisfiesBase = Assert<SatisfiesBase<typeof BinGtk, typeof BinBase, 'AdwBin'>>;
 export type BinNativeSatisfiesBase = Assert<SatisfiesBase<typeof BinNative, typeof BinBase, 'AdwBin'>>;
+export type ButtonContentGtkSatisfiesBase = Assert<
+    SatisfiesBase<typeof ButtonContentGtk, typeof ButtonContentBase, 'AdwButtonContent'>
+>;
+export type ButtonContentNativeSatisfiesBase = Assert<
+    SatisfiesBase<typeof ButtonContentNative, typeof ButtonContentBase, 'AdwButtonContent'>
+>;
 export type ClampGtkSatisfiesBase = Assert<SatisfiesBase<typeof ClampGtk, typeof ClampBase, 'AdwClamp'>>;
 export type ClampNativeSatisfiesBase = Assert<SatisfiesBase<typeof ClampNative, typeof ClampBase, 'AdwClamp'>>;
 export type HeaderBarGtkSatisfiesBase = Assert<
@@ -127,11 +152,19 @@ export type HeaderBarGtkSatisfiesBase = Assert<
 export type HeaderBarNativeSatisfiesBase = Assert<
     SatisfiesBase<typeof HeaderBarNative, typeof HeaderBarBase, 'AdwHeaderBar'>
 >;
+export type SpinnerGtkSatisfiesBase = Assert<SatisfiesBase<typeof SpinnerGtk, typeof SpinnerBase, 'AdwSpinner'>>;
+export type SpinnerNativeSatisfiesBase = Assert<SatisfiesBase<typeof SpinnerNative, typeof SpinnerBase, 'AdwSpinner'>>;
 export type StatusPageGtkSatisfiesBase = Assert<
     SatisfiesBase<typeof StatusPageGtk, typeof StatusPageBase, 'AdwStatusPage'>
 >;
 export type StatusPageNativeSatisfiesBase = Assert<
     SatisfiesBase<typeof StatusPageNative, typeof StatusPageBase, 'AdwStatusPage'>
+>;
+export type ToastOverlayGtkSatisfiesBase = Assert<
+    SatisfiesBase<typeof ToastOverlayGtk, typeof ToastOverlayBase, 'AdwToastOverlay'>
+>;
+export type ToastOverlayNativeSatisfiesBase = Assert<
+    SatisfiesBase<typeof ToastOverlayNative, typeof ToastOverlayBase, 'AdwToastOverlay'>
 >;
 export type ToolbarViewGtkSatisfiesBase = Assert<
     SatisfiesBase<typeof ToolbarViewGtk, typeof ToolbarViewBase, 'AdwToolbarView'>
@@ -157,14 +190,24 @@ export type WrapBoxNativeSatisfiesBase = Assert<SatisfiesBase<typeof WrapBoxNati
  * would otherwise wave a missing widget through.
  */
 export const PARITY_ASSERTIONS = [
+    'AvatarGtkSatisfiesBase',
+    'AvatarNativeSatisfiesBase',
+    'BannerGtkSatisfiesBase',
+    'BannerNativeSatisfiesBase',
     'BinGtkSatisfiesBase',
     'BinNativeSatisfiesBase',
+    'ButtonContentGtkSatisfiesBase',
+    'ButtonContentNativeSatisfiesBase',
     'ClampGtkSatisfiesBase',
     'ClampNativeSatisfiesBase',
     'HeaderBarGtkSatisfiesBase',
     'HeaderBarNativeSatisfiesBase',
+    'SpinnerGtkSatisfiesBase',
+    'SpinnerNativeSatisfiesBase',
     'StatusPageGtkSatisfiesBase',
     'StatusPageNativeSatisfiesBase',
+    'ToastOverlayGtkSatisfiesBase',
+    'ToastOverlayNativeSatisfiesBase',
     'ToolbarViewGtkSatisfiesBase',
     'ToolbarViewNativeSatisfiesBase',
     'WindowTitleGtkSatisfiesBase',
@@ -198,14 +241,24 @@ export default async () => {
             // still add is COMPLETENESS: one assertion per widget per platform, which
             // is the half a deleted alias would silently take with it.
             expect([...PARITY_ASSERTIONS].sort()).toStrictEqual([
+                'AvatarGtkSatisfiesBase',
+                'AvatarNativeSatisfiesBase',
+                'BannerGtkSatisfiesBase',
+                'BannerNativeSatisfiesBase',
                 'BinGtkSatisfiesBase',
                 'BinNativeSatisfiesBase',
+                'ButtonContentGtkSatisfiesBase',
+                'ButtonContentNativeSatisfiesBase',
                 'ClampGtkSatisfiesBase',
                 'ClampNativeSatisfiesBase',
                 'HeaderBarGtkSatisfiesBase',
                 'HeaderBarNativeSatisfiesBase',
+                'SpinnerGtkSatisfiesBase',
+                'SpinnerNativeSatisfiesBase',
                 'StatusPageGtkSatisfiesBase',
                 'StatusPageNativeSatisfiesBase',
+                'ToastOverlayGtkSatisfiesBase',
+                'ToastOverlayNativeSatisfiesBase',
                 'ToolbarViewGtkSatisfiesBase',
                 'ToolbarViewNativeSatisfiesBase',
                 'WindowTitleGtkSatisfiesBase',

--- a/packages/framework/adwaita-react-native/src/props.ts
+++ b/packages/framework/adwaita-react-native/src/props.ts
@@ -9,21 +9,24 @@
 // libadwaita's documentation is the property they write.
 
 import type {
+    AdwBannerButtonStyle,
     AdwLengthUnit,
+    AdwToast,
     AdwToolbarStyle,
     AdwWrapBoxJustify,
     AdwWrapBoxOrientation,
     AdwWrapBoxPackDirection,
     AdwWrapPolicy,
 } from '@gjsify/adwaita-core';
-import type { ReactNode } from 'react';
+import type { ReactNode, Ref } from 'react';
 
 /**
  * What a widget that HOLDS a child accepts.
  *
- * Not every widget does. `Adw.WindowTitle` is two labels and no child slot, so
- * {@link AdwWindowTitleProps} deliberately does not extend this — a `children` a widget
- * would have to drop is a hole in the surface, not a convenience.
+ * Not every widget does. `Adw.WindowTitle` is two labels and no child slot, and
+ * `Adw.Avatar`, `Adw.Banner`, `Adw.Spinner` and `Adw.ButtonContent` are leaves — so
+ * their prop types deliberately do not extend this. A `children` a widget would have to
+ * drop is a hole in the surface, not a convenience.
  */
 export interface AdwWidgetProps {
     children?: ReactNode;
@@ -176,4 +179,123 @@ export interface AdwWrapBoxProps extends AdwWidgetProps {
     wrapPolicy?: AdwWrapPolicy;
     /** `orientation` — the axis children are packed along. Default `horizontal`. */
     orientation?: AdwWrapBoxOrientation;
+}
+
+/**
+ * `Adw.Avatar` — a round avatar showing initials derived from a name, or a
+ * fallback icon.
+ *
+ * `size` IS REQUIRED, and that is the one place this file departs from "libadwaita's
+ * defaults are the defaults". `AdwAvatar:size`'s GParamSpec default is the `-1`
+ * sentinel meaning "take the size from the stylesheet", and a renderer with no
+ * stylesheet cannot honour a stylesheet value. Measured against libadwaita 1.9.3, that
+ * path is degenerate on GTK too: a default-constructed avatar measures 20 wide and 18
+ * tall — not even square — and raises one `Pango-CRITICAL` from `update_font_size`,
+ * because the font cap for a negative size is negative. Reproducing that is not a goal
+ * and inventing a number behind the caller's back is how the two halves come to
+ * disagree, so the caller says.
+ *
+ * `custom-image` IS ABSENT. It is a `GdkPaintable` on GTK and an image source on React
+ * Native — two types with no shared spelling, and this file may import neither. The
+ * consequence is that `avatarMode` here only ever answers `'initials'` or `'icon'`.
+ */
+export interface AdwAvatarProps {
+    /** `size` — the diameter. Required; see above. */
+    size: number;
+    /** `text` — the name the initials AND the colour are derived from. */
+    text?: string;
+    /** `show-initials` — initials instead of the fallback icon. Default false. */
+    showInitials?: boolean;
+    /** `icon-name` — the fallback icon. Default libadwaita's `adw-avatar-default-symbolic`. */
+    iconName?: string;
+}
+
+/**
+ * `Adw.Banner` — a full-width strip carrying one in-context message and an optional
+ * action button.
+ *
+ * ON `useMarkup`'s DEFAULT, which is measured and not the one written down.
+ * `AdwBanner:use-markup`'s GParamSpec declares TRUE (adw-banner.c:422-425) and
+ * `@gjsify/adwaita-core`'s `ADW_BANNER_DEFAULTS` records that — but a freshly
+ * constructed `Adw.Banner` READS BACK FALSE, measured on libadwaita 1.9.3.
+ * `adw_banner_get_use_markup` delegates to `gtk_label_get_use_markup (self->title)`,
+ * `adw-banner.ui` never sets `use-markup` on that label, and a pspec default is only
+ * applied to properties construction actually writes. So the declared default is never
+ * reached. Both halves here answer FALSE for an omitted value, because that is what the
+ * widget on the other side of the surface answers.
+ */
+export interface AdwBannerProps {
+    /** `title` — the message. Pango markup when {@link useMarkup}. */
+    title?: string;
+    /** `button-label` — empty means no button. Its `_` is always a mnemonic marker. */
+    buttonLabel?: string;
+    /** `revealed` — whether the strip is on screen. Default false. */
+    revealed?: boolean;
+    /** `use-markup` — whether {@link title} is Pango markup. Default false; see above. */
+    useMarkup?: boolean;
+    /** `button-style` — grey (`'default'`) or `.suggested-action`. */
+    buttonStyle?: AdwBannerButtonStyle;
+    /** `button-clicked` — the action button was pressed. */
+    onButtonClicked?: () => void;
+}
+
+/**
+ * `Adw.Spinner` — a busy indicator.
+ *
+ * THE PROPERTIES ARE `GtkWidget`'s, BECAUSE `Adw.Spinner` HAS NONE OF ITS OWN. Its
+ * whole `GParamSpec` set is inherited: `adw_spinner_measure` reports `MIN_SIZE` as both
+ * the minimum AND the natural size, so the widget never grows on its own and the only
+ * way to make one bigger is to ask for a size. Measured on libadwaita 1.9.3: a fresh
+ * spinner measures `[16, 16]` and one with `width-request` 200 measures `[200, 200]`.
+ * A `size` prop would therefore be a renderer-ism of exactly the kind `maximumSize`
+ * exists to avoid — the two other Adwaita renderers each invented one.
+ *
+ * The BOX and the RING are different numbers, and only the box is a property: the ring
+ * is `spinnerGeometry`'s, capped at 64 and centred on the box, so a 200-point request
+ * occupies 200 points of layout around a 64-point ring.
+ */
+export interface AdwSpinnerProps {
+    /** `width-request` — the box width. Unset (or `-1`) is libadwaita's natural 16. */
+    widthRequest?: number;
+    /** `height-request` — the box height. Unset (or `-1`) is libadwaita's natural 16. */
+    heightRequest?: number;
+}
+
+/** `Adw.ButtonContent` — an icon paired with a label, for the inside of a button. */
+export interface AdwButtonContentProps {
+    /** `icon-name` — an icon-theme name. Empty draws `image-missing`, it does not hide the icon. */
+    iconName?: string;
+    /** `label` — empty hides the label node. */
+    label?: string;
+    /** `use-underline` — whether `_` marks a mnemonic in {@link label}. Default false. */
+    useUnderline?: boolean;
+    /** `can-shrink` — whether the label ellipsizes rather than widening the button. Default false. */
+    canShrink?: boolean;
+}
+
+/**
+ * What a caller does to an {@link AdwToastOverlayProps} through its `ref`.
+ *
+ * A TOAST IS PUSHED, NEVER DECLARED, and that is libadwaita's shape rather than a
+ * React convenience: `adw_toast_overlay_add_toast` is a call, the overlay owns the
+ * queue, and nothing about "which toast is on screen" is a property a caller writes.
+ * Modelling it as a `toasts={[…]}` array would put the ordering in the caller's hands
+ * on one half and in libadwaita's on the other.
+ *
+ * `dismissAll` and not `dismiss`: `adw_toast_overlay_dismiss_all` is the only dismissal
+ * the OVERLAY has. Dismissing just the current toast is `adw_toast_dismiss`, a method on
+ * the toast, so an overlay-level `dismiss()` would be a name libadwaita does not have —
+ * and `AdwToastQueue.clear()` is the same operation on the other half.
+ */
+export interface AdwToastOverlayHandle {
+    /** `add_toast` — show it now if the slot is free, otherwise queue it FIFO. */
+    addToast(toast: AdwToast): void;
+    /** `dismiss_all` — dismiss the visible toast and discard everything behind it. */
+    dismissAll(): void;
+}
+
+/** `Adw.ToastOverlay` — wraps content and shows one transient toast at a time over it. */
+export interface AdwToastOverlayProps extends AdwWidgetProps {
+    /** The imperative surface — see {@link AdwToastOverlayHandle}. */
+    ref?: Ref<AdwToastOverlayHandle>;
 }

--- a/packages/framework/adwaita-react-native/src/test.mts
+++ b/packages/framework/adwaita-react-native/src/test.mts
@@ -9,6 +9,7 @@
 import { run } from '@gjsify/unit';
 
 import clampGtkSuite from './widgets/clamp.gtk.spec.js';
+import contentGtkSuite from './widgets/content.gtk.spec.js';
 import headerBarGtkSuite from './widgets/header-bar.gtk.spec.js';
 import paritySuite from './parity.spec.js';
 import statusPageGtkSuite from './widgets/status-page.gtk.spec.js';
@@ -19,6 +20,7 @@ import wrapBoxGtkSuite from './widgets/wrap-box.gtk.spec.js';
 run({
     paritySuite,
     clampGtkSuite,
+    contentGtkSuite,
     headerBarGtkSuite,
     statusPageGtkSuite,
     toolbarViewGtkSuite,

--- a/packages/framework/adwaita-react-native/src/test.node.mts
+++ b/packages/framework/adwaita-react-native/src/test.node.mts
@@ -9,12 +9,17 @@
 
 import { run } from '@gjsify/unit';
 
+import avatarNativeSuite from './widgets/avatar.native.spec.js';
+import bannerNativeSuite from './widgets/banner.native.spec.js';
 import binNativeSuite from './widgets/bin.native.spec.js';
+import buttonContentNativeSuite from './widgets/button-content.native.spec.js';
 import clampNativeSuite from './widgets/clamp.native.spec.js';
 import doubleSuite from './testing/react-native.spec.js';
 import headerBarNativeSuite from './widgets/header-bar.native.spec.js';
 import paritySuite from './parity.spec.js';
+import spinnerNativeSuite from './widgets/spinner.native.spec.js';
 import statusPageNativeSuite from './widgets/status-page.native.spec.js';
+import toastOverlayNativeSuite from './widgets/toast-overlay.native.spec.js';
 import toolbarViewNativeSuite from './widgets/toolbar-view.native.spec.js';
 import windowTitleNativeSuite from './widgets/window-title.native.spec.js';
 import wrapBoxNativeSuite from './widgets/wrap-box.native.spec.js';
@@ -22,10 +27,15 @@ import wrapBoxNativeSuite from './widgets/wrap-box.native.spec.js';
 run({
     paritySuite,
     doubleSuite,
+    avatarNativeSuite,
+    bannerNativeSuite,
     binNativeSuite,
+    buttonContentNativeSuite,
     clampNativeSuite,
     headerBarNativeSuite,
+    spinnerNativeSuite,
     statusPageNativeSuite,
+    toastOverlayNativeSuite,
     toolbarViewNativeSuite,
     windowTitleNativeSuite,
     wrapBoxNativeSuite,

--- a/packages/framework/adwaita-react-native/src/testing/react-native.spec.ts
+++ b/packages/framework/adwaita-react-native/src/testing/react-native.spec.ts
@@ -44,12 +44,15 @@ import { RCT_TEXT, RCT_VIEW, Text, View } from './react-native.js';
 export type DoublePropsMatchReactNative = Assert<SameKeys<Parameters<typeof View>[0], Parameters<typeof RealView>[0]>>;
 
 /**
- * The same contract for `Text`, which the window title, the status page and the header
- * bar all render.
+ * The same contract for `Text`, which most of this package's widgets render.
  *
  * A SECOND PRIMITIVE IS A SECOND CHANCE TO INVENT ONE. `View` was pinned from the day it
- * existed and `Text` arrived later, with three widgets already leaning on it — which is
- * exactly the order in which a double acquires a prop React Native does not have.
+ * existed and `Text` arrived later, with widgets already leaning on it — which is exactly
+ * the order in which a double acquires a prop React Native does not have. And it is not
+ * redundant with the assertion above: `ViewProps` and `TextProps` are different key sets
+ * — `numberOfLines`, `ellipsizeMode` and `onPress` are on one and not the other — so a
+ * `Text` double annotated `typeof RealView` by a copy-paste would satisfy every assertion
+ * about `View` and none about the component the widgets actually use.
  */
 export type TextPropsMatchReactNative = Assert<SameKeys<Parameters<typeof Text>[0], Parameters<typeof RealText>[0]>>;
 

--- a/packages/framework/adwaita-react-native/src/testing/react-native.ts
+++ b/packages/framework/adwaita-react-native/src/testing/react-native.ts
@@ -17,6 +17,15 @@
 // which nesting, after which state transitions. WHAT IT DOES NOT PROVE is Yoga: a `width`
 // in a style object is an instruction to a layout engine that is not here, so a size is
 // asserted as an instruction and never as a measured pixel. The README carries that gap.
+//
+// WHAT MAY BE DOUBLED, AND WHAT MAY NOT. Only a React Native component that IS a host
+// element with its props forwarded — `View` renders `RCTView`, `Text` renders `RCTText`,
+// both with the props they were given. A COMPOSITE that transforms its props is out, and
+// the measured case is `ActivityIndicator`: it wraps a native node inside a `View`,
+// branches on `Platform.OS`, and moves a numeric `size` out of the prop and into a style.
+// A double of it would be a nesting and a prop placement real React Native never emits,
+// and every assertion written against it would be about this file. `spinner.native.tsx`
+// says at its head that this is why it does not use one.
 
 import { createElement, type ReactElement } from 'react';
 import type { Text as RealText, View as RealView } from 'react-native';
@@ -56,5 +65,10 @@ export const RCT_TEXT = 'RCTText';
  * Same contract as {@link View} and for the same reason: the `typeof RealText`
  * annotation is what stops the double from growing a surface of its own, and
  * `react-native.spec.ts` falsifies it rather than restating it.
+ *
+ * The real `Text` additionally wires `onPress` through the press responder and reads an
+ * inherited text context, neither of which is reproduced — so a spec here asserts that a
+ * widget ASKS for a press, never that a tap arrives. Same class of gap as Yoga, and the
+ * README carries it too.
  */
 export const Text: typeof RealText = (props): ReactElement => createElement(RCT_TEXT, props as Record<string, unknown>);

--- a/packages/framework/adwaita-react-native/src/widgets/avatar.gtk.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/avatar.gtk.tsx
@@ -1,0 +1,27 @@
+/** @jsxImportSource @gjsify/gtk-host/react */
+// `AdwAvatar` on GTK — the real `Adw.Avatar`. Libadwaita derives the initials and picks
+// the colour. (The pragma above is required of every platform module; the reason is in
+// `bin.gtk.tsx`.)
+//
+// `avatarInitials` / `avatarColor` ARE NOT USED HERE, for the reason `clamp.gtk.tsx`
+// gives about `clampAllocate`: on GTK the C original is right there, and deriving the
+// same initials twice would give the widget two authorities for its own label. The
+// core's value on this path is as the ORACLE the React Native half is measured against —
+// and here that oracle is unusually direct, because libadwaita publishes its answer:
+// `set_class_color` puts `color{n}` on the avatar's internal gizmo, so
+// `content.gtk.spec.tsx` reads the class off the live tree and
+// `avatar.native.spec.tsx` asserts the palette entry with the same index.
+//
+// EVERY PROPERTY IS PASSED THROUGH VERBATIM, INCLUDING THE OMITTED ONES. There is no
+// `authoredSize`-style normaliser here because `size` is REQUIRED on this surface — the
+// measured reason (a `-1` avatar is 20×18 and raises a `Pango-CRITICAL` that
+// `installDiagnosticsGate` fails on) is in `props.ts`.
+
+import type { ReactElement } from 'react';
+
+import type { AdwAvatarProps } from '../props.js';
+
+/** {@link import('./avatar.js').AdwAvatar} on GTK. */
+export function AdwAvatar({ size, text, showInitials, iconName }: AdwAvatarProps): ReactElement | null {
+    return <adw-avatar size={size} text={text} show-initials={showInitials} icon-name={iconName} />;
+}

--- a/packages/framework/adwaita-react-native/src/widgets/avatar.native.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/avatar.native.spec.tsx
@@ -1,0 +1,124 @@
+/** @jsxImportSource react */
+// The React Native half of `AdwAvatar`, rendered through React's real reconciler.
+//
+// EVERY NUMBER HERE IS ONE THE GTK HALF IS ALSO ASSERTED WITH, and for this widget the
+// join is unusually tight: `set_class_color` PUBLISHES its answer as a CSS class, so
+// `content.gtk.spec.tsx` reads `color11` off the live GTK tree for "Ada Lovelace" and
+// this file asserts the eleventh palette entry's flattened fill, `#8c75d9`. Neither side
+// computed the other's value — one ran libadwaita's C, one ran
+// `@gjsify/adwaita-core`'s port of `g_str_hash` over UTF-8 bytes.
+//
+// TWO NAMES, NOT ONE. A single name agreeing proves the two sides landed in the same
+// bucket once, and the derivation's actual content is the hash: a renderer hashing UTF-16
+// code units instead of UTF-8 bytes lands on the same bucket for plenty of ASCII names,
+// which is how two renderers in this repository shipped the wrong colour for every
+// accented name while their suites stayed green. "Grace Hopper" is the control, and it
+// lands on a different entry.
+//
+// THE COLOURS ARE WRITTEN OUT rather than read back from `AVATAR_COLORS`. Asserting
+// `flattenAvatarGradient(avatarColor(name))` against itself would be a test of nothing;
+// the literal is what a change to the palette, to the hash or to the blend has to walk
+// past.
+//
+// The harness — `act`, the renderer, the child readers — is `../testing/render.spec.ts`.
+// On `act()` and the missing production define, see `clamp.native.spec.tsx` — the
+// measurement is the same and lives there.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { RCT_TEXT, RCT_VIEW } from '../testing/react-native.js';
+import { childrenOf, mounted, onlyChild, type Style } from '../testing/render.spec.js';
+import { AdwAvatar } from './avatar.native.js';
+
+/** The size `content.gtk.spec.tsx` builds its avatars at. */
+const SIZE = 48;
+
+/**
+ * `avatarMaxFontSize(48)` — `48 / 1.4142` less the size-proportional padding
+ * `max(48 * 0.4 - 5, 0)`, to the last bit of the double.
+ *
+ * Written out for the same reason the colours are: the alternative is the implementation
+ * asserting itself. It is also the number the NativeScript port's `size * 0.4` heuristic
+ * has to stay under, and above ~54 points it does not.
+ */
+const MAX_FONT_SIZE_48 = 19.74145099703012;
+
+export default async () => {
+    await describe('AdwAvatar on React Native — the circle it asks for', async () => {
+        await it('is a round view sized by the required size prop', async () => {
+            const tree = mounted(<AdwAvatar size={SIZE} text="Ada Lovelace" showInitials={true} />);
+            expect(tree.type).toBe(RCT_VIEW);
+            const style = tree.props.style as Record<string, unknown>;
+            expect(style.width).toBe(SIZE);
+            expect(style.height).toBe(SIZE);
+            // Half the diameter is what makes a square a circle, and it is the one
+            // geometric fact this widget has.
+            expect(style.borderRadius).toBe(24);
+        });
+
+        await it('paints the eleventh palette entry for “Ada Lovelace”, as GTK stamps color11', async () => {
+            const tree = mounted(<AdwAvatar size={SIZE} text="Ada Lovelace" showInitials={true} />);
+            // `#8c75d9` is `flattenAvatarGradient` over `#9e91e8` → `#7a59ca`, the
+            // violet entry the GTK half reaches as `color11`. A React Native style has
+            // no gradient key, which is why the blend exists at all.
+            expect((tree.props.style as Record<string, unknown>).backgroundColor).toBe('#8c75d9');
+            const label = onlyChild(tree);
+            expect(label.type).toBe(RCT_TEXT);
+            expect(label.children).toStrictEqual(['AL']);
+            expect(label.props.style as Style).toStrictEqual({
+                color: '#d5d2f5',
+                fontSize: MAX_FONT_SIZE_48,
+                display: 'flex',
+            });
+        });
+
+        await it('lands on a DIFFERENT entry for “Grace Hopper” — the control', async () => {
+            const tree = mounted(<AdwAvatar size={SIZE} text="Grace Hopper" showInitials={true} />);
+            // GTK stamps `color6` for this name; `#eba831` is that entry blended.
+            expect((tree.props.style as Record<string, unknown>).backgroundColor).toBe('#eba831');
+            expect(onlyChild(tree).children).toStrictEqual(['GH']);
+        });
+
+        await it('takes the initials from CODE POINTS, so an accented name survives', async () => {
+            // `extract_initials_from_text` upcases, strips and NFC-normalises, then reads
+            // whole characters. `charAt(0)` would return half a surrogate pair here and
+            // an ASCII-only fold would drop the accent — and the colour bucket follows the
+            // BYTES, so both would move the avatar as well as the letter.
+            const tree = mounted(<AdwAvatar size={SIZE} text="Édouard Lucas" showInitials={true} />);
+            expect(onlyChild(tree).children).toStrictEqual(['ÉL']);
+            expect((tree.props.style as Record<string, unknown>).backgroundColor).toBe('#e5c031');
+        });
+    });
+
+    await describe('AdwAvatar on React Native — the two modes it has', async () => {
+        await it('hides the initials without show-initials but KEEPS the colour', async () => {
+            // MEASURED on libadwaita 1.9.3 and asserted on the GTK half too: the gizmo
+            // still carries `color11` in icon mode, so the circle keeps its gradient. The
+            // browser renderer clears its background there; this follows the widget.
+            const tree = mounted(<AdwAvatar size={SIZE} text="Ada Lovelace" />);
+            expect((tree.props.style as Record<string, unknown>).backgroundColor).toBe('#8c75d9');
+            expect((onlyChild(tree).props.style as Record<string, unknown>).display).toBe('none');
+        });
+
+        await it('renders NO glyph in icon mode, which is the divergence', async () => {
+            // PINNED, not asserted as correct. React Native resolves no icon theme, so
+            // `adw-avatar-default-symbolic` has nothing to become and the icon mode is a
+            // coloured circle with the label hidden — where GTK draws the symbolic. A
+            // later edit that starts drawing something has to change this row.
+            const tree = mounted(<AdwAvatar size={SIZE} text="Ada Lovelace" iconName="face-smile-symbolic" />);
+            const children = childrenOf(tree);
+            expect(children.length).toBe(1);
+            expect(children[0]?.type).toBe(RCT_TEXT);
+        });
+
+        await it('stays in initials mode for a whitespace-only name, with a blank label', async () => {
+            // The gate is the length of the TEXT, not of the derived initials —
+            // `update_visibility` keeps a whitespace-only name in initials mode, and a
+            // renderer keying on the initials would fall back to the icon instead.
+            const tree = mounted(<AdwAvatar size={SIZE} text="   " showInitials={true} />);
+            const label = onlyChild(tree);
+            expect((label.props.style as Record<string, unknown>).display).toBe('flex');
+            expect(label.children).toBe(null);
+        });
+    });
+};

--- a/packages/framework/adwaita-react-native/src/widgets/avatar.native.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/avatar.native.tsx
@@ -1,0 +1,85 @@
+/** @jsxImportSource react */
+// `AdwAvatar` on React Native — libadwaita's own initials and its own palette entry.
+// (On the pragma, see `bin.native.tsx`.)
+//
+// `@gjsify/adwaita-core` DOES BOTH DERIVATIONS AND THIS FILE PAINTS THEM. `avatarInitials`
+// is `extract_initials_from_text` — upcase, strip, NFC, then CODE POINTS, so an astral
+// first letter survives where `charAt(0)` would return half a surrogate pair. `avatarColor`
+// is `set_class_color`: `g_str_hash` over the UTF-8 BYTES as a signed char, `% 14`. Both
+// details decide whether an accented name gets the same avatar here as on GTK, and both
+// were wrong in two renderers before the port existed.
+//
+// THE GRADIENT IS FLATTENED, WITH THE SAME CALL THE NATIVESCRIPT RENDERER MAKES.
+// `$avatarcolorlist` is a `start`→`stop` gradient and a React Native style has no gradient
+// key, so `flattenAvatarGradient` collapses it to the 50/50 blend — a core function rather
+// than a private average, because a second averaging is a second answer.
+//
+// THE FONT SIZE IS THE CAP, NOT A MEASUREMENT, and the core sanctions exactly that:
+// `update_font_size` scales the label's measured ASPECT RATIO against
+// `avatarMaxFontSize(size)`, and a renderer that cannot measure text may use the cap
+// alone and stay inside libadwaita's bound. React Native reports a text box only through
+// `onLayout`, i.e. after layout, which is the same missing measure pass that makes
+// `AdwClamp` pass `childMin: 0`. What is NOT done here is the 0.4 heuristic the
+// NativeScript port carries: it is not monotonic in `size` and it exceeded the cap above
+// ~54 points.
+//
+// `iconName` IS ACCEPTED AND NOT DRAWN, and the spec pins that rather than leaving it
+// silent. React Native resolves no icon theme, so there is no glyph to put in the circle
+// for `adw-avatar-default-symbolic`; what the icon mode produces here is the coloured
+// circle with the initials hidden. The GTK half draws the real symbolic, so this is a
+// one-directional divergence and the README names it.
+//
+// THE BACKGROUND IS PAINTED IN ICON MODE TOO. Measured on libadwaita 1.9.3: an avatar
+// with `show-initials` FALSE still carries `color11` on its gizmo, so the circle keeps its
+// colour and only the initials go away. The browser renderer clears its background there;
+// this half follows the widget.
+
+import type { ReactElement } from 'react';
+import { Text, View } from 'react-native';
+
+import {
+    avatarColor,
+    avatarInitials,
+    avatarMaxFontSize,
+    avatarMode,
+    flattenAvatarGradient,
+} from '@gjsify/adwaita-core';
+
+import type { AdwAvatarProps } from '../props.js';
+
+/** {@link import('./avatar.js').AdwAvatar} on React Native. */
+export function AdwAvatar({ size, text, showInitials }: AdwAvatarProps): ReactElement | null {
+    const name = text ?? '';
+    const color = avatarColor(name);
+    // `hasCustomImage` is FALSE for the life of this half — `custom-image` is a
+    // `GdkPaintable` and is absent from the surface (`props.ts`), so the `'image'` branch
+    // of `update_visibility` is unreachable here and only `'initials'`/`'icon'` remain.
+    // The gate is the TEXT and not the derived initials, which is why a whitespace-only
+    // name is in initials mode with a blank label rather than falling back to the icon.
+    const mode = avatarMode({ hasCustomImage: false, showInitials: showInitials ?? false, text: name });
+
+    return (
+        <View
+            style={{
+                width: size,
+                height: size,
+                borderRadius: size / 2,
+                backgroundColor: flattenAvatarGradient(color),
+                alignItems: 'center',
+                justifyContent: 'center',
+            }}
+        >
+            {/* The label is HIDDEN rather than unmounted in icon mode, which is
+                `gtk_widget_set_visible (self->label, …)` — libadwaita keeps the node. */}
+            <Text
+                style={{
+                    color: color.fg,
+                    fontSize: avatarMaxFontSize(size),
+                    display: mode === 'initials' ? 'flex' : 'none',
+                }}
+            >
+                {avatarInitials(name)}
+            </Text>
+        </View>
+    );
+}

--- a/packages/framework/adwaita-react-native/src/widgets/avatar.ts
+++ b/packages/framework/adwaita-react-native/src/widgets/avatar.ts
@@ -1,0 +1,21 @@
+// `AdwAvatar` — the base module. See `../refuse.ts` for who reaches this and why it throws
+// instead of resolving to something.
+
+import type { ReactElement } from 'react';
+
+import type { AdwAvatarProps } from '../props.js';
+import { refuseBaseModule } from '../refuse.js';
+
+/**
+ * A round avatar showing initials derived from a name, or a fallback icon.
+ *
+ * BOTH HALVES DERIVE THE SAME TWO THINGS FROM THE SAME PORT. The initials and the
+ * palette entry come from `@gjsify/adwaita-core`'s `avatarInitials` / `avatarColor` —
+ * `extract_initials_from_text` and `set_class_color` in TypeScript, hashing UTF-8 bytes
+ * as `g_str_hash` does. On GTK the real `Adw.Avatar` runs the C original and stamps
+ * `color11` on its internal gizmo; the React Native half paints the same palette entry.
+ * The suites assert that pair by NAME, not by "an avatar appeared".
+ */
+export function AdwAvatar(_props: AdwAvatarProps): ReactElement | null {
+    return refuseBaseModule('AdwAvatar');
+}

--- a/packages/framework/adwaita-react-native/src/widgets/banner.gtk.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/banner.gtk.tsx
@@ -1,0 +1,38 @@
+/** @jsxImportSource @gjsify/gtk-host/react */
+// `AdwBanner` on GTK — the real `Adw.Banner`. (On the pragma, see `bin.gtk.tsx`.)
+//
+// NOTHING IS DEFAULTED HERE, and that is what makes the pair in `props.ts` measurable.
+// An omitted property leaves the real widget on its own value, so `content.gtk.spec.tsx`
+// reads back what libadwaita actually answers — which for `use-markup` is FALSE, against
+// a `GParamSpec` that declares TRUE and a core constant that faithfully records the
+// declaration. The React Native half answers FALSE for the same input. Defaulting here
+// from `ADW_BANNER_DEFAULTS` would have made this half agree with the constant and
+// disagree with the widget it IS.
+//
+// `onButtonClicked` reaches `button-clicked` through gtk-host's signal mapping, so the
+// prop name is the GObject signal camelCased exactly as every other `on*` on this host.
+
+import type { ReactElement } from 'react';
+
+import type { AdwBannerProps } from '../props.js';
+
+/** {@link import('./banner.js').AdwBanner} on GTK. */
+export function AdwBanner({
+    title,
+    buttonLabel,
+    revealed,
+    useMarkup,
+    buttonStyle,
+    onButtonClicked,
+}: AdwBannerProps): ReactElement | null {
+    return (
+        <adw-banner
+            title={title}
+            button-label={buttonLabel}
+            revealed={revealed}
+            use-markup={useMarkup}
+            button-style={buttonStyle}
+            onButtonClicked={onButtonClicked}
+        />
+    );
+}

--- a/packages/framework/adwaita-react-native/src/widgets/banner.native.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/banner.native.spec.tsx
@@ -1,0 +1,140 @@
+/** @jsxImportSource react */
+// The React Native half of `AdwBanner`, rendered through React's real reconciler.
+//
+// THE DEFAULT THIS FILE IS REALLY ABOUT IS `use-markup`. `ADW_BANNER_DEFAULTS.useMarkup`
+// is TRUE, faithfully recording a `GParamSpec` that says so — and a freshly constructed
+// `Adw.Banner` reads FALSE, because `adw_banner_get_use_markup` delegates to the title
+// label and `adw-banner.ui` never sets it there. `content.gtk.spec.tsx` asserts the FALSE
+// off the real widget; this file asserts that the same omission paints the title
+// literally here. Using the constant would have made this half agree with a number no
+// widget produces.
+//
+// AND THE OTHER PAIR IS THE MNEMONIC, which is asymmetric by design and not by accident:
+// the template pins the BUTTON to `use-underline=True` and the TITLE to False, so exactly
+// one of the two strings loses its underscore. The GTK half reads `"_Undo"` back off the
+// property and paints "Undo"; this half paints "Undo" and leaves the title's underscores
+// alone. A renderer that stripped both, or neither, would be wrong in a way no single-sided
+// test can see.
+//
+// The harness — `act`, the renderer, the child readers — is `../testing/render.spec.ts`.
+//
+// WHAT A PRESS ASSERTION PROVES HERE. The double forwards `onPress` verbatim, where real
+// React Native wires it through the press responder — so this suite proves the widget ASKS
+// for the press and hands it the caller's callback, never that a tap arrives. Same class
+// of gap as Yoga; the README carries both.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { act, type ReactTestRendererJSON } from 'react-test-renderer';
+
+import { RCT_TEXT, RCT_VIEW } from '../testing/react-native.js';
+import { at, childrenOf, mounted } from '../testing/render.spec.js';
+import { AdwBanner } from './banner.native.js';
+
+/** `[title, button]` — the strip is a row of exactly those two, always both. */
+function parts(tree: ReactTestRendererJSON): [ReactTestRendererJSON, ReactTestRendererJSON] {
+    const children = childrenOf(tree);
+    if (children.length !== 2) throw new Error(`expected a title and a button, got ${JSON.stringify(children)}`);
+    return [at(children, 0), at(children, 1)];
+}
+
+export default async () => {
+    await describe('AdwBanner on React Native — the strip it emits', async () => {
+        await it('is a row of a title and a button, both always in the tree', async () => {
+            const tree = mounted(<AdwBanner title="Metered connection" revealed={true} />);
+            expect(tree.type).toBe(RCT_VIEW);
+            expect((tree.props.style as Record<string, unknown>).flexDirection).toBe('row');
+            const [title, button] = parts(tree);
+            expect(title.type).toBe(RCT_TEXT);
+            expect(button.type).toBe(RCT_TEXT);
+            // The button is HIDDEN, not absent — `gtk_widget_set_visible` keeps the node.
+            expect((button.props.style as Record<string, unknown>).display).toBe('none');
+        });
+
+        await it('collapses out of layout when revealed is omitted, rather than unmounting', async () => {
+            // `Adw.Banner`'s `GtkRevealer` keeps the widget and takes it out of the
+            // allocation; `display: 'none'` is Yoga's spelling of that. Returning `null`
+            // would rebuild the strip every time it came back.
+            const hidden = mounted(<AdwBanner title="Metered connection" />);
+            expect((hidden.props.style as Record<string, unknown>).display).toBe('none');
+            const shown = mounted(<AdwBanner title="Metered connection" revealed={true} />);
+            expect((shown.props.style as Record<string, unknown>).display).toBe('flex');
+        });
+    });
+
+    await describe('AdwBanner on React Native — the title, and the default that is not declared', async () => {
+        await it('paints markup LITERALLY when use-markup is omitted, as the widget does', async () => {
+            // GTK reads `use-markup` back as FALSE for this same input, asserted in
+            // `content.gtk.spec.tsx`. The pspec says TRUE and never applies it.
+            const [title] = parts(mounted(<AdwBanner title="<b>Metered</b> connection" revealed={true} />));
+            expect(title.children).toStrictEqual(['<b>Metered</b> connection']);
+        });
+
+        await it('reduces markup to its plain text when it is asked for', async () => {
+            // React Native has no inline-markup layer, so the honest reduction is the
+            // markup's PLAIN TEXT — `stripMarkup`, the same call the NativeScript renderer
+            // makes. Painting the tags is further from what GTK draws than dropping them.
+            const [title] = parts(
+                mounted(<AdwBanner title="<b>Metered</b> connection" useMarkup={true} revealed={true} />),
+            );
+            expect(title.children).toStrictEqual(['Metered connection']);
+        });
+
+        await it('keeps unparseable markup verbatim, which is Pango’s own fallback', async () => {
+            const [title] = parts(mounted(<AdwBanner title="5 < 7 & rising" useMarkup={true} revealed={true} />));
+            expect(title.children).toStrictEqual(['5 < 7 & rising']);
+        });
+
+        await it('leaves the TITLE’s underscores alone — only the button is a mnemonic', async () => {
+            const [title] = parts(mounted(<AdwBanner title="_Metered" revealed={true} />));
+            expect(title.children).toStrictEqual(['_Metered']);
+        });
+    });
+
+    await describe('AdwBanner on React Native — the action button', async () => {
+        await it('shows for a non-empty label and strips the mnemonic marker', async () => {
+            const [, button] = parts(mounted(<AdwBanner title="Metered" buttonLabel="_Undo" revealed={true} />));
+            expect((button.props.style as Record<string, unknown>).display).toBe('flex');
+            // GTK keeps `"_Undo"` in the property and paints "Undo"; this half has no
+            // mnemonic layer, so `bannerButtonText` does the stripping.
+            expect(button.children).toStrictEqual(['Undo']);
+        });
+
+        await it('shows for a label of SPACES — a first-character test, not a trim', async () => {
+            // `gtk_widget_set_visible (button, label && label[0])`. A renderer that
+            // trimmed would drop a button GTK draws.
+            const [, button] = parts(mounted(<AdwBanner title="Metered" buttonLabel=" " revealed={true} />));
+            expect((button.props.style as Record<string, unknown>).display).toBe('flex');
+        });
+
+        await it('paints the suggested style with the accent, which is what the class means', async () => {
+            // `.suggested-action` has no class system to live in here, but it is not
+            // decoration: Adwaita paints it with the accent background and white on top.
+            // `#3584e4` is `ADW_ACCENT_BG_COLORS.blue`, libadwaita's default accent.
+            const [, plain] = parts(mounted(<AdwBanner title="Metered" buttonLabel="Undo" revealed={true} />));
+            expect((plain.props.style as Record<string, unknown>).backgroundColor).toBe(undefined);
+            const [, suggested] = parts(
+                mounted(<AdwBanner title="Metered" buttonLabel="Undo" buttonStyle="suggested" revealed={true} />),
+            );
+            expect((suggested.props.style as Record<string, unknown>).backgroundColor).toBe('#3584e4');
+            expect((suggested.props.style as Record<string, unknown>).color).toBe('#ffffff');
+        });
+
+        await it('hands onButtonClicked to the press, so a tap reaches the caller', async () => {
+            let clicked = 0;
+            const [, button] = parts(
+                mounted(
+                    <AdwBanner
+                        title="Metered"
+                        buttonLabel="Undo"
+                        revealed={true}
+                        onButtonClicked={() => (clicked += 1)}
+                    />,
+                ),
+            );
+            const onPress = button.props.onPress as (() => void) | undefined;
+            if (typeof onPress !== 'function') throw new Error('the button carries no onPress');
+            act(() => onPress());
+            expect(clicked).toBe(1);
+        });
+    });
+};

--- a/packages/framework/adwaita-react-native/src/widgets/banner.native.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/banner.native.tsx
@@ -1,0 +1,94 @@
+/** @jsxImportSource react */
+// `AdwBanner` on React Native. (On the pragma, see `bin.native.tsx`.)
+//
+// THE OMITTED DEFAULTS ARE THE ONES THE WIDGET READS BACK, NOT THE ONES IT DECLARES, and
+// for `use-markup` those differ. `ADW_BANNER_DEFAULTS` is not used here for that reason
+// and only that one: the constant faithfully records a `GParamSpec` default of TRUE that
+// libadwaita never applies, because `adw_banner_get_use_markup` delegates to the title
+// label and `adw-banner.ui` leaves that label on `GtkLabel`'s own FALSE. Measured on
+// 1.9.3, `new Adw.Banner().use_markup` is FALSE. The full account is in `props.ts`; the
+// consequence here is that both halves answer the same for an omitted value, which is the
+// only agreement this package is trying to buy.
+//
+// MARKUP IS REDUCED TO ITS PLAIN TEXT, with the core's own `stripMarkup` — the same call
+// `@gjsify/adwaita-nativescript` makes, for the same reason: React Native has no inline
+// markup layer, and painting `<b>Metered</b>` literally is further from what GTK draws
+// than painting `Metered` is. Unparseable markup keeps the raw string, which is Pango's
+// own fallback.
+//
+// `revealed` IS `display: 'none'`, NOT AN UNMOUNT. `Adw.Banner` reveals through a
+// `GtkRevealer`, which keeps the widget and takes it out of the allocation; `display:
+// 'none'` is Yoga's spelling of that. Returning `null` would additionally unmount, so a
+// banner that is revealed and hidden again would rebuild rather than slide.
+//
+// THE SUGGESTED STYLE IS THE ACCENT COLOUR, BECAUSE THAT IS WHAT THE CLASS MEANS. There is
+// no class system to stamp `suggested-action` into — the same wall `AdwClamp`'s size class
+// hits — but the class is not decoration: Adwaita paints it with the accent background and
+// `ADW_ACCENT_FG_COLOR` on top, and both are in the core. `useSyncExternalStore` over
+// `onAdwaitaAccentChanged` is what makes a later `setAdwaitaAccent` repaint the button;
+// reading `adwaitaAccent()` during render alone would freeze it at whatever the accent was
+// on first paint.
+
+import { useSyncExternalStore, type ReactElement } from 'react';
+import { Text, View } from 'react-native';
+
+import {
+    ADW_ACCENT_FG_COLOR,
+    adwaitaAccent,
+    adwaitaAccentBgColor,
+    bannerButtonStyleClasses,
+    bannerButtonText,
+    bannerButtonVisible,
+    onAdwaitaAccentChanged,
+    parseBannerButtonStyle,
+    stripMarkup,
+} from '@gjsify/adwaita-core';
+
+import type { AdwBannerProps } from '../props.js';
+
+/** `.suggested-action`, which is the only class `button-style` manages. */
+const SUGGESTED_ACTION = 'suggested-action';
+
+/**
+ * `onAdwaitaAccentChanged` as `useSyncExternalStore`'s `subscribe`.
+ *
+ * Hoisted to module scope on purpose: the hook resubscribes whenever this argument
+ * changes identity, so an inline arrow would tear down and re-add the listener on every
+ * render of every banner on screen.
+ */
+const onAdwaitaAccentChangedStore = (notify: () => void): (() => void) => onAdwaitaAccentChanged(notify);
+
+/** {@link import('./banner.js').AdwBanner} on React Native. */
+export function AdwBanner({
+    title,
+    buttonLabel,
+    revealed,
+    useMarkup,
+    buttonStyle,
+    onButtonClicked,
+}: AdwBannerProps): ReactElement | null {
+    const accent = useSyncExternalStore(onAdwaitaAccentChangedStore, adwaitaAccent, adwaitaAccent);
+
+    const message = title ?? '';
+    const label = buttonLabel ?? '';
+    const suggested = bannerButtonStyleClasses(parseBannerButtonStyle(buttonStyle)).includes(SUGGESTED_ACTION);
+
+    return (
+        <View style={{ display: (revealed ?? false) ? 'flex' : 'none', flexDirection: 'row', alignItems: 'center' }}>
+            {/* The template pins the TITLE to `use-underline=False`, so its
+                underscores are literal and `bannerButtonText` must not touch it. */}
+            <Text style={{ flexGrow: 1 }}>{(useMarkup ?? false) ? (stripMarkup(message) ?? message) : message}</Text>
+            <Text
+                accessibilityRole="button"
+                onPress={onButtonClicked}
+                style={{
+                    display: bannerButtonVisible(label) ? 'flex' : 'none',
+                    backgroundColor: suggested ? adwaitaAccentBgColor(accent) : undefined,
+                    color: suggested ? ADW_ACCENT_FG_COLOR : undefined,
+                }}
+            >
+                {bannerButtonText(label)}
+            </Text>
+        </View>
+    );
+}

--- a/packages/framework/adwaita-react-native/src/widgets/banner.ts
+++ b/packages/framework/adwaita-react-native/src/widgets/banner.ts
@@ -1,0 +1,21 @@
+// `AdwBanner` — the base module. See `../refuse.ts` for who reaches this and why it throws
+// instead of resolving to something.
+
+import type { ReactElement } from 'react';
+
+import type { AdwBannerProps } from '../props.js';
+import { refuseBaseModule } from '../refuse.js';
+
+/**
+ * A full-width strip carrying one in-context message and an optional action button.
+ *
+ * `Adw.Banner` HAS NO ARITHMETIC — its whole specification is five property defaults
+ * and three derivations, all of them in `@gjsify/adwaita-core`. The two that are easy to
+ * get backwards are the button's visibility (`label && label[0]`, a FIRST-CHARACTER test,
+ * so a label of spaces still draws a button) and its mnemonic marker (the template pins
+ * the button to `use-underline=True` with no property to turn it off, and pins the TITLE
+ * to False, so exactly one of the two strings is stripped).
+ */
+export function AdwBanner(_props: AdwBannerProps): ReactElement | null {
+    return refuseBaseModule('AdwBanner');
+}

--- a/packages/framework/adwaita-react-native/src/widgets/button-content.gtk.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/button-content.gtk.tsx
@@ -1,0 +1,31 @@
+/** @jsxImportSource @gjsify/gtk-host/react */
+// `AdwButtonContent` on GTK — the real `Adw.ButtonContent`. (On the pragma, see
+// `bin.gtk.tsx`.)
+//
+// THE LABEL GOES IN RAW, mnemonic marker and all, and that is not the same rule the
+// React Native half follows. `AdwButtonContent`'s label node carries `use-underline`
+// itself, so libadwaita resolves the marker at PAINT time and reading the property back
+// gives `"_Save"` — measured. `buttonContentLabelText` exists for a renderer with no
+// mnemonic layer, which is the other half; running it here would delete an underscore
+// libadwaita is still going to interpret, i.e. strip it twice.
+//
+// The parent-button style class is libadwaita's own work here: `adw_button_content_root`
+// puts `image-text-button` on the nearest `GtkButton` — measured, the button's
+// `css-classes` reads `["image-text-button"]` — and `buttonContentStyleTargetIndex` is
+// for a renderer that has to walk its own tree. This one does not have a tree to walk.
+
+import type { ReactElement } from 'react';
+
+import type { AdwButtonContentProps } from '../props.js';
+
+/** {@link import('./button-content.js').AdwButtonContent} on GTK. */
+export function AdwButtonContent({
+    iconName,
+    label,
+    useUnderline,
+    canShrink,
+}: AdwButtonContentProps): ReactElement | null {
+    return (
+        <adw-button-content icon-name={iconName} label={label} use-underline={useUnderline} can-shrink={canShrink} />
+    );
+}

--- a/packages/framework/adwaita-react-native/src/widgets/button-content.native.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/button-content.native.spec.tsx
@@ -1,0 +1,103 @@
+/** @jsxImportSource react */
+// The React Native half of `AdwButtonContent`, rendered through React's real reconciler.
+//
+// THE PAIRS WITH `content.gtk.spec.tsx` ARE THE FOUR DERIVATIONS, and two of them are the
+// ones a hand-written translation gets wrong. `buttonContentIconExpands` is
+// `gtk_widget_set_hexpand (self->icon, !label[0])` — the GTK suite reads `hexpand` off the
+// real `GtkImage` (TRUE with no label, FALSE with one) and this file asserts the matching
+// `flexGrow`. `buttonContentEllipsize` is `PANGO_ELLIPSIZE_END`, which the GTK suite reads
+// back as `3` and this file spells `numberOfLines={1}` plus `ellipsizeMode="tail"`.
+//
+// THE MNEMONIC IS THE ASYMMETRY, ASSERTED FROM BOTH SIDES. The GTK suite reads `"_Save"`
+// back off the property, because the label node carries `use-underline` itself and
+// libadwaita resolves the marker at paint. This half has no mnemonic layer, so
+// `buttonContentLabelText` strips it and the painted text is "Save". Running the same
+// stripper on GTK would delete an underscore libadwaita is still going to interpret.
+//
+// The harness — `act`, the renderer, the child readers — is `../testing/render.spec.ts`.
+//
+// THE EMPTY ICON SLOT IS PINNED, NOT ASSERTED AS CORRECT. React Native resolves no icon
+// theme, so the slot is in the row with the right `flexGrow` and holds no glyph — where
+// GTK draws `folder-download-symbolic`, or `image-missing` for an empty slot. A later edit
+// that starts drawing something has to change this file.
+
+import { describe, expect, it } from '@gjsify/unit';
+import type { ReactTestRendererJSON } from 'react-test-renderer';
+
+import { RCT_TEXT, RCT_VIEW } from '../testing/react-native.js';
+import { at, childrenOf, mounted } from '../testing/render.spec.js';
+import { AdwButtonContent } from './button-content.native.js';
+
+/** `[icon slot, label]` — the box is a row of exactly those two, always both. */
+function parts(tree: ReactTestRendererJSON): [ReactTestRendererJSON, ReactTestRendererJSON] {
+    const children = childrenOf(tree);
+    if (children.length !== 2) throw new Error(`expected an icon slot and a label, got ${JSON.stringify(children)}`);
+    return [at(children, 0), at(children, 1)];
+}
+
+export default async () => {
+    await describe('AdwButtonContent on React Native — the box', async () => {
+        await it('is a row with libadwaita’s own 6-point gap', async () => {
+            // MEASURED on the real widget, not read off a selector: an
+            // `AdwButtonContent` with an icon and a label inside a presented `GtkButton`
+            // puts the image at x=161 width=16 and the label at x=183. The same widget's
+            // `GtkBox:spacing` reads 0, which is why the number is
+            // `BUTTON_CONTENT_BOX_SPACING` in the core and not a property read.
+            const tree = mounted(<AdwButtonContent iconName="folder-download-symbolic" label="Save" />);
+            expect(tree.type).toBe(RCT_VIEW);
+            expect((tree.props.style as Record<string, unknown>).flexDirection).toBe('row');
+            expect((tree.props.style as Record<string, unknown>).columnGap).toBe(6);
+        });
+
+        await it('gives the icon the free space when there is NO label, and not otherwise', async () => {
+            // `hexpand` in a row is `flexGrow`. GTK reads TRUE and FALSE for the same two
+            // inputs; with no label the icon expands and so centres itself in the button.
+            const [bare] = parts(mounted(<AdwButtonContent iconName="folder-download-symbolic" />));
+            expect((bare.props.style as Record<string, unknown>).flexGrow).toBe(1);
+            const [beside] = parts(mounted(<AdwButtonContent iconName="folder-download-symbolic" label="Save" />));
+            expect((beside.props.style as Record<string, unknown>).flexGrow).toBe(0);
+        });
+
+        await it('keeps the icon slot EMPTY, which is the divergence', async () => {
+            // Pinned. There is no icon theme to resolve `folder-download-symbolic` — or
+            // the `image-missing` an empty slot resolves to — against.
+            const [icon] = parts(mounted(<AdwButtonContent iconName="folder-download-symbolic" label="Save" />));
+            expect(icon.type).toBe(RCT_VIEW);
+            expect(icon.children).toBe(null);
+        });
+    });
+
+    await describe('AdwButtonContent on React Native — the label', async () => {
+        await it('hides the node for an empty label rather than dropping it', async () => {
+            // `gtk_widget_set_visible (self->label, label[0])` — the GTK suite reads
+            // `visible === false` for the same input, and the node stays in the tree.
+            const [, label] = parts(mounted(<AdwButtonContent />));
+            expect(label.type).toBe(RCT_TEXT);
+            expect((label.props.style as Record<string, unknown>).display).toBe('none');
+        });
+
+        await it('shows a label of SPACES — a first-character test, not a trim', async () => {
+            const [, label] = parts(mounted(<AdwButtonContent label=" " />));
+            expect((label.props.style as Record<string, unknown>).display).toBe('flex');
+        });
+
+        await it('resolves the mnemonic marker only when use-underline asks', async () => {
+            // Default FALSE, the opposite of the banner button's template, so an
+            // underscore survives unless the app asked for mnemonics.
+            const [, literal] = parts(mounted(<AdwButtonContent label="_Save" />));
+            expect(literal.children).toStrictEqual(['_Save']);
+            const [, resolved] = parts(mounted(<AdwButtonContent label="_Save" useUnderline={true} />));
+            // GTK keeps `"_Save"` in the property for this same input; the two halves
+            // differ HERE and the reason is in the file header.
+            expect(resolved.children).toStrictEqual(['Save']);
+        });
+
+        await it('ellipsizes at the end for can-shrink, and is unlimited without it', async () => {
+            const [, unlimited] = parts(mounted(<AdwButtonContent label="Download the thing" />));
+            expect(unlimited.props.numberOfLines).toBe(0);
+            const [, shrunk] = parts(mounted(<AdwButtonContent label="Download the thing" canShrink={true} />));
+            expect(shrunk.props.numberOfLines).toBe(1);
+            expect(shrunk.props.ellipsizeMode).toBe('tail');
+        });
+    });
+};

--- a/packages/framework/adwaita-react-native/src/widgets/button-content.native.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/button-content.native.tsx
@@ -1,0 +1,61 @@
+/** @jsxImportSource react */
+// `AdwButtonContent` on React Native. (On the pragma, see `bin.native.tsx`.)
+//
+// ALL FOUR DERIVATIONS COME FROM THE CORE, and two of them are places a hand-written
+// translation goes wrong. `buttonContentIconExpands` is `gtk_widget_set_hexpand
+// (self->icon, !label[0])` — the icon takes the free space exactly when there is NO label,
+// which is what centres a label-less icon inside the button; `flexGrow` is Yoga's spelling
+// of `hexpand` in a row. `buttonContentLabelVisible` is a FIRST-CHARACTER test rather than
+// a trim, so a label of spaces keeps its node.
+//
+// `canShrink` IS A REAL PORT HERE, WHICH IT IS NOT ON NATIVESCRIPT. `PANGO_ELLIPSIZE_END`
+// is `numberOfLines={1}` plus `ellipsizeMode="tail"` on a React Native `Text`, so the one
+// property `@gjsify/adwaita-nativescript` has to hold and report without honouring is
+// actually honoured on this renderer.
+//
+// `iconName` IS ACCEPTED AND NOT DRAWN. React Native resolves no icon theme, so there is
+// nothing to turn `folder-download-symbolic` — or the `image-missing` an empty slot
+// resolves to — into. What this half keeps is the icon's LAYOUT, because that is the part
+// that changes the button: the slot is in the row and it expands or does not.
+// `button-content.native.spec.tsx` pins the empty slot, so a later edit that starts
+// drawing something has to say so rather than quietly filling it.
+//
+// THE STYLE CLASS IS NOT STAMPED ANYWHERE, and cannot be: `adw_button_content_root` puts
+// `image-text-button` on the nearest `GtkButton` ancestor, and this package ships no
+// button for it to find. `buttonContentStyleTargetIndex` holds the RETARGET rule for a
+// renderer that has a tree to walk; when a button lands here, that is the call to make.
+
+import type { ReactElement } from 'react';
+import { Text, View } from 'react-native';
+
+import {
+    BUTTON_CONTENT_BOX_SPACING,
+    buttonContentEllipsize,
+    buttonContentIconExpands,
+    buttonContentLabelText,
+    buttonContentLabelVisible,
+} from '@gjsify/adwaita-core';
+
+import type { AdwButtonContentProps } from '../props.js';
+
+/** {@link import('./button-content.js').AdwButtonContent} on React Native. */
+export function AdwButtonContent({ label, useUnderline, canShrink }: AdwButtonContentProps): ReactElement | null {
+    const text = label ?? '';
+
+    return (
+        <View style={{ flexDirection: 'row', alignItems: 'center', columnGap: BUTTON_CONTENT_BOX_SPACING }}>
+            {/* The icon SLOT. Empty by construction — see the header — but in the row and
+                carrying the `hexpand` libadwaita gives it. */}
+            <View style={{ flexGrow: buttonContentIconExpands(text) ? 1 : 0 }} />
+            <Text
+                // `numberOfLines={0}` is React Native's "no limit", so the two ellipsize
+                // modes are one expression rather than a conditional prop.
+                numberOfLines={buttonContentEllipsize(canShrink ?? false) === 'end' ? 1 : 0}
+                ellipsizeMode="tail"
+                style={{ display: buttonContentLabelVisible(text) ? 'flex' : 'none' }}
+            >
+                {buttonContentLabelText(text, useUnderline ?? false)}
+            </Text>
+        </View>
+    );
+}

--- a/packages/framework/adwaita-react-native/src/widgets/button-content.ts
+++ b/packages/framework/adwaita-react-native/src/widgets/button-content.ts
@@ -1,0 +1,22 @@
+// `AdwButtonContent` — the base module. See `../refuse.ts` for who reaches this and why it
+// throws instead of resolving to something.
+
+import type { ReactElement } from 'react';
+
+import type { AdwButtonContentProps } from '../props.js';
+import { refuseBaseModule } from '../refuse.js';
+
+/**
+ * An icon paired with a label, for the inside of a button.
+ *
+ * THE DERIVATIONS ARE THE WIDGET. There is no layout arithmetic here — there are four
+ * questions (`buttonContentIconName`, `buttonContentIconExpands`,
+ * `buttonContentLabelVisible`, `buttonContentEllipsize`) and both halves ask
+ * `@gjsify/adwaita-core` all four. Two of them are places a renderer guesses wrong:
+ * an empty `icon-name` DRAWS `image-missing` rather than hiding the icon (libadwaita's
+ * own doc comments say otherwise and its code disagrees with them), and the icon takes
+ * the free space exactly when there is no label.
+ */
+export function AdwButtonContent(_props: AdwButtonContentProps): ReactElement | null {
+    return refuseBaseModule('AdwButtonContent');
+}

--- a/packages/framework/adwaita-react-native/src/widgets/content.gtk.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/content.gtk.spec.tsx
@@ -1,0 +1,472 @@
+/** @jsxImportSource @gjsify/gtk-host/react */
+// The GTK half of the CONTENT-AND-FEEDBACK group, against the libadwaita that is
+// installed.
+//
+// ONE FILE FOR FIVE WIDGETS. What every GTK spec in this package needs before it can
+// assert anything — the realised sized window, the tree search, the diagnostics gate —
+// is `../testing/gtk.spec.tsx`; what is per-widget is the reasoning, and that is at each
+// `describe`. Five files would be five `describe`s over one import, and the package
+// already answers this way: `AdwBin`'s GTK coverage lives in `clamp.gtk.spec.tsx`.
+//
+// THE ORACLE IS UNUSUALLY DIRECT FOR THE AVATAR, and that is what makes the pair with
+// `avatar.native.spec.tsx` worth having. `set_class_color` PUBLISHES its answer:
+// libadwaita stamps `color{n}` on the avatar's internal gizmo, so this file reads the
+// class off the live GTK tree and the React Native suite asserts the palette entry with
+// the same index. Neither side computes what the other computes — one runs the C and one
+// runs `@gjsify/adwaita-core`'s port of it, and the index is where they meet.
+//
+// TWO ASSERTIONS HERE ARE ABOUT A DEFAULT THAT IS NOT THE DECLARED ONE.
+// `AdwBanner:use-markup`'s GParamSpec declares TRUE (adw-banner.c:422-425) and
+// `ADW_BANNER_DEFAULTS` records that faithfully — but `adw_banner_get_use_markup`
+// delegates to `gtk_label_get_use_markup (self->title)` and `adw-banner.ui` never sets it,
+// so a freshly constructed banner reads FALSE. Reading it off the real widget rather than
+// off the constant is the whole reason this describe exists; the two would otherwise
+// disagree in exactly the place a comment would have said they agree.
+//
+// AND ONE IS ABOUT A UNIT. `Adw.Toast:timeout` counts whole SECONDS and reads back 5 on a
+// default toast; `DEFAULT_TOAST_TIMEOUT` counts 5000 MILLISECONDS. The two authorities
+// agree on the duration, so the only thing that can be wrong is the conversion — which is
+// therefore asserted against libadwaita's own number and not against itself.
+
+import Adw from 'gi://Adw?version=1';
+import GLib from 'gi://GLib?version=2.0';
+import Gtk from 'gi://Gtk?version=4.0';
+import { expect, it } from '@gjsify/unit';
+import { blankReason, shotEvidence } from '@gjsify/gtk-host';
+import { dumpTree, gtkChildren } from '@gjsify/gtk-host/conformance';
+import { AdwToast, DEFAULT_TOAST_TIMEOUT } from '@gjsify/adwaita-core';
+
+import type { AdwToastOverlayHandle } from '../props.js';
+import { capture, find, laidOut, typeOf, withGtk } from '../testing/gtk.spec.js';
+import { AdwAvatar } from './avatar.gtk.js';
+import { AdwBanner } from './banner.gtk.js';
+import { AdwButtonContent } from './button-content.gtk.js';
+import { AdwSpinner } from './spinner.gtk.js';
+import { AdwToastOverlay, adwToastTimeoutSeconds } from './toast-overlay.gtk.js';
+
+/**
+ * The frame these widgets are laid out in.
+ *
+ * Not the harness's default: the spinner rows ask for a 200-point box, and a 200-point
+ * frame would measure the window rather than the widget.
+ */
+const FRAME = { frameWidth: 600, frameHeight: 300 };
+
+/** The spinner box `spinner.native.spec.tsx` asks the same question in. */
+const SPINNER_BOX = 200;
+
+/** Every strict descendant of a GType — the count is what proves "one at a time". */
+function findAll(root: Gtk.Widget, gtype: string): Gtk.Widget[] {
+    const found: Gtk.Widget[] = [];
+    const queue: Gtk.Widget[] = [...gtkChildren(root)];
+    while (queue.length > 0) {
+        const widget = queue.shift() as Gtk.Widget;
+        if (typeOf(widget) === gtype) found.push(widget);
+        queue.push(...gtkChildren(widget));
+    }
+    return found;
+}
+
+/** Every `GtkLabel` text under a widget, in tree order. */
+function labels(root: Gtk.Widget): string[] {
+    return findAll(root, 'GtkLabel').map((label) => (label as Gtk.Label).label);
+}
+
+/** The CSS classes on the avatar's internal gizmo, which is where `set_class_color` writes. */
+function avatarGizmoClasses(avatar: Gtk.Widget): string[] {
+    const gizmo = avatar.get_first_child();
+    if (gizmo === null) throw new Error(`the avatar has no child to carry its colour:\n${dumpTree(avatar)}`);
+    return [...gizmo.get_css_classes()];
+}
+
+export default async () => {
+    await withGtk(async ({ gated, display }) => {
+        await gated('AdwAvatar is the real Adw.Avatar, and it publishes its colour', async () => {
+            await it('derives “AL” and color11 from “Ada Lovelace”, as the port does', async () => {
+                laidOut(
+                    <AdwAvatar size={48} text="Ada Lovelace" showInitials={true} />,
+                    (container) => {
+                        const avatar = find(container, 'AdwAvatar') as Adw.Avatar;
+                        expect(avatar.size).toBe(48);
+                        // `avatarInitials` answers 'AL' and `avatarColorClass` answers 11 for
+                        // the same name; `avatar.native.spec.tsx` asserts both off the port.
+                        expect(labels(avatar)).toStrictEqual(['AL']);
+                        expect(avatarGizmoClasses(avatar)).toStrictEqual(['color11']);
+                    },
+                    FRAME,
+                );
+            });
+
+            await it('derives “GH” and color6 from “Grace Hopper” — a different bucket', async () => {
+                // A SECOND NAME, because one name agreeing proves the two sides picked
+                // the same index once. `g_str_hash` over UTF-8 bytes is the whole
+                // derivation, and a renderer hashing UTF-16 code units instead lands on
+                // the same bucket for plenty of ASCII names.
+                laidOut(
+                    <AdwAvatar size={48} text="Grace Hopper" showInitials={true} />,
+                    (container) => {
+                        const avatar = find(container, 'AdwAvatar') as Adw.Avatar;
+                        expect(labels(avatar)).toStrictEqual(['GH']);
+                        expect(avatarGizmoClasses(avatar)).toStrictEqual(['color6']);
+                    },
+                    FRAME,
+                );
+            });
+
+            await it('keeps the colour but hides the initials without show-initials', async () => {
+                // MEASURED, and the browser renderer disagrees with it: libadwaita still
+                // stamps the colour class in icon mode, so the circle keeps its gradient
+                // and only the label goes away. `avatar.native.spec.tsx` asserts the same
+                // pair — background present, initials hidden.
+                laidOut(
+                    <AdwAvatar size={48} text="Ada Lovelace" />,
+                    (container) => {
+                        const avatar = find(container, 'AdwAvatar') as Adw.Avatar;
+                        expect(avatarGizmoClasses(avatar)).toStrictEqual(['color11']);
+                        expect((find(avatar, 'GtkLabel') as Gtk.Label).visible).toBe(false);
+                    },
+                    FRAME,
+                );
+            });
+        });
+
+        await gated('AdwBanner answers what the widget reads back, not what it declares', async () => {
+            await it('leaves use-markup FALSE when omitted, against a pspec that says TRUE', async () => {
+                laidOut(
+                    <AdwBanner title="Metered connection" revealed={true} />,
+                    (container) => {
+                        const banner = find(container, 'AdwBanner') as Adw.Banner;
+                        // The declared default is TRUE; `adw_banner_get_use_markup` delegates
+                        // to the title label and the template never sets it there.
+                        expect(banner.useMarkup).toBe(false);
+                        expect(banner.revealed).toBe(true);
+                    },
+                    FRAME,
+                );
+            });
+
+            await it('shows the button for a non-empty label and hides it for an empty one', async () => {
+                laidOut(
+                    <AdwBanner title="Metered" buttonLabel="_Undo" revealed={true} />,
+                    (container) => {
+                        const banner = find(container, 'AdwBanner') as Adw.Banner;
+                        expect(banner.buttonLabel).toBe('_Undo');
+                        // The template pins the button to `use-underline=True`, so the PAINTED
+                        // text drops the marker while the property keeps it — which is why
+                        // `bannerButtonText` runs on the other half and not here.
+                        expect(find(banner, 'GtkButton').visible).toBe(true);
+                    },
+                    FRAME,
+                );
+                laidOut(
+                    <AdwBanner title="Metered" revealed={true} />,
+                    (container) => {
+                        const banner = find(container, 'AdwBanner') as Adw.Banner;
+                        expect(find(banner, 'GtkButton').visible).toBe(false);
+                    },
+                    FRAME,
+                );
+            });
+
+            await it('carries button-style as the enum member the nick names', async () => {
+                laidOut(
+                    <AdwBanner title="Metered" buttonLabel="Undo" buttonStyle="suggested" revealed={true} />,
+                    (container) => {
+                        const banner = find(container, 'AdwBanner') as Adw.Banner;
+                        expect(banner.buttonStyle).toBe(Adw.BannerButtonStyle.SUGGESTED);
+                    },
+                    FRAME,
+                );
+            });
+
+            await it('fires button-clicked through the prop, which is a GObject signal', async () => {
+                let clicked = 0;
+                laidOut(
+                    <AdwBanner
+                        title="Metered"
+                        buttonLabel="Undo"
+                        revealed={true}
+                        onButtonClicked={() => (clicked += 1)}
+                    />,
+                    (container) => {
+                        const banner = find(container, 'AdwBanner') as Adw.Banner;
+                        expect(clicked).toBe(0);
+                        (find(banner, 'GtkButton') as Gtk.Button).emit('clicked');
+                        expect(clicked).toBe(1);
+                    },
+                    FRAME,
+                );
+            });
+        });
+
+        await gated('AdwSpinner sizes its BOX from GtkWidget’s own request', async () => {
+            await it('measures libadwaita’s natural 16 with no request', async () => {
+                // `resolveSpinnerSize(undefined)` answers 16 on the other half for the
+                // same input, and `spinner.native.spec.tsx` asserts it as a style.
+                laidOut(
+                    <AdwSpinner />,
+                    (container) => {
+                        const spinner = find(container, 'AdwSpinner');
+                        expect(spinner.measure(Gtk.Orientation.HORIZONTAL, -1)[0]).toBe(16);
+                        expect(spinner.measure(Gtk.Orientation.VERTICAL, -1)[0]).toBe(16);
+                    },
+                    FRAME,
+                );
+            });
+
+            await it('measures exactly what was requested, with no upper bound', async () => {
+                // 200 is the shared frame: the box stays 200 while `spinnerGeometry` caps
+                // the RING at 64, and the ring is asserted on the half where it is a node.
+                laidOut(
+                    <AdwSpinner widthRequest={SPINNER_BOX} heightRequest={SPINNER_BOX} />,
+                    (container) => {
+                        const spinner = find(container, 'AdwSpinner');
+                        expect(spinner.measure(Gtk.Orientation.HORIZONTAL, -1)[0]).toBe(SPINNER_BOX);
+                        expect(spinner.get_height()).toBe(SPINNER_BOX);
+                    },
+                    FRAME,
+                );
+            });
+        });
+
+        // INSIDE A `<gtk-button>`, WHICH IS NOT DECORATION. `adw_button_content_root`
+        // takes the nearest `GtkButton` ancestor and, with none, calls
+        // `gtk_widget_get_parent (NULL)` and `gtk_widget_add_css_class (NULL, …)`.
+        // `buttonContentStyleTargetIndex`'s doc calls that two CRITICALs; measured here it
+        // is exactly two, `assertQuiet` failed on them, and this describe is the first
+        // thing in the repository to hold libadwaita to it. So the widget is mounted the
+        // way it is used, and the class it exists to stamp becomes assertable as well.
+        await gated('AdwButtonContent resolves the icon and the label the way the C does', async () => {
+            await it('draws image-missing for an empty slot instead of hiding the icon', async () => {
+                // libadwaita's own doc comments say the icon is not shown; its code sets
+                // the fallback and never hides the image. `buttonContentIconName` follows
+                // the code, and this is the widget agreeing.
+                laidOut(
+                    <gtk-button>
+                        <AdwButtonContent />
+                    </gtk-button>,
+                    (container) => {
+                        const content = find(container, 'AdwButtonContent');
+                        const image = find(content, 'GtkImage') as Gtk.Image;
+                        expect(image.iconName).toBe('image-missing');
+                        expect(image.visible).toBe(true);
+                        // `buttonContentIconExpands('')` is TRUE, and this is why: with no
+                        // label the icon takes the free space and so centres itself.
+                        expect(image.hexpand).toBe(true);
+                        expect((find(content, 'GtkLabel') as Gtk.Label).visible).toBe(false);
+                    },
+                    FRAME,
+                );
+            });
+
+            await it('stamps image-text-button on the button, which is the point of it', async () => {
+                // `BUTTON_CONTENT_STYLE_CLASS` carries 9px of horizontal padding where a
+                // plain button has 17px, and it is the whole reason `AdwButtonContent`
+                // exists as a type rather than as a box. It is libadwaita's own work on
+                // this half — there is nothing for the React Native half to stamp it on,
+                // because this package ships no button, and the README names that.
+                laidOut(
+                    <gtk-button>
+                        <AdwButtonContent iconName="folder-download-symbolic" label="Save" />
+                    </gtk-button>,
+                    (container) => {
+                        const button = find(container, 'GtkButton');
+                        expect([...button.get_css_classes()]).toStrictEqual(['image-text-button']);
+                    },
+                    FRAME,
+                );
+            });
+
+            await it('keeps the mnemonic marker in the property and ellipsizes for can-shrink', async () => {
+                laidOut(
+                    <gtk-button>
+                        <AdwButtonContent
+                            iconName="folder-download-symbolic"
+                            label="_Save"
+                            useUnderline={true}
+                            canShrink={true}
+                        />
+                    </gtk-button>,
+                    (container) => {
+                        const content = find(container, 'AdwButtonContent');
+                        const image = find(content, 'GtkImage') as Gtk.Image;
+                        const label = find(content, 'GtkLabel') as Gtk.Label;
+                        expect(image.iconName).toBe('folder-download-symbolic');
+                        expect(image.hexpand).toBe(false);
+                        // RAW, marker included: the label node carries `use-underline`
+                        // itself and resolves it at paint. The React Native half has no
+                        // mnemonic layer, so `buttonContentLabelText` strips it there.
+                        expect(label.label).toBe('_Save');
+                        // `buttonContentEllipsize(true)` is `'end'`, which is
+                        // `PANGO_ELLIPSIZE_END`.
+                        expect(label.ellipsize).toBe(3);
+                    },
+                    FRAME,
+                );
+            });
+        });
+
+        await gated('AdwToastOverlay is libadwaita’s queue, reached through a ref', async () => {
+            await it('converts the core’s milliseconds to libadwaita’s seconds', async () => {
+                // BOTH SIDES OF THE UNIT, so the conversion is measured against
+                // libadwaita's own default rather than against itself: a default
+                // `Adw.Toast` reads 5, `DEFAULT_TOAST_TIMEOUT` is 5000 ms. The toast is
+                // constructed with NO title, which is not tidiness: a literal caption in
+                // a constructor object is what `gjsify/no-literal-widget-label` reports,
+                // and the title is not what is being measured.
+                expect(new Adw.Toast({}).timeout).toBe(5);
+                expect(adwToastTimeoutSeconds(DEFAULT_TOAST_TIMEOUT)).toBe(5);
+                // 0 is libadwaita's "until dismissed" and must survive as 0, and no
+                // POSITIVE input may reach it — which is what the 400 row is for, and it
+                // is the row that falsified `Math.round`: `Math.round(400 / 1000)` is 0,
+                // i.e. a 0.4-second toast that never goes away.
+                expect(adwToastTimeoutSeconds(0)).toBe(0);
+                expect(adwToastTimeoutSeconds(400)).toBe(1);
+                expect(adwToastTimeoutSeconds(1500)).toBe(2);
+            });
+
+            await it('shows ONE toast for two adds, which is the policy both halves keep', async () => {
+                const handle: { current: AdwToastOverlayHandle | null } = { current: null };
+                laidOut(
+                    <AdwToastOverlay ref={handle}>
+                        <gtk-label label="content" />
+                    </AdwToastOverlay>,
+                    (container) => {
+                        const overlay = find(container, 'AdwToastOverlay') as Adw.ToastOverlay;
+                        expect(typeOf(overlay.get_child() as Gtk.Widget)).toBe('GtkLabel');
+                        expect(findAll(overlay, 'AdwToastWidget').length).toBe(0);
+
+                        handle.current?.addToast(new AdwToast('first', { timeout: 0 }));
+                        handle.current?.addToast(new AdwToast('second', { timeout: 0 }));
+                        const context = GLib.MainContext.default();
+                        while (context.pending()) context.iteration(false);
+
+                        // ONE widget, showing the FIRST — the same pair
+                        // `toast-overlay.native.spec.tsx` asserts of the port.
+                        expect(findAll(overlay, 'AdwToastWidget').length).toBe(1);
+                        expect(labels(overlay)).toContain('first');
+                        expect(labels(overlay)).not.toContain('second');
+                    },
+                    FRAME,
+                );
+            });
+
+            await it('puts the action button in the toast when the label is non-empty', async () => {
+                const handle: { current: AdwToastOverlayHandle | null } = { current: null };
+                laidOut(
+                    <AdwToastOverlay ref={handle}>
+                        <gtk-label label="content" />
+                    </AdwToastOverlay>,
+                    (container) => {
+                        const overlay = find(container, 'AdwToastOverlay') as Adw.ToastOverlay;
+                        handle.current?.addToast(new AdwToast('Saved', { timeout: 0, buttonLabel: 'Undo' }));
+                        const context = GLib.MainContext.default();
+                        while (context.pending()) context.iteration(false);
+                        const toast = find(overlay, 'AdwToastWidget');
+                        expect(labels(toast)).toContain('Saved');
+                        expect(labels(toast)).toContain('Undo');
+                    },
+                    FRAME,
+                );
+            });
+
+            await it('reaches dismiss_all without a diagnostic — the only half of it GTK shows', async () => {
+                // THE TREE CANNOT ANSWER THIS ONE. `adw_toast_overlay_dismiss_all`
+                // animates the strip out, and pumping the main context for ~1.6s of real
+                // time leaves the `AdwToastWidget` in place — measured. So what is
+                // asserted is that the call lands on libadwaita and costs nothing: this
+                // describe's `assertQuiet` is the second half of the assertion. The
+                // REMOVAL is asserted on the React Native half, where the queue is ours.
+                const handle: { current: AdwToastOverlayHandle | null } = { current: null };
+                laidOut(
+                    <AdwToastOverlay ref={handle}>
+                        <gtk-label label="content" />
+                    </AdwToastOverlay>,
+                    () => {
+                        handle.current?.addToast(new AdwToast('first', { timeout: 0 }));
+                        handle.current?.dismissAll();
+                        const context = GLib.MainContext.default();
+                        while (context.pending()) context.iteration(false);
+                    },
+                    FRAME,
+                );
+            });
+        });
+
+        if (display !== null) {
+            await gated('the picture, not only the setter', async () => {
+                // GTK'S FAILURE MODE IS EXIT 0 WITH AN EMPTY WINDOW, so a tree assert and
+                // a photograph answer different questions — `clamp.gtk.spec.tsx` carries
+                // the four documentation snippets that were measured producing an empty
+                // window at exit 0 with zero diagnostics. One row per widget, because a
+                // single row that photographs three of them names none of them when it
+                // fails.
+                await it('rasterises the avatar, gradient and initials and all', async () => {
+                    laidOut(
+                        <AdwAvatar size={48} text="Ada Lovelace" showInitials={true} />,
+                        (container) => {
+                            expect(blankReason(shotEvidence(find(container, 'AdwAvatar'), capture))).toBe(null);
+                        },
+                        FRAME,
+                    );
+                });
+
+                await it('rasterises the banner through its revealer', async () => {
+                    laidOut(
+                        <AdwBanner title="Metered connection" revealed={true} />,
+                        (container) => {
+                            expect(blankReason(shotEvidence(find(container, 'AdwBanner'), capture))).toBe(null);
+                        },
+                        FRAME,
+                    );
+                });
+
+                await it('rasterises the spinner, which `blankReason` cannot be asked about', async () => {
+                    // `blankReason`'s FIRST question is the strict descendant count, and
+                    // `Adw.Spinner` has none: it draws through an `AdwSpinnerPaintable`
+                    // and holds no child widget at all. Measured — a spinner allocated
+                    // 400×200 reports 0 descendants, so the reader answers "nothing was
+                    // rendered" about a widget that renders. That is a property of the
+                    // widget, not a failure, so the evidence FIELDS are read directly.
+                    //
+                    // WITH A CONTROL IN THE ROW, because "a non-empty PNG is not proof" is
+                    // `blankReason`'s own warning. `Gtk.Snapshot.to_node()` returns NULL
+                    // for a widget that paints nothing, so an empty `Gtk.Box` at the same
+                    // allocation captures no PNG at all: box 0 bytes, spinner ~1.4 kB —
+                    // the count is not stable, the contrast is.
+                    //
+                    // THE CONTROL GETS ITS OWN WINDOW, AND THAT IS THE WHOLE POINT OF IT.
+                    // It was first written as a `Gtk.Box` appended to the spinner's
+                    // container after layout, and measured that way it is 0×0: the box
+                    // never gets an allocation, `capture` bails at `width <= 0`, and the
+                    // row proved that an UNALLOCATED widget captures nothing — which is
+                    // true of every widget, the spinner included. Falsified: swapping the
+                    // box for a `Gtk.Button`, which paints a background, left the suite at
+                    // exit 0. Laid out in its own window the control discriminates, and
+                    // its ALLOCATION is asserted first so it cannot quietly stop.
+                    laidOut(
+                        <AdwSpinner widthRequest={SPINNER_BOX} heightRequest={SPINNER_BOX} />,
+                        (container) => {
+                            const spinner = find(container, 'AdwSpinner');
+                            const evidence = shotEvidence(spinner, capture);
+                            expect(evidence.widgets).toBe(0);
+                            expect(evidence.height).toBe(SPINNER_BOX);
+                            expect(evidence.bytes > 0).toBe(true);
+                        },
+                        FRAME,
+                    );
+
+                    laidOut(
+                        <gtk-box width-request={SPINNER_BOX} height-request={SPINNER_BOX} />,
+                        (container) => {
+                            const blank = find(container, 'GtkBox');
+                            expect(blank.get_height()).toBe(SPINNER_BOX);
+                            expect(shotEvidence(blank, capture).bytes).toBe(0);
+                        },
+                        FRAME,
+                    );
+                });
+            });
+        }
+    });
+};

--- a/packages/framework/adwaita-react-native/src/widgets/spinner.gtk.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/spinner.gtk.tsx
@@ -1,0 +1,23 @@
+/** @jsxImportSource @gjsify/gtk-host/react */
+// `AdwSpinner` on GTK — the real `Adw.Spinner`. (On the pragma, see `bin.gtk.tsx`.)
+//
+// THE PROPERTIES ARE `GtkWidget`'s AND THAT IS THE WHOLE WIDGET: `Adw.Spinner` declares
+// none of its own, so `width-request`/`height-request` are what a caller has. Measured
+// on libadwaita 1.9.3 — a fresh spinner measures `[16, 16, -1, -1]` horizontally, one
+// with `width-request` 200 measures `[200, 200, -1, -1]`, and `-1` is GTK's own "no
+// request", which is why `resolveSpinnerSize(-1)` answering 16 on the other half is an
+// agreement rather than a coincidence.
+//
+// `spinnerGeometry` IS NOT USED HERE. The ring is painted by `AdwSpinnerPaintable` in C
+// and is not a node in the tree at all — so the GTK half can be asked about the BOX and
+// about whether it rasterises, and the ring diameter is asserted where it IS a node,
+// which is the React Native half. That asymmetry is named in the README.
+
+import type { ReactElement } from 'react';
+
+import type { AdwSpinnerProps } from '../props.js';
+
+/** {@link import('./spinner.js').AdwSpinner} on GTK. */
+export function AdwSpinner({ widthRequest, heightRequest }: AdwSpinnerProps): ReactElement | null {
+    return <adw-spinner width-request={widthRequest} height-request={heightRequest} />;
+}

--- a/packages/framework/adwaita-react-native/src/widgets/spinner.native.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/spinner.native.spec.tsx
@@ -1,0 +1,109 @@
+/** @jsxImportSource react */
+// The React Native half of `AdwSpinner`, rendered through React's real reconciler.
+//
+// THE BOX AND THE RING ARE TWO NUMBERS AND THIS FILE ASSERTS BOTH. `content.gtk.spec.tsx`
+// can only ask the real `Adw.Spinner` about the BOX — the ring is painted by
+// `AdwSpinnerPaintable` and is not a node in the GTK tree at all — so the shared pair is
+// the box (200 measured on GTK, 200 asked for here) and the ring is asserted where it IS a
+// node, which is here. That asymmetry is named in the README rather than papered over with
+// a rasterisation that would only say "something was drawn".
+//
+// THE RING'S THREE RULES, each with a case: the shorter side decides the radius and it is
+// FLOORED, so a 31-point box draws a 30-point ring; the radius is capped at 32 while the
+// centre still follows the box, so 200 draws 64; and the stroke is `diameter / 8` exactly,
+// so 200 gives 8 and 31 gives 3.75. A renderer that took the radius from the box without
+// the cap would agree with GTK at 16 and 24 and nowhere above 64.
+//
+// The harness — `act`, the renderer, the child readers — is `../testing/render.spec.ts`.
+//
+// WHAT IS DELIBERATELY ABSENT is the arc. The drawn circle is the TRACK —
+// `ADW_SPINNER_TRACK_OPACITY`, the widget's colour at 15%, which is exactly what the
+// browser renderer paints under its arc — and there is no breathing segment on top of it,
+// because drawing one needs a path renderer this package does not depend on. Asserting the
+// track's opacity is what keeps that from silently becoming a solid ring.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { RCT_VIEW } from '../testing/react-native.js';
+import { mounted, onlyChild, type Style } from '../testing/render.spec.js';
+import { AdwSpinner } from './spinner.native.js';
+
+/** The box `content.gtk.spec.tsx` measures the real widget at. */
+const SPINNER_BOX = 200;
+
+export default async () => {
+    await describe('AdwSpinner on React Native — the box', async () => {
+        await it('is libadwaita’s natural 16 with no request, as the widget measures', async () => {
+            // `content.gtk.spec.tsx` reads `measure(HORIZONTAL, -1)[0] === 16` off a real
+            // `Adw.Spinner` with no request. `resolveSpinnerSize(undefined)` is the same
+            // 16, because `adw_spinner_measure` reports MIN_SIZE as minimum AND natural.
+            const tree = mounted(<AdwSpinner />);
+            expect(tree.type).toBe(RCT_VIEW);
+            const style = tree.props.style as Record<string, unknown>;
+            expect(style.width).toBe(16);
+            expect(style.height).toBe(16);
+        });
+
+        await it('treats GTK’s own -1 “no request” as that same 16', async () => {
+            // Not a coincidence to be tidied away later: `-1` is what `width-request`
+            // holds when nothing asked, so the two halves have to answer alike for it.
+            const style = mounted(<AdwSpinner widthRequest={-1} heightRequest={-1} />).props.style as Record<
+                string,
+                unknown
+            >;
+            expect(style.width).toBe(16);
+            expect(style.height).toBe(16);
+        });
+
+        await it('keeps an oversized request oversized — there is no upper bound on the box', async () => {
+            const style = mounted(<AdwSpinner widthRequest={SPINNER_BOX} heightRequest={SPINNER_BOX} />).props
+                .style as Record<string, unknown>;
+            expect(style.width).toBe(SPINNER_BOX);
+            expect(style.height).toBe(SPINNER_BOX);
+        });
+    });
+
+    await describe('AdwSpinner on React Native — the ring, which is where the cap lives', async () => {
+        await it('draws a 64-point ring with an 8-point stroke inside a 200-point box', async () => {
+            const ring = onlyChild(mounted(<AdwSpinner widthRequest={SPINNER_BOX} heightRequest={SPINNER_BOX} />));
+            expect(ring.props.style as Style).toStrictEqual({
+                width: 64,
+                height: 64,
+                borderRadius: 32,
+                borderWidth: 8,
+                opacity: 0.15,
+            });
+        });
+
+        await it('floors the radius, so a 31-point box draws a 30-point ring', async () => {
+            // `Math.floor(31 / 2) * 2`. The stroke follows the DRAWN diameter, not the
+            // box, so it is 3.75 and not 3.875.
+            const ring = onlyChild(mounted(<AdwSpinner widthRequest={31} heightRequest={31} />));
+            expect(ring.props.style as Style).toStrictEqual({
+                width: 30,
+                height: 30,
+                borderRadius: 15,
+                borderWidth: 3.75,
+                opacity: 0.15,
+            });
+        });
+
+        await it('takes the SHORTER side, so an oblong box draws the smaller ring', async () => {
+            const ring = onlyChild(mounted(<AdwSpinner widthRequest={SPINNER_BOX} heightRequest={24} />));
+            expect((ring.props.style as Record<string, unknown>).width).toBe(24);
+            expect((ring.props.style as Record<string, unknown>).borderWidth).toBe(3);
+        });
+    });
+
+    await describe('AdwSpinner on React Native — what it announces', async () => {
+        await it('is a busy progressbar, which both earlier renderers shipped without', async () => {
+            // `gtk_widget_class_set_accessible_role (…, PROGRESS_BAR)` plus
+            // `GTK_ACCESSIBLE_STATE_BUSY, TRUE`. A repo-wide grep for either found ZERO
+            // hits across the two other ports before they were fixed, so a screen reader
+            // was told nothing at all.
+            const tree = mounted(<AdwSpinner />);
+            expect(tree.props.accessibilityRole).toBe('progressbar');
+            expect(tree.props.accessibilityState).toStrictEqual({ busy: true });
+        });
+    });
+};

--- a/packages/framework/adwaita-react-native/src/widgets/spinner.native.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/spinner.native.tsx
@@ -1,0 +1,66 @@
+/** @jsxImportSource react */
+// `AdwSpinner` on React Native. (On the pragma, see `bin.native.tsx`.)
+//
+// THE TWO NUMBERS ARE THE CORE'S, AND THEY ARE TWO ON PURPOSE. `resolveSpinnerSize` is
+// `adw_spinner_measure`'s floor — 16 is reported as both the minimum and the natural size,
+// so a smaller request is not representable and an unset one IS 16, which is also what
+// GTK's own `-1` "no request" produces. `spinnerGeometry` is the paintable: the SHORTER
+// side decides the radius, it is FLOORED (a 31-point box draws a 30-point ring), it is
+// capped at 32 while the CENTRE still follows the box, and the stroke is `diameter / 8`
+// exactly. So a 200-point request occupies 200 points of layout around a 64-point ring
+// with an 8-point stroke — the split the two other renderers each had to be taught.
+//
+// WHAT IS DRAWN IS THE TRACK, AND ONLY THE TRACK. `AdwSpinnerPaintable`'s arc extends,
+// overlaps, contracts and idles on an ease-in-out-sine while the whole figure turns, and
+// drawing it needs a path renderer — `react-native-svg` or a canvas, neither of which is
+// a dependency of this package, and neither of which core React Native supplies. The
+// honest subset is the circle underneath it: `CIRCLE_OPACITY` of the current colour, which
+// is `ADW_SPINNER_TRACK_OPACITY` and is exactly what the browser renderer paints under its
+// arc. What is NOT done is the `_spinner.scss` substitute — a fixed 90-degree
+// `border-top-color` chase at 0.8s — because that is a different animation with a
+// different period, and copying it would put a wrong number where there is currently an
+// absent one. The README names the gap.
+//
+// `ActivityIndicator` IS NOT USED, and that is a decision about the TEST DOUBLE rather
+// than about the phone. `@gjsify/adwaita-nativescript` reaches for the platform indicator
+// for good reasons, and the same reasoning would apply here — but React Native's
+// `ActivityIndicator` is a COMPOSITE that wraps a native node in a `View`, branches on
+// `Platform.OS` and moves a numeric `size` into a style. `testing/react-native.ts` stands
+// in only for components that ARE a host element with their props forwarded, so doubling
+// it would mean asserting a nesting and a prop placement real React Native does not
+// produce.
+
+import type { ReactElement } from 'react';
+import { View } from 'react-native';
+
+import { ADW_SPINNER_TRACK_OPACITY, resolveSpinnerSize, spinnerGeometry } from '@gjsify/adwaita-core';
+
+import type { AdwSpinnerProps } from '../props.js';
+
+/** {@link import('./spinner.js').AdwSpinner} on React Native. */
+export function AdwSpinner({ widthRequest, heightRequest }: AdwSpinnerProps): ReactElement | null {
+    const width = resolveSpinnerSize(widthRequest);
+    const height = resolveSpinnerSize(heightRequest);
+    const { diameter, lineWidth } = spinnerGeometry(width, height);
+
+    return (
+        <View
+            // `gtk_widget_class_set_accessible_role (…, PROGRESS_BAR)` plus
+            // `GTK_ACCESSIBLE_STATE_BUSY, TRUE`. Both renderers before this one shipped
+            // without either and announced nothing at all to a screen reader.
+            accessibilityRole="progressbar"
+            accessibilityState={{ busy: true }}
+            style={{ width, height, alignItems: 'center', justifyContent: 'center' }}
+        >
+            <View
+                style={{
+                    width: diameter,
+                    height: diameter,
+                    borderRadius: diameter / 2,
+                    borderWidth: lineWidth,
+                    opacity: ADW_SPINNER_TRACK_OPACITY,
+                }}
+            />
+        </View>
+    );
+}

--- a/packages/framework/adwaita-react-native/src/widgets/spinner.ts
+++ b/packages/framework/adwaita-react-native/src/widgets/spinner.ts
@@ -1,0 +1,25 @@
+// `AdwSpinner` — the base module. See `../refuse.ts` for who reaches this and why it throws
+// instead of resolving to something.
+
+import type { ReactElement } from 'react';
+
+import type { AdwSpinnerProps } from '../props.js';
+import { refuseBaseModule } from '../refuse.js';
+
+/**
+ * A busy indicator.
+ *
+ * THE SHARED NUMBERS ARE THE BOX AND THE RING, and they are deliberately two numbers:
+ * `adw_spinner_measure` reports `MIN_SIZE` as both the minimum and the natural size with
+ * no upper bound, while `adw_spinner_paintable_snapshot_with_weight` caps only the RADIUS
+ * and still centres on the box. `@gjsify/adwaita-core`'s `resolveSpinnerSize` and
+ * `spinnerGeometry` are that split, and both halves run them.
+ *
+ * What the React Native half cannot carry is the breathing ARC, and the divergence is
+ * named in the README rather than approximated with a rotating quarter-circle — which is
+ * a different animation with a different period, and the one thing the core's own header
+ * says not to copy.
+ */
+export function AdwSpinner(_props: AdwSpinnerProps): ReactElement | null {
+    return refuseBaseModule('AdwSpinner');
+}

--- a/packages/framework/adwaita-react-native/src/widgets/toast-overlay.gtk.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/toast-overlay.gtk.tsx
@@ -1,0 +1,73 @@
+/** @jsxImportSource @gjsify/gtk-host/react */
+// `AdwToastOverlay` on GTK — the real `Adw.ToastOverlay`, and libadwaita's own queue.
+// (On the pragma, see `bin.gtk.tsx`.)
+//
+// `AdwToastQueue` IS NOT USED HERE. The core's port of the one-at-a-time policy is for a
+// renderer that has no libadwaita; this half has the original, and running both would
+// give the overlay two authorities for which toast is on screen. Measured on libadwaita
+// 1.9.3: two toasts added back to back leave exactly ONE `AdwToastWidget` in the tree,
+// showing the first — the same behaviour `toast-overlay.native.spec.tsx` asserts of the
+// port.
+//
+// THE UNIT IS THE ONE THING THAT HAS TO BE CONVERTED, and it is a real divergence
+// between the two authorities rather than a formality: `Adw.Toast:timeout` counts
+// SECONDS as a `guint`, `AdwToast.timeout` counts MILLISECONDS. `DEFAULT_TOAST_TIMEOUT`
+// is 5000 and a freshly constructed `Adw.Toast` reads `timeout === 5`, so the two agree
+// on the duration and disagree on the unit — which is exactly the shape that survives as
+// a silent off-by-1000 if nobody writes it down.
+//
+// The overlay is reached through a `ref` because `add_toast` is a CALL. gtk-host's
+// `getPublicInstance` hands back the author's own widget, so the ref is the real
+// `Adw.ToastOverlay` and not a wrapper.
+
+import Adw from 'gi://Adw?version=1';
+import { useImperativeHandle, useRef, type ReactElement } from 'react';
+
+import type { AdwToast } from '@gjsify/adwaita-core';
+
+import type { AdwToastOverlayProps } from '../props.js';
+
+/**
+ * `AdwToast.timeout` (ms) as `Adw.Toast:timeout` (whole seconds).
+ *
+ * Exported so `content.gtk.spec.tsx` can assert the conversion against
+ * libadwaita's own default instead of against itself; `parity.spec.ts` allows a
+ * platform-only export beside the widget for exactly this.
+ *
+ * IT ROUNDS UP, AND `Math.round` WAS THE FIRST VERSION AND WAS WRONG. `timeout: 0` is
+ * libadwaita's "until dismissed", so any rule that can take a POSITIVE millisecond count
+ * to 0 turns a brief toast into a permanent one — and `Math.round(400 / 1000)` is exactly
+ * that, caught by the row in `content.gtk.spec.tsx` that asserts the conversion. `ceil`
+ * cannot reach 0 from a positive input and leaves an authored 0 alone, so the one value
+ * that means something else keeps meaning it.
+ *
+ * It is lossy in the other direction and the README names that: GObject stores whole
+ * seconds, so 1500 ms is 2 s on GTK and stays 1500 ms on React Native.
+ */
+export const adwToastTimeoutSeconds = (milliseconds: number): number => Math.ceil(milliseconds / 1000);
+
+/** {@link import('./toast-overlay.js').AdwToastOverlay} on GTK. */
+export function AdwToastOverlay({ children, ref }: AdwToastOverlayProps): ReactElement | null {
+    const overlay = useRef<Adw.ToastOverlay | null>(null);
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            addToast: (toast: AdwToast): void => {
+                overlay.current?.add_toast(
+                    new Adw.Toast({
+                        title: toast.title,
+                        timeout: adwToastTimeoutSeconds(toast.timeout),
+                        // `Adw.Toast:button-label` is nullable and NULL is what hides the
+                        // button; the core descriptor spells the same state `''`.
+                        buttonLabel: toast.buttonLabel.length > 0 ? toast.buttonLabel : null,
+                    }),
+                );
+            },
+            dismissAll: (): void => overlay.current?.dismiss_all(),
+        }),
+        [],
+    );
+
+    return <adw-toast-overlay ref={overlay}>{children}</adw-toast-overlay>;
+}

--- a/packages/framework/adwaita-react-native/src/widgets/toast-overlay.native.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/toast-overlay.native.spec.tsx
@@ -1,0 +1,201 @@
+/** @jsxImportSource react */
+// The React Native half of `AdwToastOverlay`, rendered through React's real reconciler.
+//
+// THE SHARED CLAIM IS A BEHAVIOUR, NOT A NUMBER, and it is the one thing "one API surface"
+// has to mean for a widget with state: two toasts added back to back show ONE.
+// `content.gtk.spec.tsx` measures that against libadwaita 1.9.3 — a single
+// `AdwToastWidget` in the tree, carrying the FIRST title — and this file asserts it of
+// `@gjsify/adwaita-core`'s port. Neither half runs the other's queue.
+//
+// MOST OF THIS SUITE IS TIMER-FREE ON PURPOSE. `timeout: 0` is libadwaita's "until
+// dismissed", so ordering, one-at-a-time and `dismissAll` can all be asked without a
+// clock — and the auto-dismiss LIFECYCLE is already held against a deterministic fake
+// scheduler in `@gjsify/adwaita-core`'s own suite, which is where it belongs. What that
+// leaves unproven is the WIRING: that this component actually hands the queue a working
+// timer rather than a scheduler that never fires.
+//
+// THAT TAKES TWO ROWS, NOT ONE, AND THE SECOND IS WHERE THE DURATION LIVES. A single
+// "the toast went away" row is passed by a scheduler that ignores the millisecond count
+// entirely and fires on the next tick — measured: replacing `setTimeout(callback, ms)`
+// with `setTimeout(callback, 0)` left it green. So a second toast with a MINUTE-long
+// timeout is asserted still on screen after the same wait. One row says the timer fires,
+// the other says it fires on the toast's own clock; neither says it alone.
+//
+// The harness — `act`, the renderer, the child readers — is `../testing/render.spec.ts`.
+//
+// THE `dismissAll` ROW IS THE OTHER HALF OF A PAIR THE GTK SIDE CANNOT COMPLETE.
+// `adw_toast_overlay_dismiss_all` animates the strip out over real time, and pumping the
+// main context for ~1.6s leaves the widget in place — measured. So GTK asserts that the
+// call lands and costs no diagnostic, and the REMOVAL is asserted here, where the queue is
+// ours.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { act, type ReactTestRendererJSON } from 'react-test-renderer';
+
+import { AdwToast } from '@gjsify/adwaita-core';
+
+import type { AdwToastOverlayHandle } from '../props.js';
+import { RCT_TEXT, RCT_VIEW } from '../testing/react-native.js';
+import { mount } from '../testing/render.spec.js';
+import { AdwToastOverlay } from './toast-overlay.native.js';
+
+/**
+ * The real timeouts in this file, and the margin around them.
+ *
+ * A short lifetime and a generous wait: what is being proven is that a timer FIRES, not
+ * when — a tight margin would turn a scheduler assertion into a scheduler race. The long
+ * one is the other side of the same question, and it is a MINUTE rather than a second so
+ * that neither the wait below nor a slow machine can reach it.
+ */
+const SHORT_TIMEOUT_MS = 10;
+const LONG_TIMEOUT_MS = 60_000;
+const WAIT_MS = 250;
+
+/**
+ * How many `setTimeout` handles the host is currently holding.
+ *
+ * The teardown row reads the DELTA and never the total: `react-test-renderer` and the
+ * runner hold timers of their own, and a total would make the assertion about them.
+ */
+const pendingTimers = (): number =>
+    process.getActiveResourcesInfo().filter((resource) => resource === 'Timeout').length;
+
+/** Mount with a ref, and hand back both the renderer and the handle. */
+function overlay(children: React.ReactNode = null): {
+    handle: AdwToastOverlayHandle;
+    tree: () => ReactTestRendererJSON;
+    unmount: () => void;
+} {
+    const ref: { current: AdwToastOverlayHandle | null } = { current: null };
+    const renderer = mount(<AdwToastOverlay ref={ref}>{children}</AdwToastOverlay>);
+    if (ref.current === null) throw new Error('the overlay exposed no imperative handle');
+    return {
+        handle: ref.current,
+        tree: () => renderer.toJSON() as ReactTestRendererJSON,
+        unmount: () => act(() => renderer.unmount()),
+    };
+}
+
+/** Every string in the rendered tree, in order — the strip's title and button land here. */
+function texts(node: ReactTestRendererJSON | string | null): string[] {
+    if (node === null) return [];
+    if (typeof node === 'string') return [node];
+    return (node.children ?? []).flatMap((child) => texts(child as ReactTestRendererJSON | string));
+}
+
+/** The strip, or `null` when nothing is on screen. */
+function strip(tree: ReactTestRendererJSON): ReactTestRendererJSON | null {
+    const children = (tree.children ?? []) as ReactTestRendererJSON[];
+    const last = children[children.length - 1];
+    if (last === undefined || typeof last === 'string') return null;
+    return (last.props.style as Record<string, unknown> | undefined)?.position === 'absolute' ? last : null;
+}
+
+export default async () => {
+    await describe('AdwToastOverlay on React Native — the wrapper', async () => {
+        await it('renders its content and no strip until something is queued', async () => {
+            const { tree } = overlay('wrapped');
+            expect(tree().type).toBe(RCT_VIEW);
+            expect(texts(tree())).toStrictEqual(['wrapped']);
+            expect(strip(tree())).toBe(null);
+        });
+    });
+
+    await describe('AdwToastOverlay on React Native — the queue, which is one at a time', async () => {
+        await it('shows the FIRST of two toasts added together, as libadwaita does', async () => {
+            const { handle, tree } = overlay('wrapped');
+            act(() => {
+                handle.addToast(new AdwToast('first', { timeout: 0 }));
+                handle.addToast(new AdwToast('second', { timeout: 0 }));
+            });
+            expect(texts(tree())).toStrictEqual(['wrapped', 'first']);
+        });
+
+        await it('advances to the queued toast when the visible one is pressed away', async () => {
+            // The action button dismisses the current toast, which is what advances the
+            // queue — the same thing both other renderers do with theirs.
+            const { handle, tree } = overlay('wrapped');
+            act(() => {
+                handle.addToast(new AdwToast('first', { timeout: 0, buttonLabel: 'Undo' }));
+                handle.addToast(new AdwToast('second', { timeout: 0 }));
+            });
+            expect(texts(tree())).toStrictEqual(['wrapped', 'first', 'Undo']);
+            const row = strip(tree())?.children?.[0] as ReactTestRendererJSON | undefined;
+            const button = (row?.children ?? [])[1] as ReactTestRendererJSON | undefined;
+            expect(button?.type).toBe(RCT_TEXT);
+            const onPress = button?.props.onPress as (() => void) | undefined;
+            if (typeof onPress !== 'function') throw new Error('the toast button carries no onPress');
+            act(() => onPress());
+            expect(texts(tree())).toStrictEqual(['wrapped', 'second']);
+        });
+
+        await it('renders no button for a toast with no label', async () => {
+            const { handle, tree } = overlay('wrapped');
+            act(() => handle.addToast(new AdwToast('first', { timeout: 0 })));
+            const row = strip(tree())?.children?.[0] as ReactTestRendererJSON | undefined;
+            expect((row?.children ?? []).length).toBe(1);
+        });
+
+        await it('dismissAll clears the visible toast AND the backlog', async () => {
+            // Not `dismiss`: `adw_toast_overlay_dismiss_all` is the only dismissal the
+            // OVERLAY has, and `AdwToastQueue.clear()` is the same operation — it drops
+            // the pending toasts instead of advancing to them.
+            const { handle, tree } = overlay('wrapped');
+            act(() => {
+                handle.addToast(new AdwToast('first', { timeout: 0 }));
+                handle.addToast(new AdwToast('second', { timeout: 0 }));
+            });
+            act(() => handle.dismissAll());
+            expect(strip(tree())).toBe(null);
+            expect(texts(tree())).toStrictEqual(['wrapped']);
+        });
+    });
+
+    await describe('AdwToastOverlay on React Native — the scheduler is really wired', async () => {
+        await it('auto-dismisses through a real timer, which no fake would prove', async () => {
+            const { handle, tree } = overlay('wrapped');
+            act(() => handle.addToast(new AdwToast('first', { timeout: SHORT_TIMEOUT_MS })));
+            expect(texts(tree())).toStrictEqual(['wrapped', 'first']);
+            await act(async () => {
+                await new Promise((resolve) => setTimeout(resolve, WAIT_MS));
+            });
+            expect(strip(tree())).toBe(null);
+        });
+
+        await it('waits the toast’s OWN timeout and not a fixed one', async () => {
+            // The control for the row above, and the reason there are two: a scheduler
+            // that dropped the millisecond count and fired on the next tick passes that
+            // row and fails this one.
+            const { handle, tree } = overlay('wrapped');
+            act(() => handle.addToast(new AdwToast('first', { timeout: LONG_TIMEOUT_MS })));
+            await act(async () => {
+                await new Promise((resolve) => setTimeout(resolve, WAIT_MS));
+            });
+            expect(texts(tree())).toStrictEqual(['wrapped', 'first']);
+            // Not tidiness: the minute-long handle would otherwise hold the event loop
+            // open for a minute after the last assertion.
+            act(() => handle.dismissAll());
+        });
+
+        await it('cancels a pending timer on unmount instead of leaving it running', async () => {
+            // THE FIRST VERSION OF THIS ROW COULD NOT GO RED, which is the one failure
+            // this file is otherwise written against. It unmounted a showing overlay,
+            // waited out a short timeout and asserted NOTHING — on the reasoning that a
+            // leaked timer is invisible to a test. Measured: replacing the component's
+            // `useEffect(() => () => queue.current?.clear(), [])` with a no-op teardown
+            // left the suite at exit 0, because React 19 drops a `setState` on an
+            // unmounted tree with no warning at all.
+            //
+            // The claim is about a HANDLE that outlives the tree, so the handle is what
+            // is counted. `process.getActiveResourcesInfo()` is the host's own register
+            // of them, and the timeout is a minute so that the row cannot be passed by
+            // the timer firing on its own.
+            const { handle, unmount } = overlay('wrapped');
+            const before = pendingTimers();
+            act(() => handle.addToast(new AdwToast('first', { timeout: LONG_TIMEOUT_MS })));
+            expect(pendingTimers()).toBe(before + 1);
+            unmount();
+            expect(pendingTimers()).toBe(before);
+        });
+    });
+};

--- a/packages/framework/adwaita-react-native/src/widgets/toast-overlay.native.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/toast-overlay.native.tsx
@@ -1,0 +1,88 @@
+/** @jsxImportSource react */
+// `AdwToastOverlay` on React Native — `@gjsify/adwaita-core`'s port of libadwaita's queue.
+// (On the pragma, see `bin.native.tsx`.)
+//
+// WHERE THE STATE LIVES, AND WHY IT IS SPLIT IN TWO.
+//
+// The QUEUE is in a `useRef` and is never re-created. `AdwToastQueue` owns the ordering,
+// the one-at-a-time policy and a live timer handle; rebuilding it on a render would
+// restart the timer of the toast currently on screen and lose everything queued behind
+// it, and putting it in `useState` would additionally make React the thing that decides
+// when the queue exists. It is the authority, so it outlives every render — exactly as
+// `Adw.ToastOverlay` does on the other half, where the authority is libadwaita's own C.
+//
+// The VISIBLE TOAST is in `useState`, because that is the only part React has to react
+// to. The queue pushes it there through `onShow`/`onHide`, which is the same seam the
+// browser and NativeScript renderers use to mount and tear down their strip.
+//
+// So neither half holds the queue in React, and the two are asserted against each other
+// by BEHAVIOUR rather than by shape: two toasts added back to back show ONE, measured on
+// libadwaita 1.9.3 (a single `AdwToastWidget` in the tree, showing the first) and asserted
+// of the port here.
+//
+// THE SCHEDULER IS THE PLATFORM TIMER, injected rather than reached for inside the core —
+// that seam is why the queue's auto-dismiss lifecycle is testable at all, and it is
+// already exercised against a deterministic fake in `@gjsify/adwaita-core`'s own suite.
+// What this file's suite adds is that the wiring is real, which needs one real timer.
+//
+// THE ACTION BUTTON DISMISSES AND ADVANCES, WITH NO CALLBACK. `AdwToast` carries a label
+// and no action — `Adw.Toast` expresses the action as `action-name`, a `GAction` this
+// package has no surface for — so pressing it does what both other renderers do: dismiss
+// the current toast, which advances the queue. The README names the absent callback.
+
+import { useEffect, useImperativeHandle, useRef, useState, type ReactElement } from 'react';
+import { Text, View } from 'react-native';
+
+import { AdwToastQueue, type AdwToast, type ToastScheduler, type ToastTimerHandle } from '@gjsify/adwaita-core';
+
+import type { AdwToastOverlayProps } from '../props.js';
+
+/** The platform timing seam the core queue's auto-dismiss runs on. */
+const TIMEOUT_SCHEDULER: ToastScheduler = {
+    schedule: (callback, ms) => setTimeout(callback, ms) as unknown as ToastTimerHandle,
+    cancel: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+/** {@link import('./toast-overlay.js').AdwToastOverlay} on React Native. */
+export function AdwToastOverlay({ children, ref }: AdwToastOverlayProps): ReactElement | null {
+    const [current, setCurrent] = useState<AdwToast | null>(null);
+    const queue = useRef<AdwToastQueue | null>(null);
+    queue.current ??= new AdwToastQueue({
+        scheduler: TIMEOUT_SCHEDULER,
+        onShow: (toast) => setCurrent(toast),
+        onHide: () => setCurrent(null),
+    });
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            addToast: (toast: AdwToast): void => queue.current?.add(toast),
+            dismissAll: (): void => queue.current?.clear(),
+        }),
+        [],
+    );
+
+    // The timer is the only thing here that outlives the tree, so it is the only thing
+    // that has to be torn down: `clear()` cancels a pending auto-dismiss and drops the
+    // backlog. Without it an unmounted overlay keeps a `setTimeout` alive for up to its
+    // last toast's timeout.
+    useEffect(() => () => queue.current?.clear(), []);
+
+    return (
+        <View style={{ flex: 1 }}>
+            {children}
+            {current === null ? null : (
+                <View style={{ position: 'absolute', bottom: 0, left: 0, right: 0, alignItems: 'center' }}>
+                    <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                        <Text>{current.title}</Text>
+                        {current.hasButton ? (
+                            <Text accessibilityRole="button" onPress={() => queue.current?.dismiss()}>
+                                {current.buttonLabel}
+                            </Text>
+                        ) : null}
+                    </View>
+                </View>
+            )}
+        </View>
+    );
+}

--- a/packages/framework/adwaita-react-native/src/widgets/toast-overlay.ts
+++ b/packages/framework/adwaita-react-native/src/widgets/toast-overlay.ts
@@ -1,0 +1,26 @@
+// `AdwToastOverlay` — the base module. See `../refuse.ts` for who reaches this and why it
+// throws instead of resolving to something.
+
+import type { ReactElement } from 'react';
+
+import type { AdwToastOverlayProps } from '../props.js';
+import { refuseBaseModule } from '../refuse.js';
+
+/**
+ * Wraps content and shows one transient toast at a time over it.
+ *
+ * THIS IS THE ONE WIDGET IN THE PACKAGE WITH STATE RATHER THAN LAYOUT, and the two
+ * halves therefore hold it in two places on purpose. On GTK the queue is libadwaita's
+ * own: `adw_toast_overlay_add_toast` enqueues, the overlay shows one at a time and
+ * builds the `AdwToastWidget` itself, and nothing about it is reachable from a renderer.
+ * On React Native the queue is `@gjsify/adwaita-core`'s `AdwToastQueue` — the port of
+ * that policy — living in a `useRef` because it owns timers whose identity must survive
+ * a re-render, with only the VISIBLE toast in `useState` because that is what React
+ * re-renders on.
+ *
+ * So there is exactly one authority per half and neither is React's. What is asserted
+ * across them is the behaviour: two toasts added at once show ONE, on both.
+ */
+export function AdwToastOverlay(_props: AdwToastOverlayProps): ReactElement | null {
+    return refuseBaseModule('AdwToastOverlay');
+}

--- a/packages/framework/gtk-host/src/descriptors/adw.ts
+++ b/packages/framework/gtk-host/src/descriptors/adw.ts
@@ -137,6 +137,22 @@ export const ADW_DESCRIPTORS: readonly WidgetDescriptor[] = [
         children: { kind: 'single', set: 'set_child' },
     },
     {
+        gtype: 'AdwToastOverlay',
+        ctor: () => Adw.ToastOverlay,
+        // MEASURED on libadwaita 1.9.3: the only child-taking pair on this class is
+        // `set_child`/`get_child` — the same `AdwBin` rule. `add_toast` and
+        // `dismiss_all` are on it too and are NOT placement: an `Adw.Toast` is a
+        // GObject, not a widget, and libadwaita builds the `AdwToastWidget` that shows
+        // it itself. So the overlay has exactly one child (the wrapped content) and the
+        // toast layer is not addressable from a renderer at all.
+        //
+        // It was uncurated until `@gjsify/adwaita-react-native` needed it, which means
+        // `<adw-toast-overlay>` with a child raised `uncurated-placement` in every JSX
+        // dialect this host serves — the same hole `AdwClamp` had, on the widget an
+        // application wraps its whole window in.
+        children: { kind: 'single', set: 'set_child' },
+    },
+    {
         gtype: 'AdwClampScrollable',
         ctor: () => Adw.ClampScrollable,
         // The scrollable sibling, and the same measurement: `set_child`/`get_child`.

--- a/packages/web/adwaita-core/src/button-content.spec.ts
+++ b/packages/web/adwaita-core/src/button-content.spec.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from '@gjsify/unit';
 
 import {
     ADW_BUTTON_CONTENT_DEFAULTS,
+    BUTTON_CONTENT_BOX_SPACING,
     BUTTON_CONTENT_FALLBACK_ICON,
     BUTTON_CONTENT_STYLE_CLASS,
     buttonContentEllipsize,
@@ -40,6 +41,17 @@ export default async () => {
                 expect(DEFAULT_BY_PROPERTY[property]).toBe(value);
             });
         }
+    });
+
+    await describe('BUTTON_CONTENT_BOX_SPACING (measured, not read off a selector)', async () => {
+        await it('is the 6px the widget actually draws, not GtkBox:spacing', () => {
+            // Against libadwaita 1.9.3, an AdwButtonContent with an icon and a label
+            // inside a presented GtkButton: image at x=161 width=16, label at x=183.
+            // The same widget's `GtkBox:spacing` reads 0, so a renderer that copied the
+            // PROPERTY would draw the two touching — which is why the number is here and
+            // not derived by a renderer from the box it can see.
+            expect(BUTTON_CONTENT_BOX_SPACING).toBe(6);
+        });
     });
 
     await describe('buttonContentIconName (:355-358 — code, not the :228/:343 docs)', async () => {

--- a/packages/web/adwaita-core/src/button-content.ts
+++ b/packages/web/adwaita-core/src/button-content.ts
@@ -28,6 +28,21 @@ import { stripMnemonic } from './glib.js';
 /** The style class `AdwButtonContent` stamps on its parent button, removed on unroot. */
 export const BUTTON_CONTENT_STYLE_CLASS = 'image-text-button';
 
+/**
+ * The gap between the icon and the label, in px.
+ *
+ * MEASURED rather than read off a selector, because the selector is easy to read
+ * wrong — the header above says why `_buttons.scss`'s 4px variant never reaches an
+ * `AdwButtonContent`. Against libadwaita 1.9.3: an `AdwButtonContent` with
+ * `icon-name` and `label` inside a `GtkButton` in a presented window puts the image
+ * at x=161 width=16 and the label at x=183, i.e. exactly 6px apart.
+ *
+ * It is `border-spacing` on `buttoncontent > box` and NOT `GtkBox:spacing`, which
+ * reads 0 on the same widget — a renderer copying the property would draw them
+ * touching.
+ */
+export const BUTTON_CONTENT_BOX_SPACING = 6;
+
 /** The icon `GtkImage` falls back to for an empty `icon-name`. */
 export const BUTTON_CONTENT_FALLBACK_ICON = 'image-missing';
 

--- a/packages/web/adwaita-core/src/index.ts
+++ b/packages/web/adwaita-core/src/index.ts
@@ -103,6 +103,7 @@ export type { AdwBannerButtonStyle, AdwBannerProps, AdwBannerRenderState } from 
 // --- Button content: icon+label slots + the parent-button style class (Adw.ButtonContent) ---
 export {
     ADW_BUTTON_CONTENT_DEFAULTS,
+    BUTTON_CONTENT_BOX_SPACING,
     BUTTON_CONTENT_FALLBACK_ICON,
     BUTTON_CONTENT_STYLE_CLASS,
     buttonContentEllipsize,


### PR DESCRIPTION
Five widgets on `@gjsify/adwaita-react-native`'s "one API surface, two implementations"
design — `AdwAvatar`, `AdwBanner`, `AdwButtonContent`, `AdwSpinner`, `AdwToastOverlay` —
each as this package's three modules (a base that refuses by name, the real `Adw.*`
through `@gjsify/gtk-host`, React Native primitives over `@gjsify/adwaita-core`), plus an
`exports` entry naming both halves, a parity witness per platform, and a suite on each
side. That takes the package from two widgets to seven.

> **Stacked.** The branch is based on `feat/vocabulary-consumer` (#1449), so the diff here
> carries that PR's commits until it lands. This PR's own work is the last three commits.

## The shared half is a DERIVATION, not a shape

That is the point of the group. Each widget's two implementations are held to the same
NUMBER, computed once in `@gjsify/adwaita-core` and asserted on both sides:

- **`AdwAvatar`** — `g_str_hash` over UTF-8 bytes, `% 14`. libadwaita PUBLISHES its answer:
  `set_class_color` stamps `color{n}` on the avatar's internal gizmo, so the GTK suite
  reads `color11` off the live tree for "Ada Lovelace" and the React Native suite asserts
  `#8c75d9`, that entry flattened. **Two names**, because one agreeing proves only that
  both landed in a bucket once — a renderer hashing UTF-16 code units agrees for plenty of
  ASCII names, which is how two renderers here once shipped the wrong colour for every
  accented one.
- **`AdwBanner`** — the `use-markup` default is the FALSE the widget READS BACK, not the
  TRUE its `GParamSpec` declares. `adw_banner_get_use_markup` delegates to the title label
  and `adw-banner.ui` never sets it there. Both halves answer FALSE; neither uses
  `ADW_BANNER_DEFAULTS` for it.
- **`AdwButtonContent`** — four core derivations, including the 6px gap, which is
  `border-spacing` on `buttoncontent > box` and NOT `GtkBox:spacing` (that reads 0 on the
  same widget).
- **`AdwSpinner`** — the box and the ring are two numbers. GTK measures the BOX (`[16, 16]`
  unrequested, 200 requested, no upper bound); the RING is an `AdwSpinnerPaintable` and not
  a node on GTK at all, so it is asserted on the half where it is one: 64 points with an
  8-point stroke inside a 200-point box.
- **`AdwToastOverlay`** — the one-at-a-time policy (two adds show ONE, measured on
  libadwaita 1.9.3 and asserted of `AdwToastQueue`) and the unit: `Adw.Toast:timeout`
  counts whole SECONDS, `AdwToast.timeout` counts milliseconds. The conversion is `ceil`,
  because `Math.round(400 / 1000)` is 0 — which is libadwaita's "until dismissed".

## Two suites are here because they could NOT go red

Every assertion in this PR was A/B'd: the behaviour it claims was reverted, the leg run,
the exit code recorded; then restored and run again. 82 mutations, and two findings.

1. **The unmount teardown row asserted nothing.** It unmounted a showing overlay, waited
   out a short timeout, and made no assertion — on the reasoning that a leaked timer is
   invisible to a test. Measured: replacing the component's
   `useEffect(() => () => queue.current?.clear(), [])` with a no-op teardown left the suite
   at **exit 0**, because React 19 drops a `setState` on an unmounted tree silently. It now
   counts the host's own `Timeout` handles as a delta, and goes red under that same
   mutation. A second row was added beside it: a minute-long toast is still on screen after
   the same wait, which a scheduler that dropped the millisecond count and fired on the
   next tick would fail — and did.
2. **The spinner's rasterisation control was inert.** An empty `Gtk.Box` appended to the
   spinner's container after layout measures **0×0**, so `capture` bailed at `width <= 0`
   and the row proved that an *unallocated* widget captures nothing — true of every widget,
   the spinner included. Falsified: swapping the box for a `Gtk.Button`, which paints a
   background, left the suite at exit 0. Laid out in its own window the control
   discriminates, and its allocation is asserted first so it cannot quietly stop again.

Nothing else survived. `assertQuiet` is armed and was shown catching the two `CRITICAL`s an
`AdwButtonContent` with no `GtkButton` ancestor raises, and one on the toast overlay path.

## Two changes outside the package

- **`@gjsify/adwaita-core`** gains `BUTTON_CONTENT_BOX_SPACING`. The React Native half has
  no widget to read a spacing off, and a private literal there would be the drift.
- **`@gjsify/gtk-host`** curates `AdwToastOverlay`. Uncurated, `<adw-toast-overlay>` with a
  child raised `uncurated-placement` in every JSX dialect this host serves — the same hole
  `AdwClamp` had, on the widget an application wraps its whole window in.

## Verification

`gjsify format --check` 0 · `gjsify lint` 0 (proved live: exit 1 on a deliberate
`todo-needs-anchor` violation) · `check-adwaita-rn-platform-split` 0 (7 widgets) ·
`check-vocabulary-alignment` 0 (7 RN widgets, 7 sharing a spelling) ·
`check-storybook-widget-coverage` 0 · `check-doc-revert --base origin/main` 0 ·
`check-agent-context-size --check` 0 · `gjsify tsc` 0 on `adwaita-core`, `gtk-host` and
`adwaita-react-native` · node leg 113 tests exit 0 · GJS leg 70 tests exit 0 ·
`adwaita-core` 12 742 exit 0 · `gtk-host` 2 385 exit 0.

**Not proven: Yoga, and the device.** A `width` in a style object is an instruction to a
layout engine no test here runs, and the React Native half has never been on a phone. The
README names that and eleven other divergences, including the one the spinner does not
have: there is no animation assertion, because there is no animation.
