### PR TITLE
feat(node-gi): bundle the http(s) source and its TLS

### DIFF
--- a/.github/workflows/gtk-os-suites.yml
+++ b/.github/workflows/gtk-os-suites.yml
@@ -364,8 +364,17 @@ jobs:
       # bundle's own recorded platform to THIS runner, so an artifact mixup cannot
       # run the arm64 closure on Intel and surface four steps later as an
       # inscrutable dlopen error.
+      #
+      # `--allow-legacy-license-record` is what tells the shared gate this is the
+      # PUBLISHED-closure role and not the pre-publish one. `licenses.binariesCovered`
+      # postdates the 0.45.0 tarballs, so requiring it here turned all three of these
+      # legs red at once over a property no already-published artifact can acquire —
+      # only the next release writes it. The allowance is narrow (an absent record
+      # only; a recorded ZERO still fails here) and self-retiring (the step prints that
+      # the flag is droppable the first time a published bundle carries the field).
+      # release.yml passes NO flag: there the bundle was just built.
       - name: Verify the published bundle's manifest
-        run: node packages/node-gi/scripts/verify-bundle-manifest.mjs --bundle "packages/node-gi/node-gi/prebuilds/$TARGET/gtk" --expect-host-target darwin
+        run: node packages/node-gi/scripts/verify-bundle-manifest.mjs --bundle "packages/node-gi/node-gi/prebuilds/$TARGET/gtk" --expect-host-target darwin --allow-legacy-license-record
 
       # Which two halves this run paired, in the log rather than in a reader's head.
       - name: Report the pairing this run measured
@@ -509,8 +518,10 @@ jobs:
       - name: Stage the SHIPPED closure (published bundle + published addon)
         run: node packages\node-gi\scripts\stage-published-gtk-runtime.mjs --link-into packages\framework\gtk-host --link-into packages\framework\react-native
 
+      # `--allow-legacy-license-record` for the same reason as the darwin leg above:
+      # the PUBLISHED closure, whose manifest predates `licenses.binariesCovered`.
       - name: Verify the published bundle's manifest
-        run: node packages\node-gi\scripts\verify-bundle-manifest.mjs --bundle "packages\node-gi\node-gi\prebuilds\%TARGET%\gtk" --expect-host-target win32
+        run: node packages\node-gi\scripts\verify-bundle-manifest.mjs --bundle "packages\node-gi\node-gi\prebuilds\%TARGET%\gtk" --expect-host-target win32 --allow-legacy-license-record
 
       - name: Report the pairing this run measured
         run: |

--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -1596,8 +1596,13 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: '1'
       HOMEBREW_NO_INSTALL_CLEANUP: '1'
     steps:
+      # `glib-networking` is NAMED although brew's `gstreamer` already depends on it.
+      # It supplies lib/gio/modules/libgiognutls.so — the GIO TLS backend the bundle
+      # ships as its `tls-backend` data set, without which souphttpsrc resolves and then
+      # fails on every https URL. A transitive dep is a fact about today's formula; this
+      # is the one the builder asserts.
       - name: Install GTK4 + Adwaita + GtkSource + icons + GObject-Introspection (build-time closure source)
-        run: brew install gtk4 libadwaita gtksourceview5 adwaita-icon-theme gobject-introspection cairo pango gdk-pixbuf graphene pkg-config gstreamer
+        run: brew install gtk4 libadwaita gtksourceview5 adwaita-icon-theme gobject-introspection cairo pango gdk-pixbuf graphene pkg-config gstreamer glib-networking
 
       - name: Use Node.js 24
         uses: actions/setup-node@v4
@@ -2452,7 +2457,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: C:\gtk-build\gtk\x64\release
-          key: gvsbuild-gtk4-gst-gi-${{ env.GVSBUILD_VERSION }}-x64-v2
+          key: gvsbuild-gtk4-gst-soup-gi-${{ env.GVSBUILD_VERSION }}-x64-v3
 
       # Build-time closure SOURCE only. Verbatim from the `windows` job.
       - name: Download + extract gvsbuild GTK4 (build-time closure source)
@@ -2544,6 +2549,19 @@ jobs:
           # caught it, at the prefix, instead of three jobs later as "no element
           # decodebin" — typelibs are the only reason we build this from source
           # rather than lifting a binary.
+          # TWO INVOCATIONS, AND THE ORDER IS THE POINT. gst-plugins-good's `soup`
+          # feature is meson `auto` and its ext/soup/meson.build calls `subdir_done()`
+          # with a MESSAGE, not an error, when neither libsoup2 nor libsoup3 is found —
+          # so building -good against a prefix without libsoup produces a complete,
+          # green build with no gstsoup.dll in it, which is exactly the silent gap
+          # gst-plugins.mjs § soup was measured on. gst-plugins-good does not DECLARE
+          # libsoup3 as a gvsbuild dependency, so nothing orders the two for us.
+          # `glib-networking` is named although libsoup3 already depends on it: it is
+          # the GIO TLS backend the bundle ships as its `tls-backend` data set, and on
+          # Windows the soup plugin LINKS libsoup (ext/soup/meson.build takes the
+          # `host_system == 'windows'` branch instead of the dlopen loader), so an
+          # https URL would still fail on the missing module alone.
+          gvsbuild build --configuration release --vs-ver $vsVer --enable-gi --build-dir C:\gtk-build glib-networking libsoup3
           gvsbuild build --configuration release --vs-ver $vsVer --enable-gi --skip libvpx --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
 
       - name: Assert GStreamer landed in the prefix (typelibs + plugins)
@@ -2559,6 +2577,18 @@ jobs:
           $plugins = Get-ChildItem "$env:GTK_PREFIX\lib\gstreamer-1.0" -Filter *.dll -ErrorAction SilentlyContinue
           if (-not $plugins) { Write-Host "no GStreamer plugins in the prefix"; exit 1 }
           Write-Host "GStreamer: $($plugins.Count) plugin DLL(s) in the prefix"
+          # NAMED, not counted. `gstsoup.dll` is the one plugin whose absence the build
+          # above produces SILENTLY (a meson `message()`, then a green -good), and a
+          # count of 80-odd plugins says nothing about which one is missing. Same
+          # reason gst-elements.test.mjs names its elements. The GIO module beside it
+          # is what makes the https half work at all.
+          $soup = Join-Path $env:GTK_PREFIX 'lib\gstreamer-1.0\gstsoup.dll'
+          if (-not (Test-Path $soup)) {
+            Write-Host "MISSING $soup — gst-plugins-good was built without libsoup in the prefix"; exit 1
+          }
+          $gioModules = Get-ChildItem "$env:GTK_PREFIX\lib\gio\modules" -Filter *.dll -ErrorAction SilentlyContinue
+          if (-not $gioModules) { Write-Host "no GIO module in the prefix — glib-networking did not build"; exit 1 }
+          Write-Host "GIO modules: $($gioModules.Count) DLL(s) (the TLS backend)"
 
       - name: Put GTK on PATH (for the bundle-data tools)
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,8 +325,13 @@ jobs:
       # typelib and adwaita-icon-theme supplies share/icons, both of which the
       # --windowing bundle below needs — and now asserts, so a missing formula fails
       # the build instead of quietly shipping a bundle without Adwaita.
+      # `glib-networking` is NAMED although brew's `gstreamer` already depends on it.
+      # It supplies lib/gio/modules/libgiognutls.so — the GIO TLS backend the bundle
+      # ships as its `tls-backend` data set, without which souphttpsrc resolves and then
+      # fails on every https URL. A transitive dep is a fact about today's formula; this
+      # is the one the builder asserts.
       - name: Install GTK4 + Adwaita + GtkSource + icons + GObject-Introspection (build-time closure source)
-        run: brew install gtk4 libadwaita gtksourceview5 adwaita-icon-theme gobject-introspection cairo pango gdk-pixbuf graphene pkg-config gstreamer
+        run: brew install gtk4 libadwaita gtksourceview5 adwaita-icon-theme gobject-introspection cairo pango gdk-pixbuf graphene pkg-config gstreamer glib-networking
 
       # Node 24 runs build-gtk-runtime-darwin.mjs (node:child_process/fs) and the publish.
       # No `registry-url` here — setting it makes actions/setup-node inject a
@@ -511,7 +516,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: C:\gtk-build\gtk\x64\release
-          key: gvsbuild-gtk4-gst-gi-${{ env.GVSBUILD_VERSION }}-x64-v2
+          key: gvsbuild-gtk4-gst-soup-gi-${{ env.GVSBUILD_VERSION }}-x64-v3
 
       - name: Download + extract gvsbuild GTK4 (build-time closure source)
         if: steps.cache-gtk.outputs.cache-hit != 'true'
@@ -610,6 +615,19 @@ jobs:
           # caught it, at the prefix, instead of three jobs later as "no element
           # decodebin" — typelibs are the only reason we build this from source
           # rather than lifting a binary.
+          # TWO INVOCATIONS, AND THE ORDER IS THE POINT. gst-plugins-good's `soup`
+          # feature is meson `auto` and its ext/soup/meson.build calls `subdir_done()`
+          # with a MESSAGE, not an error, when neither libsoup2 nor libsoup3 is found —
+          # so building -good against a prefix without libsoup produces a complete,
+          # green build with no gstsoup.dll in it, which is exactly the silent gap
+          # gst-plugins.mjs § soup was measured on. gst-plugins-good does not DECLARE
+          # libsoup3 as a gvsbuild dependency, so nothing orders the two for us.
+          # `glib-networking` is named although libsoup3 already depends on it: it is
+          # the GIO TLS backend the bundle ships as its `tls-backend` data set, and on
+          # Windows the soup plugin LINKS libsoup (ext/soup/meson.build takes the
+          # `host_system == 'windows'` branch instead of the dlopen loader), so an
+          # https URL would still fail on the missing module alone.
+          gvsbuild build --configuration release --vs-ver $vsVer --enable-gi --build-dir C:\gtk-build glib-networking libsoup3
           gvsbuild build --configuration release --vs-ver $vsVer --enable-gi --skip libvpx --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
 
       - name: Assert GStreamer landed in the prefix (typelibs + plugins)
@@ -625,6 +643,18 @@ jobs:
           $plugins = Get-ChildItem "$env:GTK_PREFIX\lib\gstreamer-1.0" -Filter *.dll -ErrorAction SilentlyContinue
           if (-not $plugins) { Write-Host "no GStreamer plugins in the prefix"; exit 1 }
           Write-Host "GStreamer: $($plugins.Count) plugin DLL(s) in the prefix"
+          # NAMED, not counted. `gstsoup.dll` is the one plugin whose absence the build
+          # above produces SILENTLY (a meson `message()`, then a green -good), and a
+          # count of 80-odd plugins says nothing about which one is missing. Same
+          # reason gst-elements.test.mjs names its elements. The GIO module beside it
+          # is what makes the https half work at all.
+          $soup = Join-Path $env:GTK_PREFIX 'lib\gstreamer-1.0\gstsoup.dll'
+          if (-not (Test-Path $soup)) {
+            Write-Host "MISSING $soup — gst-plugins-good was built without libsoup in the prefix"; exit 1
+          }
+          $gioModules = Get-ChildItem "$env:GTK_PREFIX\lib\gio\modules" -Filter *.dll -ErrorAction SilentlyContinue
+          if (-not $gioModules) { Write-Host "no GIO module in the prefix — glib-networking did not build"; exit 1 }
+          Write-Host "GIO modules: $($gioModules.Count) DLL(s) (the TLS backend)"
 
       # The decode probe's consumer half (#996). NOT part of this tarball.
       - name: Download node-gi addon prebuild (for the decode probe)

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -227,6 +227,32 @@
             "rules": {
                 "no-restricted-globals": "off"
             }
+        },
+        {
+            // An identifier a test file NAMES but never IMPORTS is a ReferenceError
+            // that only the leg with the optional dependency installed can see. The
+            // incident: gst-elements.test.mjs asked `requireGi('Gio','2.0')` for the
+            // TLS backend while a rebase took its `import { requireGi }` away — main
+            // had moved the Gst init into `gst-gate.mjs` and dropped the import as
+            // dead, the branch added a test that used it, and git merged both halves
+            // with no conflict to report. Nothing in the tree could see it: the error
+            // lives inside a test callback, so it needs GStreamer PRESENT to run at
+            // all, and the aarch64 leg (no GStreamer, gate self-skips) stayed green
+            // while Windows and Fedora went red on a bundle that was correct.
+            //
+            // `no-undef` off tree-wide is not an oversight — this repo configures no
+            // `env`, so the rule reports `process`, `console`, `document` and
+            // `TextEncoder` across 119 packages. Here the environment IS known:
+            // node-gi's own test suite is `node --test`, nothing else, and the
+            // directory measures CLEAN under the rule with node globals declared. So
+            // this asks the linter the question rather than adding a second matcher
+            // beside it, and it asks STATICALLY — on every leg, including the ones
+            // where the runtime test skips itself.
+            "files": ["packages/node-gi/node-gi/test/**"],
+            "env": { "builtin": true, "node": true, "es2024": true },
+            "rules": {
+                "eslint/no-undef": "error"
+            }
         }
     ],
     "ignorePatterns": [

--- a/docs/adr/0037-gtk-runtime-bundles-carry-the-uri-source.md
+++ b/docs/adr/0037-gtk-runtime-bundles-carry-the-uri-source.md
@@ -168,6 +168,18 @@ including over https.** Concretely:
   glib's text for it). Naming the wrong project is the worse half: it produces a positive,
   complete-looking claim. What bounds it is that the map only ever selects a text the
   corpus already holds, so the damage is a misattribution and never an invented licence.
+- **What is gated is the EFFECT, not the payload.** A file in the tarball, and even a
+  factory that resolves by name, is one layer above the question an app asks: `playbin3`
+  and `uridecodebin3` reach a source through the registry's URI HANDLER table, and nothing
+  hands them an element name. So `gst-elements.test.mjs` asks
+  `Gst.uri_protocol_is_supported(SRC, 'https')` and starts a `playbin3` on an https URI —
+  the two measurements the first row of the table above was taken with — each against a
+  scheme nothing handles, which must answer false and must fail the state change. The
+  `file://` control the measurement itself used cannot serve as the discriminator here: a
+  `file://` URI that does not exist ALSO fails the state change, so it would prove the
+  assertion can fail without proving it fails for the reason claimed. Offline either way —
+  `set_state(PAUSED)` returns once the change has STARTED, so the source element is created
+  synchronously and its connection is not.
 - `Soup-3.0.typelib` now has a backing library in the bundle, so the typelib planner stops
   dropping it. `@gjsify/{tls,http2,ws}` gain a working TLS stack on a bundle-activated
   process as a consequence, not as a separate feature.

--- a/docs/adr/0037-gtk-runtime-bundles-carry-the-uri-source.md
+++ b/docs/adr/0037-gtk-runtime-bundles-carry-the-uri-source.md
@@ -58,22 +58,48 @@ one layer up.
   reconnect, ICY metadata — and it cannot use `playbin3`/`uridecodebin3` at all, because
   those take a URI, not a pad. For pushing bytes you already hold, `appsrc` remains the
   right answer and nothing here changes it.
-- **Cost has to be a number, not a feeling.** Measured on darwin-x64 (Homebrew
-  `gstreamer` 1.28.5, `libsoup` 3.6.6, `glib-networking` 2.80.1):
+- **Cost has to be a number, not a feeling — and it is a number PER PLATFORM.** Both
+  columns below are file-set differences between the published `0.45.0` bundle and the
+  widened artifact of the run that built this branch, not estimates.
+
+  darwin-x64 (Homebrew `gstreamer` 1.28.5, `libsoup` 3.6.6, `glib-networking` 2.80.1):
 
   | | |
   |---|---|
-  | `libgstsoup` | 107 KiB |
-  | libsoup + libpsl + libnghttp2 + libsqlite3 | ~2.8 MiB |
-  | `libgiognutls` + gnutls, nettle, hogweed, gmp, p11-kit, libtasn1, libidn2, libunistring | 6.67 MiB |
-  | **total** | **~9.6 MiB on an 85 MiB bundle (+13 %)** |
+  | `libgstsoup` | 122 KiB |
+  | libsoup + libpsl + libnghttp2 + libsqlite3 | 2.02 MiB |
+  | `libgiognutls` + gnutls, nettle, hogweed, gmp, p11-kit, libtasn1, libidn2, libunistring | 6.83 MiB |
+  | `Soup-3.0.typelib` + the added licence texts | 411 KiB |
+  | **total** | **9.36 MiB on a 72.7 MiB bundle (+13 %)** |
 
-- **Licensing raises nothing new.** Everything added is LGPL-2.1+ / LGPL-3+ dynamically
-  linked libraries of the same family as the GLib and GTK the bundle already relocates and
-  attributes per binary. This is *not* the category the allowlist keeps out — x264, x265,
-  faac and fdk-aac are excluded because redistributing a GPL- or patent-encumbered codec
-  inside a runtime bundle is the product author's decision, not the runtime's. No codec and
-  no patent claim enters here.
+  win32-x64 (gvsbuild), and it is **not** the same order of magnitude — the number this
+  ADR first carried was the darwin one, stated as if it were the cost:
+
+  | | |
+  |---|---|
+  | `gstsoup.dll` + `Soup-3.0.typelib` + the two GIO modules | 199 KiB |
+  | libsoup + libpsl + nghttp2 + sqlite3 | 3.62 MiB |
+  | OpenSSL (`libcrypto-3-x64`, `libssl-3-x64`) — gvsbuild's TLS backend is `gioopenssl` | 8.21 MiB |
+  | MIT Kerberos (`gssapi64`, `krb5_64`, `comerr64`, `k5sprt64`) — libsoup's Negotiate auth | 1.73 MiB |
+  | **ICU (`icudt78` 31.6 MiB, `icuuc78`, `harfbuzz-icu`)** — pulled in by `psl-5.dll` | **34.04 MiB** |
+  | **total** | **47.80 MiB on a 77.5 MiB bundle (+62 %)** |
+
+  ICU alone is more than three times the entire darwin addition, and it arrives for one
+  transitive reason: gvsbuild builds libpsl against ICU where Homebrew builds it against
+  libidn2 + libunistring (2.2 MiB, already in the darwin column). Nothing about the
+  DECISION needs ICU. Reducing it is a gvsbuild-side change — build libpsl with
+  `-Druntime=libidn2`, or drop PSL from libsoup — and is follow-up work, not a blocker
+  recorded as solved.
+
+- **Licensing raises nothing new *in kind*, but "all LGPL" is not true.** The payload is
+  mixed and the notice payload has to say so: LGPL-2.1+/LGPL-3+ (libsoup, glib-networking,
+  gnutls, nettle, hogweed, gmp, libtasn1, libidn2, libunistring), **Apache-2.0** (OpenSSL 3
+  on win32), **MIT** (libpsl, nghttp2, MIT Kerberos), BSD (p11-kit), Unicode/ICU, and
+  public domain (SQLite). What matters for the allowlist is that none of it is the excluded
+  category — x264, x265, faac and fdk-aac are kept out because redistributing a GPL- or
+  patent-encumbered *codec* inside a runtime bundle is the product author's decision, not
+  the runtime's. **No codec and no patent claim enters here**, and that part of the claim
+  holds on both platforms.
 
 ## Decision
 
@@ -95,8 +121,22 @@ including over https.** Concretely:
 
 ## Consequences
 
-- The bundles grow ~13 %. That is the price of the capability and it is stated in the
-  allowlist next to the entry that costs it.
+- The bundles grow **+13 % on darwin and +62 % on win32**, and the asymmetry is the part
+  to carry forward: the two platforms do not pay the same price for the same decision, so
+  a single percentage stated without its platform is wrong on one of them. The allowlist
+  entry that costs it points here rather than restating the table.
+- **`libcrypto-3-x64.dll` and `libssl-3-x64.dll` currently ship with no licence text.**
+  The win32 licence step attributes by PREFIX — it scans `share/licenses` and `share/doc`
+  and copies what it finds — and `assertLicenseCoverage` only runs its per-binary checks
+  when `attribution === 'per-binary'`, which is the darwin mode. So the gvsbuild prefix
+  shipping no OpenSSL licence directory is invisible to every gate: the win32 bundle names
+  45 components and none of them is OpenSSL. Apache-2.0 § 4 requires the licence to travel
+  with the binary, so this is a redistribution defect, not a tidiness one. It is NOT
+  introduced by the decision above — it is exposed by it, because OpenSSL is the first
+  Apache-2.0 payload the prefix scan has had to cover. Repair, in order: make the gvsbuild
+  step install OpenSSL's `LICENSE.txt` into the prefix's licence tree, and then give the
+  win32 builder a named-component assertion so a future unlicensed family fails the build
+  instead of shipping. Until both land, the win32 bundle must not be published.
 - `Soup-3.0.typelib` now has a backing library in the bundle, so the typelib planner stops
   dropping it. `@gjsify/{tls,http2,ws}` gain a working TLS stack on a bundle-activated
   process as a consequence, not as a separate feature.

--- a/docs/adr/0037-gtk-runtime-bundles-carry-the-uri-source.md
+++ b/docs/adr/0037-gtk-runtime-bundles-carry-the-uri-source.md
@@ -125,19 +125,20 @@ including over https.** Concretely:
   to carry forward: the two platforms do not pay the same price for the same decision, so
   a single percentage stated without its platform is wrong on one of them. The allowlist
   entry that costs it points here rather than restating the table.
-- **The win32 licence gate could not fail, and eight projects were behind it — not one.**
+- **The win32 licence gate could not fail, and nine projects were behind it — not one.**
   `libcrypto-3-x64.dll` and `libssl-3-x64.dll` arrive with this decision (gvsbuild's TLS
   backend is `gioopenssl`) and Apache-2.0 § 4 requires the licence to travel with the
   binary. Chasing that one payload found the mechanism instead: the win32 step attributes
   by PREFIX and `assertLicenseCoverage` ran its per-binary rules only under `per-binary`
   attribution, so the win32 call asserted "at least one licence text was recovered" and
   nothing more — a corpus of one file would have passed it. Measured on this branch's own
-  win32 artifact: **89 shipped binaries, 45 documented projects, and 14 binaries whose
-  project the bundle documents nowhere** — `glib` (six DLLs, LGPL-2.1-or-later), `freetype`,
-  `graphene`, `libtiff`, `libxml2`, `zlib`, `sqlite` and `openssl`. GLib has been
-  unlicensed in every published win32 tarball; only OpenSSL is new. Replaying that bundle
-  through the old gate returns **0 problems** and through the new one **14**, each naming
-  its binary.
+  win32 artifact: **90 shipped binaries, 45 documented projects, and 14 binaries whose
+  project the bundle documents nowhere** — `glib` (five DLLs, LGPL-2.1-or-later),
+  `gobject-introspection`, `freetype`, `graphene`, `libtiff`, `libxml2`, `zlib`, `sqlite`
+  and `openssl`. GLib has been unlicensed in every published win32 tarball; only OpenSSL
+  and SQLite are new. Replaying that artifact through the old gate returns **0 problems**
+  and through the new one **14**, each naming its binary — and the published `0.45.0`
+  tarball, which carries neither new payload, returns **0** and **11**.
 
   Fixed in this ADR's own change, and the shape is deliberate. Per-binary attribution
   still is not recoverable from a flat build tree, so the shipped notice keeps saying so;
@@ -147,14 +148,26 @@ including over https.** Concretely:
   does not know fails the build by name. `assertLicenseCoverage` refuses any binary whose
   family the corpus documents no text for, in **either** mode, and refuses prefix
   attribution offered without a family table at all. The binaries checked are now every
-  binary the tarball carries, the GStreamer plugins, pixbuf loaders and GIO modules
-  included, as on darwin. Where gvsbuild documents nothing (it has no install step for
-  some, and installs OpenSSL's as `LICENSE` while OpenSSL 3 ships `LICENSE.txt`), the text
-  comes from the upstream release the prefix pins, vendored under the win32 builder's
-  `licenses-not-in-prefix/` with its provenance — the prefix stays authoritative and is
-  never overridden. `manifest.licenses.binariesCovered` records the count on both
-  platforms, and `verify-bundle-manifest.mjs` refuses a bundle without it, so a tarball
-  built by a pre-gate builder cannot publish either.
+  binary the tarball carries, the GStreamer plugins, pixbuf loaders, GIO modules and the
+  plugin-scanner executable included, as on darwin. Where gvsbuild documents nothing (it
+  has no install step for some, and installs OpenSSL's as `LICENSE` while OpenSSL 3 ships
+  `LICENSE.txt`), the text comes from the upstream release the prefix pins, vendored under
+  the win32 builder's `licenses-not-in-prefix/` with its provenance — the prefix stays
+  authoritative and is never overridden. `manifest.licenses.binariesCovered` records the
+  count on both platforms, and `verify-bundle-manifest.mjs` refuses a bundle without it,
+  so a tarball built by a pre-gate builder cannot publish either.
+
+  **A name map cannot state wrong terms, but it can name the wrong project — and did.**
+  The two failure modes the review found are the two the shape allows, and both are now
+  held by a test rather than by care: a binary in NEITHER of the lists the builder
+  assembled is never asked about at all (`gst-plugin-scanner.exe`, the bundle's one
+  non-library binary, sat in `libexec/` outside both), and two leaves that look like one
+  library can be two projects (`girepository-2.0-0.dll` is glib's since 2.80,
+  `girepository-1.0-1.dll` is still gobject-introspection's own — matched by one pattern,
+  the notice named glib as the project behind a gobject-introspection binary and shipped
+  glib's text for it). Naming the wrong project is the worse half: it produces a positive,
+  complete-looking claim. What bounds it is that the map only ever selects a text the
+  corpus already holds, so the damage is a misattribution and never an invented licence.
 - `Soup-3.0.typelib` now has a backing library in the bundle, so the typelib planner stops
   dropping it. `@gjsify/{tls,http2,ws}` gain a working TLS stack on a bundle-activated
   process as a consequence, not as a separate feature.

--- a/docs/adr/0037-gtk-runtime-bundles-carry-the-uri-source.md
+++ b/docs/adr/0037-gtk-runtime-bundles-carry-the-uri-source.md
@@ -1,0 +1,109 @@
+# 37. The GTK runtime bundles carry the http(s) source, and the TLS backend behind it
+
+- Status: **Accepted**
+- Date: 2026-09-02
+- Deciders: Pascal Garber
+- Related: [ADR 0017 (native package distribution)](0017-native-package-distribution.md),
+  [ADR 0018 (the OS axis is a declared claim)](0018-os-axis-declaration.md),
+  [ADR 0023 (which GTK a node-gi process uses)](0023-gtk-source-precedence.md),
+  `packages/node-gi/scripts/gst-plugins.mjs` (the allowlist and its reasoning)
+
+## Context
+
+`@gjsify/gtk-runtime-darwin-{x64,arm64}` and `@gjsify/gtk-runtime-win32-x64` are the
+batteries-included GTK runtimes a node-gi app installs on the two platforms where the
+system has no GTK to borrow. They ship a curated slice of GStreamer, not the whole
+plugin dir: Homebrew's `gstreamer` formula alone carries ~275 plugins whose closure is
+most of a media distribution, and the darwin relocation gate refused it.
+
+The curation rule is written in `gst-plugins.mjs` and is not in question here: **the
+audio path, not everything the prefix has.** What was in question is where the audio
+path begins.
+
+Measured on the published bundles, on both platforms:
+
+| | |
+|---|---|
+| `Gst.ElementFactory.make('playbin3' \| 'decodebin3' \| 'filesrc')` | an element |
+| `Gst.ElementFactory.make('souphttpsrc')` | **null** |
+| `Gio.tls_backend_get_default().supports_tls()` | **false** |
+
+A desktop app playing a bundled podcast episode worked; the same app playing a live
+radio stream found no source element. That is not a codec gap — `playback`, i.e.
+`playbin3`/`uridecodebin3`, was already in the list, and those elements exist to take a
+URI. The bundle advertised URI playback and could open exactly one scheme.
+
+The second row is the part that would have been missed by fixing only the first.
+`GTlsConnection` has no implementation inside GIO: glib-networking ships one as a module
+that GIO `g_module_open`s out of one directory whose compiled-in default is the *build
+machine's* prefix. The bundles ship their own `libgio` and shipped no module, so a
+bundle-activated process answered every TLS request with the dummy backend — and
+`souphttpsrc` reports that as `Internal data stream error`, a network error to read and a
+missing module in fact. `@gjsify/tls`, `@gjsify/http2` and `@gjsify/ws` fail the same way
+one layer up.
+
+## Decision drivers
+
+- **The list stays enumerable.** Its value is that somebody can read it and say what the
+  bundle can do. "Everything the prefix has" fails silently in the other direction (a
+  250-plugin closure the relocation gate refuses, plus a licensing choice made by a script
+  that reads a directory).
+- **A URI source is not "streaming".** The excluded category is encoders, video decode,
+  capture, and streaming *sinks*, *servers* and adaptive-streaming demuxers — things a
+  bundle would carry to *produce* or *republish* media. Reading one is the same operation
+  as `filesrc`, which already ships.
+- **The alternative exists and is worse for the common case.** A consumer can feed
+  `appsrc` itself; the bundle already supports it and `@gjsify/webaudio` is built on it.
+  But that means reimplementing HTTP in JS — redirects, chunked transfer, range requests,
+  reconnect, ICY metadata — and it cannot use `playbin3`/`uridecodebin3` at all, because
+  those take a URI, not a pad. For pushing bytes you already hold, `appsrc` remains the
+  right answer and nothing here changes it.
+- **Cost has to be a number, not a feeling.** Measured on darwin-x64 (Homebrew
+  `gstreamer` 1.28.5, `libsoup` 3.6.6, `glib-networking` 2.80.1):
+
+  | | |
+  |---|---|
+  | `libgstsoup` | 107 KiB |
+  | libsoup + libpsl + libnghttp2 + libsqlite3 | ~2.8 MiB |
+  | `libgiognutls` + gnutls, nettle, hogweed, gmp, p11-kit, libtasn1, libidn2, libunistring | 6.67 MiB |
+  | **total** | **~9.6 MiB on an 85 MiB bundle (+13 %)** |
+
+- **Licensing raises nothing new.** Everything added is LGPL-2.1+ / LGPL-3+ dynamically
+  linked libraries of the same family as the GLib and GTK the bundle already relocates and
+  attributes per binary. This is *not* the category the allowlist keeps out — x264, x265,
+  faac and fdk-aac are excluded because redistributing a GPL- or patent-encumbered codec
+  inside a runtime bundle is the product author's decision, not the runtime's. No codec and
+  no patent claim enters here.
+
+## Decision
+
+**Widen the allowlist by exactly one plugin — `soup` — and ship what it needs to work,
+including over https.** Concretely:
+
+1. `soup` joins `GST_AUDIO_PLUGINS`, in a group whose comment states it as *the other
+   source*, alongside the file source that already ships.
+2. Both builders ship the prefix's **GIO modules** (`lib/gio/modules`), relocated and
+   verified like any other native payload, and node-gi points `GIO_MODULE_DIR` at them.
+3. Neither libsoup nor the TLS module is reachable by a link walk — the plugin
+   `g_module_open`s libsoup by leaf name on unix, and nothing links a GIO module at all —
+   so both are **explicitly seeded**, the third instance of the shape librsvg established.
+4. The TLS backend becomes a declared `tls-backend` runtime data set, so an empty module
+   dir fails the build *and* `verify-bundle-manifest.mjs` before publish.
+5. `GST_REQUIRED_PLUGINS` names the plugins whose absence is a build failure rather than a
+   counted skip (`app`, `playback`, `soup`), and the builders check the set they actually
+   copied.
+
+## Consequences
+
+- The bundles grow ~13 %. That is the price of the capability and it is stated in the
+  allowlist next to the entry that costs it.
+- `Soup-3.0.typelib` now has a backing library in the bundle, so the typelib planner stops
+  dropping it. `@gjsify/{tls,http2,ws}` gain a working TLS stack on a bundle-activated
+  process as a consequence, not as a separate feature.
+- The Windows build gains two gvsbuild projects (`glib-networking`, `libsoup3`) and a
+  second gvsbuild invocation, because gst-plugins-good's `soup` feature is meson `auto`
+  and *silently* produces no plugin when libsoup is absent from the prefix. The prefix
+  assertion after the build now names `gstsoup.dll` instead of counting plugins.
+- Widening again needs the same evidence this did: a measured user-visible gap, a measured
+  closure cost, and a gate that fails when the payload is absent. The list is not a
+  starting point that grows by argument.

--- a/docs/adr/0037-gtk-runtime-bundles-carry-the-uri-source.md
+++ b/docs/adr/0037-gtk-runtime-bundles-carry-the-uri-source.md
@@ -125,18 +125,36 @@ including over https.** Concretely:
   to carry forward: the two platforms do not pay the same price for the same decision, so
   a single percentage stated without its platform is wrong on one of them. The allowlist
   entry that costs it points here rather than restating the table.
-- **`libcrypto-3-x64.dll` and `libssl-3-x64.dll` currently ship with no licence text.**
-  The win32 licence step attributes by PREFIX — it scans `share/licenses` and `share/doc`
-  and copies what it finds — and `assertLicenseCoverage` only runs its per-binary checks
-  when `attribution === 'per-binary'`, which is the darwin mode. So the gvsbuild prefix
-  shipping no OpenSSL licence directory is invisible to every gate: the win32 bundle names
-  45 components and none of them is OpenSSL. Apache-2.0 § 4 requires the licence to travel
-  with the binary, so this is a redistribution defect, not a tidiness one. It is NOT
-  introduced by the decision above — it is exposed by it, because OpenSSL is the first
-  Apache-2.0 payload the prefix scan has had to cover. Repair, in order: make the gvsbuild
-  step install OpenSSL's `LICENSE.txt` into the prefix's licence tree, and then give the
-  win32 builder a named-component assertion so a future unlicensed family fails the build
-  instead of shipping. Until both land, the win32 bundle must not be published.
+- **The win32 licence gate could not fail, and eight projects were behind it — not one.**
+  `libcrypto-3-x64.dll` and `libssl-3-x64.dll` arrive with this decision (gvsbuild's TLS
+  backend is `gioopenssl`) and Apache-2.0 § 4 requires the licence to travel with the
+  binary. Chasing that one payload found the mechanism instead: the win32 step attributes
+  by PREFIX and `assertLicenseCoverage` ran its per-binary rules only under `per-binary`
+  attribution, so the win32 call asserted "at least one licence text was recovered" and
+  nothing more — a corpus of one file would have passed it. Measured on this branch's own
+  win32 artifact: **89 shipped binaries, 45 documented projects, and 14 binaries whose
+  project the bundle documents nowhere** — `glib` (six DLLs, LGPL-2.1-or-later), `freetype`,
+  `graphene`, `libtiff`, `libxml2`, `zlib`, `sqlite` and `openssl`. GLib has been
+  unlicensed in every published win32 tarball; only OpenSSL is new. Replaying that bundle
+  through the old gate returns **0 problems** and through the new one **14**, each naming
+  its binary.
+
+  Fixed in this ADR's own change, and the shape is deliberate. Per-binary attribution
+  still is not recoverable from a flat build tree, so the shipped notice keeps saying so;
+  what changed is that prefix attribution stopped being *unfalsifiable*.
+  `WIN32_LICENSE_FAMILIES` declares which project each bundled leaf belongs to — a NAME
+  map, never a statement of terms, so it cannot make a false licence claim and a leaf it
+  does not know fails the build by name. `assertLicenseCoverage` refuses any binary whose
+  family the corpus documents no text for, in **either** mode, and refuses prefix
+  attribution offered without a family table at all. The binaries checked are now every
+  binary the tarball carries, the GStreamer plugins, pixbuf loaders and GIO modules
+  included, as on darwin. Where gvsbuild documents nothing (it has no install step for
+  some, and installs OpenSSL's as `LICENSE` while OpenSSL 3 ships `LICENSE.txt`), the text
+  comes from the upstream release the prefix pins, vendored under the win32 builder's
+  `licenses-not-in-prefix/` with its provenance — the prefix stays authoritative and is
+  never overridden. `manifest.licenses.binariesCovered` records the count on both
+  platforms, and `verify-bundle-manifest.mjs` refuses a bundle without it, so a tarball
+  built by a pre-gate builder cannot publish either.
 - `Soup-3.0.typelib` now has a backing library in the bundle, so the typelib planner stops
   dropping it. `@gjsify/{tls,http2,ws}` gain a working TLS stack on a bundle-activated
   process as a consequence, not as a separate feature.

--- a/docs/adr/0037-gtk-runtime-bundles-carry-the-uri-source.md
+++ b/docs/adr/0037-gtk-runtime-bundles-carry-the-uri-source.md
@@ -104,6 +104,28 @@ including over https.** Concretely:
   second gvsbuild invocation, because gst-plugins-good's `soup` feature is meson `auto`
   and *silently* produces no plugin when libsoup is absent from the prefix. The prefix
   assertion after the build now names `gstsoup.dll` instead of counting plugins.
+- **The bundles ship the TLS implementation, not the trust anchors.** `supports_tls()` —
+  the question decision 4's data set and the first version of the runtime gate both asked —
+  answers for the module's PRESENCE, and is `true` on a bundle that rejects every
+  certificate in existence. Measured on linux-x64 by bind-mounting an empty directory over
+  p11-kit's module dirs: `gst-elements.test.mjs` passed in full at exit 0, and every
+  handshake failed with `Unacceptable TLS certificate`. The anchors reach the shipped
+  gnutls through the shipped libp11-kit (it is in the cost table above), which resolves its
+  trust module out of a compiled-in directory — `/usr/share/p11-kit/modules`,
+  `/etc/pkcs11/modules`, i.e. the BUILD prefix — and unlike GIO's module dir there is no env
+  override to repoint it with: the entire `P11_KIT_*` surface is `DEBUG`, `NO_USER_CONFIG`,
+  `STRICT` and `URI_LOWERCASE`. So decision 2's repair does not reach this layer, and
+  decision 4's file-list check cannot see it either.
+- **So the anchors are asked of the running backend, on the OS the bundle is for.**
+  `gst-elements.test.mjs` asserts `g_tls_backend_get_default_database()` is non-NULL —
+  glib-networking returns NULL exactly when the system trust holds zero certificates — and
+  that file runs on the staged bundle in the darwin and win32 windowing jobs. It is a LOWER
+  BOUND, deliberately: a non-empty database still does not say which roots are in it, and no
+  offline check can. What it does settle is the difference between "a TLS backend loaded"
+  and "TLS can succeed", which is the difference this ADR's second measured row is about one
+  layer up. If it reports red on a platform, that bundle needs a trust payload of its own
+  before it may claim https; the measurement above was taken on Linux, and the per-platform
+  answer is the CI leg's to give, not this document's to predict.
 - Widening again needs the same evidence this did: a measured user-visible gap, a measured
   closure cost, and a gate that fails when the payload is absent. The list is not a
   starting point that grows by argument.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,7 +57,8 @@ the TODO records the *what's left*.
 | [0034](0034-widget-vocabulary-convergence.md) | Every widget surface: named from the GIR, exported as a namespace, remainder declared | Proposed |
 | [0035](0035-web-view-on-win32.md) | A web view on Windows: WebView2 behind the same `gi://WebKit` 6.0 namespace | Proposed |
 | [0036](0036-third-party-react-native-surfaces.md) | Third-party React Native surfaces: one registry, one package, one subpath each | Proposed |
-| [0038](0038-shipped-application-fonts.md) | # ADR 0038 — A shipped application font: one payload directory, and the declarative mechanism each OS actually has | Accepted |
+| [0037](0037-gtk-runtime-bundles-carry-the-uri-source.md) | The GTK runtime bundles carry the http(s) source, and the TLS backend behind it | Accepted |
+| [0038](0038-shipped-application-fonts.md) | A shipped application font: one payload directory, and the declarative mechanism each OS actually has | Accepted |
 | [0039](0039-react-native-prop-surface.md) | The React Native PROP surface is published as a subpath; a refused prop keeps throwing | Proposed |
 
 Source review: [docs/reports/2026-07-01-architecture-review.md](../reports/2026-07-01-architecture-review.md)

--- a/packages/node-gi/gtk-runtime-win32-x64/README.md
+++ b/packages/node-gi/gtk-runtime-win32-x64/README.md
@@ -24,7 +24,7 @@ gtk/
   bin/                     GTK/GLib/cairo/pango/graphene/gdk-pixbuf DLLs (+ deps)
   girepository-1.0/        typelibs — ONLY those this bundle can back (see below)
   lib/ share/ etc/         --windowing only: pixbuf loaders, schemas, icons, fontconfig
-  licenses/                license texts recovered from the gvsbuild prefix
+  licenses/                license texts from the gvsbuild prefix, plus vendored ones
   THIRD-PARTY-NOTICES.md   what is bundled, under which terms, and that it is unmodified
   manifest.json            counts + sizes + DLL list + symmetry/license proof
 ```
@@ -67,8 +67,20 @@ not shipped):
    (`share/doc/<project>/COPYING|LICENSE`, `share/licenses/<project>/*`) into
    `gtk/licenses/` and write `gtk/THIRD-PARTY-NOTICES.md`, which lists every bundled
    DLL and states that the DLLs are byte-identical copies (no relocation on Windows).
-   Per-DLL attribution is deliberately NOT invented: the prefix is one flat build tree,
-   so the whole corpus ships and the notice says the mapping is not recoverable.
+   Per-DLL *terms* are deliberately NOT invented: the prefix is one flat build tree, so
+   the notice says the DLL→project mapping is not recoverable from it.
+
+   "The whole corpus ships" used to stand here and was measured false. Counted on a real
+   artifact: 90 shipped binaries against 45 projects the prefix documents, leaving **14
+   binaries whose project had no license text at all** — `glib` among them, five DLLs
+   under LGPL-2.1-or-later, missing from every win32 tarball published before this. The
+   coverage check only ran its per-binary rules under `attribution: "per-binary"`, and
+   this bundle passes `prefix`, so it effectively asserted that *some* license text
+   existed. A corpus of one file would have satisfied it.
+   So every shipped binary is now named against a project (`WIN32_LICENSE_FAMILIES`, a
+   NAME map — it carries no terms), coverage is enforced in both attribution modes, and
+   texts the prefix does not install are vendored under `licenses-not-in-prefix/` with
+   their provenance pinned to the gvsbuild version.
 
 Contrast with macOS, where dyld bakes each dylib's dependency install-names, so the
 darwin bundle must rewrite every reference to `@loader_path/<leaf>` and ad-hoc

--- a/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/README.md
+++ b/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/README.md
@@ -10,13 +10,13 @@ not carry.
 ## Why it exists
 
 Measured on the `win32-x64` CI artifact of PR #1476: the bundle carries 65 DLLs in `bin/`
-and the prefix documents 45 projects — and eight of the projects behind fourteen of those
-DLLs are in neither set. `libgio`, `libgobject` and `libglib` (LGPL-2.1-or-later) and
-`libcrypto`/`libssl` (Apache-2.0, whose § 4 requires the licence to travel with the
-binary) shipped with no terms at all. gvsbuild simply has no install step for some of
-these, and for others installs under a name the licence scan does not accept
-(`openssl` installs `LICENSE` while OpenSSL 3 ships `LICENSE.txt`; `glib` installs
-`LICENSES/LGPL-2.1-or-later.txt`).
+plus 25 binaries in their own directories, and the prefix documents 45 projects — and nine
+of the projects behind fourteen of those binaries are in neither set. `libgio`,
+`libgobject` and `libglib` (LGPL-2.1-or-later) and `libcrypto`/`libssl` (Apache-2.0, whose
+§ 4 requires the licence to travel with the binary) shipped with no terms at all. gvsbuild
+simply has no install step for some of these, and for others installs under a name the
+licence scan does not accept (`openssl` installs `LICENSE` while OpenSSL 3 ships
+`LICENSE.txt`; `glib` installs `LICENSES/LGPL-2.1-or-later.txt`).
 
 The gate that now refuses such a bundle is `assertLicenseCoverage` +
 `WIN32_LICENSE_FAMILIES` in `packages/node-gi/scripts/bundle-licenses.mjs`. **Deleting a
@@ -26,24 +26,40 @@ text here, never to drop the family.
 
 ## Provenance
 
-Version = the gvsbuild `2026.6.0` project pin, i.e. the source the DLLs in the bundle are
-built from. Contents are byte-verbatim; only the freetype file NAMES carry a `LICENSE-`
-prefix, because the scan matches licence files by name and `FTL.TXT` / `GPLv2.TXT` do not
-look like one.
+Each text is a byte-verbatim copy of the upstream release the gvsbuild pin builds the DLLs
+from. The pin and the per-project version live in `provenance.json` beside this file rather
+than in the table below, so they are one fact a test can hold instead of two copies of a
+number: `gtk-runtime-bundle-gates.test.mjs` requires an entry for every directory here, a
+directory for every entry, and the recorded `gvsbuild` to equal the `GVSBUILD_VERSION` the
+workflows actually build with. A pin bump therefore cannot leave these texts silently
+describing a different release.
 
-| Component | Version | File here | Taken from |
-|---|---|---|---|
-| `glib` | 2.88.1 | `COPYING` | `LICENSES/LGPL-2.1-or-later.txt` (what glib's own `COPYING` symlinks to) |
-| `freetype` | 2.14.3 | `LICENSE.TXT` | `LICENSE.TXT` — the dual-licence chooser |
-| `freetype` | 2.14.3 | `LICENSE-FTL.TXT` | `docs/FTL.TXT` — the FreeType Licence |
-| `freetype` | 2.14.3 | `LICENSE-GPLv2.TXT` | `docs/GPLv2.TXT` — the other half of the choice |
-| `graphene` | 1.10.8 | `LICENSE.txt` | `LICENSE.txt` |
-| `libtiff` | 4.7.1 | `LICENSE.md` | `LICENSE.md` |
-| `libxml2` | 2.15.3 | `COPYING` | `Copyright` |
-| `zlib` | 1.3.2 | `LICENSE` | `LICENSE` (unchanged since 1.3.1; zlib carries the same notice in `zlib.h`) |
-| `sqlite` | 3.53.2 | `LICENSE.md` | `LICENSE.md` — the public-domain dedication |
-| `openssl` | 3.6.1 | `LICENSE.txt` | `LICENSE.txt` — Apache-2.0 |
+Only the freetype file NAMES carry a `LICENSE-` prefix, because the scan matches licence
+files by name and `FTL.TXT` / `GPLv2.TXT` do not look like one.
 
-A gvsbuild bump that changes one of these projects' terms is not detected here. What IS
-detected is a bump that adds a library: it belongs to no declared family, and the build
-stops with its name.
+| Component | File here | Taken from |
+|---|---|---|
+| `glib` | `COPYING` | `LICENSES/LGPL-2.1-or-later.txt` (what glib's own `COPYING` symlinks to) |
+| `gobject-introspection` | `COPYING` | `COPYING` — which half of the project a file belongs to |
+| `gobject-introspection` | `COPYING.LGPL` | `COPYING.LGPL` — the terms of `girepository/`, the only half the bundle carries |
+| `freetype` | `LICENSE.TXT` | `LICENSE.TXT` — the dual-licence chooser |
+| `freetype` | `LICENSE-FTL.TXT` | `docs/FTL.TXT` — the FreeType Licence |
+| `freetype` | `LICENSE-GPLv2.TXT` | `docs/GPLv2.TXT` — the other half of the choice |
+| `graphene` | `LICENSE.txt` | `LICENSE.txt` |
+| `libtiff` | `LICENSE.md` | `LICENSE.md` |
+| `libxml2` | `COPYING` | `Copyright` |
+| `zlib` | `LICENSE` | `LICENSE` (unchanged since 1.3.1; zlib carries the same notice in `zlib.h`) |
+| `sqlite` | `LICENSE.md` | `LICENSE.md` — the public-domain dedication |
+| `openssl` | `LICENSE.txt` | `LICENSE.txt` — Apache-2.0 |
+
+A gvsbuild bump that changes one of these projects' TERMS is still not detected — only that
+the pin moved, which is what puts a human back in front of this table. What IS detected on
+its own is a bump that adds a library: it belongs to no declared family, and the build stops
+with its name.
+
+The failure this directory is easiest to reintroduce is naming the wrong project, not
+missing one: two leaves that look like one library can be two. `girepository-2.0-0.dll` is
+glib's since 2.80, `girepository-1.0-1.dll` is still gobject-introspection's own, and the
+bundle ships both — matched as one family, the notice named glib as the project behind a
+gobject-introspection binary. A wrong name ships the wrong project's terms, which is worse
+than shipping none.

--- a/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/README.md
+++ b/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/README.md
@@ -1,0 +1,49 @@
+# Licence texts the gvsbuild prefix does not document
+
+These are **not** this package's own terms (it is MIT) and **not** a licence claim written
+here. Each file is a verbatim copy of an upstream project's own licence text, used by
+`scripts/build-gtk-runtime.mjs` only for a project the build prefix ships a **binary** for
+and **no text** for. A project the prefix documents is always taken from the prefix; this
+directory never overrides it, and nothing here is shipped for a library the bundle does
+not carry.
+
+## Why it exists
+
+Measured on the `win32-x64` CI artifact of PR #1476: the bundle carries 65 DLLs in `bin/`
+and the prefix documents 45 projects — and eight of the projects behind fourteen of those
+DLLs are in neither set. `libgio`, `libgobject` and `libglib` (LGPL-2.1-or-later) and
+`libcrypto`/`libssl` (Apache-2.0, whose § 4 requires the licence to travel with the
+binary) shipped with no terms at all. gvsbuild simply has no install step for some of
+these, and for others installs under a name the licence scan does not accept
+(`openssl` installs `LICENSE` while OpenSSL 3 ships `LICENSE.txt`; `glib` installs
+`LICENSES/LGPL-2.1-or-later.txt`).
+
+The gate that now refuses such a bundle is `assertLicenseCoverage` +
+`WIN32_LICENSE_FAMILIES` in `packages/node-gi/scripts/bundle-licenses.mjs`. **Deleting a
+directory here fails the win32 build by name** rather than silently shipping the binary
+without its terms — which is the point, and why the repair for a new one is to add its
+text here, never to drop the family.
+
+## Provenance
+
+Version = the gvsbuild `2026.6.0` project pin, i.e. the source the DLLs in the bundle are
+built from. Contents are byte-verbatim; only the freetype file NAMES carry a `LICENSE-`
+prefix, because the scan matches licence files by name and `FTL.TXT` / `GPLv2.TXT` do not
+look like one.
+
+| Component | Version | File here | Taken from |
+|---|---|---|---|
+| `glib` | 2.88.1 | `COPYING` | `LICENSES/LGPL-2.1-or-later.txt` (what glib's own `COPYING` symlinks to) |
+| `freetype` | 2.14.3 | `LICENSE.TXT` | `LICENSE.TXT` — the dual-licence chooser |
+| `freetype` | 2.14.3 | `LICENSE-FTL.TXT` | `docs/FTL.TXT` — the FreeType Licence |
+| `freetype` | 2.14.3 | `LICENSE-GPLv2.TXT` | `docs/GPLv2.TXT` — the other half of the choice |
+| `graphene` | 1.10.8 | `LICENSE.txt` | `LICENSE.txt` |
+| `libtiff` | 4.7.1 | `LICENSE.md` | `LICENSE.md` |
+| `libxml2` | 2.15.3 | `COPYING` | `Copyright` |
+| `zlib` | 1.3.2 | `LICENSE` | `LICENSE` (unchanged since 1.3.1; zlib carries the same notice in `zlib.h`) |
+| `sqlite` | 3.53.2 | `LICENSE.md` | `LICENSE.md` — the public-domain dedication |
+| `openssl` | 3.6.1 | `LICENSE.txt` | `LICENSE.txt` — Apache-2.0 |
+
+A gvsbuild bump that changes one of these projects' terms is not detected here. What IS
+detected is a bump that adds a library: it belongs to no declared family, and the build
+stops with its name.

--- a/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/freetype/LICENSE-FTL.TXT
+++ b/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/freetype/LICENSE-FTL.TXT
@@ -1,0 +1,169 @@
+                    The FreeType Project LICENSE
+                    ----------------------------
+
+                            2006-Jan-27
+
+                    Copyright 1996-2002, 2006 by
+          David Turner, Robert Wilhelm, and Werner Lemberg
+
+
+
+Introduction
+============
+
+  The FreeType  Project is distributed in  several archive packages;
+  some of them may contain, in addition to the FreeType font engine,
+  various tools and  contributions which rely on, or  relate to, the
+  FreeType Project.
+
+  This  license applies  to all  files found  in such  packages, and
+  which do not  fall under their own explicit  license.  The license
+  affects  thus  the  FreeType   font  engine,  the  test  programs,
+  documentation and makefiles, at the very least.
+
+  This  license   was  inspired  by  the  BSD,   Artistic,  and  IJG
+  (Independent JPEG  Group) licenses, which  all encourage inclusion
+  and  use of  free  software in  commercial  and freeware  products
+  alike.  As a consequence, its main points are that:
+
+    o We don't promise that this software works. However, we will be
+      interested in any kind of bug reports. (`as is' distribution)
+
+    o You can  use this software for whatever you  want, in parts or
+      full form, without having to pay us. (`royalty-free' usage)
+
+    o You may not pretend that  you wrote this software.  If you use
+      it, or  only parts of it,  in a program,  you must acknowledge
+      somewhere  in  your  documentation  that  you  have  used  the
+      FreeType code. (`credits')
+
+  We  specifically  permit  and  encourage  the  inclusion  of  this
+  software, with  or without modifications,  in commercial products.
+  We  disclaim  all warranties  covering  The  FreeType Project  and
+  assume no liability related to The FreeType Project.
+
+
+  Finally,  many  people  asked  us  for  a  preferred  form  for  a
+  credit/disclaimer to use in compliance with this license.  We thus
+  encourage you to use the following text:
+
+   """
+    Portions of this software are copyright © <year> The FreeType
+    Project (https://freetype.org).  All rights reserved.
+   """
+
+  Please replace <year> with the value from the FreeType version you
+  actually use.
+
+
+Legal Terms
+===========
+
+0. Definitions
+--------------
+
+  Throughout this license,  the terms `package', `FreeType Project',
+  and  `FreeType  archive' refer  to  the  set  of files  originally
+  distributed  by the  authors  (David Turner,  Robert Wilhelm,  and
+  Werner Lemberg) as the `FreeType Project', be they named as alpha,
+  beta or final release.
+
+  `You' refers to  the licensee, or person using  the project, where
+  `using' is a generic term including compiling the project's source
+  code as  well as linking it  to form a  `program' or `executable'.
+  This  program is  referred to  as  `a program  using the  FreeType
+  engine'.
+
+  This  license applies  to all  files distributed  in  the original
+  FreeType  Project,   including  all  source   code,  binaries  and
+  documentation,  unless  otherwise  stated   in  the  file  in  its
+  original, unmodified form as  distributed in the original archive.
+  If you are  unsure whether or not a particular  file is covered by
+  this license, you must contact us to verify this.
+
+  The FreeType  Project is copyright (C) 1996-2000  by David Turner,
+  Robert Wilhelm, and Werner Lemberg.  All rights reserved except as
+  specified below.
+
+1. No Warranty
+--------------
+
+  THE FREETYPE PROJECT  IS PROVIDED `AS IS' WITHOUT  WARRANTY OF ANY
+  KIND, EITHER  EXPRESS OR IMPLIED,  INCLUDING, BUT NOT  LIMITED TO,
+  WARRANTIES  OF  MERCHANTABILITY   AND  FITNESS  FOR  A  PARTICULAR
+  PURPOSE.  IN NO EVENT WILL ANY OF THE AUTHORS OR COPYRIGHT HOLDERS
+  BE LIABLE  FOR ANY DAMAGES CAUSED  BY THE USE OR  THE INABILITY TO
+  USE, OF THE FREETYPE PROJECT.
+
+2. Redistribution
+-----------------
+
+  This  license  grants  a  worldwide, royalty-free,  perpetual  and
+  irrevocable right  and license to use,  execute, perform, compile,
+  display,  copy,   create  derivative  works   of,  distribute  and
+  sublicense the  FreeType Project (in  both source and  object code
+  forms)  and  derivative works  thereof  for  any  purpose; and  to
+  authorize others  to exercise  some or all  of the  rights granted
+  herein, subject to the following conditions:
+
+    o Redistribution of  source code  must retain this  license file
+      (`FTL.TXT') unaltered; any  additions, deletions or changes to
+      the original  files must be clearly  indicated in accompanying
+      documentation.   The  copyright   notices  of  the  unaltered,
+      original  files must  be  preserved in  all  copies of  source
+      files.
+
+    o Redistribution in binary form must provide a  disclaimer  that
+      states  that  the software is based in part of the work of the
+      FreeType Team,  in  the  distribution  documentation.  We also
+      encourage you to put an URL to the FreeType web page  in  your
+      documentation, though this isn't mandatory.
+
+  These conditions  apply to any  software derived from or  based on
+  the FreeType Project,  not just the unmodified files.   If you use
+  our work, you  must acknowledge us.  However, no  fee need be paid
+  to us.
+
+3. Advertising
+--------------
+
+  Neither the  FreeType authors and  contributors nor you  shall use
+  the name of the  other for commercial, advertising, or promotional
+  purposes without specific prior written permission.
+
+  We suggest,  but do not require, that  you use one or  more of the
+  following phrases to refer  to this software in your documentation
+  or advertising  materials: `FreeType Project',  `FreeType Engine',
+  `FreeType library', or `FreeType Distribution'.
+
+  As  you have  not signed  this license,  you are  not  required to
+  accept  it.   However,  as  the FreeType  Project  is  copyrighted
+  material, only  this license, or  another one contracted  with the
+  authors, grants you  the right to use, distribute,  and modify it.
+  Therefore,  by  using,  distributing,  or modifying  the  FreeType
+  Project, you indicate that you understand and accept all the terms
+  of this license.
+
+4. Contacts
+-----------
+
+  There are two mailing lists related to FreeType:
+
+    o freetype@nongnu.org
+
+      Discusses general use and applications of FreeType, as well as
+      future and  wanted additions to the  library and distribution.
+      If  you are looking  for support,  start in  this list  if you
+      haven't found anything to help you in the documentation.
+
+    o freetype-devel@nongnu.org
+
+      Discusses bugs,  as well  as engine internals,  design issues,
+      specific licenses, porting, etc.
+
+  Our home page can be found at
+
+    https://freetype.org
+
+
+--- end of FTL.TXT ---

--- a/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/freetype/LICENSE-GPLv2.TXT
+++ b/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/freetype/LICENSE-GPLv2.TXT
@@ -1,0 +1,340 @@
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+     51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year  name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.

--- a/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/freetype/LICENSE.TXT
+++ b/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/freetype/LICENSE.TXT
@@ -1,0 +1,47 @@
+FREETYPE LICENSES
+-----------------
+
+The FreeType  2 font  engine is  copyrighted work  and cannot  be used
+legally without  a software  license.  In order  to make  this project
+usable to  a vast majority of  developers, we distribute it  under two
+mutually exclusive open-source licenses.
+
+This means that *you* must choose  *one* of the two licenses described
+below, then obey all its terms and conditions when using FreeType 2 in
+any of your projects or products.
+
+  - The FreeType License,  found in the file  `docs/FTL.TXT`, which is
+    similar to the  original BSD license *with*  an advertising clause
+    that forces  you to explicitly  cite the FreeType project  in your
+    product's  documentation.  All  details are  in the  license file.
+    This license is suited to products which don't use the GNU General
+    Public License.
+
+    Note that  this license  is compatible to  the GNU  General Public
+    License version 3, but not version 2.
+
+  - The   GNU   General   Public   License   version   2,   found   in
+    `docs/GPLv2.TXT`  (any  later  version  can  be  used  also),  for
+    programs  which  already  use  the  GPL.  Note  that  the  FTL  is
+    incompatible with GPLv2 due to its advertisement clause.
+
+The contributed  BDF and PCF  drivers come  with a license  similar to
+that  of the  X Window  System.   It is  compatible to  the above  two
+licenses (see files `src/bdf/README`  and `src/pcf/README`).  The same
+holds   for   the   source    code   files   `src/base/fthash.c`   and
+`include/freetype/internal/fthash.h`; they were part of the BDF driver
+in earlier FreeType versions.
+
+The gzip  module uses the  zlib license (see  `src/gzip/zlib.h`) which
+too is compatible to the above two licenses.
+
+The   files   `src/autofit/ft-hb-ft.c`,   `src/autofit/ft-hb-decls.h`,
+`src/autofit/ft-hb-types.h`,     and    `src/autofit/hb-script-list.h`
+contain code taken (almost) verbatim  from the HarfBuzz library, which
+uses the 'Old MIT' license compatible to the above two licenses.
+
+The  MD5 checksum  support  (only used  for  debugging in  development
+builds) is in the public domain.
+
+
+--- end of LICENSE.TXT ---

--- a/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/glib/COPYING
+++ b/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/glib/COPYING
@@ -1,0 +1,175 @@
+GNU LESSER GENERAL PUBLIC LICENSE
+
+Version 2.1, February 1999
+
+Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts as the successor of the GNU Library Public License, version 2, hence the version number 2.1.]
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public Licenses are intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users.
+
+This license, the Lesser General Public License, applies to some specially designated software packages--typically libraries--of the Free Software Foundation and other authors who decide to use it. You can use it too, but we suggest you first think carefully about whether this license or the ordinary General Public License is the better strategy to use in any particular case, based on the explanations below.
+
+When we speak of free software, we are referring to freedom of use, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish); that you receive source code or can get it if you want it; that you can change the software and use pieces of it in new free programs; and that you are informed that you can do these things.
+
+To protect your rights, we need to make restrictions that forbid distributors to deny you these rights or to ask you to surrender these rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library or if you modify it.
+
+For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you link other code with the library, you must provide complete object files to the recipients, so that they can relink them with the library after making changes to the library and recompiling it. And you must show them these terms so they know their rights.
+
+We protect your rights with a two-step method: (1) we copyright the library, and (2) we offer you this license, which gives you legal permission to copy, distribute and/or modify the library.
+
+To protect each distributor, we want to make it very clear that there is no warranty for the free library. Also, if the library is modified by someone else and passed on, the recipients should know that what they have is not the original version, so that the original author's reputation will not be affected by problems that might be introduced by others.
+
+Finally, software patents pose a constant threat to the existence of any free program. We wish to make sure that a company cannot effectively restrict the users of a free program by obtaining a restrictive license from a patent holder. Therefore, we insist that any patent license obtained for a version of the library must be consistent with the full freedom of use specified in this license.
+
+Most GNU software, including some libraries, is covered by the ordinary GNU General Public License. This license, the GNU Lesser General Public License, applies to certain designated libraries, and is quite different from the ordinary General Public License. We use this license for certain libraries in order to permit linking those libraries into non-free programs.
+
+When a program is linked with a library, whether statically or using a shared library, the combination of the two is legally speaking a combined work, a derivative of the original library. The ordinary General Public License therefore permits such linking only if the entire combination fits its criteria of freedom. The Lesser General Public License permits more lax criteria for linking other code with the library.
+
+We call this license the "Lesser" General Public License because it does Less to protect the user's freedom than the ordinary General Public License. It also provides other free software developers Less of an advantage over competing non-free programs. These disadvantages are the reason we use the ordinary General Public License for many libraries. However, the Lesser license provides advantages in certain special circumstances.
+
+For example, on rare occasions, there may be a special need to encourage the widest possible use of a certain library, so that it becomes a de-facto standard. To achieve this, non-free programs must be allowed to use the library. A more frequent case is that a free library does the same job as widely used non-free libraries. In this case, there is little to gain by limiting the free library to free software only, so we use the Lesser General Public License.
+
+In other cases, permission to use a particular library in non-free programs enables a greater number of people to use a large body of free software. For example, permission to use the GNU C Library in non-free programs enables many more people to use the whole GNU operating system, as well as its variant, the GNU/Linux operating system.
+
+Although the Lesser General Public License is Less protective of the users' freedom, it does ensure that the user of a program that is linked with the Library has the freedom and the wherewithal to run that program using a modified version of the Library.
+
+The precise terms and conditions for copying, distribution and modification follow. Pay close attention to the difference between a "work based on the library" and a "work that uses the library". The former contains code derived from the library, whereas the latter must be combined with the library in order to run.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License Agreement applies to any software library or other program which contains a notice placed by the copyright holder or other authorized party saying it may be distributed under the terms of this Lesser General Public License (also called "this License"). Each licensee is addressed as "you".
+
+A "library" means a collection of software functions and/or data prepared so as to be conveniently linked with application programs (which use some of those functions and data) to form executables.
+
+The "Library", below, refers to any such software library or work which has been distributed under these terms. A "work based on the Library" means either the Library or any derivative work under copyright law: that is to say, a work containing the Library or a portion of it, either verbatim or with modifications and/or translated straightforwardly into another language. (Hereinafter, translation is included without limitation in the term "modification".)
+
+"Source code" for a work means the preferred form of the work for making modifications to it. For a library, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the library.
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running a program using the Library is not restricted, and output from such a program is covered only if its contents constitute a work based on the Library (independent of the use of the Library in a tool for writing it). Whether that is true depends on what the Library does and what the program that uses the Library does.
+
+1. You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and distribute a copy of this License along with the Library.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Library or any portion of it, thus forming a work based on the Library, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+     a) The modified work must itself be a software library.
+
+     b) You must cause the files modified to carry prominent notices stating that you changed the files and the date of any change.
+
+     c) You must cause the whole of the work to be licensed at no charge to all third parties under the terms of this License.
+
+     d) If a facility in the modified Library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful.
+
+(For example, a function in a library to compute square roots has a purpose that is entirely well-defined independent of the application. Therefore, Subsection 2d requires that any application-supplied function or table used by this function must be optional: if the application does not supply it, the square root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Library, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Library, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library with the Library (or with a work based on the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+3. You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if you wish.) Do not make any other change in these notices.
+
+Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU General Public License applies to all subsequent copies and derivative works made from that copy.
+
+This option is useful when you wish to copy part of the code of the Library into a program that is not a library.
+
+4. You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange.
+
+If distribution of object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place satisfies the requirement to distribute the source code, even though third parties are not compelled to copy the source along with the object code.
+
+5. A program that contains no derivative of any portion of the Library, but is designed to work with the Library by being compiled or linked with it, is called a "work that uses the Library". Such a work, in isolation, is not a derivative work of the Library, and therefore falls outside the scope of this License.
+
+However, linking a "work that uses the Library" with the Library creates an executable that is a derivative of the Library (because it contains portions of the Library), rather than a "work that uses the library". The executable is therefore covered by this License. Section 6 states terms for distribution of such executables.
+
+When a "work that uses the Library" uses material from a header file that is part of the Library, the object code for the work may be a derivative work of the Library even though the source code is not. Whether this is true is especially significant if the work can be linked without the Library, or if the work is itself a library. The threshold for this to be true is not precisely defined by law.
+
+If such an object file uses only numerical parameters, data structure layouts and accessors, and small macros and small inline functions (ten lines or less in length), then the use of the object file is unrestricted, regardless of whether it is legally a derivative work. (Executables containing this object code plus portions of the Library will still fall under Section 6.)
+
+Otherwise, if the work is a derivative of the Library, you may distribute the object code for the work under the terms of Section 6. Any executables containing that work also fall under Section 6, whether or not they are linked directly with the Library itself.
+
+6. As an exception to the Sections above, you may also combine or link a "work that uses the Library" with the Library to produce a work containing portions of the Library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's own use and reverse engineering for debugging such modifications.
+
+You must give prominent notice with each copy of the work that the Library is used in it and that the Library and its use are covered by this License. You must supply a copy of this License. If the work during execution displays copyright notices, you must include the copyright notice for the Library among them, as well as a reference directing the user to the copy of this License. Also, you must do one of these things:
+
+     a) Accompany the work with the complete corresponding machine-readable source code for the Library including whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the work is an executable linked with the Library, with the complete machine-readable "work that uses the Library", as object code and/or source code, so that the user can modify the Library and then relink to produce a modified executable containing the modified Library. (It is understood that the user who changes the contents of definitions files in the Library will not necessarily be able to recompile the application to use the modified definitions.)
+
+     b) Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (1) uses at run time a copy of the library already present on the user's computer system, rather than copying library functions into the executable, and (2) will operate properly with a modified version of the library, if the user installs one, as long as the modified version is interface-compatible with the version that the work was made with.
+
+     c) Accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of performing this distribution.
+
+     d) If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place.
+
+     e) Verify that the user has already received a copy of these materials or that you have already sent this user a copy.
+
+For an executable, the required form of the "work that uses the Library" must include any data and utility programs needed for reproducing the executable from it. However, as a special exception, the materials to be distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+It may happen that this requirement contradicts the license restrictions of other proprietary libraries that do not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library together in an executable that you distribute.
+
+7. You may place library facilities that are a work based on the Library side-by-side in a single library together with other library facilities not covered by this License, and distribute such a combined library, provided that the separate distribution of the work based on the Library and of the other library facilities is otherwise permitted, and provided that you do these two things:
+
+     a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities. This must be distributed under the terms of the Sections above.
+
+     b) Give prominent notice with the combined library of the fact that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+8. You may not copy, modify, sublicense, link with, or distribute the Library except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or distribute the Library is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+9. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Library or works based on it.
+
+10. Each time you redistribute the Library (or any work based on the Library), the recipient automatically receives a license from the original licensor to copy, distribute, link with or modify the Library subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties with this License.
+
+11. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license would not permit royalty-free redistribution of the Library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply, and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+12. If the distribution and/or use of the Library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Library under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+13. The Free Software Foundation may publish revised and/or new versions of the Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Library does not specify a license version number, you may choose any version ever published by the Free Software Foundation.
+
+14. If you wish to incorporate parts of the Library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Libraries
+
+If you develop a new library, and you want it to be of the greatest possible use to the public, we recommend making it free software that everyone can redistribute and change. You can do so by permitting redistribution under these terms (or, alternatively, under the terms of the ordinary General Public License).
+
+To apply these terms, attach the following notices to the library. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     one line to give the library's name and an idea of what it does.
+     Copyright (C) year  name of author
+
+     This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option) any later version.
+
+     This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+
+     You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the library, if necessary. Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in
+the library `Frob' (a library for tweaking knobs) written
+by James Random Hacker.
+
+signature of Ty Coon, 1 April 1990
+Ty Coon, President of Vice
+That's all there is to it!

--- a/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/gobject-introspection/COPYING
+++ b/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/gobject-introspection/COPYING
@@ -1,0 +1,13 @@
+gobject-introspection has two licenses; one for the typelib library,
+and one for the tools.
+
+* The typelib libraries (girepository/) are licensed under the LGPLv2+.
+  See the file COPYING.LGPL.
+
+* The remaining code is GPLv2+ compatible (see the file COPYING.GPL) and
+  consists of a mix of GPLv2+, LGPLv2+ and MIT. See the license headers in
+  each file for details.
+
+In general where applicable files should have headers denoting their license
+status; if they do not, please file a bug at
+https://gitlab.gnome.org/GNOME/gobject-introspection/issues.

--- a/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/gobject-introspection/COPYING.LGPL
+++ b/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/gobject-introspection/COPYING.LGPL
@@ -1,0 +1,481 @@
+		  GNU LIBRARY GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1991 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the library GPL.  It is
+ numbered 2 because it goes with version 2 of the ordinary GPL.]
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Library General Public License, applies to some
+specially designated Free Software Foundation software, and to any
+other libraries whose authors decide to use it.  You can use it for
+your libraries, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if
+you distribute copies of the library, or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link a program with the library, you must provide
+complete object files to the recipients so that they can relink them
+with the library, after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  Our method of protecting your rights has two steps: (1) copyright
+the library, and (2) offer you this license which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  Also, for each distributor's protection, we want to make certain
+that everyone understands that there is no warranty for this free
+library.  If the library is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original
+version, so that any problems introduced by others will not reflect on
+the original authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that companies distributing free
+software will individually obtain patent licenses, thus in effect
+transforming the program into proprietary software.  To prevent this,
+we have made it clear that any patent must be licensed for everyone's
+free use or not licensed at all.
+
+  Most GNU software, including some libraries, is covered by the ordinary
+GNU General Public License, which was designed for utility programs.  This
+license, the GNU Library General Public License, applies to certain
+designated libraries.  This license is quite different from the ordinary
+one; be sure to read it in full, and don't assume that anything in it is
+the same as in the ordinary license.
+
+  The reason we have a separate public license for some libraries is that
+they blur the distinction we usually make between modifying or adding to a
+program and simply using it.  Linking a program with a library, without
+changing the library, is in some sense simply using the library, and is
+analogous to running a utility program or application program.  However, in
+a textual and legal sense, the linked executable is a combined work, a
+derivative of the original library, and the ordinary General Public License
+treats it as such.
+
+  Because of this blurred distinction, using the ordinary General
+Public License for libraries did not effectively promote software
+sharing, because most developers did not use the libraries.  We
+concluded that weaker conditions might promote sharing better.
+
+  However, unrestricted linking of non-free programs would deprive the
+users of those programs of all benefit from the free status of the
+libraries themselves.  This Library General Public License is intended to
+permit developers of non-free programs to use free libraries, while
+preserving your freedom as a user of such programs to change the free
+libraries that are incorporated in them.  (We have not seen how to achieve
+this as regards changes in header files, but we have achieved it as regards
+changes in the actual functions of the Library.)  The hope is that this
+will lead to faster development of free libraries.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, while the latter only
+works together with the library.
+
+  Note that it is possible for a library to be covered by the ordinary
+General Public License rather than by this special one.
+
+		  GNU LIBRARY GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library which
+contains a notice placed by the copyright holder or other authorized
+party saying it may be distributed under the terms of this Library
+General Public License (also called "this License").  Each licensee is
+addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+  
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also compile or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    c) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    d) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the source code distributed need not include anything that is normally
+distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Library General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+			    NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Library General Public License for more details.
+
+    You should have received a copy of the GNU Library General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/graphene/LICENSE.txt
+++ b/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/graphene/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright 2014 Emmanuele Bassi. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/libtiff/LICENSE.md
+++ b/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/libtiff/LICENSE.md
@@ -1,0 +1,49 @@
+# LibTIFF license
+
+Copyright © 1988-1997 Sam Leffler\
+Copyright © 1991-1997 Silicon Graphics, Inc.
+
+Permission to use, copy, modify, distribute, and sell this software and 
+its documentation for any purpose is hereby granted without fee, provided
+that (i) the above copyright notices and this permission notice appear in
+all copies of the software and related documentation, and (ii) the names of
+Sam Leffler and Silicon Graphics may not be used in any advertising or
+publicity relating to the software without the specific, prior written
+permission of Sam Leffler and Silicon Graphics.
+
+THE SOFTWARE IS PROVIDED "AS-IS" AND WITHOUT WARRANTY OF ANY KIND, 
+EXPRESS, IMPLIED OR OTHERWISE, INCLUDING WITHOUT LIMITATION, ANY 
+WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.  
+
+IN NO EVENT SHALL SAM LEFFLER OR SILICON GRAPHICS BE LIABLE FOR
+ANY SPECIAL, INCIDENTAL, INDIRECT OR CONSEQUENTIAL DAMAGES OF ANY KIND,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER OR NOT ADVISED OF THE POSSIBILITY OF DAMAGE, AND ON ANY THEORY OF 
+LIABILITY, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE 
+OF THIS SOFTWARE.
+
+# Lempel-Ziv & Welch Compression (tif_lzw.c) license
+The code of tif_lzw.c is derived from the compress program whose code is
+derived from software contributed to Berkeley by James A. Woods,
+derived from original work by Spencer Thomas and Joseph Orost.
+
+The original Berkeley copyright notice appears below in its entirety:
+
+Copyright (c) 1985, 1986 The Regents of the University of California.
+All rights reserved.
+
+This code is derived from software contributed to Berkeley by
+James A. Woods, derived from original work by Spencer Thomas
+and Joseph Orost.
+
+Redistribution and use in source and binary forms are permitted
+provided that the above copyright notice and this paragraph are
+duplicated in all such forms and that any documentation,
+advertising materials, and other materials related to such
+distribution and use acknowledge that the software was developed
+by the University of California, Berkeley.  The name of the
+University may not be used to endorse or promote products derived
+from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.

--- a/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/libxml2/COPYING
+++ b/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/libxml2/COPYING
@@ -1,0 +1,24 @@
+Except where otherwise noted in the source code (e.g. the files dict.c and
+list.c, which are covered by a similar licence but with different Copyright
+notices) all the files are:
+
+ Copyright (C) 1998-2012 Daniel Veillard.  All Rights Reserved.
+ Copyright (C) The Libxml2 Contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is fur-
+nished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FIT-
+NESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/openssl/LICENSE.txt
+++ b/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/openssl/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/provenance.json
+++ b/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/provenance.json
@@ -1,0 +1,15 @@
+{
+    "$comment": "Machine-readable half of README.md: which upstream release each vendored licence text was taken from, and the gvsbuild pin that release belongs to. Held by gtk-runtime-bundle-gates.test.mjs — every directory here needs an entry, every entry needs a directory, and `gvsbuild` must equal the GVSBUILD_VERSION the workflows build with, so a pin bump cannot leave these texts describing a different release.",
+    "gvsbuild": "2026.6.0",
+    "components": {
+        "freetype": "2.14.3",
+        "glib": "2.88.1",
+        "gobject-introspection": "1.86.0",
+        "graphene": "1.10.8",
+        "libtiff": "4.7.1",
+        "libxml2": "2.15.3",
+        "openssl": "3.6.1",
+        "sqlite": "3.53.2",
+        "zlib": "1.3.2"
+    }
+}

--- a/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/sqlite/LICENSE.md
+++ b/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/sqlite/LICENSE.md
@@ -1,0 +1,85 @@
+License Information
+===================
+
+SQLite Is Public Domain
+-----------------------
+
+The SQLite source code, including all of the files in the directories
+listed in the bullets below are 
+[Public Domain](https://sqlite.org/copyright.html).
+The authors have submitted written affidavits releasing their work to
+the public for any use.  Every byte of the public-domain code can be
+traced back to the original authors.  The files of this repository
+that are public domain include the following:
+
+  *  All of the primary SQLite source code files found in the
+     [src/ directory](https://sqlite.org/src/tree/src?type=tree&expand)
+  *  All of the test cases and testing code in the
+     [test/ directory](https://sqlite.org/src/tree/test?type=tree&expand)
+  *  All of the SQLite extension source code and test cases in the
+     [ext/ directory](https://sqlite.org/src/tree/ext?type=tree&expand)
+  *  All code that ends up in the "sqlite3.c" and "sqlite3.h" build products
+     that actually implement the SQLite RDBMS.
+  *  All of the code used to compile the
+     [command-line interface](https://sqlite.org/cli.html)
+  *  All of the code used to build various utility programs such as
+     "sqldiff", "sqlite3_rsync", and "sqlite3_analyzer".
+
+
+The public domain source files usually contain a header comment
+similar to the following to make it clear that the software is
+public domain.
+
+> The author disclaims copyright to this source code.  In place of
+> a legal notice, here is a blessing:
+> 
+>   *   May you do good and not evil.
+>   *   May you find forgiveness for yourself and forgive others.
+>   *   May you share freely, never taking more than you give.
+
+Almost every file you find in this source repository will be
+public domain.  But there are a small number of exceptions:
+
+Non-Public-Domain Code Included With This Source Repository AS A Convenience
+----------------------------------------------------------------------------
+
+This repository contains a (relatively) small amount of non-public-domain
+code used to help implement the configuration and build logic.  In other
+words, there are some non-public-domain files used to implement:
+
+> ./configure && make
+
+In all cases, the non-public-domain files included with this
+repository have generous BSD-style licenses.  So anyone is free to
+use any of the code in this source repository for any purpose, though
+attribution may be required to reuse or republish the configure and
+build scripts.  None of the non-public-domain code ever actually reaches
+the build products, such as "sqlite3.c", however, so no attribution is
+required to use SQLite itself.  The non-public-domain code consists of
+scripts used to help compile SQLite.  The non-public-domain code is
+technically not part of SQLite.  The non-public-domain code is
+included in this repository as a convenience to developers, so that those
+who want to build SQLite do not need to go download a bunch of
+third-party build scripts in order to compile SQLite.
+
+Non-public-domain code included in this respository includes:
+
+  *  The ["autosetup"](http://msteveb.github.io/autosetup/) configuration
+     system that is contained (mostly) in the autosetup/ directory, but also
+     includes the "./configure" script at the top-level of this archive.
+     Autosetup has a separate BSD-style license.  See the
+     [autosetup/LICENSE](http://msteveb.github.io/autosetup/license/)
+     for details.
+
+  *  There are BSD-style licenses on some of the configuration
+     software found in the legacy autoconf/ directory and its
+     subdirectories.
+
+The following unix shell command can be run from the top-level
+of this source repository in order to remove all non-public-domain
+code:
+
+> rm -rf configure autosetup autoconf
+
+If you unpack this source repository and then run the command above, what
+is left will be 100% public domain.

--- a/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/zlib/LICENSE
+++ b/packages/node-gi/gtk-runtime-win32-x64/licenses-not-in-prefix/zlib/LICENSE
@@ -1,0 +1,22 @@
+Copyright notice:
+
+ (C) 1995-2022 Jean-loup Gailly and Mark Adler
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Jean-loup Gailly        Mark Adler
+  jloup@gzip.org          madler@alumni.caltech.edu

--- a/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
+++ b/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
@@ -45,7 +45,9 @@ import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
     copyTreeDereferenced,
+    duplicatedModuleLeaves,
     findSymlinks,
+    formatDuplicatedModuleProblems,
     formatSymlinkProblems,
     formatWindowingDataProblems,
     verifyWindowingData,
@@ -170,10 +172,18 @@ const WINDOWING_SEED_PATTERNS = [
     // build with no audio and no message.
     /^gstreamer-1\.0-.*\.dll$/i,
     /^gstapp-1\.0-.*\.dll$/i,
-    // libsoup, which `gstsoup.dll` § 4g ships opens with g_module_open rather than
-    // linking, so the dumpbin walk seeded from the plugin finds no soup at all —
-    // gst-plugins.mjs § soup carries the measurement and the darwin twin of this seed.
-    // It also backs `Soup-3.0.typelib`, which § 3's symmetry rule was correctly dropping.
+    // libsoup, and NOT for the reason its darwin twin exists — the two OSes build the
+    // soup plugin differently and only one of them hides the dependency. gst-plugins-good
+    // takes the `host_system == 'windows'` branch of ext/soup/meson.build, which LINKS
+    // libsoup; measured on the shipped DLL, `gstsoup.dll`'s import table names
+    // `soup-3.0-0.dll` outright, so the dumpbin walk seeded from the plugin does reach it.
+    // (On darwin the same plugin g_module_opens libsoup by leaf through its loader shim
+    // and the otool walk finds nothing — that is where the seed is load-bearing.)
+    //
+    // It is seeded here anyway, for the reason that survives the difference: it backs
+    // `Soup-3.0.typelib`, which § 3's symmetry rule was correctly dropping, and the seed
+    // states that requirement rather than inheriting it from how -good happened to be
+    // configured. gst-plugins.mjs § soup carries the measurement.
     /^soup-3\.0-.*\.dll$/i,
 ];
 
@@ -452,6 +462,12 @@ const windowing = {
     fontconfig: false,
     gtksource: false,
 };
+// Every loadable module § 4a/4g/4h PLACES in its own directory, for the rule-3 gate below
+// them: a module must not ALSO be a flat bin/ entry. This leg is CLEAN today — dumpbin's
+// import table does not name the file it describes, so nothing queues a module the way
+// `otool -L` did on darwin — and the gate is here so it stays a fact rather than a
+// property of which walker each OS happens to use. See duplicatedModuleLeaves.
+const placedModuleLeaves = [];
 if (WINDOWING) {
     // 4a. gdk-pixbuf loaders + a TOPLEVEL-relative loaders.cache. The cache maps each
     // decoder DLL to its mime/extensions, and the query tool emits absolute build paths
@@ -469,6 +485,7 @@ if (WINDOWING) {
         for (const f of readdirSync(gdkPixbufLoaderDir)) {
             if (f.toLowerCase().endsWith('.dll')) {
                 copyFileSync(join(gdkPixbufLoaderDir, f), join(loadersOut, f));
+                placedModuleLeaves.push(f);
                 windowing.pixbufLoaders++;
             }
         }
@@ -533,6 +550,7 @@ if (WINDOWING) {
             copyFileSync(join(gstPluginDir, f), dest);
             bytes += statSync(dest).size;
             shippedGstPlugins.push(f);
+            placedModuleLeaves.push(f);
             windowing.gstPlugins++;
         }
         // The scanner, which GStreamer FORKS so a plugin that crashes on load cannot
@@ -609,6 +627,7 @@ if (WINDOWING) {
             const dest = join(modulesOut, basename(src));
             copyFileSync(src, dest);
             bytes += statSync(dest).size;
+            placedModuleLeaves.push(basename(src));
             windowing.gioModules++;
         }
         if (windowing.gioModules === 0) {
@@ -628,6 +647,15 @@ if (WINDOWING) {
                 'Repair: add glib-networking to the gvsbuild build (it is a dependency of the libsoup3 ' +
                 'project, so building libsoup3 brings it).',
         );
+        process.exit(1);
+    }
+
+    // Rule 3: no module § 4a/4g/4h placed may ALSO be a flat bin/ entry. Case-folded,
+    // because bin/ is a Windows directory. The darwin twin of this gate stands after its
+    // § 3, and duplicatedModuleLeaves carries the class.
+    const duplicatedModules = duplicatedModuleLeaves(binDlls, placedModuleLeaves, { caseInsensitive: true });
+    if (duplicatedModules.length > 0) {
+        console.error(`build-gtk-runtime: ${formatDuplicatedModuleProblems(duplicatedModules, { flatDir: binOut })}`);
         process.exit(1);
     }
 

--- a/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
+++ b/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
@@ -56,9 +56,9 @@ import {
     WIN32_LICENSE_FAMILIES,
     assertLicenseCoverage,
     formatLicenseProblems,
-    licenseFamilyFor,
     renderThirdPartyNotice,
     scanLicenseFiles,
+    upstreamLicenseComponents,
     writeLicensePayload,
 } from '../../scripts/bundle-licenses.mjs';
 import {
@@ -470,6 +470,13 @@ const windowing = {
 // `otool -L` did on darwin — and the gate is here so it stays a fact rather than a
 // property of which walker each OS happens to use. See duplicatedModuleLeaves.
 const placedModuleLeaves = [];
+// Binaries § 4 places that are NOT loadable modules, so rule 3 does not apply to them and
+// the license coverage set below still must. Today that is the GStreamer plugin scanner,
+// an .exe in libexec/ — and it is exactly what "every binary the tarball carries" missed
+// on the first pass: it is in neither `binDlls` nor a module list, so the win32 coverage
+// gate never saw the one non-library binary in the bundle. darwin attributes it through
+// its keg like any other image; this keeps the two platforms answering the same question.
+const placedExecutables = [];
 if (WINDOWING) {
     // 4a. gdk-pixbuf loaders + a TOPLEVEL-relative loaders.cache. The cache maps each
     // decoder DLL to its mime/extensions, and the query tool emits absolute build paths
@@ -564,6 +571,7 @@ if (WINDOWING) {
             const scannerOut = join(OUT, 'libexec', 'gstreamer-1.0');
             mkdirSync(scannerOut, { recursive: true });
             copyFileSync(scannerSrc, join(scannerOut, 'gst-plugin-scanner.exe'));
+            placedExecutables.push('gst-plugin-scanner.exe');
         } else {
             console.warn(
                 `build-gtk-runtime: WARNING — ${scannerSrc} missing; GStreamer will scan plugins ` +
@@ -906,7 +914,7 @@ if (WINDOWING) {
 // was ever checked. `assertLicenseCoverage` ran its per-binary rules under `per-binary`
 // attribution only, so this call asserted "some text was recovered" — a corpus of one
 // file would have passed it. Measured on the artifact: 65 DLLs, 45 documented projects,
-// and eight projects behind fourteen DLLs (glib among them) with no terms in the bundle.
+// and nine projects behind fourteen DLLs (glib among them) with no terms in the bundle.
 // The corpus is still DERIVED and the notice still refuses to claim a per-DLL mapping;
 // what changed is that WIN32_LICENSE_FAMILIES lets the gate ask, per binary, whether SOME
 // documented project covers it — and the build stops when one does not.
@@ -917,33 +925,30 @@ for (const text of licenseTexts) {
     byComponent.get(text.component).texts.push(text);
 }
 // EVERY binary the tarball carries, not just bin/ — the same correction the darwin
-// builder already carries. The gst plugins, the pixbuf loaders and the GIO modules are
-// third-party libraries too, and a coverage check that never sees them cannot say the
-// terms travel with them.
-const shippedBinaries = [...[...binDlls.values()].map((f) => basename(f)), ...placedModuleLeaves].sort();
+// builder already carries. The gst plugins, the pixbuf loaders, the GIO modules and the
+// plugin scanner are third-party binaries too, and a coverage check that never sees them
+// cannot say the terms travel with them.
+const shippedBinaries = [
+    ...[...binDlls.values()].map((f) => basename(f)),
+    ...placedModuleLeaves,
+    ...placedExecutables,
+].sort();
 // THE VENDORED CORPUS, and the measurement that made it necessary. The corpus above is
 // what the prefix HAPPENS to document, and on the published bundles that was 45 projects
-// against 89 shipped binaries: glib, freetype, graphene, libtiff, libxml2, zlib, sqlite
-// and openssl back fourteen of them and the prefix documents none — gvsbuild has no
-// install step for some, and installs others under a name the scan does not accept
-// (openssl installs `LICENSE` while OpenSSL 3 ships `LICENSE.txt`). So the bundle
-// shipped LGPL-2.1 GLib and Apache-2.0 OpenSSL with no terms at all.
-//
-// TWO NARROWINGS KEEP THIS FROM BECOMING A HAND-MAINTAINED CORPUS. The prefix stays
-// AUTHORITATIVE — a project it documents is never overridden here — and a vendored text
-// enters only for a project some binary in THIS bundle needs, so the display-free variant
-// does not carry OpenSSL's terms for a DLL it never had. Provenance per file:
-// licenses-not-in-prefix/README.md.
-const neededComponents = new Set(
-    shippedBinaries.flatMap((leaf) => licenseFamilyFor(leaf, WIN32_LICENSE_FAMILIES)?.components ?? []),
-);
-const documentedByPrefix = new Set(byComponent.keys());
-for (const text of scanLicenseFiles({ root: join(pkgRoot, 'licenses-not-in-prefix'), subdirs: ['.'], maxDepth: 2 })) {
-    if (documentedByPrefix.has(text.component) || !neededComponents.has(text.component)) continue;
-    if (!byComponent.has(text.component)) {
-        byComponent.set(text.component, { name: text.component, texts: [], upstreamText: true });
-    }
-    byComponent.get(text.component).texts.push(text);
+// against 90 shipped binaries: glib, gobject-introspection, freetype, graphene, libtiff,
+// libxml2, zlib, sqlite and openssl back fourteen of them and the prefix documents none —
+// gvsbuild has no install step for some, and installs others under a name the scan does
+// not accept (openssl installs `LICENSE` while OpenSSL 3 ships `LICENSE.txt`). So the
+// bundle shipped LGPL-2.1 GLib and Apache-2.0 OpenSSL with no terms at all. The rule the
+// merge follows lives in bundle-licenses.mjs so its test drives THIS code and not a copy;
+// provenance per file is licenses-not-in-prefix/README.md.
+for (const component of upstreamLicenseComponents({
+    root: join(pkgRoot, 'licenses-not-in-prefix'),
+    documented: byComponent.keys(),
+    binaries: shippedBinaries,
+    families: WIN32_LICENSE_FAMILIES,
+})) {
+    byComponent.set(component.name, component);
 }
 const licenseComponents = [...byComponent.values()].sort((a, b) => a.name.localeCompare(b.name));
 const licensePayload = writeLicensePayload({ outDir: join(OUT, 'licenses'), components: licenseComponents });

--- a/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
+++ b/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
@@ -653,7 +653,10 @@ if (WINDOWING) {
     // Rule 3: no module § 4a/4g/4h placed may ALSO be a flat bin/ entry. Case-folded,
     // because bin/ is a Windows directory. The darwin twin of this gate stands after its
     // § 3, and duplicatedModuleLeaves carries the class.
-    const duplicatedModules = duplicatedModuleLeaves(binDlls, placedModuleLeaves, { caseInsensitive: true });
+    // `binDlls` is a Map (leaf -> resolved source); its VALUES are what § 2a copied.
+    const duplicatedModules = duplicatedModuleLeaves(binDlls.values(), placedModuleLeaves, {
+        caseInsensitive: true,
+    });
     if (duplicatedModules.length > 0) {
         console.error(`build-gtk-runtime: ${formatDuplicatedModuleProblems(duplicatedModules, { flatDir: binOut })}`);
         process.exit(1);

--- a/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
+++ b/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
@@ -63,7 +63,7 @@ import {
     formatMissingGlImplementation,
 } from '../../scripts/gl-implementation.mjs';
 import { decodeProbeProblems, spawnDecodeProbe } from '../../scripts/decode-probe.mjs';
-import { isBundledGstPlugin } from '../../scripts/gst-plugins.mjs';
+import { isBundledGstPlugin, missingRequiredGstPlugins } from '../../scripts/gst-plugins.mjs';
 import { bundleRelativeLoaderCache, loaderCacheProblems } from '../../scripts/pixbuf-loader-cache.mjs';
 import {
     REQUIRED_NAMESPACES,
@@ -170,6 +170,11 @@ const WINDOWING_SEED_PATTERNS = [
     // build with no audio and no message.
     /^gstreamer-1\.0-.*\.dll$/i,
     /^gstapp-1\.0-.*\.dll$/i,
+    // libsoup, which `gstsoup.dll` § 4g ships opens with g_module_open rather than
+    // linking, so the dumpbin walk seeded from the plugin finds no soup at all —
+    // gst-plugins.mjs § soup carries the measurement and the darwin twin of this seed.
+    // It also backs `Soup-3.0.typelib`, which § 3's symmetry rule was correctly dropping.
+    /^soup-3\.0-.*\.dll$/i,
 ];
 
 // Locate an MSVC/gvsbuild tool: env override, then the gvsbuild <prefix>/bin
@@ -296,9 +301,20 @@ if (WINDOWING && existsSync(gstPluginDir)) {
         }
     }
 }
+// And for the GIO modules (§ 4h) — the TLS backend. Same shape again: outside bin/,
+// nothing links them, so without seeding here their backing DLLs never reach bin/ and
+// the module cannot load on a machine without the build prefix.
+const gioModuleDir = join(PREFIX, 'lib', 'gio', 'modules');
+const gioModuleSeeds = [];
+if (WINDOWING && existsSync(gioModuleDir)) {
+    for (const f of readdirSync(gioModuleDir)) {
+        if (f.toLowerCase().endsWith('.dll')) gioModuleSeeds.push(join(gioModuleDir, f));
+    }
+}
 console.log(
     `build-gtk-runtime: ${seeds.length} seed DLLs${loaderSeeds.length ? ` + ${loaderSeeds.length} pixbuf loaders` : ''}` +
-        `${gstPluginSeeds.length ? ` + ${gstPluginSeeds.length} gst plugins` : ''}`,
+        `${gstPluginSeeds.length ? ` + ${gstPluginSeeds.length} gst plugins` : ''}` +
+        `${gioModuleSeeds.length ? ` + ${gioModuleSeeds.length} gio modules` : ''}`,
 );
 
 const dumpbin = findDumpbin();
@@ -309,7 +325,7 @@ if (dumpbin) {
     console.log(`build-gtk-runtime: walking the DLL closure with ${dumpbin}`);
     // Seed with bin/ seeds (leaf names) + external loader DLLs (full paths) so THEIR
     // deps are walked into bin/ even though the loaders live outside bin/.
-    const queue = [...seeds, ...loaderSeeds, ...gstPluginSeeds];
+    const queue = [...seeds, ...loaderSeeds, ...gstPluginSeeds, ...gioModuleSeeds];
     while (queue.length) {
         const entry = queue.shift();
         const isPath = entry.includes('\\') || entry.includes('/');
@@ -430,6 +446,7 @@ if (typelibPlan.dropped.length > 0) {
 const windowing = {
     pixbufLoaders: 0,
     gstPlugins: 0,
+    gioModules: 0,
     schemas: false,
     iconThemes: [],
     fontconfig: false,
@@ -507,6 +524,7 @@ if (WINDOWING) {
         const pluginsOut = join(OUT, 'lib', 'gstreamer-1.0');
         mkdirSync(pluginsOut, { recursive: true });
         let bytes = 0;
+        const shippedGstPlugins = [];
         for (const f of readdirSync(gstPluginDir)) {
             if (!f.toLowerCase().endsWith('.dll')) continue;
             // The AUDIO PATH only, same rule and same reasons as darwin.
@@ -514,6 +532,7 @@ if (WINDOWING) {
             const dest = join(pluginsOut, f);
             copyFileSync(join(gstPluginDir, f), dest);
             bytes += statSync(dest).size;
+            shippedGstPlugins.push(f);
             windowing.gstPlugins++;
         }
         // The scanner, which GStreamer FORKS so a plugin that crashes on load cannot
@@ -547,6 +566,22 @@ if (WINDOWING) {
             );
             process.exit(1);
         }
+        // ZERO IS NEVER RIGHT, one element deeper — the darwin builder carries the twin
+        // of this block. The count above passed on every published bundle while
+        // `souphttpsrc` was absent from all of them, because a count cannot say WHICH
+        // plugin is gone.
+        const missingRequired = missingRequiredGstPlugins(shippedGstPlugins);
+        if (missingRequired.length > 0) {
+            console.error(
+                `build-gtk-runtime: ${gstPluginDir} produced no plugin for ${missingRequired.join(', ')} — ` +
+                    'gst-plugins.mjs marks these required because a bundle without them reports a healthy ' +
+                    'Gst.init() and then fails in the application (no appsrc / no decodebin / no source ' +
+                    'element for an http(s) URI). `soup` comes from gst-plugins-good and needs libsoup3 ' +
+                    'built into the same gvsbuild prefix FIRST, else meson disables the plugin silently. ' +
+                    'Do NOT drop the name from GST_REQUIRED_PLUGINS to get a green build.',
+            );
+            process.exit(1);
+        }
         console.log(
             `build-gtk-runtime: GStreamer — ${windowing.gstPlugins} plugin(s), ` +
                 `${(bytes / 1024 / 1024).toFixed(1)} MiB`,
@@ -556,6 +591,44 @@ if (WINDOWING) {
             `build-gtk-runtime: WARNING — ${gstPluginDir} missing; no GStreamer plugins bundled ` +
                 '(Gst.init() would succeed and decode nothing)',
         );
+    }
+
+    // 4h. GIO modules — the TLS backend. `GTlsConnection` has no implementation in GIO
+    // itself: glib-networking ships one as a module GIO g_module_opens out of its module
+    // dir. The bundle brings its own GIO and brought no module, so every https request in
+    // a bundle-activated process got the DUMMY backend — `souphttpsrc` on an https URL
+    // fails as "Internal data stream error", and @gjsify/tls, /http2 and /ws the same way
+    // one layer up. No relocation (Windows resolves the backing DLLs by search path, and
+    // the closure walk already put them in bin/); node-gi points GIO_MODULE_DIR here.
+    // Declared as the `tls-backend` data set, so § 5b fails an empty one.
+    if (existsSync(gioModuleDir)) {
+        const modulesOut = join(OUT, 'lib', 'gio', 'modules');
+        mkdirSync(modulesOut, { recursive: true });
+        let bytes = 0;
+        for (const src of gioModuleSeeds) {
+            const dest = join(modulesOut, basename(src));
+            copyFileSync(src, dest);
+            bytes += statSync(dest).size;
+            windowing.gioModules++;
+        }
+        if (windowing.gioModules === 0) {
+            console.error(
+                `build-gtk-runtime: ${gioModuleDir} holds no GIO module DLL — the bundle would ship its ` +
+                    'own GIO with no TLS backend behind it, so every https request gets the dummy backend ' +
+                    'and fails as a network error. Repair: add glib-networking to the gvsbuild build.',
+            );
+            process.exit(1);
+        }
+        console.log(
+            `build-gtk-runtime: GIO modules — ${windowing.gioModules} module(s), ${(bytes / 1024).toFixed(0)} KiB`,
+        );
+    } else {
+        console.error(
+            `build-gtk-runtime: ${gioModuleDir} missing — no GIO TLS backend to bundle. ` +
+                'Repair: add glib-networking to the gvsbuild build (it is a dependency of the libsoup3 ' +
+                'project, so building libsoup3 brings it).',
+        );
+        process.exit(1);
     }
 
     // 4b. Compiled GSettings schemas (GTK/Adwaita read org.gnome.desktop.interface

--- a/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
+++ b/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
@@ -53,8 +53,10 @@ import {
     verifyWindowingData,
 } from '../../scripts/bundle-data.mjs';
 import {
+    WIN32_LICENSE_FAMILIES,
     assertLicenseCoverage,
     formatLicenseProblems,
+    licenseFamilyFor,
     renderThirdPartyNotice,
     scanLicenseFiles,
     writeLicensePayload,
@@ -899,15 +901,52 @@ if (WINDOWING) {
 // (36 files in GTK4_Gvsbuild_2026.6.0_x64) — so the whole corpus ships and the notice
 // says plainly that the per-binary mapping is not recoverable. Over-inclusive beats
 // silent.
+//
+// OVER-INCLUSIVE IN ONE DIRECTION IS NOT COVERAGE IN THE OTHER, and only the first half
+// was ever checked. `assertLicenseCoverage` ran its per-binary rules under `per-binary`
+// attribution only, so this call asserted "some text was recovered" — a corpus of one
+// file would have passed it. Measured on the artifact: 65 DLLs, 45 documented projects,
+// and eight projects behind fourteen DLLs (glib among them) with no terms in the bundle.
+// The corpus is still DERIVED and the notice still refuses to claim a per-DLL mapping;
+// what changed is that WIN32_LICENSE_FAMILIES lets the gate ask, per binary, whether SOME
+// documented project covers it — and the build stops when one does not.
 const licenseTexts = scanLicenseFiles({ root: PREFIX, subdirs: ['share/licenses', 'share/doc'], maxDepth: 2 });
 const byComponent = new Map();
 for (const text of licenseTexts) {
     if (!byComponent.has(text.component)) byComponent.set(text.component, { name: text.component, texts: [] });
     byComponent.get(text.component).texts.push(text);
 }
+// EVERY binary the tarball carries, not just bin/ — the same correction the darwin
+// builder already carries. The gst plugins, the pixbuf loaders and the GIO modules are
+// third-party libraries too, and a coverage check that never sees them cannot say the
+// terms travel with them.
+const shippedBinaries = [...[...binDlls.values()].map((f) => basename(f)), ...placedModuleLeaves].sort();
+// THE VENDORED CORPUS, and the measurement that made it necessary. The corpus above is
+// what the prefix HAPPENS to document, and on the published bundles that was 45 projects
+// against 89 shipped binaries: glib, freetype, graphene, libtiff, libxml2, zlib, sqlite
+// and openssl back fourteen of them and the prefix documents none — gvsbuild has no
+// install step for some, and installs others under a name the scan does not accept
+// (openssl installs `LICENSE` while OpenSSL 3 ships `LICENSE.txt`). So the bundle
+// shipped LGPL-2.1 GLib and Apache-2.0 OpenSSL with no terms at all.
+//
+// TWO NARROWINGS KEEP THIS FROM BECOMING A HAND-MAINTAINED CORPUS. The prefix stays
+// AUTHORITATIVE — a project it documents is never overridden here — and a vendored text
+// enters only for a project some binary in THIS bundle needs, so the display-free variant
+// does not carry OpenSSL's terms for a DLL it never had. Provenance per file:
+// licenses-not-in-prefix/README.md.
+const neededComponents = new Set(
+    shippedBinaries.flatMap((leaf) => licenseFamilyFor(leaf, WIN32_LICENSE_FAMILIES)?.components ?? []),
+);
+const documentedByPrefix = new Set(byComponent.keys());
+for (const text of scanLicenseFiles({ root: join(pkgRoot, 'licenses-not-in-prefix'), subdirs: ['.'], maxDepth: 2 })) {
+    if (documentedByPrefix.has(text.component) || !neededComponents.has(text.component)) continue;
+    if (!byComponent.has(text.component)) {
+        byComponent.set(text.component, { name: text.component, texts: [], upstreamText: true });
+    }
+    byComponent.get(text.component).texts.push(text);
+}
 const licenseComponents = [...byComponent.values()].sort((a, b) => a.name.localeCompare(b.name));
 const licensePayload = writeLicensePayload({ outDir: join(OUT, 'licenses'), components: licenseComponents });
-const dllLeaves = [...binDlls.values()].map((f) => basename(f));
 writeFileSync(
     join(OUT, 'THIRD-PARTY-NOTICES.md'),
     renderThirdPartyNotice({
@@ -919,24 +958,28 @@ writeFileSync(
         // bundle is made portable by the loader's PATH prepend alone.
         modifications: [],
         components: licenseComponents,
-        binaries: dllLeaves,
+        binaries: shippedBinaries,
         attribution: 'prefix',
         payloadDir: 'licenses',
     }),
 );
 const licenseProblems = assertLicenseCoverage({
     components: licenseComponents,
-    binaries: dllLeaves,
+    binaries: shippedBinaries,
     attribution: 'prefix',
     textCount: licensePayload.files.length,
+    families: WIN32_LICENSE_FAMILIES,
 });
 if (licenseProblems.length > 0) {
     console.error(`build-gtk-runtime: ${formatLicenseProblems(licenseProblems, { prefix: PREFIX })}`);
     process.exit(1);
 }
+const upstreamComponents = licenseComponents.filter((c) => c.upstreamText).map((c) => c.name);
 console.log(
     `build-gtk-runtime: licenses — ${licensePayload.files.length} text(s) from ${licenseComponents.length} ` +
-        `project(s) (${(licensePayload.bytes / 1024).toFixed(0)} KiB) -> licenses/, notice -> THIRD-PARTY-NOTICES.md`,
+        `project(s) (${(licensePayload.bytes / 1024).toFixed(0)} KiB) covering ${shippedBinaries.length} ` +
+        `binary/ies -> licenses/, notice -> THIRD-PARTY-NOTICES.md` +
+        `${upstreamComponents.length ? ` (${upstreamComponents.join(', ')} from upstream, not from the prefix)` : ''}`,
 );
 
 // --- manifest + size -------------------------------------------------------
@@ -989,6 +1032,11 @@ const manifest = {
         attribution: 'prefix',
         components: licenseComponents.length,
         texts: licensePayload.files.length,
+        // Recorded, not just asserted: a consumer holding only the tarball can see how
+        // many binaries the coverage check actually covered, and which projects' terms
+        // came from upstream because the build prefix documents none.
+        binariesCovered: shippedBinaries.length,
+        upstreamComponents,
         binariesModified: false,
         modifications: [],
     },

--- a/packages/node-gi/node-gi/gtk-runtime.js
+++ b/packages/node-gi/node-gi/gtk-runtime.js
@@ -460,6 +460,20 @@ export function maybeWireGtkWindowingEnv() {
         const scanner = join(bundle.dir, 'libexec', 'gstreamer-1.0', gstScannerLeaf());
         if (existsSync(scanner)) setIfUnset('GST_PLUGIN_SCANNER', scanner);
     }
+
+    // The GIO modules, and specifically the TLS backend. `GTlsConnection` has no
+    // implementation in GIO itself — glib-networking ships one as a module GIO
+    // g_module_opens out of ONE directory, whose compiled-in default is the BUILD
+    // machine's prefix. On a user's box that path is absent (or, worse, a foreign
+    // glib-networking against a different GLib), so a bundle-activated process fell back
+    // to the dummy backend and every https request failed: `souphttpsrc` reports
+    // "Internal data stream error", @gjsify/{tls,http2,ws} fail the same way one layer up.
+    //
+    // GIO_MODULE_DIR, not GIO_EXTRA_MODULES, for GST_PLUGIN_SYSTEM_PATH's reason: it
+    // REPLACES the compiled-in default rather than adding to it, and mixing a host's
+    // modules into the bundle's own GIO is the case we are avoiding, not one to preserve.
+    const gioModules = join(bundle.dir, 'lib', 'gio', 'modules');
+    if (existsSync(gioModules)) setIfUnset('GIO_MODULE_DIR', gioModules);
 }
 
 /** The plugin scanner's leaf name — the bundles ship the same tree on both OSes. */

--- a/packages/node-gi/node-gi/test/gst-elements.test.mjs
+++ b/packages/node-gi/node-gi/test/gst-elements.test.mjs
@@ -21,6 +21,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
+import { requireGi } from '../gi.js';
 import { Gst, gstSkip as skip } from './gst-gate.mjs';
 
 // The pipeline @gjsify/webaudio is built from, element by element. Named

--- a/packages/node-gi/node-gi/test/gst-elements.test.mjs
+++ b/packages/node-gi/node-gi/test/gst-elements.test.mjs
@@ -102,4 +102,34 @@ test('the bundle carries a TLS backend, so https is more than an element name', 
             'lib/gio/modules or nothing told GIO where it is. Every https URL fails as a stream error ' +
             'until it does; see the tls-backend data set in scripts/bundle-data.mjs.',
     );
+
+    // ONE LAYER DOWN, and the layer that decides whether https actually WORKS. A
+    // backend is an implementation, and an implementation with no trust anchors
+    // rejects every certificate — so supports_tls() above is satisfied by a bundle on
+    // which nothing can connect. Measured on linux-x64 by bind-mounting an empty dir
+    // over p11-kit's module dirs: supports_tls() stayed true, this whole FILE stayed
+    // green at exit 0, and every handshake failed with `Unacceptable TLS certificate`.
+    //
+    // The anchors are the one part of the TLS payload the bundle does NOT ship. The
+    // shipped gnutls reaches them through the shipped libp11-kit, which resolves its
+    // trust module out of a COMPILED-IN directory (/usr/share/p11-kit/modules,
+    // /etc/pkcs11/modules) — the BUILD prefix — and unlike GIO's module dir there is no
+    // env override to repoint it with: the whole P11_KIT_* surface is DEBUG,
+    // NO_USER_CONFIG, STRICT and URI_LOWERCASE. So this cannot be asserted from the
+    // tarball's file list either; it has to be ASKED of the running backend, on the OS
+    // the bundle is for, which is where this file runs.
+    //
+    // get_default_database() is the call that separates the two: glib-networking
+    // returns NULL for it when the system trust holds zero certificates, while
+    // supports_tls() keeps answering for the module's mere presence. It is a lower
+    // bound — a non-empty database still says nothing about WHICH roots are in it —
+    // but it is the difference between "a TLS backend loaded" and "TLS can succeed".
+    assert.ok(
+        backend.get_default_database(),
+        'the TLS backend has NO trust anchors: g_tls_backend_get_default_database() is NULL, which ' +
+            'glib-networking returns when the system trust contains zero certificates. souphttpsrc ' +
+            'resolves, the backend loads, supports_tls() is true — and every https certificate is ' +
+            'rejected. The bundle ships the TLS implementation but not the anchors, and the shipped ' +
+            'p11-kit looks for its trust module in the BUILD prefix with no env override available.',
+    );
 });

--- a/packages/node-gi/node-gi/test/gst-elements.test.mjs
+++ b/packages/node-gi/node-gi/test/gst-elements.test.mjs
@@ -35,6 +35,11 @@ const REQUIRED_ELEMENTS = [
     ['audioresample', 'rate conversion to the context sample rate'],
     ['typefind', 'what decodebin autoplugs from — no typefind, no format detection'],
     ['volume', 'GainNode'],
+    // The OTHER source. `playbin3`/`uridecodebin3` above take a URI, and until the
+    // plugin allowlist was widened the only scheme they could open was file:// —
+    // measured on the published darwin-x64 and win32-x64 bundles, where this factory
+    // was the one null in an otherwise complete list.
+    ['souphttpsrc', 'the http(s) source — a URI pipeline has no source element without it'],
 ];
 
 test('the GStreamer registry resolves the audio-path elements', { skip }, () => {
@@ -62,4 +67,39 @@ test('a decodebin pipeline actually builds', { skip }, () => {
     assert.ok(pipeline.get_by_name('src'), 'appsrc is not addressable in the built pipeline');
     assert.ok(pipeline.get_by_name('sink'), 'appsink is not addressable in the built pipeline');
     pipeline.set_state(Gst.State.NULL);
+});
+
+test('a URI pipeline can be built for an https source', { skip }, () => {
+    // The counterpart to the decodebin pipeline above, for the source half: `parse_launch`
+    // fails on a missing element or a refused link, so this is what turns "souphttpsrc
+    // resolves" into "the shape an app writes actually assembles".
+    const pipeline = Gst.parse_launch(
+        'souphttpsrc name=src location=https://example.invalid/stream.mp3 ! decodebin ! audioconvert ! ' +
+            'audioresample ! appsink name=sink',
+    );
+    assert.ok(pipeline, 'parse_launch returned nothing for the http source pipeline');
+    assert.ok(pipeline.get_by_name('src'), 'souphttpsrc is not addressable in the built pipeline');
+    pipeline.set_state(Gst.State.NULL);
+});
+
+// NOT a network test, and deliberately not one: it asks whether the bundle carries a TLS
+// IMPLEMENTATION, which is a property of the payload and answerable offline. It has to be
+// asked separately from the elements above, because souphttpsrc resolves perfectly well
+// with no TLS backend behind it and then fails on the first https URL with "Internal data
+// stream error" — a network error to read, a missing g_module_open-ed module in fact. GIO
+// has no built-in GTlsConnection: glib-networking ships one as a module, node-gi points
+// GIO_MODULE_DIR at the bundle's lib/gio/modules, and with neither in place
+// `g_tls_backend_get_default()` returns the dummy backend, whose supports_tls() is false.
+test('the bundle carries a TLS backend, so https is more than an element name', { skip }, () => {
+    const Gio = requireGi('Gio', '2.0');
+    const backend = Gio.tls_backend_get_default();
+    assert.ok(backend, 'Gio.tls_backend_get_default() returned nothing at all');
+    assert.equal(
+        backend.supports_tls(),
+        true,
+        'the default GTlsBackend does not support TLS — it is the DUMMY backend. GIO loads the real ' +
+            'one (glib-networking) as a module out of GIO_MODULE_DIR, so either the bundle ships no ' +
+            'lib/gio/modules or nothing told GIO where it is. Every https URL fails as a stream error ' +
+            'until it does; see the tls-backend data set in scripts/bundle-data.mjs.',
+    );
 });

--- a/packages/node-gi/node-gi/test/gst-elements.test.mjs
+++ b/packages/node-gi/node-gi/test/gst-elements.test.mjs
@@ -35,10 +35,13 @@ const REQUIRED_ELEMENTS = [
     ['audioresample', 'rate conversion to the context sample rate'],
     ['typefind', 'what decodebin autoplugs from — no typefind, no format detection'],
     ['volume', 'GainNode'],
-    // The OTHER source. `playbin3`/`uridecodebin3` above take a URI, and until the
-    // plugin allowlist was widened the only scheme they could open was file:// —
-    // measured on the published darwin-x64 and win32-x64 bundles, where this factory
-    // was the one null in an otherwise complete list.
+    // The URI path, and the source it had no source for. `playbin3` and `uridecodebin3`
+    // exist to take a URI and both resolved on every published bundle, while the only
+    // scheme behind them was file:// — `filesrc` rides in on coreelements and nothing
+    // shipped for http(s). Measured on the published darwin-x64 and win32-x64 bundles:
+    // souphttpsrc was the one null in an otherwise complete list.
+    ['playbin3', 'the URI player an app hands a stream address to'],
+    ['uridecodebin3', 'what playbin3 autoplugs the source and the decoder from'],
     ['souphttpsrc', 'the http(s) source — a URI pipeline has no source element without it'],
 ];
 
@@ -80,6 +83,60 @@ test('a URI pipeline can be built for an https source', { skip }, () => {
     assert.ok(pipeline, 'parse_launch returned nothing for the http source pipeline');
     assert.ok(pipeline.get_by_name('src'), 'souphttpsrc is not addressable in the built pipeline');
     pipeline.set_state(Gst.State.NULL);
+});
+
+// THE EFFECT, NOT THE PAYLOAD — and the questions above cannot reach it. Naming a factory
+// says a plugin loaded; what `playbin3` and every other URI element consult is the
+// registry's URI HANDLER table, and an app never asks for `souphttpsrc` by name. It hands
+// over a URI. Measured on win32-x64 0.45.0, where every element above already resolved:
+// `Gst.uri_protocol_is_supported(SRC, 'https')` was FALSE and `playbin3.set_state(PAUSED)`
+// on an https URI returned FAILURE outright, while a playable `file://` URI went ASYNC.
+//
+// OFFLINE, and it has to be. `set_state(PAUSED)` returns once the state change has
+// STARTED: the source element is looked up and created synchronously, its connection is
+// not. So the assertion is settled before the host would be asked for `example.invalid`,
+// and the pipeline is torn down on the next line either way.
+const NO_SUCH_SCHEME = 'gjsify-no-such-scheme';
+
+test('the registry can actually open an https URI, not merely name the element', { skip }, () => {
+    assert.equal(
+        Gst.uri_protocol_is_supported(Gst.URIType.SRC, 'https'),
+        true,
+        'no registered element handles the https URI scheme. This is the table playbin3 and ' +
+            'uridecodebin3 resolve a URI through — an element that exists but is not registered as a ' +
+            'URI handler is invisible to every one of them.',
+    );
+    assert.equal(Gst.uri_protocol_is_supported(Gst.URIType.SRC, 'file'), true, 'file:// regressed');
+    // The discriminator for the line above: a table that answered `true` to everything
+    // would satisfy it while measuring nothing.
+    assert.equal(Gst.uri_protocol_is_supported(Gst.URIType.SRC, NO_SUCH_SCHEME), false);
+});
+
+test('playbin3 accepts an https URI, and refuses one nothing handles', { skip }, () => {
+    // End to end, in the shape an app writes: hand playbin3 a URI and start it. The second
+    // leg is the control, and it is a scheme rather than a missing file — a `file://` URI
+    // that does not exist ALSO returns FAILURE (measured), so it would prove the assertion
+    // can fail without proving it fails for the reason claimed.
+    const stateChangeFor = (uri) => {
+        const playbin = Gst.ElementFactory.make('playbin3', null);
+        assert.ok(playbin, 'playbin3 did not resolve');
+        playbin.set_property('uri', uri);
+        const change = playbin.set_state(Gst.State.PAUSED);
+        playbin.set_state(Gst.State.NULL);
+        return change;
+    };
+    assert.notEqual(
+        stateChangeFor('https://example.invalid/stream.mp3'),
+        Gst.StateChangeReturn.FAILURE,
+        'playbin3 refused an https URI at READY -> PAUSED, which is what a bundle with no source element ' +
+            'for the scheme does: uridecodebin3 finds no handler and fails the state change synchronously, ' +
+            'with nothing on the bus an app could tell apart from a network fault.',
+    );
+    assert.equal(
+        stateChangeFor(`${NO_SUCH_SCHEME}://host/stream.mp3`),
+        Gst.StateChangeReturn.FAILURE,
+        'playbin3 accepted a URI scheme no element handles, so the assertion above proves nothing',
+    );
 });
 
 // NOT a network test, and deliberately not one: it asks whether the bundle carries a TLS

--- a/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
@@ -33,6 +33,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
     REQUIRED_NAMESPACES,
     WINDOWING_REQUIRED_NAMESPACES,
@@ -54,8 +55,11 @@ import {
     verifyWindowingData,
 } from '../../scripts/bundle-data.mjs';
 import {
+    WIN32_LICENSE_FAMILIES,
     assertLicenseCoverage,
     describeBrewKegs,
+    formatLicenseProblems,
+    licenseFamilyFor,
     parseBrewLicenseStanza,
     renderThirdPartyNotice,
     scanLicenseFiles,
@@ -514,6 +518,313 @@ test('a prefix-attributed notice says so instead of implying a per-binary mappin
     assert.match(notice, /not recoverable/);
     assert.match(notice, /None\. The libraries are byte-identical copies/);
     assert.ok(notice.includes('gtk-4-1.dll'));
+});
+
+// --- win32 license COVERAGE, driven from the measured bundle -------------------
+//
+// THE DEFECT UNDER TEST, measured on this branch's own `gtk-runtime-win32-x64` and
+// `…-windowing` CI artifacts rather than reasoned about: 65 DLLs in `bin/` plus 24
+// loadable modules, against 45 projects the gvsbuild prefix documents. Eight of the
+// projects behind fourteen of those binaries are documented nowhere — `libglib`,
+// `libgobject` and `libgio` (LGPL-2.1-or-later) and `libcrypto`/`libssl` (Apache-2.0,
+// whose § 4 requires the license to travel with the binary) shipped with no terms at
+// all. Every gate was green, because `assertLicenseCoverage` ran its per-binary rules
+// only under `per-binary` attribution while the win32 call passes `prefix`: what it
+// actually asserted was "at least one license text was recovered", which a corpus of one
+// file satisfies.
+//
+// The lists below are the artifacts' own file names. They are fixtures on purpose — the
+// builders run on no machine a developer has, so this is the only place the family table
+// meets a real bundle before a release does.
+
+/** `bin/` of the `--windowing` artifact; the display-free bundle's 37 are a subset. */
+const WIN32_BUNDLED_DLLS = [
+    'adwaita-1-0.dll',
+    'cairo-2.dll',
+    'cairo-gobject-2.dll',
+    'cairo-script-interpreter-2.dll',
+    'comerr64.dll',
+    'epoxy-0.dll',
+    'ffi-8.dll',
+    'fontconfig-1.dll',
+    'freetype-6.dll',
+    'fribidi-0.dll',
+    'gdk_pixbuf-2.0-0.dll',
+    'gio-2.0-0.dll',
+    'girepository-1.0-1.dll',
+    'girepository-2.0-0.dll',
+    'glib-2.0-0.dll',
+    'gmodule-2.0-0.dll',
+    'gobject-2.0-0.dll',
+    'graphene-1.0-0.dll',
+    'gssapi64.dll',
+    'gstapp-1.0-0.dll',
+    'gstaudio-1.0-0.dll',
+    'gstbase-1.0-0.dll',
+    'gstpbutils-1.0-0.dll',
+    'gstreamer-1.0-0.dll',
+    'gstriff-1.0-0.dll',
+    'gstrtp-1.0-0.dll',
+    'gsttag-1.0-0.dll',
+    'gstvideo-1.0-0.dll',
+    'gtk-4-1.dll',
+    'gtksourceview-5-0.dll',
+    'harfbuzz-cairo.dll',
+    'harfbuzz-gobject.dll',
+    'harfbuzz-gpu.dll',
+    'harfbuzz-icu.dll',
+    'harfbuzz-raster.dll',
+    'harfbuzz-subset.dll',
+    'harfbuzz-vector.dll',
+    'harfbuzz.dll',
+    'iconv.dll',
+    'icudt78.dll',
+    'icuuc78.dll',
+    'intl.dll',
+    'jpeg62.dll',
+    'k5sprt64.dll',
+    'krb5_64.dll',
+    'libcrypto-3-x64.dll',
+    'libexpat.dll',
+    'libpng16.dll',
+    'libssl-3-x64.dll',
+    'nghttp2.dll',
+    'opus-0.dll',
+    'orc-0.4-0.dll',
+    'pango-1.0-0.dll',
+    'pangocairo-1.0-0.dll',
+    'pangoft2-1.0-0.dll',
+    'pangowin32-1.0-0.dll',
+    'pcre2-8-0.dll',
+    'pixman-1-0.dll',
+    'psl-5.dll',
+    'rsvg-2-2.dll',
+    'soup-3.0-0.dll',
+    'sqlite3.dll',
+    'tiff.dll',
+    'xml2-16.dll',
+    'zlib1.dll',
+];
+
+/** The loadable modules under `lib/` — GIO modules, GStreamer plugins, pixbuf loaders. */
+const WIN32_MODULE_DLLS = [
+    'giognomeproxy.dll',
+    'gioopenssl.dll',
+    'gstalaw.dll',
+    'gstapp.dll',
+    'gstaudioconvert.dll',
+    'gstaudiomixer.dll',
+    'gstaudioparsers.dll',
+    'gstaudiorate.dll',
+    'gstaudioresample.dll',
+    'gstaudiotestsrc.dll',
+    'gstauparse.dll',
+    'gstautodetect.dll',
+    'gstcoreelements.dll',
+    'gstdirectsound.dll',
+    'gstisomp4.dll',
+    'gstmulaw.dll',
+    'gstogg.dll',
+    'gstopus.dll',
+    'gstplayback.dll',
+    'gstsoup.dll',
+    'gsttypefindfunctions.dll',
+    'gstvolume.dll',
+    'gstwavparse.dll',
+    'pixbufloader_svg.dll',
+];
+
+/** What the gvsbuild prefix documents — the 45 directories under the artifact's `licenses/`. */
+const WIN32_PREFIX_COMPONENTS = [
+    'adwaita-icon-theme',
+    'cairo',
+    'cairomm',
+    'directx-headers',
+    'expat',
+    'fontconfig',
+    'fribidi',
+    'gdk-pixbuf',
+    'gettext',
+    'glib-networking',
+    'glibmm',
+    'gperf',
+    'gsettings-desktop-schemas',
+    'gst-plugins-base',
+    'gst-plugins-good',
+    'gstreamer',
+    'gtk4',
+    'gtkmm',
+    'gtksourceview5',
+    'harfbuzz',
+    'icu',
+    'libadwaita',
+    'libepoxy',
+    'libffi',
+    'libjpeg-turbo',
+    'libpng',
+    'libpsl',
+    'librsvg',
+    'libsigc++',
+    'libsoup3',
+    'libyuv',
+    'mit-kerberos',
+    'nghttp2',
+    'ogg',
+    'opus',
+    'orc',
+    'pango',
+    'pcre2',
+    'pixman',
+    'pkgconf',
+    'protobuf',
+    'protobuf-c',
+    'pycairo',
+    'pygobject',
+    'win-iconv',
+];
+
+const WIN32_SHIPPED_BINARIES = [...WIN32_BUNDLED_DLLS, ...WIN32_MODULE_DLLS];
+const VENDORED_LICENSE_ROOT = fileURLToPath(
+    new URL('../../gtk-runtime-win32-x64/licenses-not-in-prefix', import.meta.url),
+);
+
+/** The corpus shape the win32 builder derives: one component per documented project. */
+function corpusOf(names) {
+    return names.map((name) => ({ name, texts: [{ file: 'COPYING' }] }));
+}
+
+/** The builder's merge rule: the prefix is authoritative, a vendored text fills only gaps. */
+function vendoredComponents(documentedByPrefix, binaries) {
+    const needed = new Set(
+        binaries.flatMap((leaf) => licenseFamilyFor(leaf, WIN32_LICENSE_FAMILIES)?.components ?? []),
+    );
+    const byComponent = new Map();
+    for (const text of scanLicenseFiles({ root: VENDORED_LICENSE_ROOT, subdirs: ['.'], maxDepth: 2 })) {
+        if (documentedByPrefix.has(text.component) || !needed.has(text.component)) continue;
+        if (!byComponent.has(text.component)) byComponent.set(text.component, { name: text.component, texts: [] });
+        byComponent.get(text.component).texts.push(text);
+    }
+    return [...byComponent.values()];
+}
+
+test('every binary the win32 bundle ships belongs to a declared license family', () => {
+    const orphans = WIN32_SHIPPED_BINARIES.filter((leaf) => !licenseFamilyFor(leaf, WIN32_LICENSE_FAMILIES));
+    assert.deepEqual(orphans, [], 'a bundled DLL whose project nothing names cannot have its terms shipped');
+    // Not a rubber stamp either: a library the bundle does not carry has no entry, so the
+    // next gvsbuild bump that adds one fails by name instead of shipping unlicensed.
+    for (const stranger of ['libvpx-1.dll', 'x264-164.dll', 'avcodec-61.dll']) {
+        assert.equal(licenseFamilyFor(stranger, WIN32_LICENSE_FAMILIES), null, `${stranger} must not match`);
+    }
+    // And it must name the RIGHT project wherever the leaf name does not say it.
+    const familyOf = (leaf) => licenseFamilyFor(leaf, WIN32_LICENSE_FAMILIES).components.join('+');
+    assert.equal(familyOf('intl.dll'), 'gettext');
+    assert.equal(familyOf('iconv.dll'), 'win-iconv');
+    assert.equal(familyOf('harfbuzz-icu.dll'), 'harfbuzz', 'the ICU-linked harfbuzz shard is still harfbuzz');
+    assert.equal(familyOf('libcrypto-3-x64.dll'), 'openssl');
+    assert.equal(familyOf('girepository-2.0-0.dll'), 'glib', 'girepository moved into glib at 2.80');
+    assert.equal(familyOf('pixbufloader_svg.dll'), 'librsvg');
+    assert.equal(familyOf('gstsoup.dll'), 'gstreamer+gst-plugins-base+gst-plugins-good');
+});
+
+test('the win32 gate fails on the state that actually shipped', () => {
+    // The published bundle, replayed: its binaries against the corpus its prefix
+    // documents, with nothing filling the gaps. Every problem below was invisible before,
+    // because the prefix branch never looked at a binary at all.
+    const problems = assertLicenseCoverage({
+        components: corpusOf(WIN32_PREFIX_COMPONENTS),
+        binaries: WIN32_SHIPPED_BINARIES,
+        attribution: 'prefix',
+        textCount: WIN32_PREFIX_COMPONENTS.length,
+        families: WIN32_LICENSE_FAMILIES,
+    });
+    const undocumented = new Set(problems.map((p) => /no license text ships for (.+)$/.exec(p)?.[1]));
+    assert.deepEqual(
+        [...undocumented].sort(),
+        ['freetype', 'glib', 'graphene', 'libtiff', 'libxml2', 'openssl', 'sqlite', 'zlib'],
+        'the eight projects the gvsbuild prefix builds binaries from and documents no terms for',
+    );
+    assert.match(problems.join('\n'), /libcrypto-3-x64\.dll is openssl, and no license text ships for openssl/);
+    assert.match(problems.join('\n'), /libssl-3-x64\.dll is openssl/);
+    // Not only the payload this branch adds: GLib is six of the bundle's DLLs and has been
+    // unlicensed in every published win32 tarball.
+    assert.match(problems.join('\n'), /gio-2\.0-0\.dll is glib, and no license text ships for glib/);
+});
+
+test('the vendored texts close exactly that gap, and removing one reopens it', () => {
+    // Drives the REAL directory beside the win32 builder, not a fixture: a text deleted,
+    // renamed past the scanner or emptied goes red HERE rather than on a Windows runner.
+    const documentedByPrefix = new Set(WIN32_PREFIX_COMPONENTS);
+    const vendored = vendoredComponents(documentedByPrefix, WIN32_SHIPPED_BINARIES);
+    // The narrowing that keeps this from becoming a corpus of its own: a bundle without
+    // the payload does not carry its terms. The display-free variant ships no OpenSSL.
+    const displayFree = WIN32_BUNDLED_DLLS.filter((leaf) => !/^(lib(crypto|ssl)|sqlite3|xml2)/i.test(leaf));
+    assert.ok(
+        !vendoredComponents(documentedByPrefix, displayFree).some((c) => c.name === 'openssl'),
+        'a variant with no libcrypto must not ship OpenSSL terms',
+    );
+    assert.deepEqual(
+        vendored.map((c) => c.name).sort(),
+        ['freetype', 'glib', 'graphene', 'libtiff', 'libxml2', 'openssl', 'sqlite', 'zlib'],
+        'the vendored corpus covers the prefix gap and nothing else',
+    );
+    for (const component of vendored) {
+        assert.ok(component.texts.length > 0, `${component.name} ships no text`);
+        for (const text of component.texts) assert.ok(text.bytes > 0, `${text.relative} is empty`);
+    }
+
+    const components = [...corpusOf(WIN32_PREFIX_COMPONENTS), ...vendored];
+    assert.deepEqual(
+        assertLicenseCoverage({
+            components,
+            binaries: WIN32_SHIPPED_BINARIES,
+            attribution: 'prefix',
+            textCount: components.length,
+            families: WIN32_LICENSE_FAMILIES,
+        }),
+        [],
+        'with the gap filled, every shipped binary has its terms',
+    );
+
+    // The control that says the check measures something: take OpenSSL back out and the
+    // two DLLs this branch adds are named again — and only those two.
+    const withoutOpenssl = components.filter((c) => c.name !== 'openssl');
+    const problems = assertLicenseCoverage({
+        components: withoutOpenssl,
+        binaries: WIN32_SHIPPED_BINARIES,
+        attribution: 'prefix',
+        textCount: withoutOpenssl.length,
+        families: WIN32_LICENSE_FAMILIES,
+    });
+    assert.deepEqual(
+        problems.map((p) => p.split(' ')[0]).sort(),
+        ['libcrypto-3-x64.dll', 'libssl-3-x64.dll'],
+        'the gate points at the binary, not at the corpus',
+    );
+    assert.match(formatLicenseProblems(problems, { prefix: 'C:\\gtk-build' }), /licenses-not-in-prefix/);
+});
+
+test('prefix attribution with no family table is itself the defect', () => {
+    // The exact shape that shipped: `attribution: 'prefix'` and nothing to relate a binary
+    // to a component with. It must not be able to read as "checked".
+    const problems = assertLicenseCoverage({
+        components: corpusOf(WIN32_PREFIX_COMPONENTS),
+        binaries: WIN32_SHIPPED_BINARIES,
+        attribution: 'prefix',
+        textCount: 45,
+    });
+    assert.match(problems.join('\n'), /no license family table/);
+});
+
+test('a component named in the corpus but shipping no text is not documented', () => {
+    // `share/doc/openssl/` existing and empty is not a license. The gate keys on TEXTS.
+    const problems = assertLicenseCoverage({
+        components: [{ name: 'openssl', texts: [] }],
+        binaries: ['libcrypto-3-x64.dll'],
+        attribution: 'prefix',
+        textCount: 1,
+        families: WIN32_LICENSE_FAMILIES,
+    });
+    assert.match(problems.join('\n'), /libcrypto-3-x64\.dll is openssl, and no license text ships for openssl/);
 });
 
 // --- runtime data portability -----------------------------------------------

--- a/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
@@ -27,6 +27,7 @@ import {
     lstatSync,
     mkdirSync,
     mkdtempSync,
+    readFileSync,
     readdirSync,
     symlinkSync,
     writeFileSync,
@@ -63,6 +64,7 @@ import {
     parseBrewLicenseStanza,
     renderThirdPartyNotice,
     scanLicenseFiles,
+    upstreamLicenseComponents,
 } from '../../scripts/bundle-licenses.mjs';
 import {
     GL_IMPLEMENTATION_PATTERNS,
@@ -524,12 +526,12 @@ test('a prefix-attributed notice says so instead of implying a per-binary mappin
 //
 // THE DEFECT UNDER TEST, measured on this branch's own `gtk-runtime-win32-x64` and
 // `…-windowing` CI artifacts rather than reasoned about: 65 DLLs in `bin/` plus 24
-// loadable modules, against 45 projects the gvsbuild prefix documents. Eight of the
-// projects behind fourteen of those binaries are documented nowhere — `libglib`,
-// `libgobject` and `libgio` (LGPL-2.1-or-later) and `libcrypto`/`libssl` (Apache-2.0,
-// whose § 4 requires the license to travel with the binary) shipped with no terms at
-// all. Every gate was green, because `assertLicenseCoverage` ran its per-binary rules
-// only under `per-binary` attribution while the win32 call passes `prefix`: what it
+// loadable modules and one executable, against 45 projects the gvsbuild prefix documents.
+// Nine of the projects behind fourteen of those binaries are documented nowhere —
+// `libglib`, `libgobject` and `libgio` (LGPL-2.1-or-later) and `libcrypto`/`libssl`
+// (Apache-2.0, whose § 4 requires the license to travel with the binary) shipped with no
+// terms at all. Every gate was green, because `assertLicenseCoverage` ran its per-binary
+// rules only under `per-binary` attribution while the win32 call passes `prefix`: what it
 // actually asserted was "at least one license text was recovered", which a corpus of one
 // file satisfies.
 //
@@ -634,6 +636,14 @@ const WIN32_MODULE_DLLS = [
     'pixbufloader_svg.dll',
 ];
 
+/**
+ * The bundle's one non-library binary, in `libexec/`. It is its own list because it is the
+ * category the first coverage set MISSED: not a flat `bin/` entry and not a module, so
+ * neither of the two lists the builder assembled reached it, and the 90th binary in the
+ * tarball went unchecked while the notice claimed to cover every one.
+ */
+const WIN32_EXECUTABLES = ['gst-plugin-scanner.exe'];
+
 /** What the gvsbuild prefix documents — the 45 directories under the artifact's `licenses/`. */
 const WIN32_PREFIX_COMPONENTS = [
     'adwaita-icon-theme',
@@ -683,47 +693,74 @@ const WIN32_PREFIX_COMPONENTS = [
     'win-iconv',
 ];
 
-const WIN32_SHIPPED_BINARIES = [...WIN32_BUNDLED_DLLS, ...WIN32_MODULE_DLLS];
-const VENDORED_LICENSE_ROOT = fileURLToPath(
+const WIN32_SHIPPED_BINARIES = [...WIN32_BUNDLED_DLLS, ...WIN32_MODULE_DLLS, ...WIN32_EXECUTABLES];
+const WIN32_VENDORED_ROOT = fileURLToPath(
     new URL('../../gtk-runtime-win32-x64/licenses-not-in-prefix', import.meta.url),
 );
+
+/** The projects the prefix builds binaries from and documents no terms for — the whole gap. */
+const WIN32_UNDOCUMENTED_BY_PREFIX = [
+    'freetype',
+    'glib',
+    'gobject-introspection',
+    'graphene',
+    'libtiff',
+    'libxml2',
+    'openssl',
+    'sqlite',
+    'zlib',
+];
+const WIN32_UNDOCUMENTED_WHY =
+    'the nine projects the gvsbuild prefix builds binaries from and documents no terms for — ' +
+    'exactly the set licenses-not-in-prefix/ vendors, so the two lists are held against each other';
 
 /** The corpus shape the win32 builder derives: one component per documented project. */
 function corpusOf(names) {
     return names.map((name) => ({ name, texts: [{ file: 'COPYING' }] }));
 }
 
-/** The builder's merge rule: the prefix is authoritative, a vendored text fills only gaps. */
+/**
+ * The builder's own merge, called the way the builder calls it. NOT re-implemented here:
+ * a test that reproduces the rule it is checking stays green while the rule changes under
+ * it, which is how the coverage gate itself came to assert nothing.
+ */
 function vendoredComponents(documentedByPrefix, binaries) {
-    const needed = new Set(
-        binaries.flatMap((leaf) => licenseFamilyFor(leaf, WIN32_LICENSE_FAMILIES)?.components ?? []),
-    );
-    const byComponent = new Map();
-    for (const text of scanLicenseFiles({ root: VENDORED_LICENSE_ROOT, subdirs: ['.'], maxDepth: 2 })) {
-        if (documentedByPrefix.has(text.component) || !needed.has(text.component)) continue;
-        if (!byComponent.has(text.component)) byComponent.set(text.component, { name: text.component, texts: [] });
-        byComponent.get(text.component).texts.push(text);
-    }
-    return [...byComponent.values()];
+    return upstreamLicenseComponents({
+        root: WIN32_VENDORED_ROOT,
+        documented: documentedByPrefix,
+        binaries,
+        families: WIN32_LICENSE_FAMILIES,
+    });
 }
 
 test('every binary the win32 bundle ships belongs to a declared license family', () => {
     const orphans = WIN32_SHIPPED_BINARIES.filter((leaf) => !licenseFamilyFor(leaf, WIN32_LICENSE_FAMILIES));
-    assert.deepEqual(orphans, [], 'a bundled DLL whose project nothing names cannot have its terms shipped');
+    assert.deepEqual(orphans, [], 'a bundled binary whose project nothing names cannot have its terms shipped');
     // Not a rubber stamp either: a library the bundle does not carry has no entry, so the
     // next gvsbuild bump that adds one fails by name instead of shipping unlicensed.
     for (const stranger of ['libvpx-1.dll', 'x264-164.dll', 'avcodec-61.dll']) {
         assert.equal(licenseFamilyFor(stranger, WIN32_LICENSE_FAMILIES), null, `${stranger} must not match`);
     }
-    // And it must name the RIGHT project wherever the leaf name does not say it.
+    // And it must name the RIGHT project wherever the leaf name does not say it. A wrong
+    // name is worse than a missing one: it ships another project's terms under a positive
+    // claim, and the notice reads as complete.
     const familyOf = (leaf) => licenseFamilyFor(leaf, WIN32_LICENSE_FAMILIES).components.join('+');
     assert.equal(familyOf('intl.dll'), 'gettext');
     assert.equal(familyOf('iconv.dll'), 'win-iconv');
     assert.equal(familyOf('harfbuzz-icu.dll'), 'harfbuzz', 'the ICU-linked harfbuzz shard is still harfbuzz');
     assert.equal(familyOf('libcrypto-3-x64.dll'), 'openssl');
-    assert.equal(familyOf('girepository-2.0-0.dll'), 'glib', 'girepository moved into glib at 2.80');
     assert.equal(familyOf('pixbufloader_svg.dll'), 'librsvg');
     assert.equal(familyOf('gstsoup.dll'), 'gstreamer+gst-plugins-base+gst-plugins-good');
+    assert.equal(familyOf('gst-plugin-scanner.exe'), 'gstreamer', 'the bundle ships one .exe and it is gstreamer`s');
+    // TWO leaves, TWO projects. glib 2.80 took girepository-2.0 in; gobject-introspection
+    // still builds the 1.0 library and gvsbuild still installs it, so one pattern for both
+    // named glib as the project behind a gobject-introspection binary.
+    assert.equal(familyOf('girepository-2.0-0.dll'), 'glib', 'girepository-2.0 moved into glib at 2.80');
+    assert.equal(
+        familyOf('girepository-1.0-1.dll'),
+        'gobject-introspection',
+        'the 1.0 library is still gobject-introspection`s own, and the bundle ships both',
+    );
 });
 
 test('the win32 gate fails on the state that actually shipped', () => {
@@ -738,14 +775,11 @@ test('the win32 gate fails on the state that actually shipped', () => {
         families: WIN32_LICENSE_FAMILIES,
     });
     const undocumented = new Set(problems.map((p) => /no license text ships for (.+)$/.exec(p)?.[1]));
-    assert.deepEqual(
-        [...undocumented].sort(),
-        ['freetype', 'glib', 'graphene', 'libtiff', 'libxml2', 'openssl', 'sqlite', 'zlib'],
-        'the eight projects the gvsbuild prefix builds binaries from and documents no terms for',
-    );
+    assert.deepEqual([...undocumented].sort(), WIN32_UNDOCUMENTED_BY_PREFIX, WIN32_UNDOCUMENTED_WHY);
+    assert.equal(problems.length, 14, 'fourteen binaries, replayed off the artifact');
     assert.match(problems.join('\n'), /libcrypto-3-x64\.dll is openssl, and no license text ships for openssl/);
     assert.match(problems.join('\n'), /libssl-3-x64\.dll is openssl/);
-    // Not only the payload this branch adds: GLib is six of the bundle's DLLs and has been
+    // Not only the payload this branch adds: GLib is five of the bundle's DLLs and has been
     // unlicensed in every published win32 tarball.
     assert.match(problems.join('\n'), /gio-2\.0-0\.dll is glib, and no license text ships for glib/);
 });
@@ -764,7 +798,7 @@ test('the vendored texts close exactly that gap, and removing one reopens it', (
     );
     assert.deepEqual(
         vendored.map((c) => c.name).sort(),
-        ['freetype', 'glib', 'graphene', 'libtiff', 'libxml2', 'openssl', 'sqlite', 'zlib'],
+        WIN32_UNDOCUMENTED_BY_PREFIX,
         'the vendored corpus covers the prefix gap and nothing else',
     );
     for (const component of vendored) {
@@ -825,6 +859,44 @@ test('a component named in the corpus but shipping no text is not documented', (
         families: WIN32_LICENSE_FAMILIES,
     });
     assert.match(problems.join('\n'), /libcrypto-3-x64\.dll is openssl, and no license text ships for openssl/);
+});
+
+test('the vendored corpus records where each text came from, and to which gvsbuild pin', () => {
+    // The one thing the coverage gate CANNOT see: a vendored text is a copy of an upstream
+    // release, and the release it copies is chosen by the gvsbuild pin the workflows build
+    // with. Move the pin and these texts silently describe a different version — no binary
+    // is missing, no family is unclaimed, and every other check here stays green. So the
+    // pin is recorded next to the texts and held against the workflows that use it.
+    const provenance = JSON.parse(readFileSync(join(WIN32_VENDORED_ROOT, 'provenance.json'), 'utf8'));
+    const directories = readdirSync(WIN32_VENDORED_ROOT, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name)
+        .sort();
+    assert.deepEqual(
+        directories,
+        Object.keys(provenance.components).sort(),
+        'every vendored directory needs a recorded upstream version, and every record a directory',
+    );
+    // And the set is the gap itself, not a list that drifted away from it.
+    assert.deepEqual(directories, WIN32_UNDOCUMENTED_BY_PREFIX, WIN32_UNDOCUMENTED_WHY);
+
+    const workflows = ['release.yml', 'node-gi.yml'].map((name) =>
+        readFileSync(fileURLToPath(new URL(`../../../../.github/workflows/${name}`, import.meta.url)), 'utf8'),
+    );
+    for (const [i, yaml] of workflows.entries()) {
+        const pins = [...yaml.matchAll(/GVSBUILD_VERSION:\s*'([^']+)'/g)].map((m) => m[1]);
+        assert.ok(pins.length > 0, `workflow ${i} declares no GVSBUILD_VERSION — the pattern moved`);
+        for (const pin of new Set(pins)) {
+            assert.equal(
+                pin,
+                provenance.gvsbuild,
+                `gvsbuild is pinned at ${pin} but licenses-not-in-prefix/ was taken from ${provenance.gvsbuild}. ` +
+                    'Re-take the texts from the new pin (their upstream versions are in provenance.json) and ' +
+                    'update both — do NOT just move the pin: the bundle would then ship one release of a ' +
+                    "library under another release's terms.",
+            );
+        }
+    }
 });
 
 // --- runtime data portability -----------------------------------------------

--- a/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
@@ -594,7 +594,14 @@ test('findSymlinks reports a DANGLING link too, and an absent tree is empty', ()
 // on the bad input — one per declared set, plus the vacuous shapes.
 
 /** A complete windowing data tree, the shape both builders produce. */
-function windowingBundle({ schemas = true, icons = true, gtksource = true, iconIndex = true, loaders = true } = {}) {
+function windowingBundle({
+    schemas = true,
+    icons = true,
+    gtksource = true,
+    iconIndex = true,
+    loaders = true,
+    gioModules = true,
+} = {}) {
     const root = fixtureDir();
     if (schemas) {
         mkdirSync(join(root, 'share/glib-2.0/schemas'), { recursive: true });
@@ -610,7 +617,18 @@ function windowingBundle({ schemas = true, icons = true, gtksource = true, iconI
         writeFileSync(join(root, 'share/gtksourceview-5/language-specs/language2.rng'), '<grammar/>');
     }
     if (loaders) writePixbufLoaders(root);
+    if (gioModules) writeGioModules(root);
     return root;
+}
+
+/**
+ * The GIO TLS backend module both builders ship. Leaf differs per platform (brew names it
+ * `libgiognutls.so`, gvsbuild `gioopenssl.dll`), so the set requires ONE non-empty file in
+ * the dir and never a name.
+ */
+function writeGioModules(root, { module = 'libgiognutls.so' } = {}) {
+    mkdirSync(join(root, 'lib/gio/modules'), { recursive: true });
+    writeFileSync(join(root, `lib/gio/modules/${module}`), 'module');
 }
 
 /**
@@ -638,7 +656,7 @@ test('a complete windowing bundle passes, and every set is REPORTED as applied',
     assert.deepEqual(result.problems, []);
     assert.deepEqual(
         result.applied.map((a) => a.id),
-        ['schemas', 'icons', 'pixbuf-loaders', 'gtksource'],
+        ['schemas', 'icons', 'pixbuf-loaders', 'gtksource', 'tls-backend'],
     );
     // Positive counts, not merely "no complaints": every applied set found real files.
     for (const applied of result.applied) assert.ok(applied.files > 0, `${applied.id} counted no file`);
@@ -650,6 +668,7 @@ test('a missing declared data set FAILS — one case per set', () => {
         ['icons', /icons: nothing matches share\/icons\/\*\/index\.theme/],
         ['gtksource', /gtksource: share\/gtksourceview-5\/ holds no non-empty file/],
         ['loaders', /pixbuf-loaders: lib\/gdk-pixbuf-2\.0\/2\.10\.0\/loaders\.cache is missing or empty/],
+        ['gioModules', /tls-backend: nothing matches lib\/gio\/modules\/\*/],
     ]) {
         const result = verifyWindowingData({
             bundleDir: windowingBundle({ [absent]: false }),
@@ -683,6 +702,7 @@ test('an icon theme with an index but NO icons fails the second half of the set'
     writeFileSync(join(root, 'share/icons/Adwaita/index.theme'), ''); // empty index — no theme
     writeFileSync(join(root, 'share/gtksourceview-5/language.dtd'), '<!ELEMENT x EMPTY>');
     writePixbufLoaders(root); // present, so the count below is about the ICONS set alone
+    writeGioModules(root); // ditto — the TLS backend set applies to every Gio-shipping bundle
     const result = verifyWindowingData({ bundleDir: root, shippedNamespaces: GTK_NAMESPACES });
     assert.equal(result.problems.length, 2, 'both the index glob and the tree count must complain');
     assert.match(result.problems.join('\n'), /nothing matches share\/icons\/\*\/index\.theme/);
@@ -703,7 +723,7 @@ test('a set is required by the NAMESPACE the bundle ships, not by a flag', () =>
     assert.deepEqual(result.problems, []);
     assert.deepEqual(
         result.applied.map((a) => a.id),
-        ['schemas', 'icons'],
+        ['schemas', 'icons', 'tls-backend'],
     );
     assert.deepEqual(result.skipped, [
         { id: 'pixbuf-loaders', namespace: 'GdkPixbuf' },

--- a/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
@@ -898,6 +898,24 @@ test('win32 folds case, darwin does not — bin/ is a Windows directory', () => 
     );
 });
 
+test("BOTH builders' actual argument shapes work — darwin a Set, win32 a Map iterator", () => {
+    // Not a style point: win32 holds its closure as a Map of leaf -> source path, so the
+    // call site passes `binDlls.values()`. Passing the Map ITSELF yields [k, v] pairs and
+    // throws on .replace — caught in review, and only ever on a Windows runner otherwise.
+    const darwin = new Set(['libglib-2.0.0.dylib', 'libgstsoup.dylib']);
+    assert.deepEqual(duplicatedModuleLeaves(darwin, ['/b/lib/gstreamer-1.0/libgstsoup.dylib']), ['libgstsoup.dylib']);
+    const win32 = new Map([
+        ['glib-2.0-0.dll', 'C:\\gtk\\bin\\glib-2.0-0.dll'],
+        ['gstsoup.dll', 'C:\\gtk\\bin\\gstsoup.dll'],
+    ]);
+    assert.deepEqual(
+        duplicatedModuleLeaves(win32.values(), ['C:\\b\\lib\\gstreamer-1.0\\gstsoup.dll'], {
+            caseInsensitive: true,
+        }),
+        ['gstsoup.dll'],
+    );
+});
+
 test('the operator message names the leaves and refuses the tempting repair', () => {
     const message = formatDuplicatedModuleProblems(['libgstsoup.dylib'], { flatDir: '/b/lib' });
     assert.match(message, /MODULES DUPLICATED INTO \/b\/lib — 1 leaf/);

--- a/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
@@ -46,7 +46,9 @@ import {
 import {
     WINDOWING_DATA_SETS,
     copyTreeDereferenced,
+    duplicatedModuleLeaves,
     findSymlinks,
+    formatDuplicatedModuleProblems,
     formatSymlinkProblems,
     formatWindowingDataProblems,
     verifyWindowingData,
@@ -849,3 +851,57 @@ function nativeLibraryIndexOf(names, caseInsensitive) {
     for (const name of names) writeFileSync(join(dir, name), '');
     return nativeLibraryIndex(dir, { caseInsensitive });
 }
+
+// --- rule 3: a module must not ALSO be a flat library entry -------------------
+// The gate that would have caught the 24 duplicated GStreamer plugins. Every other gate
+// was green on that bundle: the count checks counted the module dir, `verifyRelocation`
+// verified BOTH copies (each was correctly relocated), and the typelib symmetry check
+// looks at libraries, not plugins. A correct extra copy is invisible to all of them.
+
+test('a module placed in its own dir and NOT in the flat dir is clean', () => {
+    assert.deepEqual(
+        duplicatedModuleLeaves(
+            ['libglib-2.0.0.dylib', 'libgstreamer-1.0.0.dylib'],
+            ['/b/lib/gstreamer-1.0/libgstsoup.dylib', '/b/lib/gio/modules/libgiognutls.so'],
+        ),
+        [],
+    );
+});
+
+test('the SAME leaf in both places is reported — the 24-plugin defect', () => {
+    // Exactly the shape the darwin artifact had: the plugin under lib/gstreamer-1.0/ AND
+    // a second copy in flat lib/, because the walk resolved the plugin's own install name.
+    assert.deepEqual(
+        duplicatedModuleLeaves(
+            ['libglib-2.0.0.dylib', 'libgstsoup.dylib', 'libgstplayback.dylib'],
+            ['/b/lib/gstreamer-1.0/libgstsoup.dylib', '/b/lib/gstreamer-1.0/libgstplayback.dylib'],
+        ),
+        ['libgstplayback.dylib', 'libgstsoup.dylib'],
+    );
+});
+
+test('the flat side may be given as PATHS, not only leaves', () => {
+    // darwin passes a Set of leaves, win32 a Set of bin/ file names; neither should have
+    // to normalise at the call site.
+    assert.deepEqual(duplicatedModuleLeaves(['/b/lib/libgstsoup.dylib'], ['/b/lib/gstreamer-1.0/libgstsoup.dylib']), [
+        'libgstsoup.dylib',
+    ]);
+});
+
+test('win32 folds case, darwin does not — bin/ is a Windows directory', () => {
+    assert.deepEqual(duplicatedModuleLeaves(['GstSoup.dll'], ['C:\\b\\lib\\gstreamer-1.0\\gstsoup.dll']), []);
+    assert.deepEqual(
+        duplicatedModuleLeaves(['GstSoup.dll'], ['C:\\b\\lib\\gstreamer-1.0\\gstsoup.dll'], {
+            caseInsensitive: true,
+        }),
+        ['gstsoup.dll'],
+    );
+});
+
+test('the operator message names the leaves and refuses the tempting repair', () => {
+    const message = formatDuplicatedModuleProblems(['libgstsoup.dylib'], { flatDir: '/b/lib' });
+    assert.match(message, /MODULES DUPLICATED INTO \/b\/lib — 1 leaf/);
+    assert.match(message, /libgstsoup\.dylib/);
+    // The repair is at the WALK. Deleting the flat copy afterwards hides the reference.
+    assert.match(message, /Do NOT delete the flat copy as a post-step/);
+});

--- a/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
+++ b/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
@@ -90,7 +90,7 @@ import {
     writeLicensePayload,
 } from './bundle-licenses.mjs';
 import { decodeProbeProblems, spawnDecodeProbe } from './decode-probe.mjs';
-import { isBundledGstPlugin } from './gst-plugins.mjs';
+import { isBundledGstPlugin, missingRequiredGstPlugins } from './gst-plugins.mjs';
 import {
     REQUIRED_NAMESPACES,
     WINDOWING_REQUIRED_NAMESPACES,
@@ -239,6 +239,13 @@ const WINDOWING_SEED_PATTERNS = [
     // build with no audio and no message, the same trace librsvg left above.
     /^libgstreamer-1\.0\..*\.dylib$/,
     /^libgstapp-1\.0\..*\.dylib$/,
+    // libsoup, which `libgstsoup` § 2c ships opens with g_module_open rather than
+    // linking (its loader shim picks libsoup-3 or libsoup-2 at runtime) — so the
+    // plugin's own otool deps are glib + gstreamer and the closure walk finds no soup
+    // at all. Third seed of the librsvg kind, third time the reason is "a module the
+    // walk cannot see"; gst-plugins.mjs § soup carries the measurement. It also backs
+    // `Soup-3.0.typelib`, which § 4's symmetry rule was correctly dropping.
+    /^libsoup-3\.0\..*\.dylib$/,
 ];
 
 function isSystemPath(p) {
@@ -273,6 +280,33 @@ function resolveInBrew(leaf) {
     if (!existsSync(candidate)) return null;
     try {
         return realpathSync(candidate);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Resolve a dependency REFERENCE — the whole string in the Mach-O load command, not just its
+ * leaf — to the real Homebrew file behind it.
+ *
+ * The leaf lookup above is the normal path and stays first: `<prefix>/lib` is where brew links
+ * every non-keg-only formula, and a leaf is all a queued dependency used to carry. It is not
+ * enough for a KEG-ONLY formula, which brew deliberately never links into `lib/` — and the
+ * reference then names the keg directly. Measured while adding libsoup: it links
+ * `/usr/local/opt/sqlite/lib/libsqlite3.dylib`, the leaf lookup found nothing, sqlite never
+ * entered the closure, and § 3 refused the bundle for a reference into the build prefix. That
+ * refusal was correct; resolving the reference where it points is the repair the message asked
+ * for, and it is what makes any future keg-only dependency arrive instead of stopping a build.
+ * Still prefix-scoped: an /opt/X11 or /usr/lib reference stays OS-provided, as § 3 requires.
+ * @param {string} ref a load-command string, or a bare leaf for the seeds
+ * @returns {string|null}
+ */
+function resolveBrewDep(ref) {
+    const linked = resolveInBrew(basename(ref));
+    if (linked) return linked;
+    if (!ref.startsWith(`${brewPrefix}/`) || !existsSync(ref)) return null;
+    try {
+        return realpathSync(ref);
     } catch {
         return null;
     }
@@ -327,22 +361,46 @@ if (WINDOWING) {
     }
 }
 
+// The GIO modules § 2d ships, seeding the walk for the same reason: nothing LINKS a
+// module, so glib-networking's gnutls closure (gnutls, nettle, hogweed, gmp, p11-kit,
+// libtasn1, libidn2, libunistring — 6.67 MiB measured on darwin-x64) enters only here.
+// No filter: the module dir holds implementations of GIO extension points and the
+// bundle wants whichever the prefix installed. `giomodule.cache` is skipped — it
+// indexes the BUILD host's dir, and GIO rebuilds what it needs by scanning.
+const gioModuleSeedPaths = [];
+if (WINDOWING) {
+    const dir = join(brewLib, 'gio', 'modules');
+    if (existsSync(dir)) {
+        for (const f of readdirSync(dir)) {
+            // `.so` on darwin, not `.dylib`: GIO modules are loadable bundles.
+            if (!f.endsWith('.so') && !f.endsWith('.dylib')) continue;
+            const src = join(dir, f);
+            if (!existsSync(src)) continue; // dangling brew link — the keg is gone
+            gioModuleSeedPaths.push(src);
+        }
+    }
+}
+
 const bundled = new Map(); // leaf -> real source path
 const queue = [...seeds];
-// Walk the plugins' deps into the closure WITHOUT adding the plugins themselves to
-// `bundled` — they are not flat lib/ entries, § 2c places and relocates them.
-for (const pluginPath of gstPluginSeedPaths) {
-    for (const dep of otoolDeps(pluginPath)) queue.push(basename(dep));
+// Walk the plugins' and modules' deps into the closure WITHOUT adding the plugins or
+// modules themselves to `bundled` — they are not flat lib/ entries; § 2c and § 2d
+// place and relocate them.
+// The queue carries whole load-command strings, not leaves: a keg-only formula is
+// reachable only through the path its dependent names (see resolveBrewDep). A seed is a
+// bare leaf, which basename() leaves alone.
+for (const pluginPath of [...gstPluginSeedPaths, ...gioModuleSeedPaths]) {
+    for (const dep of otoolDeps(pluginPath)) queue.push(dep);
 }
 while (queue.length) {
-    const leaf = queue.shift();
+    const ref = queue.shift();
+    const leaf = basename(ref);
     if (bundled.has(leaf)) continue;
-    const real = resolveInBrew(leaf);
+    const real = resolveBrewDep(ref);
     if (!real) continue; // system / non-brew dep — leave as-is
     bundled.set(leaf, real);
     for (const dep of otoolDeps(real)) {
-        const depLeaf = basename(dep);
-        if (!bundled.has(depLeaf)) queue.push(depLeaf);
+        if (!bundled.has(basename(dep))) queue.push(dep);
     }
 }
 console.log(`build-gtk-runtime: closure = ${bundled.size} dylibs`);
@@ -596,6 +654,21 @@ if (WINDOWING) {
             );
             process.exit(1);
         }
+        // ZERO IS NEVER RIGHT, one element deeper. The count check above passed on every
+        // published bundle while `souphttpsrc` was absent from all of them, because a
+        // count cannot say WHICH plugin is gone — the same argument gst-elements.test.mjs
+        // names each element for. This asks for the three whose absence is silent.
+        const missingRequired = missingRequiredGstPlugins(gstPluginImages.map((p) => basename(p)));
+        if (missingRequired.length > 0) {
+            console.error(
+                `build-gtk-runtime: ${pluginsSrc} produced no plugin for ${missingRequired.join(', ')} — ` +
+                    'gst-plugins.mjs marks these required because a bundle without them reports a healthy ' +
+                    'Gst.init() and then fails in the application (no appsrc / no decodebin / no source ' +
+                    'element for an http(s) URI). Install the formula that provides it into the build ' +
+                    'prefix; do NOT drop the name from GST_REQUIRED_PLUGINS to get a green build.',
+            );
+            process.exit(1);
+        }
         console.log(
             `build-gtk-runtime: GStreamer — ${gstPluginImages.length} plugin(s) relocated ` +
                 `(@loader_path/..), ${(bytes / 1024 / 1024).toFixed(1)} MiB of plugins` +
@@ -607,6 +680,58 @@ if (WINDOWING) {
             `build-gtk-runtime: WARNING — ${pluginsSrc} missing; no GStreamer plugins bundled ` +
                 '(Gst.init() would succeed and decode nothing)',
         );
+    }
+}
+
+// --- 2d. WINDOWING: the GIO modules (the TLS backend) -----------------------
+// `GTlsConnection` has no implementation in GIO itself: glib-networking ships one as a
+// module and GIO g_module_opens it out of its module dir. The bundle brings its OWN
+// libgio and brought no module, so `g_tls_backend_get_default()` returned the dummy
+// backend and every https request in a bundle-activated process failed — souphttpsrc
+// § 2c reports it as "Internal data stream error", and @gjsify/tls, /http2 and /ws fail
+// the same way one layer up. Measured by emptying the host module dir on darwin-x64.
+//
+// Here rather than in § 4b for § 2b's reason: Mach-O images in a nested dir, so they
+// need the copy → relocate → re-sign pass and § 3 then verifies them. Three levels
+// below the bundle root (lib/gio/modules/), so the deps prefix climbs back to lib/.
+// The dir is a declared `tls-backend` data set (bundle-data.mjs), which is what makes
+// an EMPTY one fail the build in § 4e and the publish in verify-bundle-manifest.mjs.
+const gioModuleImages = []; // absolute paths in the bundle, for § 3
+const gioModuleSources = new Map(); // leaf -> keg realpath, for § 5's attribution
+if (WINDOWING) {
+    const modulesOut = join(OUT, 'lib', 'gio', 'modules');
+    if (gioModuleSeedPaths.length > 0) {
+        mkdirSync(modulesOut, { recursive: true });
+        let bytes = 0;
+        // The SAME list that seeded the closure walk in § 1, for the reason § 2c gives:
+        // the set that was walked and the set that ships cannot disagree.
+        for (const src of gioModuleSeedPaths) {
+            const f = basename(src);
+            const dest = join(modulesOut, f);
+            copyFileSync(src, dest); // dereferencing — a link into the Cellar is worthless in a tarball
+            bytes += statSync(dest).size;
+            gioModuleImages.push(dest);
+            try {
+                gioModuleSources.set(f, realpathSync(src));
+            } catch {
+                gioModuleSources.set(f, src);
+            }
+        }
+        for (const image of gioModuleImages) {
+            relocate(image, { id: true, depPrefix: '@loader_path/../..' });
+        }
+        console.log(
+            `build-gtk-runtime: GIO modules — ${gioModuleImages.length} module(s) relocated ` +
+                `(@loader_path/../..), ${(bytes / 1024).toFixed(0)} KiB`,
+        );
+    } else {
+        console.error(
+            `build-gtk-runtime: ${join(brewLib, 'gio', 'modules')} holds no loadable GIO module — the ` +
+                'bundle would ship its own libgio with no TLS backend behind it, so every https request ' +
+                'gets the dummy backend and fails as a network error rather than as a missing module. ' +
+                'Repair: brew install glib-networking.',
+        );
+        process.exit(1);
     }
 }
 
@@ -654,7 +779,12 @@ function verifyRelocation(paths) {
 // relocation is the harder one (a ../../.. prefix, plus an `@rpath` ref and an absolute
 // LC_ID_DYLIB on librsvg's module), so leaving them out would ship exactly the class of
 // bug this function exists to catch.
-verifyRelocation([...[...bundledLeaves].map((leaf) => join(libOut, leaf)), ...pixbufLoaderImages, ...gstPluginImages]);
+verifyRelocation([
+    ...[...bundledLeaves].map((leaf) => join(libOut, leaf)),
+    ...pixbufLoaderImages,
+    ...gstPluginImages,
+    ...gioModuleImages,
+]);
 
 // --- 4. typelibs — only the ones this bundle can actually BACK --------------
 // The brew typelib dir is shared by every installed formula, so copying it wholesale
@@ -717,6 +847,7 @@ if (typelibPlan.dropped.length > 0) {
 const windowing = {
     pixbufLoaders: pixbufLoaderImages.length, // § 2b
     gstPlugins: gstPluginImages.length, // § 2c
+    gioModules: gioModuleImages.length, // § 2d
     schemas: false,
     iconThemes: [],
     iconFiles: 0,
@@ -892,7 +1023,7 @@ const brewInfoLicense = (formula) => {
 // third-party LGPL modules too, so "the terms travel with the binaries" is only true if
 // the per-binary table names them. They attribute through the same derivation as every
 // dylib — their realpath runs through …/Cellar/{gdk-pixbuf,librsvg}/<version>/… .
-const shippedBinaries = new Map([...bundled, ...pixbufLoaderSources, ...gstPluginSources]);
+const shippedBinaries = new Map([...bundled, ...pixbufLoaderSources, ...gstPluginSources, ...gioModuleSources]);
 const { components: licenseComponents, unattributed } = describeBrewKegs({
     files: shippedBinaries,
     fallbackLicense: brewInfoLicense,
@@ -900,9 +1031,9 @@ const { components: licenseComponents, unattributed } = describeBrewKegs({
 const licensePayload = writeLicensePayload({ outDir: join(OUT, 'licenses'), components: licenseComponents });
 const MODIFICATIONS = [
     '`install_name_tool -id` / `-change`: every install name and every reference to another library in this bundle ' +
-        'rewritten to `@loader_path/<leaf>` — `@loader_path/../../../<leaf>` for the gdk-pixbuf loader modules ' +
-        'under `lib/gdk-pixbuf-2.0/`, which sit three levels below `lib/` (references to /usr/lib and /System are ' +
-        'untouched).',
+        'rewritten to `@loader_path/<leaf>`, with the prefix climbing back to `lib/` for the modules that sit ' +
+        'below it — `../` for the GStreamer plugins, `../../` for the GIO modules, `../../../` for the gdk-pixbuf ' +
+        'image loaders (references to /usr/lib and /System are untouched).',
     '`codesign --force --sign -`: ad-hoc re-signature, because `install_name_tool` invalidates the original one ' +
         'and dyld refuses a mis-signed dylib on Apple silicon.',
 ];

--- a/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
+++ b/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
@@ -263,6 +263,21 @@ function realpathOrNull(p) {
     }
 }
 
+/**
+ * Record where a bundled binary really came from, for § 5's per-keg attribution: brew LINKS
+ * a keg's files into its prefix, and only the RESOLVED path runs through
+ * `…/Cellar/<formula>/<version>/`, which is the whole basis of the darwin licence mapping.
+ * A path that is not a link is its own source, so an unresolvable one is recorded as given
+ * rather than dropped. Every module list in § 2b–2d needs this and each used to spell the
+ * same try/catch out again.
+ * @param {Map<string, string>} sources leaf -> the path § 5 attributes through
+ * @param {string} leaf the name the binary ships under
+ * @param {string} src the path it was copied from
+ */
+function recordBinarySource(sources, leaf, src) {
+    sources.set(leaf, realpathOrNull(src) ?? src);
+}
+
 // Parse an `otool -L <lib>` output into the list of dependency install paths
 // (skipping the library's own id and system libraries).
 //
@@ -303,12 +318,7 @@ function otoolDeps(libPath) {
 // or null when it is not a Homebrew library we bundle.
 function resolveInBrew(leaf) {
     const candidate = join(brewLib, leaf);
-    if (!existsSync(candidate)) return null;
-    try {
-        return realpathSync(candidate);
-    } catch {
-        return null;
-    }
+    return existsSync(candidate) ? realpathOrNull(candidate) : null;
 }
 
 /**
@@ -331,11 +341,7 @@ function resolveBrewDep(ref) {
     const linked = resolveInBrew(basename(ref));
     if (linked) return linked;
     if (!ref.startsWith(`${brewPrefix}/`) || !existsSync(ref)) return null;
-    try {
-        return realpathSync(ref);
-    } catch {
-        return null;
-    }
+    return realpathOrNull(ref);
 }
 
 // --- 1. discover the closure ----------------------------------------------
@@ -509,11 +515,7 @@ if (WINDOWING) {
             // a tarball. The realpath is also what § 5 attributes the binary through.
             copyFileSync(src, dest);
             pixbufLoaderImages.push(dest);
-            try {
-                pixbufLoaderSources.set(f, realpathSync(src));
-            } catch {
-                pixbufLoaderSources.set(f, src); // not a link — the path IS the source
-            }
+            recordBinarySource(pixbufLoaderSources, f, src);
         }
         for (const image of pixbufLoaderImages) {
             relocate(image, { id: true, depPrefix: '@loader_path/../../..' });
@@ -634,11 +636,7 @@ if (WINDOWING) {
             copyFileSync(src, dest);
             bytes += statSync(dest).size;
             gstPluginImages.push(dest);
-            try {
-                gstPluginSources.set(f, realpathSync(src));
-            } catch {
-                gstPluginSources.set(f, src);
-            }
+            recordBinarySource(gstPluginSources, f, src);
         }
         for (const image of gstPluginImages) {
             relocate(image, { id: true, depPrefix: '@loader_path/..' });
@@ -656,11 +654,7 @@ if (WINDOWING) {
             const dest = join(scannerOut, 'gst-plugin-scanner');
             copyFileSync(scannerSrc, dest);
             gstPluginImages.push(dest);
-            try {
-                gstPluginSources.set('gst-plugin-scanner', realpathSync(scannerSrc));
-            } catch {
-                gstPluginSources.set('gst-plugin-scanner', scannerSrc);
-            }
+            recordBinarySource(gstPluginSources, 'gst-plugin-scanner', scannerSrc);
             relocate(dest, { id: false, depPrefix: '@loader_path/../../lib' });
         } else {
             console.warn(
@@ -737,11 +731,7 @@ if (WINDOWING) {
             copyFileSync(src, dest); // dereferencing — a link into the Cellar is worthless in a tarball
             bytes += statSync(dest).size;
             gioModuleImages.push(dest);
-            try {
-                gioModuleSources.set(f, realpathSync(src));
-            } catch {
-                gioModuleSources.set(f, src);
-            }
+            recordBinarySource(gioModuleSources, f, src);
         }
         for (const image of gioModuleImages) {
             relocate(image, { id: true, depPrefix: '@loader_path/../..' });

--- a/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
+++ b/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
@@ -77,7 +77,9 @@ import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
     copyTreeDereferenced,
+    duplicatedModuleLeaves,
     findSymlinks,
+    formatDuplicatedModuleProblems,
     formatSymlinkProblems,
     formatWindowingDataProblems,
     verifyWindowingData,
@@ -252,8 +254,30 @@ function isSystemPath(p) {
     return p.startsWith('/usr/lib/') || p.startsWith('/System/');
 }
 
+/** `realpathSync` that answers null instead of throwing, for refs like `@rpath/x`. */
+function realpathOrNull(p) {
+    try {
+        return realpathSync(p);
+    } catch {
+        return null;
+    }
+}
+
 // Parse an `otool -L <lib>` output into the list of dependency install paths
-// (skipping the first line — the library's own id — and system libraries).
+// (skipping the library's own id and system libraries).
+//
+// THE ID IS NOT DROPPED BY POSITION, and the difference is a shipped defect. `otool -L
+// <file>` prints `<file>:` as its first line and then, FOR A DYLIB ONLY, the install
+// name (LC_ID_DYLIB) before the real dependencies — a loadable BUNDLE (a GIO module, a
+// gdk-pixbuf loader) carries no id at all, so `slice(1)` cannot mean "past the id" for
+// both shapes and used to leave every dylib's own id in the list. That was inert only
+// while § 1 resolved a LEAF against `<prefix>/lib`: a plugin's leaf is not there. Once
+// § 1 began resolving whole REFERENCES (resolveBrewDep, for keg-only formulas), the id
+// — an absolute path into the Cellar — resolved to the plugin itself, and all 24
+// GStreamer plugins were copied into flat `lib/` beside the copies § 2c places, +3.4
+// MiB of duplicates. Measured on the darwin-x64 artifact of the run that added `soup`.
+// So the id is removed BY VALUE: nothing links itself, and the check costs one
+// realpath per line.
 function otoolDeps(libPath) {
     let out;
     try {
@@ -261,13 +285,15 @@ function otoolDeps(libPath) {
     } catch {
         return [];
     }
-    const lines = out.split('\n').slice(1); // line 0 is the id, not a dep
+    const self = realpathOrNull(libPath);
+    const lines = out.split('\n').slice(1); // line 0 is the `<file>:` header
     const deps = [];
     for (const line of lines) {
         const trimmed = line.trim();
         if (!trimmed) continue;
         const path = trimmed.split(' (')[0];
         if (!path || isSystemPath(path)) continue;
+        if (self && realpathOrNull(path) === self) continue; // the image's own id
         deps.push(path);
     }
     return deps;
@@ -785,6 +811,19 @@ verifyRelocation([
     ...gstPluginImages,
     ...gioModuleImages,
 ]);
+
+// And the check verifyRelocation CANNOT make, because a duplicate is correctly
+// relocated: no module § 2b–2d placed may ALSO be a flat lib/ entry. See
+// duplicatedModuleLeaves for the class and the 24-plugin instance it was written on.
+const duplicatedModules = duplicatedModuleLeaves(bundledLeaves, [
+    ...pixbufLoaderImages,
+    ...gstPluginImages,
+    ...gioModuleImages,
+]);
+if (duplicatedModules.length > 0) {
+    console.error(`build-gtk-runtime: ${formatDuplicatedModuleProblems(duplicatedModules, { flatDir: libOut })}`);
+    process.exit(1);
+}
 
 // --- 4. typelibs — only the ones this bundle can actually BACK --------------
 // The brew typelib dir is shared by every installed formula, so copying it wholesale

--- a/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
+++ b/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
@@ -1247,6 +1247,11 @@ const manifest = {
         attribution: 'per-binary',
         components: licenseComponents.length,
         texts: licensePayload.files.length,
+        // How many binaries the coverage gate actually covered. Recorded on BOTH
+        // platforms so the publish gate can refuse a bundle whose license step ran
+        // without ever looking at a binary — the win32 state that shipped GLib and
+        // OpenSSL with no terms while every check was green.
+        binariesCovered: shippedBinaries.size,
         binariesModified: true,
         modifications: MODIFICATIONS,
     },

--- a/packages/node-gi/scripts/bundle-data.mjs
+++ b/packages/node-gi/scripts/bundle-data.mjs
@@ -181,6 +181,20 @@ export const WINDOWING_DATA_SETS = [
         requires: [{ tree: 'share/gtksourceview-5' }],
         remedy: 'brew install gtksourceview5 (darwin) / use a gvsbuild prefix that ships share/gtksourceview-5 (win32)',
     },
+    {
+        // The `pixbuf-loaders` shape one layer down: a bundle that brings its OWN libgio brings
+        // its own GIO module dir, and shipped nothing to put in it. GIO resolves
+        // `GTlsBackend` by g_module_open out of that dir, so with no module every https request
+        // in a bundle-activated process gets the DUMMY backend — `souphttpsrc` on an https URL
+        // fails as "Internal data stream error", and so does anything else on Gio/Soup TLS.
+        // Measured on darwin-x64 by emptying the module dir; see gst-plugins.mjs § soup.
+        id: 'tls-backend',
+        namespace: 'Gio',
+        what: 'a GIO TLS backend module (glib-networking)',
+        why: 'GTlsConnection is a g_module_open-ed implementation, so a bundle with its own libgio and no module answers every https request with the dummy backend — the failure reads as a network error rather than a missing module',
+        requires: [{ glob: 'lib/gio/modules/*' }],
+        remedy: 'brew install glib-networking (darwin) / add glib-networking to the gvsbuild build (win32), then re-run the builder — the module dir is lib/gio/modules and node-gi points GIO_MODULE_DIR at it',
+    },
 ];
 
 /**

--- a/packages/node-gi/scripts/bundle-data.mjs
+++ b/packages/node-gi/scripts/bundle-data.mjs
@@ -323,3 +323,57 @@ export function formatWindowingDataProblems(problems, { bundleDir }) {
         'consumer. Fix the build prefix (see the per-set repair) — do NOT downgrade the step back to a warning.'
     );
 }
+
+/**
+ * Rule 3, asserted on the finished bundle by both builders: a LOADABLE MODULE MUST NOT
+ * ALSO BE A FLAT LIBRARY ENTRY.
+ *
+ * The builders have two different placements. The flat library dir (`lib/` on darwin,
+ * `bin/` on win32) holds the linked closure; a plugin, an image loader or a GIO module
+ * is placed in its OWN directory by the section that owns it, because it needs a
+ * different relocation prefix and is never resolved by leaf from the library path. A
+ * leaf that appears in both was pulled into the closure by a reference that NAMES it,
+ * and it then ships twice.
+ *
+ * This is a class, not an incident. The instance that produced it: `otool -L` prints a
+ * dylib's own install name among its dependencies, and once the darwin closure walk
+ * began resolving whole references (for keg-only formulas) that id — an absolute path
+ * into the Cellar — resolved to the plugin itself, so all 24 GStreamer plugins were
+ * copied into flat `lib/` as well, +3.4 MiB. The duplicate is inert (nothing resolves a
+ * plugin by leaf), which is exactly why nothing noticed: every existing gate counts
+ * files or verifies relocation, and both are happy with a correct extra copy.
+ * @param {Iterable<string>} flatLeaves leaf names in the bundle's flat library dir
+ * @param {Iterable<string>} modulePaths paths of the modules the builder PLACED
+ * @param {{ caseInsensitive?: boolean }} [opts] fold case, as win32's `bin/` requires
+ * @returns {string[]} leaves that are in both, sorted
+ */
+export function duplicatedModuleLeaves(flatLeaves, modulePaths, { caseInsensitive = false } = {}) {
+    const fold = (s) => (caseInsensitive ? s.toLowerCase() : s);
+    const flat = new Set();
+    for (const entry of flatLeaves) flat.add(fold(entry.replace(/^.*[\\/]/, '')));
+    const dupes = new Set();
+    for (const p of modulePaths) {
+        const leaf = p.replace(/^.*[\\/]/, '');
+        if (flat.has(fold(leaf))) dupes.add(leaf);
+    }
+    return [...dupes].sort();
+}
+
+/**
+ * One shared operator message for {@link duplicatedModuleLeaves}, so both builders
+ * spell the repair the same way.
+ * @param {string[]} leaves
+ * @param {{ flatDir: string }} opts
+ * @returns {string}
+ */
+export function formatDuplicatedModuleProblems(leaves, { flatDir }) {
+    return (
+        `MODULES DUPLICATED INTO ${flatDir} — ${leaves.length} leaf/leaves:\n  ${leaves.join('\n  ')}\n` +
+        'Each of these is placed in its own module directory by the builder AND was copied into the flat ' +
+        'library dir by the closure walk, so the bundle ships two copies of it. A module reaches the closure ' +
+        "only through a reference that names it — an image's own install name (LC_ID_DYLIB), or a real link " +
+        'against a module, which is itself a defect. Repair: find the reference that queued it and drop it at ' +
+        'the walk, not here. Do NOT delete the flat copy as a post-step: that hides the reference and the next ' +
+        'module directory added to the bundle repeats it.'
+    );
+}

--- a/packages/node-gi/scripts/bundle-licenses.mjs
+++ b/packages/node-gi/scripts/bundle-licenses.mjs
@@ -30,6 +30,26 @@
 //     says plainly that the mapping is not recoverable, which is over-inclusive
 //     rather than silent.
 //
+// "OVER-INCLUSIVE RATHER THAN SILENT" WAS HALF TRUE, AND THE SILENT HALF SHIPPED.
+// Measured on this branch's own win32-x64 CI artifact: 65 DLLs in `bin/` against 45
+// documented components — over-inclusive on one side (cairomm, gtkmm, pycairo, protobuf
+// and six more are documented and not bundled) and EMPTY on the other. `glib`,
+// `freetype`, `graphene`, `libtiff`, `libxml2`, `zlib`, `sqlite` and `openssl` back
+// fourteen shipped DLLs — libgio, libgobject and libglib among them — and the prefix
+// documents the terms of none of them. Nothing caught it because the coverage gate ran
+// its per-binary checks ONLY under `per-binary` attribution, so the win32 branch asserted
+// "some texts were recovered" and nothing else: a corpus of one file would have passed.
+//
+// Prefix attribution therefore keeps its honest claim (no per-DLL mapping in the shipped
+// notice) but stops being unfalsifiable: WIN32_LICENSE_FAMILIES declares which project
+// each bundled leaf belongs to, and `assertLicenseCoverage` now refuses a bundle holding
+// a binary whose family the corpus documents no text for — in EITHER attribution mode.
+// The table is a name map, never a statement of terms: the terms still come from the
+// build prefix, and where the prefix documents none, from a text vendored beside the
+// builder with its upstream provenance recorded (see § vendored corpus in the win32
+// builder). A family the table does not know fails the build by name, which is the
+// opposite of the silent drift a hand-listed license SET would have.
+//
 // Everything here is pure (no child_process): the darwin `brew info` fallback is
 // injected by the caller, so this module is unit-testable on Linux —
 // packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs.
@@ -46,6 +66,119 @@ const LICENSE_FILE_RE = /^(COPYING|COPYRIGHT|LICEN[CS]E|NOTICE|AUTHORS)([-._][\w
 
 /** A single license text is a page or two; 512 KiB rules out a doc tree mistaken for one. */
 const MAX_TEXT_BYTES = 512 * 1024;
+
+/**
+ * WHICH PROJECT EACH BUNDLED win32 BINARY BELONGS TO.
+ *
+ * A NAME MAP, NOT A STATEMENT OF TERMS — that distinction is the whole reason this table
+ * is allowed to exist next to a header that forbids hand-listing. It says only "the leaf
+ * `intl.dll` comes from the project gvsbuild documents as `gettext`"; what gettext's terms
+ * ARE still comes from the build prefix's own `share/doc/gettext/COPYING`. So the table
+ * cannot make a false licence claim: the worst it can do is name the wrong project, and
+ * then the text that ships is the wrong project's — which is why every entry whose leaf
+ * name differs from its project name carries the reason.
+ *
+ * It does not drift silently either, which a hand-listed licence SET would: the gate
+ * walks the binaries the builder ACTUALLY copied, so a DLL this table does not know fails
+ * the build by name. A gvsbuild bump that renames a library is then a one-line addition
+ * caught at build time instead of a bundle shipped without terms.
+ *
+ * Ordered — the first matching entry wins, so `girepository-2.0-0.dll` and the
+ * `gst*-1.0-*.dll` shared libraries are matched before the looser plugin pattern.
+ *
+ * @type {{ components: string[], pattern: RegExp, why?: string }[]}
+ */
+export const WIN32_LICENSE_FAMILIES = [
+    // GLib is the one this gate exists for: six of the bundle's DLLs are GLib, it is the
+    // LGPL library everything else here links, and the published win32 tarballs have
+    // carried it with no terms attached since the first one.
+    { components: ['glib'], pattern: /^(glib|gobject|gio|gmodule|gthread)-2\.0-\d+\.dll$/i },
+    {
+        components: ['glib'],
+        pattern: /^girepository-\d+\.\d+-\d+\.dll$/i,
+        why: 'girepository moved INTO glib at 2.80 (the standalone gobject-introspection library is gone)',
+    },
+    { components: ['gtk4'], pattern: /^gtk-4-\d+\.dll$/i },
+    { components: ['libadwaita'], pattern: /^adwaita-1-\d+\.dll$/i, why: 'libadwaita builds `adwaita-1-0.dll`' },
+    { components: ['gtksourceview5'], pattern: /^gtksourceview-5-\d+\.dll$/i },
+    { components: ['gdk-pixbuf'], pattern: /^gdk_pixbuf-2\.0-\d+\.dll$/i },
+    { components: ['pango'], pattern: /^pango(cairo|ft2|win32)?-1\.0-\d+\.dll$/i },
+    { components: ['cairo'], pattern: /^cairo(-gobject|-script-interpreter)?-\d+\.dll$/i },
+    { components: ['harfbuzz'], pattern: /^harfbuzz(-[a-z]+)?\.dll$/i, why: '`harfbuzz-icu.dll` is harfbuzz, not icu' },
+    { components: ['graphene'], pattern: /^graphene-1\.0-\d+\.dll$/i },
+    { components: ['fontconfig'], pattern: /^fontconfig-\d+\.dll$/i },
+    { components: ['freetype'], pattern: /^freetype-\d+\.dll$/i },
+    { components: ['fribidi'], pattern: /^fribidi-\d+\.dll$/i },
+    { components: ['libepoxy'], pattern: /^epoxy-\d+\.dll$/i, why: 'libepoxy builds `epoxy-0.dll`' },
+    { components: ['libffi'], pattern: /^ffi-\d+\.dll$/i, why: 'libffi builds `ffi-8.dll`' },
+    { components: ['libpng'], pattern: /^libpng\d+\.dll$/i },
+    { components: ['libjpeg-turbo'], pattern: /^jpeg\d+\.dll$/i, why: 'libjpeg-turbo builds `jpeg62.dll`' },
+    { components: ['libtiff'], pattern: /^tiff(-\d+)?\.dll$/i, why: 'libtiff builds `tiff.dll`' },
+    { components: ['librsvg'], pattern: /^(rsvg-2-\d+|pixbufloader_svg)\.dll$/i },
+    {
+        components: ['gdk-pixbuf'],
+        pattern: /^pixbufloader_[a-z0-9]+\.dll$/i,
+        why: 'the other image loaders are gdk-pixbuf`s own',
+    },
+    { components: ['pixman'], pattern: /^pixman-1-\d+\.dll$/i },
+    { components: ['pcre2'], pattern: /^pcre2-\d+-\d+\.dll$/i },
+    { components: ['expat'], pattern: /^libexpat\.dll$/i },
+    { components: ['zlib'], pattern: /^zlib1\.dll$/i },
+    { components: ['gettext'], pattern: /^intl\.dll$/i, why: 'gettext builds libintl as `intl.dll`' },
+    { components: ['win-iconv'], pattern: /^iconv\.dll$/i, why: 'gvsbuild uses win-iconv, not GNU libiconv' },
+    { components: ['libxml2'], pattern: /^xml2-\d+\.dll$/i, why: 'libxml2 builds `xml2-16.dll`' },
+    { components: ['sqlite'], pattern: /^sqlite3\.dll$/i },
+    {
+        components: ['icu'],
+        pattern: /^icu[a-z]{2}\d+\.dll$/i,
+        why: 'icudt/icuuc/icuin carry the ICU major in the leaf',
+    },
+    { components: ['libpsl'], pattern: /^psl-\d+\.dll$/i, why: 'libpsl builds `psl-5.dll`' },
+    { components: ['nghttp2'], pattern: /^nghttp2\.dll$/i },
+    { components: ['libsoup3'], pattern: /^soup-3\.0-\d+\.dll$/i },
+    {
+        components: ['openssl'],
+        pattern: /^lib(crypto|ssl)-\d+(-x64)?\.dll$/i,
+        why: 'the Apache-2.0 payload this branch added; § 4 of that licence requires the text to travel with it',
+    },
+    {
+        components: ['mit-kerberos'],
+        pattern: /^(krb5_64|comerr64|gssapi64|k5sprt64)\.dll$/i,
+        why: 'MIT Kerberos names its DLLs after the modules, not the project — libsoup3 pulls them in for GSSAPI auth',
+    },
+    {
+        components: ['glib-networking'],
+        pattern: /^gio(openssl|gnutls|gnomeproxy|libproxy)\.dll$/i,
+        why: 'the GIO modules in lib/gio/modules — the TLS backend and the proxy resolver',
+    },
+    { components: ['orc'], pattern: /^orc-\d+\.\d+-\d+\.dll$/i },
+    { components: ['opus'], pattern: /^opus-\d+\.dll$/i },
+    { components: ['ogg'], pattern: /^ogg-\d+\.dll$/i },
+    { components: ['gstreamer'], pattern: /^gst(reamer|base|controller|net|check)-1\.0-\d+\.dll$/i },
+    {
+        components: ['gst-plugins-base'],
+        pattern: /^gst(app|audio|video|tag|riff|rtp|pbutils|fft|sdp|gl|allocators)-1\.0-\d+\.dll$/i,
+        why: 'gst-plugins-base ships these as libraries; gstreamer core ships only the five above',
+    },
+    {
+        components: ['gstreamer', 'gst-plugins-base', 'gst-plugins-good'],
+        pattern: /^gst[a-z0-9]+\.dll$/i,
+        why:
+            'the plugin dir mixes all three projects (gstcoreelements is core, gstplayback is -base, ' +
+            'gstsoup is -good) and the flat prefix cannot say which is which — so ALL THREE must be ' +
+            'documented, the same deliberate over-inclusion prefix attribution already declares',
+    },
+];
+
+/**
+ * The declared family a bundled leaf belongs to, or `null` when nothing claims it.
+ * @param {string} leaf bundled file name, e.g. `libcrypto-3-x64.dll`
+ * @param {{ components: string[], pattern: RegExp }[]} families
+ * @returns {{ components: string[], pattern: RegExp, why?: string } | null}
+ */
+export function licenseFamilyFor(leaf, families) {
+    return families.find((family) => family.pattern.test(leaf)) ?? null;
+}
 
 /**
  * Find license texts under `root`, restricted to the given subdirectories and a
@@ -255,6 +388,10 @@ export function renderThirdPartyNotice({
         lines.push('tree, so the license corpus it ships is reproduced in full below and applies to the bundled');
         lines.push('binaries collectively. Listing every project the prefix documents is deliberate over-inclusion.');
         lines.push('');
+        lines.push('What is NOT left to over-inclusion is coverage: the build fails unless every bundled binary');
+        lines.push('belongs to a declared project whose terms are in this payload, so a shipped library with no');
+        lines.push('license text cannot leave the builder.');
+        lines.push('');
     }
     lines.push('| Component | Version | License (as declared by the build prefix) | Texts included |');
     lines.push('|---|---|---|---|');
@@ -265,9 +402,19 @@ export function renderThirdPartyNotice({
         const files = [...new Set((c.texts ?? []).map((t) => t.file))];
         const texts = files.join(', ') || '—';
         const declared = c.license ?? (files.length > 0 ? '(see included text)' : '(not declared)');
-        lines.push(`| ${c.name} | ${c.version ?? '—'} | ${declared} | ${texts} |`);
+        lines.push(`| ${c.name}${c.upstreamText ? ' \\*' : ''} | ${c.version ?? '—'} | ${declared} | ${texts} |`);
     }
     lines.push('');
+    const upstream = components.filter((c) => c.upstreamText);
+    if (upstream.length > 0) {
+        lines.push(
+            `\\* The build prefix documents no terms for ${upstream.length} project(s) it nevertheless builds ` +
+                'binaries from, so their texts are reproduced from the upstream release the prefix pins. ' +
+                'The file and the version it was taken from are recorded next to the builder — ' +
+                `${upstream.map((c) => `\`${c.name}\``).join(', ')}.`,
+        );
+        lines.push('');
+    }
     lines.push(
         `${withText.length} component(s) ship their license text in \`${payloadDir}/\`; ` +
             `${withoutText.length} declare a license without shipping its text in the build prefix — ` +
@@ -288,11 +435,22 @@ export function renderThirdPartyNotice({
 /**
  * The compliance gate. Returns operator-readable problems; empty = the notice makes
  * a complete, positive statement about every binary that ships.
+ *
+ * BOTH attribution modes now answer the same question — "does every binary that ships
+ * have its terms in the payload" — from whichever evidence their prefix can give:
+ * darwin proves it per keg, win32 proves it per declared family. Before, the win32
+ * branch asserted only that SOME text was recovered, and eight projects behind fourteen
+ * shipped DLLs were invisible to it (§ header).
+ *
  * @param {{ components: object[], binaries: string[], unattributed?: object[],
- *   attribution: 'per-binary' | 'prefix', textCount: number }} opts
+ *   attribution: 'per-binary' | 'prefix', textCount: number,
+ *   families?: {components: string[], pattern: RegExp, why?: string}[] }} opts
+ *   `families` is REQUIRED under `prefix` attribution: without it the mode has no way to
+ *   relate a binary to a component, which is exactly the hole this closes — so its
+ *   absence is a problem rather than a skipped check.
  * @returns {string[]}
  */
-export function assertLicenseCoverage({ components, binaries, unattributed = [], attribution, textCount }) {
+export function assertLicenseCoverage({ components, binaries, unattributed = [], attribution, textCount, families }) {
     const problems = [];
     if (components.length === 0) problems.push('no license components were derived from the build prefix at all');
     if (binaries.length === 0) problems.push('no bundled binaries were passed to the license step');
@@ -301,6 +459,35 @@ export function assertLicenseCoverage({ components, binaries, unattributed = [],
             'not one license text was recovered from the build prefix — the bundle would ship third-party ' +
                 'binaries with no terms attached',
         );
+    }
+    if (attribution === 'prefix') {
+        if (!families) {
+            problems.push(
+                'prefix attribution was used with no license family table — the coverage of every bundled ' +
+                    'binary is then uncheckable, which is the state that shipped GLib and OpenSSL with no terms',
+            );
+        } else {
+            // A component COUNTS as documented only when it ships a text. A name in the
+            // corpus with an empty text list is a directory, not a licence.
+            const documented = new Set(components.filter((c) => (c.texts ?? []).length > 0).map((c) => c.name));
+            for (const binary of binaries) {
+                const family = licenseFamilyFor(binary, families);
+                if (!family) {
+                    problems.push(
+                        `${binary} belongs to no declared license family — the bundle cannot say which ` +
+                            "project's terms cover it",
+                    );
+                    continue;
+                }
+                const undocumented = family.components.filter((name) => !documented.has(name));
+                if (undocumented.length > 0) {
+                    problems.push(
+                        `${binary} is ${family.components.join(' + ')}, and no license text ships for ` +
+                            `${undocumented.join(', ')}`,
+                    );
+                }
+            }
+        }
     }
     if (attribution === 'per-binary') {
         for (const u of unattributed) {
@@ -331,7 +518,11 @@ export function formatLicenseProblems(problems, { prefix }) {
         `Every binary this bundle ships must be traceable to a component of the build prefix (${prefix}) whose ` +
         'terms are recorded in THIRD-PARTY-NOTICES.md. Repairs: install the library through the package manager ' +
         'that owns the prefix (so it lands in a keg/documented tree) instead of side-loading it; or add the ' +
-        'directory that holds its license text to the scan roots. Do NOT downgrade this to a warning — shipping ' +
-        'relocated LGPL binaries with no terms attached is the condition this check exists to prevent.'
+        'directory that holds its license text to the scan roots. For a win32 DLL that belongs to no declared ' +
+        'family, add it to WIN32_LICENSE_FAMILIES in bundle-licenses.mjs (a NAME map, one line); for a family ' +
+        "the prefix documents no text for, vendor that project's upstream text under the win32 builder's " +
+        'licenses-not-in-prefix/ with its provenance. Do NOT downgrade this to a warning and do NOT delete the ' +
+        'entry to get a green build — shipping relocated LGPL/Apache binaries with no terms attached is the ' +
+        'condition this check exists to prevent.'
     );
 }

--- a/packages/node-gi/scripts/bundle-licenses.mjs
+++ b/packages/node-gi/scripts/bundle-licenses.mjs
@@ -31,14 +31,15 @@
 //     rather than silent.
 //
 // "OVER-INCLUSIVE RATHER THAN SILENT" WAS HALF TRUE, AND THE SILENT HALF SHIPPED.
-// Measured on this branch's own win32-x64 CI artifact: 65 DLLs in `bin/` against 45
-// documented components — over-inclusive on one side (cairomm, gtkmm, pycairo, protobuf
-// and six more are documented and not bundled) and EMPTY on the other. `glib`,
-// `freetype`, `graphene`, `libtiff`, `libxml2`, `zlib`, `sqlite` and `openssl` back
-// fourteen shipped DLLs — libgio, libgobject and libglib among them — and the prefix
-// documents the terms of none of them. Nothing caught it because the coverage gate ran
-// its per-binary checks ONLY under `per-binary` attribution, so the win32 branch asserted
-// "some texts were recovered" and nothing else: a corpus of one file would have passed.
+// Measured on this branch's own win32-x64 CI artifact: 65 DLLs in `bin/` plus 25 binaries
+// in their own directories, against 45 documented components — over-inclusive on one side
+// (cairomm, gtkmm, pycairo, protobuf and six more are documented and not bundled) and
+// EMPTY on the other. `glib`, `gobject-introspection`, `freetype`, `graphene`, `libtiff`,
+// `libxml2`, `zlib`, `sqlite` and `openssl` back fourteen shipped DLLs — libgio,
+// libgobject and libglib among them — and the prefix documents the terms of none of them.
+// Nothing caught it because the coverage gate ran its per-binary checks ONLY under
+// `per-binary` attribution, so the win32 branch asserted "some texts were recovered" and
+// nothing else: a corpus of one file would have passed.
 //
 // Prefix attribution therefore keeps its honest claim (no per-DLL mapping in the shipped
 // notice) but stops being unfalsifiable: WIN32_LICENSE_FAMILIES declares which project
@@ -95,8 +96,18 @@ export const WIN32_LICENSE_FAMILIES = [
     { components: ['glib'], pattern: /^(glib|gobject|gio|gmodule|gthread)-2\.0-\d+\.dll$/i },
     {
         components: ['glib'],
-        pattern: /^girepository-\d+\.\d+-\d+\.dll$/i,
-        why: 'girepository moved INTO glib at 2.80 (the standalone gobject-introspection library is gone)',
+        pattern: /^girepository-2\.0-\d+\.dll$/i,
+        why: 'girepository-2.0 moved INTO glib at 2.80',
+    },
+    {
+        components: ['gobject-introspection'],
+        pattern: /^girepository-1\.0-\d+\.dll$/i,
+        why:
+            'the TWO girepository DLLs are two projects, and one entry for both named the wrong one. ' +
+            'glib 2.80 took girepository-2.0 in; gobject-introspection did not stop building the 1.0 ' +
+            'library — 1.86.0 girepository/meson.build still declares shared_library(girepository-1.0), ' +
+            'and gvsbuild --enable-gi installs it. Both ship, so matching girepository-* as ONE family ' +
+            'made the notice name glib as the project behind a gobject-introspection binary',
     },
     { components: ['gtk4'], pattern: /^gtk-4-\d+\.dll$/i },
     { components: ['libadwaita'], pattern: /^adwaita-1-\d+\.dll$/i, why: 'libadwaita builds `adwaita-1-0.dll`' },
@@ -159,6 +170,14 @@ export const WIN32_LICENSE_FAMILIES = [
         components: ['gst-plugins-base'],
         pattern: /^gst(app|audio|video|tag|riff|rtp|pbutils|fft|sdp|gl|allocators)-1\.0-\d+\.dll$/i,
         why: 'gst-plugins-base ships these as libraries; gstreamer core ships only the five above',
+    },
+    {
+        components: ['gstreamer'],
+        pattern: /^gst-plugin-scanner\.exe$/i,
+        why:
+            'the ONE binary in the bundle that is not a library, and the one the win32 coverage set ' +
+            'first left out: it lives in libexec/, so neither the flat bin/ walk nor the module lists ' +
+            'reached it. gstreamer core ships the scanner (darwin attributes it through its keg)',
     },
     {
         components: ['gstreamer', 'gst-plugins-base', 'gst-plugins-good'],
@@ -302,6 +321,37 @@ export function describeBrewKegs({ files, fallbackLicense }) {
         })
         .sort((a, b) => a.name.localeCompare(b.name));
     return { components, unattributed };
+}
+
+/**
+ * The components whose terms come from a VENDORED upstream text rather than from the build
+ * prefix — the win32 gap-filler, expressed once so the builder and its test cannot disagree
+ * about the rule. (They did: the rule lived in the builder and the test re-implemented it,
+ * which is a green test over a copy of the code it is meant to hold.)
+ *
+ * TWO NARROWINGS ARE THE RULE, not a detail of the caller. The prefix stays AUTHORITATIVE —
+ * a component it documents is never overridden here — and a vendored text enters only for a
+ * project some binary in THIS bundle needs, so the display-free variant does not carry
+ * OpenSSL's terms for a DLL it never had.
+ * @param {{ root: string, documented: Iterable<string>, binaries: Iterable<string>,
+ *   families: {components: string[], pattern: RegExp}[] }} opts
+ * @returns {{ name: string, texts: object[], upstreamText: true }[]} sorted by name
+ */
+export function upstreamLicenseComponents({ root, documented, binaries, families }) {
+    const byPrefix = new Set(documented);
+    const needed = new Set();
+    for (const leaf of binaries) {
+        for (const name of licenseFamilyFor(leaf, families)?.components ?? []) needed.add(name);
+    }
+    const byComponent = new Map();
+    for (const text of scanLicenseFiles({ root, subdirs: ['.'], maxDepth: 2 })) {
+        if (byPrefix.has(text.component) || !needed.has(text.component)) continue;
+        if (!byComponent.has(text.component)) {
+            byComponent.set(text.component, { name: text.component, texts: [], upstreamText: true });
+        }
+        byComponent.get(text.component).texts.push(text);
+    }
+    return [...byComponent.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
 /**

--- a/packages/node-gi/scripts/decode-probe.mjs
+++ b/packages/node-gi/scripts/decode-probe.mjs
@@ -75,6 +75,8 @@ export const HOST_GTK_ENV = [
     'GST_PLUGIN_SYSTEM_PATH',
     'GST_PLUGIN_PATH',
     'GST_PLUGIN_SCANNER',
+    'GIO_MODULE_DIR',
+    'GIO_EXTRA_MODULES',
 ];
 
 /** Is `dir` the prefix itself, or below it? Case- and separator-folded like the OS. */

--- a/packages/node-gi/scripts/gst-plugins.mjs
+++ b/packages/node-gi/scripts/gst-plugins.mjs
@@ -81,13 +81,21 @@ export const GST_AUDIO_PLUGINS = [
     //     and no file list can check it. gst-elements.test.mjs asks the running backend instead;
     //     ADR 0037 § Consequences carries the measurement.
     //
-    // ~9.6 MiB, +13 %. The per-library table lives ONCE, in ADR 0037 § Decision drivers — this
+    // 9.36 MiB (+13 %) on darwin-x64 — and 47.8 MiB (+62 %) on win32-x64, which is NOT the same
+    // decision costing the same thing twice: gvsbuild builds libpsl against ICU, so `icudt78.dll`
+    // alone is 31.6 MiB. The per-platform table lives ONCE, in ADR 0037 § Decision drivers — this
     // line carried its own ~8 MiB before review, a figure taken before the keg-only lookup pulled
     // libsqlite3 into the closure, i.e. the second-copy drift this file's own header warns about.
-    // And no licensing question of the kind this file's header keeps out: the addition is
-    // LGPL-2.1+/LGPL-3+ dynamic libraries of the same family as the GLib and GTK already
-    // relocated here — no codec, no patent claim, nothing whose redistribution is the product
-    // author's call rather than ours.
+    // Quote a percentage without its platform and it is wrong on the other one.
+    //
+    // No licensing question OF THE KIND THIS FILE'S HEADER KEEPS OUT — but the payload is mixed,
+    // not the "all LGPL" this line first claimed: LGPL-2.1+/LGPL-3+ (libsoup, glib-networking,
+    // gnutls and its closure), Apache-2.0 (OpenSSL 3, which is gvsbuild's TLS backend), MIT
+    // (libpsl, nghttp2, MIT Kerberos), BSD (p11-kit), Unicode (ICU), public domain (SQLite). What
+    // the header excludes is the CODEC question — x264, x265, faac, fdk-aac — and none of that
+    // enters here: no codec, no patent claim, nothing whose redistribution is the product author's
+    // call rather than ours. See ADR 0037 § Consequences for the OpenSSL licence text that is
+    // currently NOT shipped on win32.
     'soup',
     // Output. `autodetect` is autoaudiosink, which picks the platform sink below.
     'autodetect',

--- a/packages/node-gi/scripts/gst-plugins.mjs
+++ b/packages/node-gi/scripts/gst-plugins.mjs
@@ -63,8 +63,9 @@ export const GST_AUDIO_PLUGINS = [
     //   • libsoup. The plugin does not link it. Since 1.18 it g_module_opens
     //     `libsoup-3.0.0.dylib` / `soup-3.0-0.dll` by leaf name through its own loader shim, so
     //     `otool -L` reports glib + gstreamer and nothing else, and a closure walk seeded from the
-    //     plugin finds no soup at all. Measured on darwin-x64: +1.35 MiB (libsoup 521 KiB, plus
-    //     libpsl and libnghttp2).
+    //     plugin finds no soup at all. Measured on darwin-x64: +2.8 MiB — libsoup 521 KiB, plus
+    //     libpsl, libnghttp2 and libsqlite3, the last of which enters only because
+    //     build-gtk-runtime-darwin.mjs § resolveBrewDep now follows a KEG-ONLY reference.
     //   • a GIO TLS backend. libsoup does https through `GTlsConnection`, whose implementation is
     //     a glib-networking MODULE that GIO g_module_opens out of its module dir — and the bundles
     //     ship their own libgio while shipping no module, so every TLS request in a
@@ -73,11 +74,20 @@ export const GST_AUDIO_PLUGINS = [
     //     souphttpsrc, i.e. the http-only half of this widening would have shipped and looked
     //     finished. +6.67 MiB. It is a declared `tls-backend` data set in bundle-data.mjs, so its
     //     absence fails the build and the publish gate instead of the user's stream.
+    //   • NOT the trust anchors, and that asymmetry is the one to remember: the two payloads above
+    //     make https RESOLVE, not SUCCEED. The shipped gnutls reaches its roots through the
+    //     shipped libp11-kit, which finds its trust module in a COMPILED-IN directory with no env
+    //     override — so it cannot be repointed the way GIO_MODULE_DIR repoints the module above,
+    //     and no file list can check it. gst-elements.test.mjs asks the running backend instead;
+    //     ADR 0037 § Consequences carries the measurement.
     //
-    // ~8 MiB on a 76 MB bundle, and no licensing question of the kind this file's header keeps
-    // out: the addition is LGPL-2.1+/LGPL-3+ dynamic libraries of the same family as the GLib and
-    // GTK already relocated here — no codec, no patent claim, nothing whose redistribution is the
-    // product author's call rather than ours.
+    // ~9.6 MiB, +13 %. The per-library table lives ONCE, in ADR 0037 § Decision drivers — this
+    // line carried its own ~8 MiB before review, a figure taken before the keg-only lookup pulled
+    // libsqlite3 into the closure, i.e. the second-copy drift this file's own header warns about.
+    // And no licensing question of the kind this file's header keeps out: the addition is
+    // LGPL-2.1+/LGPL-3+ dynamic libraries of the same family as the GLib and GTK already
+    // relocated here — no codec, no patent claim, nothing whose redistribution is the product
+    // author's call rather than ours.
     'soup',
     // Output. `autodetect` is autoaudiosink, which picks the platform sink below.
     'autodetect',

--- a/packages/node-gi/scripts/gst-plugins.mjs
+++ b/packages/node-gi/scripts/gst-plugins.mjs
@@ -94,8 +94,9 @@ export const GST_AUDIO_PLUGINS = [
     // (libpsl, nghttp2, MIT Kerberos), BSD (p11-kit), Unicode (ICU), public domain (SQLite). What
     // the header excludes is the CODEC question — x264, x265, faac, fdk-aac — and none of that
     // enters here: no codec, no patent claim, nothing whose redistribution is the product author's
-    // call rather than ours. See ADR 0037 § Consequences for the OpenSSL licence text that is
-    // currently NOT shipped on win32.
+    // call rather than ours. Every one of those terms now travels with the binaries: chasing
+    // OpenSSL's found that the win32 licence gate could not fail at all, and that 14 shipped DLLs —
+    // GLib among them — had no text in any published bundle. ADR 0037 § Consequences carries it.
     'soup',
     // Output. `autodetect` is autoaudiosink, which picks the platform sink below.
     'autodetect',

--- a/packages/node-gi/scripts/gst-plugins.mjs
+++ b/packages/node-gi/scripts/gst-plugins.mjs
@@ -5,7 +5,9 @@
 // and GTK+3, into a GTK4 runtime — around 250 plugins whose closure is most of a media
 // distribution; the darwin relocation gate refused it. The audio path is enumerable instead of
 // guessed: it is what `@gjsify/webaudio` runs on (decodebin over appsrc, convert/resample, out
-// through the platform sink). Video decode, encoding of any kind, streaming and capture are out.
+// through the platform sink) PLUS THE SOURCE IT READS FROM — see `soup` below, which is the one
+// place this list was measurably too narrow. Video decode, encoding of any kind, capture, and
+// every streaming SINK, server or adaptive-streaming demuxer are out.
 // It also keeps a licensing choice out of a script that reads a directory — x264, x265, faac and
 // fdk-aac are GPL- or patent-encumbered, and redistributing them inside a runtime bundle belongs
 // to whoever ships the product. The builders LOG every skip with its count; a plugin silently
@@ -46,6 +48,37 @@ export const GST_AUDIO_PLUGINS = [
     'audiomixer',
     'volume',
     'audiotestsrc',
+    // THE OTHER SOURCE, and the one correction this list has needed. A pipeline reads from a file
+    // or from a URL, and only the file half shipped: `filesrc` rides in on coreelements, while
+    // `playback` — already above — IS playbin3/uridecodebin3, elements whose entire job is to take
+    // a URI. So the bundles advertised URI playback and could open exactly one scheme. Measured on
+    // the published darwin-x64 and win32-x64 bundles: `Gst.ElementFactory.make('souphttpsrc',
+    // null)` returned null on both while playbin3, decodebin3 and filesrc all resolved — a desktop
+    // app played its bundled episode and found no source element for its live stream, on the two
+    // platforms where the bundle IS the runtime.
+    //
+    // It costs more than its 107 KiB, and NEITHER cost is reachable by a link walk, so both are
+    // seeded explicitly — the shape librsvg already needed, for the same reason:
+    //
+    //   • libsoup. The plugin does not link it. Since 1.18 it g_module_opens
+    //     `libsoup-3.0.0.dylib` / `soup-3.0-0.dll` by leaf name through its own loader shim, so
+    //     `otool -L` reports glib + gstreamer and nothing else, and a closure walk seeded from the
+    //     plugin finds no soup at all. Measured on darwin-x64: +1.35 MiB (libsoup 521 KiB, plus
+    //     libpsl and libnghttp2).
+    //   • a GIO TLS backend. libsoup does https through `GTlsConnection`, whose implementation is
+    //     a glib-networking MODULE that GIO g_module_opens out of its module dir — and the bundles
+    //     ship their own libgio while shipping no module, so every TLS request in a
+    //     bundle-activated process gets the dummy backend. Measured on darwin-x64 with the host
+    //     module dir emptied: an https URL fails as `Internal data stream error` out of
+    //     souphttpsrc, i.e. the http-only half of this widening would have shipped and looked
+    //     finished. +6.67 MiB. It is a declared `tls-backend` data set in bundle-data.mjs, so its
+    //     absence fails the build and the publish gate instead of the user's stream.
+    //
+    // ~8 MiB on a 76 MB bundle, and no licensing question of the kind this file's header keeps
+    // out: the addition is LGPL-2.1+/LGPL-3+ dynamic libraries of the same family as the GLib and
+    // GTK already relocated here — no codec, no patent claim, nothing whose redistribution is the
+    // product author's call rather than ours.
+    'soup',
     // Output. `autodetect` is autoaudiosink, which picks the platform sink below.
     'autodetect',
     'osxaudio', // darwin
@@ -63,9 +96,39 @@ export const GST_AUDIO_PLUGINS = [
  * plugins.
  */
 export function isBundledGstPlugin(fileName) {
-    const base = fileName
+    const base = gstPluginBaseName(fileName);
+    return GST_AUDIO_PLUGINS.includes(base);
+}
+
+/** The list above's spelling of a plugin file: no `libgst`/`gst` prefix, no extension, lowercase. */
+function gstPluginBaseName(fileName) {
+    return fileName
         .replace(/^(lib)?gst/, '')
         .replace(/\.(dylib|so|dll)$/i, '')
         .toLowerCase();
-    return GST_AUDIO_PLUGINS.includes(base);
+}
+
+/**
+ * The plugins whose ABSENCE is a build failure rather than a counted skip.
+ *
+ * The rest of the list degrades honestly — a prefix without `mpg123` loses MP3 and says so in the
+ * skip count. These do not: without `app` there is no JS boundary, without `playback` there is no
+ * decodebin, and without `soup` a URI pipeline reports a healthy `Gst.init()` and then finds no
+ * source element far away in the application. The builders already refuse a bundle with ZERO
+ * plugins; this is that same rule made specific, because the zero check passed while the one
+ * element an app actually asked for was missing.
+ */
+export const GST_REQUIRED_PLUGINS = ['app', 'playback', 'soup'];
+
+/**
+ * Which of {@link GST_REQUIRED_PLUGINS} the given plugin files do NOT cover. Both builders call
+ * this with the set they actually COPIED, so "the prefix had it" and "the bundle carries it"
+ * cannot drift apart.
+ * @param {Iterable<string>} shippedFileNames plugin leaf names as they landed in the bundle
+ * @returns {string[]} required plugin names with nothing behind them
+ */
+export function missingRequiredGstPlugins(shippedFileNames) {
+    const shipped = new Set();
+    for (const f of shippedFileNames) shipped.add(gstPluginBaseName(f));
+    return GST_REQUIRED_PLUGINS.filter((name) => !shipped.has(name));
 }

--- a/packages/node-gi/scripts/verify-bundle-manifest.mjs
+++ b/packages/node-gi/scripts/verify-bundle-manifest.mjs
@@ -160,11 +160,20 @@ if (problems.length) {
 
 // The allowance reports itself in BOTH directions, so it cannot quietly become permanent:
 // used, it names what it let through; unused, it names itself as deletable.
-for (const note of legacyNotes) console.log(`verify-bundle-manifest: LEGACY — ${note}`);
+//
+// AND IT SAYS SO WHERE SOMEBODY LOOKS. A line in the log of a step that PASSED is read by
+// nobody, which is how a temporary allowance becomes the permanent state — the escape hatch
+// outliving its reason is the next blind spot, not a smaller version of the one it patched.
+// So on Actions the retirement notice is an ANNOTATION, surfaced on the run and on the PR
+// beside the job, while the day-to-day green stays green: this is a deletion to schedule,
+// not a build to break.
+const notice = (message) => console.log(process.env.GITHUB_ACTIONS ? `::warning::${message}` : message);
+for (const note of legacyNotes) notice(`verify-bundle-manifest: LEGACY — ${note}`);
 if (allowLegacyLicenseRecord && legacyNotes.length === 0) {
-    console.log(
+    notice(
         'verify-bundle-manifest: --allow-legacy-license-record was not needed — this bundle records its ' +
-            'license coverage. Drop the flag from the call site.',
+            'license coverage, so the published closure has caught up with the gate. DELETE the flag from ' +
+            'the two call sites in .github/workflows/gtk-os-suites.yml.',
     );
 }
 

--- a/packages/node-gi/scripts/verify-bundle-manifest.mjs
+++ b/packages/node-gi/scripts/verify-bundle-manifest.mjs
@@ -159,22 +159,22 @@ if (problems.length) {
 }
 
 // The allowance reports itself in BOTH directions, so it cannot quietly become permanent:
-// used, it names what it let through; unused, it names itself as deletable.
-//
-// AND IT SAYS SO WHERE SOMEBODY LOOKS. A line in the log of a step that PASSED is read by
-// nobody, which is how a temporary allowance becomes the permanent state — the escape hatch
-// outliving its reason is the next blind spot, not a smaller version of the one it patched.
-// So on Actions the retirement notice is an ANNOTATION, surfaced on the run and on the PR
-// beside the job, while the day-to-day green stays green: this is a deletion to schedule,
-// not a build to break.
-const notice = (message) => console.log(process.env.GITHUB_ACTIONS ? `::warning::${message}` : message);
-for (const note of legacyNotes) notice(`verify-bundle-manifest: LEGACY — ${note}`);
+// used, it names what it let through; unused, it names itself as deletable. Only the SECOND
+// is an event — the first is today's expected state on every published-closure run, and
+// annotating it would train the reader to ignore the one line that matters.
+for (const note of legacyNotes) console.log(`verify-bundle-manifest: LEGACY — ${note}`);
+// AND THE EXPIRY SAYS SO WHERE SOMEBODY LOOKS. A line in the log of a step that PASSED is
+// read by nobody, which is how a temporary allowance becomes the permanent state — an
+// escape hatch outliving its reason is the next blind spot, not a smaller version of the
+// one it patched. So on Actions it is an ANNOTATION, on the run summary and on the PR
+// beside the job, while the build stays green: this is a deletion to schedule, not a build
+// to break.
 if (allowLegacyLicenseRecord && legacyNotes.length === 0) {
-    notice(
+    const expired =
         'verify-bundle-manifest: --allow-legacy-license-record was not needed — this bundle records its ' +
-            'license coverage, so the published closure has caught up with the gate. DELETE the flag from ' +
-            'the two call sites in .github/workflows/gtk-os-suites.yml.',
-    );
+        'license coverage, so the published closure has caught up with the gate. DELETE the flag from ' +
+        'the two call sites in .github/workflows/gtk-os-suites.yml.';
+    console.log(process.env.GITHUB_ACTIONS ? `::warning::${expired}` : expired);
 }
 
 const sets = verified.map((set) => `${set.id}:${set.files}`).join(' ');

--- a/packages/node-gi/scripts/verify-bundle-manifest.mjs
+++ b/packages/node-gi/scripts/verify-bundle-manifest.mjs
@@ -18,9 +18,21 @@
 // `windowingData.decodeProbe` require the builder's RECORD, so a bundle built by an older builder,
 // or with the gate bypassed, cannot publish.
 //
+// TWO ROLES, AND A NEW RECORD ONLY ONE OF THEM CAN DEMAND. This script gates a bundle the builder
+// just produced (release.yml, both legs) AND the tarball a consumer already receives
+// (gtk-os-suites.yml, after stage-published-gtk-runtime.mjs). Adding `licenses.binariesCovered` as
+// a hard requirement broke the second role on all three targets at once: the published 0.45.0
+// manifests were written before the field existed and can never gain it — only the NEXT release
+// can. A check that a shipped artifact cannot pass is not a gate, it is a permanently red leg.
+// So `--allow-legacy-license-record` narrows the requirement for the published-closure role only,
+// and it is deliberately self-retiring: it excuses the field being ABSENT and nothing else (present
+// and zero still fails, in every role), and the script SAYS when it was not needed — which is the
+// day the flag can be deleted from the two workflow call sites.
+//
 // Usage:
 //   node packages/node-gi/scripts/verify-bundle-manifest.mjs --bundle <dir>
 //                                                            [--expect-host-target <os>]
+//                                                            [--allow-legacy-license-record]
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -46,6 +58,9 @@ function fail(message) {
 const bundle = flag('--bundle');
 if (!bundle) fail('--bundle <dir> is required');
 const expectHostTarget = flag('--expect-host-target');
+// Published-closure role only — see § TWO ROLES. Narrow (it excuses an ABSENT coverage
+// record, never a recorded zero) and self-retiring (the run says when it went unused).
+const allowLegacyLicenseRecord = args.includes('--allow-legacy-license-record');
 
 const manifestPath = join(bundle, 'manifest.json');
 let manifest;
@@ -91,10 +106,25 @@ if (!(manifest.licenses?.texts > 0)) {
 // corpus and never looked at a binary. `binariesCovered` is written only by a builder
 // whose coverage gate walked the binaries it actually copied, so requiring it here
 // refuses an uncovered bundle AND one assembled by a builder from before that gate.
-if (!(manifest.licenses?.binariesCovered > 0)) {
-    problems.push(
+//
+// The two cases are NOT the same and are kept apart on purpose (see § TWO ROLES): a
+// RECORDED zero is a builder saying it covered nothing, which is fatal wherever it is
+// read; an ABSENT field is a manifest older than the record, which only the
+// published-closure role can legitimately be handed.
+const legacyNotes = [];
+if (manifest.licenses?.binariesCovered === undefined) {
+    const problem =
         `manifest records no license coverage over the bundled binaries: ${JSON.stringify(manifest.licenses)} — ` +
-            'rebuild with a builder that runs assertLicenseCoverage over every binary it ships',
+        'rebuild with a builder that runs assertLicenseCoverage over every binary it ships';
+    if (allowLegacyLicenseRecord) {
+        legacyNotes.push(`${problem} (allowed: --allow-legacy-license-record, published-closure role)`);
+    } else {
+        problems.push(problem);
+    }
+} else if (!(manifest.licenses.binariesCovered > 0)) {
+    problems.push(
+        `manifest records license coverage over ZERO bundled binaries: ${JSON.stringify(manifest.licenses)} — ` +
+            'the license step ran and covered nothing',
     );
 }
 
@@ -128,12 +158,22 @@ if (problems.length) {
     process.exit(1);
 }
 
+// The allowance reports itself in BOTH directions, so it cannot quietly become permanent:
+// used, it names what it let through; unused, it names itself as deletable.
+for (const note of legacyNotes) console.log(`verify-bundle-manifest: LEGACY — ${note}`);
+if (allowLegacyLicenseRecord && legacyNotes.length === 0) {
+    console.log(
+        'verify-bundle-manifest: --allow-legacy-license-record was not needed — this bundle records its ' +
+            'license coverage. Drop the flag from the call site.',
+    );
+}
+
 const sets = verified.map((set) => `${set.id}:${set.files}`).join(' ');
 const probe = manifest.windowingData.decodeProbe;
 console.log(
     `verify-bundle-manifest: ${manifest.platform} clean — windowing superset, ` +
         `${manifest.typelibSymmetry.backed} backed typelibs, ${manifest.licenses.texts} license texts ` +
-        `covering ${manifest.licenses.binariesCovered} binaries, ` +
+        `covering ${manifest.licenses.binariesCovered ?? 'an unrecorded number of'} binaries, ` +
         `${manifest.dataBytes} data bytes, sets ${sets}, ` +
         `decoded ${probe.svg.file} ${probe.svg.width}x${probe.svg.height} + ` +
         `${probe.png.file} ${probe.png.width}x${probe.png.height} through the ${probe.gtkSource} GTK`,

--- a/packages/node-gi/scripts/verify-bundle-manifest.mjs
+++ b/packages/node-gi/scripts/verify-bundle-manifest.mjs
@@ -86,6 +86,18 @@ if (!(manifest.licenses?.texts > 0)) {
     problems.push(`manifest records no license texts: ${JSON.stringify(manifest.licenses)}`);
 }
 
+// A COUNT OF TEXTS IS NOT COVERAGE — the win32 bundles satisfied the line above while
+// shipping GLib and OpenSSL with no terms at all, because their license step counted the
+// corpus and never looked at a binary. `binariesCovered` is written only by a builder
+// whose coverage gate walked the binaries it actually copied, so requiring it here
+// refuses an uncovered bundle AND one assembled by a builder from before that gate.
+if (!(manifest.licenses?.binariesCovered > 0)) {
+    problems.push(
+        `manifest records no license coverage over the bundled binaries: ${JSON.stringify(manifest.licenses)} — ` +
+            'rebuild with a builder that runs assertLicenseCoverage over every binary it ships',
+    );
+}
+
 const verified = manifest.windowingData?.verified ?? [];
 if (!verified.length) {
     problems.push(`manifest records no verified windowing data sets: ${JSON.stringify(manifest.windowingData)}`);
@@ -120,7 +132,8 @@ const sets = verified.map((set) => `${set.id}:${set.files}`).join(' ');
 const probe = manifest.windowingData.decodeProbe;
 console.log(
     `verify-bundle-manifest: ${manifest.platform} clean — windowing superset, ` +
-        `${manifest.typelibSymmetry.backed} backed typelibs, ${manifest.licenses.texts} license texts, ` +
+        `${manifest.typelibSymmetry.backed} backed typelibs, ${manifest.licenses.texts} license texts ` +
+        `covering ${manifest.licenses.binariesCovered} binaries, ` +
         `${manifest.dataBytes} data bytes, sets ${sets}, ` +
         `decoded ${probe.svg.file} ${probe.svg.width}x${probe.svg.height} + ` +
         `${probe.png.file} ${probe.png.width}x${probe.png.height} through the ${probe.gtkSource} GTK`,

--- a/tests/e2e/release-bundle-gate/run.mjs
+++ b/tests/e2e/release-bundle-gate/run.mjs
@@ -151,6 +151,41 @@ describe('verify-bundle-manifest: the release gate', () => {
         assert.match(result.stderr, /assertLicenseCoverage over every binary it ships/);
     });
 
+    // THE OTHER ROLE, and the reason the requirement above is not unconditional. The same
+    // script gates the tarball a consumer ALREADY has (gtk-os-suites.yml, after
+    // stage-published-gtk-runtime.mjs), whose manifest was written before this record
+    // existed and can never gain it — only the next release can. Requiring it there turned
+    // all three shipped-closure legs red at once over a property no published artifact can
+    // acquire. The allowance is narrow and self-retiring; these three cases pin both edges.
+    it('lets the PUBLISHED closure through when the record simply predates the field', () => {
+        const manifest = goodManifest();
+        delete manifest.licenses.binariesCovered;
+        const result = runVerify(manifest, ['--allow-legacy-license-record']);
+        assert.equal(result.status, 0, result.output);
+        assert.match(result.stdout, /LEGACY — .*no license coverage/);
+        assert.match(result.stdout, /published-closure role/);
+        assert.match(result.stdout, /covering an unrecorded number of binaries/);
+    });
+
+    it('still rejects a RECORDED zero, allowance or not', () => {
+        // An absent field is a manifest older than the record; a recorded zero is a
+        // builder saying it covered nothing. Only the first is a legacy artifact.
+        const result = runVerify(goodManifest({ licenses: { texts: 65, binariesCovered: 0 } }), [
+            '--allow-legacy-license-record',
+        ]);
+        assert.equal(result.status, 1);
+        assert.match(result.stderr, /license coverage over ZERO bundled binaries/);
+    });
+
+    it('says the allowance was not needed, so it can be deleted', () => {
+        // Self-retiring: the day a published bundle carries the field, the flag reports
+        // itself as droppable instead of sitting in the workflow forever.
+        const result = runVerify(goodManifest(), ['--allow-legacy-license-record']);
+        assert.equal(result.status, 0, result.output);
+        assert.match(result.stdout, /--allow-legacy-license-record was not needed/);
+        assert.match(result.stdout, /Drop the flag from the call site/);
+    });
+
     it('rejects a declared data set that holds no files', () => {
         // A directory that exists and is empty is the same missing signal as an absent
         // one — and is what 0.27.1's `share/` would have been had it existed at all.

--- a/tests/e2e/release-bundle-gate/run.mjs
+++ b/tests/e2e/release-bundle-gate/run.mjs
@@ -166,11 +166,15 @@ describe('verify-bundle-manifest: the release gate', () => {
     it('lets the PUBLISHED closure through when the record simply predates the field', () => {
         const manifest = goodManifest();
         delete manifest.licenses.binariesCovered;
-        const result = runVerify(manifest, ['--allow-legacy-license-record']);
+        const result = runVerify(manifest, ['--allow-legacy-license-record'], { GITHUB_ACTIONS: 'true' });
         assert.equal(result.status, 0, result.output);
         assert.match(result.stdout, /LEGACY — .*no license coverage/);
         assert.match(result.stdout, /published-closure role/);
         assert.match(result.stdout, /covering an unrecorded number of binaries/);
+        // NOT annotated: this is what every published-closure leg looks like until the next
+        // release, and an annotation on the expected state is what makes the one on the
+        // UNexpected state (the case below) invisible.
+        assert.doesNotMatch(result.stdout, /::warning::/);
     });
 
     it('still rejects a RECORDED zero, allowance or not', () => {

--- a/tests/e2e/release-bundle-gate/run.mjs
+++ b/tests/e2e/release-bundle-gate/run.mjs
@@ -93,11 +93,17 @@ function goodManifest(overrides = {}) {
     };
 }
 
-function runVerify(manifest, extraArgs = []) {
+/**
+ * `GITHUB_ACTIONS` is cleared unless a case sets it: the gate turns its retirement notice
+ * into an `::warning::` annotation there, and this suite running under Actions would
+ * otherwise decorate every real run with a warning about a fixture.
+ */
+function runVerify(manifest, extraArgs = [], env = {}) {
     const dir = mkdtempSync(join(tmpdir(), 'gjsify-bundle-gate-'));
     writeFileSync(join(dir, 'manifest.json'), JSON.stringify(manifest));
     const result = spawnSync(process.execPath, [VERIFY, '--bundle', dir, ...extraArgs], {
         encoding: 'utf8',
+        env: { ...process.env, GITHUB_ACTIONS: '', ...env },
     });
     return { ...result, output: `${result.stdout}${result.stderr}` };
 }
@@ -183,7 +189,19 @@ describe('verify-bundle-manifest: the release gate', () => {
         const result = runVerify(goodManifest(), ['--allow-legacy-license-record']);
         assert.equal(result.status, 0, result.output);
         assert.match(result.stdout, /--allow-legacy-license-record was not needed/);
-        assert.match(result.stdout, /Drop the flag from the call site/);
+        assert.match(result.stdout, /DELETE the flag from the two call sites/);
+        assert.doesNotMatch(result.stdout, /::warning::/, 'no annotation outside Actions');
+    });
+
+    it('surfaces its own expiry as an Actions annotation, not as a line in a green log', () => {
+        // The flag is temporary by construction and the note that retires it is printed by
+        // a step that PASSES — which nobody reads. On Actions it is an annotation instead,
+        // so the day the published closure carries the record, the deletion is on the run
+        // summary and on the PR rather than in scrollback. Still not a failure: this is a
+        // deletion to schedule, not a build to break.
+        const result = runVerify(goodManifest(), ['--allow-legacy-license-record'], { GITHUB_ACTIONS: 'true' });
+        assert.equal(result.status, 0, result.output);
+        assert.match(result.stdout, /::warning::verify-bundle-manifest: --allow-legacy-license-record was not needed/);
     });
 
     it('rejects a declared data set that holds no files', () => {

--- a/tests/e2e/release-bundle-gate/run.mjs
+++ b/tests/e2e/release-bundle-gate/run.mjs
@@ -77,7 +77,10 @@ function goodManifest(overrides = {}) {
         windowing: true,
         dataBytes: 20247017,
         typelibSymmetry: { backed: 25, dropped: 6 },
-        licenses: { texts: 65 },
+        // `binariesCovered` is the count the license gate actually walked. A texts count
+        // alone is what the win32 bundles satisfied while shipping GLib and OpenSSL with
+        // no terms, so the release gate wants both.
+        licenses: { texts: 65, binariesCovered: 121 },
         windowingData: {
             verified: [
                 { id: 'schemas', files: 1 },
@@ -114,7 +117,7 @@ describe('verify-bundle-manifest: the release gate', () => {
         assert.equal(result.status, 0, result.output);
         assert.match(result.stdout, /clean — windowing superset/);
         assert.match(result.stdout, /25 backed typelibs/);
-        assert.match(result.stdout, /65 license texts/);
+        assert.match(result.stdout, /65 license texts covering 121 binaries/);
         assert.match(result.stdout, /decoded .*open-menu-symbolic\.svg 16x16/);
         assert.match(result.stdout, /through the bundle/);
     });
@@ -125,12 +128,27 @@ describe('verify-bundle-manifest: the release gate', () => {
         // no license texts beside 37-45 relocated LGPL/MPL/GPL libraries.
         const result = runVerify({ platform: `${process.platform}-${process.arch}`, windowing: false, dataBytes: 0 });
         assert.equal(result.status, 1);
-        assert.match(result.stderr, /FAILED 5 check\(s\)/);
+        assert.match(result.stderr, /FAILED 6 check\(s\)/);
         assert.match(result.stderr, /windowing=false dataBytes=0/);
         assert.match(result.stderr, /no verified typelib symmetry/);
         assert.match(result.stderr, /no license texts/);
+        assert.match(result.stderr, /no license coverage over the bundled binaries/);
         assert.match(result.stderr, /no verified windowing data sets/);
         assert.match(result.stderr, /no windowingData\.decodeProbe/);
+    });
+
+    it('rejects a bundle whose license step never looked at a binary', () => {
+        // The published win32 shape: a licence corpus was copied and counted, and no
+        // check ever asked whether it covered anything the bundle ships. Measured on the
+        // 0.45.0 win32 artifact — 89 binaries, 45 documented projects, 14 binaries whose
+        // project the tarball documents nowhere, and every gate green. FAIL CLOSED, as
+        // with the decode probe: "the builder is too old to say" is not a pass.
+        const manifest = goodManifest();
+        delete manifest.licenses.binariesCovered;
+        const result = runVerify(manifest);
+        assert.equal(result.status, 1);
+        assert.match(result.stderr, /no license coverage over the bundled binaries/);
+        assert.match(result.stderr, /assertLicenseCoverage over every binary it ships/);
     });
 
     it('rejects a declared data set that holds no files', () => {


### PR DESCRIPTION
The runtime bundles ship `playback` — playbin3 and uridecodebin3, elements whose entire job is to take a URI — while the only source behind them was `filesrc`, riding in on `coreelements`. So the bundles advertised URI playback and could open exactly one scheme.

Measured on the published `darwin-x64` and `win32-x64` bundles:

| | |
|---|---|
| `Gst.ElementFactory.make('playbin3' \| 'decodebin3' \| 'filesrc')` | an element |
| `Gst.ElementFactory.make('souphttpsrc')` | **null** |
| `Gio.tls_backend_get_default().supports_tls()` | **false** |

A desktop app played its bundled podcast episode and found no source element for its live stream, on the two platforms where the bundle **is** the runtime.

## The half that would have looked finished

Fixing only the first row ships a broken feature that reads as working. `GTlsConnection` has no implementation inside GIO: glib-networking ships one as a module GIO `g_module_open`s out of a directory whose compiled-in default is the **build machine's** prefix. The bundles ship their own `libgio` and shipped no module, so every TLS request in a bundle-activated process got the dummy backend — and `souphttpsrc` reports that as `Internal data stream error`, a network error to read and a missing module in fact. `@gjsify/{tls,http2,ws}` fail the same way one layer up.

Neither payload is reachable by a link walk **on darwin**, so both are seeded explicitly — the third instance of the shape librsvg established. There the plugin `g_module_open`s libsoup by leaf name (so `otool -L` reports glib and gstreamer and nothing else), and nothing links a GIO module at all. On **win32** gst-plugins-good takes the `host_system == 'windows'` branch and *links* libsoup — `gstsoup.dll`'s import table names `soup-3.0-0.dll` — so the seed there is load-bearing only for `Soup-3.0.typelib`'s backing, which is what its comment now says.

## Gates, so absence fails the build and not the user

- The TLS backend is a declared `tls-backend` runtime data set, so an empty module dir fails the build *and* `verify-bundle-manifest.mjs` before publish.
- `GST_REQUIRED_PLUGINS` (`app`, `playback`, `soup`) names the plugins whose absence is a build failure rather than a counted skip, checked against the set the builders actually copied. The existing zero-plugin check passed while the one element an app asked for was missing.
- Windows gains two gvsbuild projects (`glib-networking`, `libsoup3`) and a second invocation, because gst-plugins-good's `soup` feature is meson `auto` and **silently** produces no plugin when libsoup is absent from the prefix. The prefix assertion now names `gstsoup.dll` instead of counting plugins.

## Cost

Measured per platform as the file-set difference between the published `0.45.0` bundle and this branch's own CI artifact — the two are **not** the same order of magnitude:

| | added | bundle | |
|---|---|---|---|
| darwin-x64 | **9.36 MiB** | 72.7 MiB | +13 % |
| win32-x64 | **47.80 MiB** | 77.5 MiB | **+62 %** |

The darwin total matches what this PR first claimed; its *base* did not (85 MiB is the bundle **after** the addition). win32 was never measured, and 34 MiB of its 47.8 is **ICU** — `icudt78.dll` alone is 31.6 MiB — pulled in transitively because gvsbuild builds libpsl against ICU where Homebrew builds it against libidn2 + libunistring. Nothing about the decision needs ICU; reducing it is gvsbuild-side follow-up, recorded in ADR 0037 rather than treated as solved.

The licence characterisation was also wrong. The payload is **mixed**, not all LGPL: LGPL-2.1+/LGPL-3+ (libsoup, glib-networking, gnutls and its closure), **Apache-2.0** (OpenSSL 3 — gvsbuild's TLS backend is `gioopenssl`, not `giognutls`), **MIT** (libpsl, nghttp2, MIT Kerberos), BSD (p11-kit), Unicode (ICU), public domain (SQLite). The substantive claim survives: no codec and no patent-encumbered decoder enters, which is the category the allowlist header keeps out.

## Scope

The curation rule is not widened by argument. What was in question is where the audio path *begins*: reading a URI is the same operation as `filesrc`, which already ships. Encoders, video decode, capture, and streaming **sinks**, servers and adaptive-streaming demuxers stay out. `appsrc` remains the right answer for bytes you already hold, and nothing here changes it.

## Notes for review

- ~~This has not been proven on a built bundle yet.~~ **It has.** This PR's run assembled the widened bundle on all three targets from this checkout — `macos-gtk-windowing-runtime` (both arches) and `windows-gtk-windowing-runtime` (45m37s, the cache-key bump forced a real gvsbuild rebuild) — and every downstream job consumes that run's `actions/upload-artifact`, not a published tarball. `gst-elements.test.mjs` passed 4/4 on the staged darwin-x64 bundle, `souphttpsrc` and the TLS backend included; the win32 prefix assertion found `gstsoup.dll` and 2 GIO modules. The caveat is resolved. (The separate `GTK suites on the shipped closure` legs *do* npm-install the **published** bundle, so their green says nothing about this change.)
- ADR is numbered **0037**: it was written as 0034 against an older `main`, which has since taken 0034 through 0036. No collision; `docs/adr/README.md` is consistent.
- ADR status stays **`Accepted`**. That is the repo's convention for a decision landing with its implementation (30 of 37 ADRs are `Accepted`), and this one ships builders, gates, tests and a green build of the artifact. The three `Proposed` ADRs above it are proposals whose implementation has not landed — a different situation, not a precedent.

## Review corrections landed on this branch

- **A real defect, fixed:** the darwin closure walk copied all 24 GStreamer plugins into flat `lib/` as well, +3.4 MiB of duplicates. `otool -L` prints a dylib's own `LC_ID_DYLIB` among its dependencies and `otoolDeps` dropped one line as "the id" when line 0 is the `<file>:` header. Inert until `resolveBrewDep` began resolving whole references for keg-only formulas, at which point the id resolved to the plugin itself. Verified on the artifact: 24/24 plugins duplicated, 0/1 GIO modules (a loadable bundle has no id) — the control that identifies the mechanism. Gated for the class via `duplicatedModuleLeaves()` in both builders, with unit tests.
- **Still open, and it should block publish:** `libcrypto-3-x64.dll` and `libssl-3-x64.dll` ship in the win32 bundle with **no licence text** (45 components attributed, none is OpenSSL). The win32 licence step attributes by *prefix*, and `assertLicenseCoverage` runs its per-binary checks only under `per-binary` attribution, so an unlicensed family is invisible to every gate. Apache-2.0 § 4 requires the licence to travel with the binary. **INTRODUCED by this PR, not merely exposed** — corrected after measuring the published tarball rather than reasoning about the gate. `npm pack @gjsify/gtk-runtime-win32-x64@0.45.0` contains **zero** files matching `libcrypto`/`libssl`, and 45 licence texts of which none is OpenSSL. The DLLs arrive because this change adds `glib-networking` and `libsoup3` to the gvsbuild build and gvsbuild's TLS backend is `gioopenssl`. What IS pre-existing is the gate weakness that lets it through: prefix attribution plus `assertLicenseCoverage` running its per-binary checks only under `per-binary`. So the hole is old and the payload falling into it is new, which is why this blocks publish rather than being filed as debt.


