### PR TITLE
feat(adwaita-react-native): add navigation widgets

### DIFF
--- a/packages/framework/adwaita-react-native/README.md
+++ b/packages/framework/adwaita-react-native/README.md
@@ -510,6 +510,16 @@ than smoothed over.
   pane, which libadwaita uses for the header of a collapsed view. The React Native half has
   no header bar to put a title in, so it carries them and draws neither — the same shape as
   `iconName`.
+- **`onNotifyVisibleChild` does not carry the same set of changes on both halves.** A
+  press on the switcher reaches both. A change the CALLER made through
+  `visibleChildName` reaches the React Native half only — it re-applies the prop through
+  `selectName` and reports what the stack settled on, while gtk-host drops the notify
+  raised inside its own property write, which is the same rule `onNotifyExpanded` already
+  records. The mount AUTO-PICK reaches neither: libadwaita notifies it from inside
+  `adw_view_stack_add_titled`, before React has committed the `ref` the settled name
+  would be read off (measured — the GTK half used to report `''` there, a name no page
+  carries), and on the other half the core's auto-pick lands before the subscription
+  exists. Both halves are asserted at the two ends of that.
 - **`AdwViewSwitcher` bundles the stack libadwaita keeps separate.** `Adw.ViewSwitcher:stack`
   points at an `Adw.ViewStack` elsewhere in the tree, and a React prop cannot hold a widget
   that does not exist yet on the half where widgets exist at all. Both other renderers made

--- a/packages/framework/adwaita-react-native/README.md
+++ b/packages/framework/adwaita-react-native/README.md
@@ -71,6 +71,10 @@ a GTK-only consumer does not need it installed.
 | `AdwEntryRow` | `title`, `text`, `maxLength` (0), `editable` (true), `showApplyButton` (false), `onNotifyText`, `onApply`, `onEntryActivated` | The row IS the entry. `max-length` counts CHARACTERS |
 | `AdwExpanderRow` | `title`, `subtitle`, `expanded` (false), `onNotifyExpanded`, `children` | `children` are the DISCLOSED rows. The header toggles, the disclosure does not |
 | `AdwHeaderBar` | `start`, `titleWidget`, `title`, `subtitle`, `end` | The three slots as PROPS, in draw order. No window controls: a phone has none |
+| `AdwNavigationPage` | `children`, `title`, `tag`, `canPop` (true) | One page of a navigation view, or one pane of a navigation split view. A widget on GTK because `adw_navigation_view_add` takes one; three properties and no drawing of its own |
+| `AdwNavigationSplitView` | `children` (the content), `sidebar`, `sidebarTag`, `contentTag`, `sidebarTitle`, `contentTitle`, `collapsed`, `showContent`, `sidebarPosition`, plus the four sizing props | Sidebar beside content; a navigation stack when collapsed. Both panes are wrapped in an `Adw.NavigationPage` on GTK, because the two slots take nothing else |
+| `AdwNavigationView` | `children` (the pages, first is the root), `animateTransitions` (true), `popOnEscape` (true), `ref` (`push`, `pop`, `popToTag`, `replaceWithTags`, `visiblePageTag`, `canGoBack`, `backButtonTooltip`) | A page stack. Pushed BY TAG through the ref, never by prop — `Adw.NavigationView:visible-page` is read-only |
+| `AdwOverlaySplitView` | `children` (the content), `sidebar`, `collapsed`, `showSidebar` (true), `pinSidebar`, `sidebarPosition`, `enableShowGesture` (true), `enableHideGesture` (true), `onNotifyShowSidebar`, plus the four sizing props | Sidebar that slides OVER the content when collapsed. Collapsing hides an unpinned sidebar itself, which is what `onNotifyShowSidebar` reports |
 | `AdwPasswordEntryRow` | `title`, `text`, `maxLength`, `editable`, `showApplyButton`, `onNotifyText`, `onApply`, `onEntryActivated` | `Adw.EntryRow`'s surface exactly — the subclass declares no property of its own. `maxLength` counts CHARACTERS through the core, never `TextInput.maxLength`'s UTF-16 units |
 | `AdwPreferencesGroup` | `children` (the rows), `title`, `description` | A titled card. Five visibility answers from one `derivePreferencesGroupHeader` call; the card hides itself at zero rows while its header stays |
 | `AdwPreferencesPage` | `children` (the groups), `title`, `iconName`, `name`, `description`, `descriptionCentered`, `useUnderline` | Four of the five properties are identity a view switcher reads, drawn by neither half — as in libadwaita. Only `description` is painted |
@@ -80,6 +84,8 @@ a GTK-only consumer does not need it installed.
 | `AdwSwitchRow` | `title`, `subtitle`, `active` (false), `onNotifyActive` | Controlled. The whole row toggles, not only the handle |
 | `AdwToastOverlay` | `children`, `ref` (`addToast`, `dismissAll`) | One toast at a time. A toast is PUSHED through the ref, never declared as a prop — `add_toast` is a call |
 | `AdwToolbarView` | `children` (the content), `topBar`, `bottomBar`, `topBarStyle` (`flat`), `bottomBarStyle` (`flat`), `extendContentToTopEdge` (false), `extendContentToBottomEdge` (false) | Content framed by bars. The two styles reach the real widget on GTK and draw nothing on a phone |
+| `AdwViewStack` | `pages` (`name`, `title`, `iconName`, `visible`, `badgeNumber`, `needsAttention`, `useUnderline`, `child`), `visibleChildName`, `onNotifyVisibleChild` | Named pages, one visible. A page is a PROP OBJECT because `Adw.ViewStackPage` is a GObject and not a widget |
+| `AdwViewSwitcher` | `AdwViewStack`'s props plus `policy` (`narrow`) | A button row over the stack. It BUNDLES the stack libadwaita keeps separate, as both other renderers do — on GTK it still builds a real `Adw.ViewStack` and binds it to `Adw.ViewSwitcher:stack` |
 | `AdwWindowTitle` | `title`, `subtitle` | Two labels; an EMPTY one takes no space, a blank one does |
 | `AdwWrapBox` | `children` plus libadwaita's fourteen: `childSpacing`/`childSpacingUnit`, `lineSpacing`/`lineSpacingUnit`, `align`, `justify`, `justifyLastLine`, `lineHomogeneous`, `naturalLineLength`/`naturalLineLengthUnit`, `packDirection`, `wrapReverse`, `wrapPolicy`, `orientation` | Children flow onto new lines. The line DECISION is `@gjsify/adwaita-core`'s, the line BREAKING is Yoga's |
 
@@ -444,3 +450,69 @@ than smoothed over.
   it. The other two stateful rows go the GTK way (see [Widgets](#widgets)); this one goes
   React Native's, because a `Switch` that disagrees with its `value` prop is a bug on that
   platform.
+- **The navigation view animates on GTK and swaps instantly on React Native, and there
+  is no automatic back button.** `animateTransitions` reaches the real
+  `Adw.NavigationView` and reaches `NavigationViewState` on the other half, where nothing
+  spends it — this package has no animation layer, which is the same position
+  `@gjsify/adwaita-nativescript` records ("kept for API parity"). `popOnEscape` is inert
+  for the plainer reason that a phone has no Escape key. And where the browser renderer
+  finds an `<adw-header-bar>` inside the visible page and injects a back button into it,
+  neither NativeScript nor this package can identify a header bar inside an opaque child:
+  `canGoBack()` and `backButtonTooltip()` on the handle are libadwaita's own two
+  derivations, and the caller wires its own button to them.
+- **An untitled `Adw.NavigationPage` is a GTK warning and nothing at all on React
+  Native.** Measured on libadwaita 1.9.3: a page with no title prints `AdwNavigationPage
+  0x… is missing a title. To hide a header bar title, consider using
+  AdwHeaderBar:show-title instead.` The React Native half has no counterpart, so the
+  `'Back'` tooltip fallback — which needs an empty title — is asserted on that half only,
+  against the constant both halves import from `@gjsify/adwaita-core`.
+- **Neither split view has a content minimum to protect on React Native.** libadwaita
+  caps the sidebar with the content pane's own minimum width and reports
+  `sidebar_min + content_min` as the view's own minimum; React Native hands a component an
+  already-laid-out size and never a child's intrinsic minimum, so `contentMin` and
+  `sidebarChildMin` go in as 0. The consequences are one-directional and both measured:
+  the sidebar can take its full share of a view too narrow for both panes, and the view
+  cannot refuse to be narrower than its contents the way GTK does (the GTK suite asserts
+  that refusal at 380 against `measureSplitViewHorizontal`; the React Native suite cannot
+  ask). Same class as `AdwClamp`'s `childMin`.
+- **The two sidebar-width rules disagree only where GTK cannot go.**
+  `resolveNavigationSidebarWidth` caps the sidebar's MAX BOUND by `width - content_min`
+  and `resolveOverlaySidebarWidth` caps the RESULT, which the core's own vectors separate
+  at 300 points (180 versus 100). Measured through the real widgets, that width is
+  unreachable: `measure` makes `sidebar_min + content_min` the view's minimum, GTK never
+  allocates below it, and from there upwards the two rules agree. So the difference is a
+  property of the two functions, held by `@gjsify/adwaita-core`'s vectors, and this
+  package asserts the minimum instead.
+- **The overlay's reveal is instant on React Native.** libadwaita animates with a spring
+  `(1, 0.5, 500)`; `@gjsify/adwaita-web` approximates it from `requestAnimationFrame` and
+  `@gjsify/adwaita-nativescript` from `View.animate()`. React Native's own answer is
+  `Animated`, a COMPOSITE surface the test double may not stand in for, so the core's
+  `INSTANT_SPLIT_VIEW_ANIMATOR` default stands and `enableShowGesture` /
+  `enableHideGesture` are carried and inert. `show-progress` still runs through the core,
+  so the continuum is expressible the day an animator is plugged in.
+- **The React Native split views resolve `start`/`end` against `ltr` only.**
+  `isSidebarAtVisualStart` takes a reading direction, GTK resolves it from the widget, and
+  React Native's lives on `I18nManager` — not a host component, so not something
+  `testing/react-native.ts` may double. The core call still takes the parameter; closing
+  this is one argument.
+- **`sidebar-position: end` is invisible on a COLLAPSED React Native split view.**
+  `resolveNavigationStack` builds the stack the other way round for `end` — the content is
+  the root page and the sidebar is pushed on top of it — but the LAST entry, which is the
+  pane on screen, is the same for both positions at every value of `show-content`. What
+  differs is the push/pop DIRECTION, which a renderer spends on a slide and this one has
+  none of. The position IS asserted where it is observable: the docked draw order.
+- **`sidebarTitle` and `contentTitle` reach a real page on GTK and nothing on a phone.**
+  They are `Adw.NavigationPage:title` of the wrap `AdwNavigationSplitView` puts around each
+  pane, which libadwaita uses for the header of a collapsed view. The React Native half has
+  no header bar to put a title in, so it carries them and draws neither — the same shape as
+  `iconName`.
+- **`AdwViewSwitcher` bundles the stack libadwaita keeps separate.** `Adw.ViewSwitcher:stack`
+  points at an `Adw.ViewStack` elsewhere in the tree, and a React prop cannot hold a widget
+  that does not exist yet on the half where widgets exist at all. Both other renderers made
+  the same call. On GTK nothing is simulated: the component builds a real `Adw.ViewStack`
+  and writes it into that property, which the GTK suite asserts by identity.
+- **The switcher's buttons carry no icon.** Same icon-theme rule as above, with one extra
+  consequence worth naming: a page with an icon and NO title still gets a button, because
+  `isViewSwitcherButtonVisible` tests both — and on React Native that button's label is
+  empty. The button's ORIENTATION is still applied, since it is what arranges the label
+  and the badge.

--- a/packages/framework/adwaita-react-native/README.md
+++ b/packages/framework/adwaita-react-native/README.md
@@ -475,14 +475,18 @@ than smoothed over.
   cannot refuse to be narrower than its contents the way GTK does (the GTK suite asserts
   that refusal at 380 against `measureSplitViewHorizontal`; the React Native suite cannot
   ask). Same class as `AdwClamp`'s `childMin`.
-- **The two sidebar-width rules disagree only where GTK cannot go.**
+- **The two sidebar-width rules can only be told apart one at a time on GTK.**
   `resolveNavigationSidebarWidth` caps the sidebar's MAX BOUND by `width - content_min`
   and `resolveOverlaySidebarWidth` caps the RESULT, which the core's own vectors separate
-  at 300 points (180 versus 100). Measured through the real widgets, that width is
-  unreachable: `measure` makes `sidebar_min + content_min` the view's minimum, GTK never
-  allocates below it, and from there upwards the two rules agree. So the difference is a
-  property of the two functions, held by `@gjsify/adwaita-core`'s vectors, and this
-  package asserts the minimum instead.
+  at 300 points (180 versus 100). The NAVIGATION half of that pair is unreachable through
+  a window: `measure_uncollapsed` makes `sidebar_min + content_min` its minimum, GTK never
+  allocates below a minimum, and from there upwards `width - content_min` never falls under
+  `sidebar_min`, so the bound cap never inverts. The OVERLAY half is reachable, because its
+  minimum is `(int) (sidebar_min * show_progress) + content_min` — a hidden sidebar takes
+  that term out — and the GTK suite reads its 100 off the live tree. So the two answers are
+  never asserted side by side here; the disagreement itself is held by
+  `@gjsify/adwaita-core`'s vectors, and this package asserts the navigation minimum and the
+  overlay cap separately.
 - **The overlay's reveal is instant on React Native.** libadwaita animates with a spring
   `(1, 0.5, 500)`; `@gjsify/adwaita-web` approximates it from `requestAnimationFrame` and
   `@gjsify/adwaita-nativescript` from `View.animate()`. React Native's own answer is

--- a/packages/framework/adwaita-react-native/package.json
+++ b/packages/framework/adwaita-react-native/package.json
@@ -66,10 +66,30 @@
             "react-native": "./lib/esm/widgets/header-bar.native.js",
             "default": "./lib/esm/widgets/header-bar.gtk.js"
         },
+        "./widgets/navigation-page": {
+            "types": "./lib/types/widgets/navigation-page.d.ts",
+            "react-native": "./lib/esm/widgets/navigation-page.native.js",
+            "default": "./lib/esm/widgets/navigation-page.gtk.js"
+        },
+        "./widgets/navigation-split-view": {
+            "types": "./lib/types/widgets/navigation-split-view.d.ts",
+            "react-native": "./lib/esm/widgets/navigation-split-view.native.js",
+            "default": "./lib/esm/widgets/navigation-split-view.gtk.js"
+        },
+        "./widgets/navigation-view": {
+            "types": "./lib/types/widgets/navigation-view.d.ts",
+            "react-native": "./lib/esm/widgets/navigation-view.native.js",
+            "default": "./lib/esm/widgets/navigation-view.gtk.js"
+        },
         "./widgets/password-entry-row": {
             "types": "./lib/types/widgets/password-entry-row.d.ts",
             "react-native": "./lib/esm/widgets/password-entry-row.native.js",
             "default": "./lib/esm/widgets/password-entry-row.gtk.js"
+        },
+        "./widgets/overlay-split-view": {
+            "types": "./lib/types/widgets/overlay-split-view.d.ts",
+            "react-native": "./lib/esm/widgets/overlay-split-view.native.js",
+            "default": "./lib/esm/widgets/overlay-split-view.gtk.js"
         },
         "./widgets/preferences-group": {
             "types": "./lib/types/widgets/preferences-group.d.ts",
@@ -110,6 +130,16 @@
             "types": "./lib/types/widgets/toolbar-view.d.ts",
             "react-native": "./lib/esm/widgets/toolbar-view.native.js",
             "default": "./lib/esm/widgets/toolbar-view.gtk.js"
+        },
+        "./widgets/view-stack": {
+            "types": "./lib/types/widgets/view-stack.d.ts",
+            "react-native": "./lib/esm/widgets/view-stack.native.js",
+            "default": "./lib/esm/widgets/view-stack.gtk.js"
+        },
+        "./widgets/view-switcher": {
+            "types": "./lib/types/widgets/view-switcher.d.ts",
+            "react-native": "./lib/esm/widgets/view-switcher.native.js",
+            "default": "./lib/esm/widgets/view-switcher.gtk.js"
         },
         "./widgets/window-title": {
             "types": "./lib/types/widgets/window-title.d.ts",

--- a/packages/framework/adwaita-react-native/src/index.gtk.ts
+++ b/packages/framework/adwaita-react-native/src/index.gtk.ts
@@ -19,10 +19,16 @@ export type {
     AdwEntryRowProps,
     AdwExpanderRowProps,
     AdwHeaderBarProps,
+    AdwNavigationPageProps,
+    AdwNavigationSplitViewProps,
+    AdwNavigationViewHandle,
+    AdwNavigationViewProps,
+    AdwOverlaySplitViewProps,
     AdwPasswordEntryRowProps,
     AdwPreferencesGroupProps,
     AdwPreferencesPageProps,
     AdwRowProps,
+    AdwSidebarWidthProps,
     AdwSpinRowProps,
     AdwSpinnerProps,
     AdwStatusPageProps,
@@ -30,6 +36,9 @@ export type {
     AdwToastOverlayHandle,
     AdwToastOverlayProps,
     AdwToolbarViewProps,
+    AdwViewStackPageProps,
+    AdwViewStackProps,
+    AdwViewSwitcherProps,
     AdwWidgetProps,
     AdwWindowTitleProps,
     AdwWrapBoxProps,
@@ -46,6 +55,10 @@ export { AdwComboRow } from './widgets/combo-row.gtk.js';
 export { AdwEntryRow } from './widgets/entry-row.gtk.js';
 export { AdwExpanderRow } from './widgets/expander-row.gtk.js';
 export { AdwHeaderBar } from './widgets/header-bar.gtk.js';
+export { AdwNavigationPage } from './widgets/navigation-page.gtk.js';
+export { AdwNavigationSplitView } from './widgets/navigation-split-view.gtk.js';
+export { AdwNavigationView } from './widgets/navigation-view.gtk.js';
+export { AdwOverlaySplitView } from './widgets/overlay-split-view.gtk.js';
 export { AdwPasswordEntryRow } from './widgets/password-entry-row.gtk.js';
 export { AdwPreferencesGroup } from './widgets/preferences-group.gtk.js';
 export { AdwPreferencesPage } from './widgets/preferences-page.gtk.js';
@@ -55,6 +68,8 @@ export { AdwStatusPage } from './widgets/status-page.gtk.js';
 export { AdwSwitchRow } from './widgets/switch-row.gtk.js';
 export { AdwToastOverlay } from './widgets/toast-overlay.gtk.js';
 export { AdwToolbarView } from './widgets/toolbar-view.gtk.js';
+export { AdwViewStack } from './widgets/view-stack.gtk.js';
+export { AdwViewSwitcher } from './widgets/view-switcher.gtk.js';
 export { AdwWindowTitle } from './widgets/window-title.gtk.js';
 export { AdwWrapBox } from './widgets/wrap-box.gtk.js';
 
@@ -80,6 +95,10 @@ import { AdwComboRow as ComboRow } from './widgets/combo-row.gtk.js';
 import { AdwEntryRow as EntryRow } from './widgets/entry-row.gtk.js';
 import { AdwExpanderRow as ExpanderRow } from './widgets/expander-row.gtk.js';
 import { AdwHeaderBar as HeaderBar } from './widgets/header-bar.gtk.js';
+import { AdwNavigationPage as NavigationPage } from './widgets/navigation-page.gtk.js';
+import { AdwNavigationSplitView as NavigationSplitView } from './widgets/navigation-split-view.gtk.js';
+import { AdwNavigationView as NavigationView } from './widgets/navigation-view.gtk.js';
+import { AdwOverlaySplitView as OverlaySplitView } from './widgets/overlay-split-view.gtk.js';
 import { AdwPasswordEntryRow as PasswordEntryRow } from './widgets/password-entry-row.gtk.js';
 import { AdwPreferencesGroup as PreferencesGroup } from './widgets/preferences-group.gtk.js';
 import { AdwPreferencesPage as PreferencesPage } from './widgets/preferences-page.gtk.js';
@@ -89,6 +108,8 @@ import { AdwStatusPage as StatusPage } from './widgets/status-page.gtk.js';
 import { AdwSwitchRow as SwitchRow } from './widgets/switch-row.gtk.js';
 import { AdwToastOverlay as ToastOverlay } from './widgets/toast-overlay.gtk.js';
 import { AdwToolbarView as ToolbarView } from './widgets/toolbar-view.gtk.js';
+import { AdwViewStack as ViewStack } from './widgets/view-stack.gtk.js';
+import { AdwViewSwitcher as ViewSwitcher } from './widgets/view-switcher.gtk.js';
 import { AdwWindowTitle as WindowTitle } from './widgets/window-title.gtk.js';
 import { AdwWrapBox as WrapBox } from './widgets/wrap-box.gtk.js';
 
@@ -104,6 +125,10 @@ export const Adw = {
     EntryRow,
     ExpanderRow,
     HeaderBar,
+    NavigationPage,
+    NavigationSplitView,
+    NavigationView,
+    OverlaySplitView,
     PasswordEntryRow,
     PreferencesGroup,
     PreferencesPage,
@@ -113,6 +138,8 @@ export const Adw = {
     SwitchRow,
     ToastOverlay,
     ToolbarView,
+    ViewStack,
+    ViewSwitcher,
     WindowTitle,
     WrapBox,
 };

--- a/packages/framework/adwaita-react-native/src/index.native.ts
+++ b/packages/framework/adwaita-react-native/src/index.native.ts
@@ -17,10 +17,16 @@ export type {
     AdwEntryRowProps,
     AdwExpanderRowProps,
     AdwHeaderBarProps,
+    AdwNavigationPageProps,
+    AdwNavigationSplitViewProps,
+    AdwNavigationViewHandle,
+    AdwNavigationViewProps,
+    AdwOverlaySplitViewProps,
     AdwPasswordEntryRowProps,
     AdwPreferencesGroupProps,
     AdwPreferencesPageProps,
     AdwRowProps,
+    AdwSidebarWidthProps,
     AdwSpinRowProps,
     AdwSpinnerProps,
     AdwStatusPageProps,
@@ -28,6 +34,9 @@ export type {
     AdwToastOverlayHandle,
     AdwToastOverlayProps,
     AdwToolbarViewProps,
+    AdwViewStackPageProps,
+    AdwViewStackProps,
+    AdwViewSwitcherProps,
     AdwWidgetProps,
     AdwWindowTitleProps,
     AdwWrapBoxProps,
@@ -44,6 +53,10 @@ export { AdwComboRow } from './widgets/combo-row.native.js';
 export { AdwEntryRow } from './widgets/entry-row.native.js';
 export { AdwExpanderRow } from './widgets/expander-row.native.js';
 export { AdwHeaderBar } from './widgets/header-bar.native.js';
+export { AdwNavigationPage } from './widgets/navigation-page.native.js';
+export { AdwNavigationSplitView } from './widgets/navigation-split-view.native.js';
+export { AdwNavigationView } from './widgets/navigation-view.native.js';
+export { AdwOverlaySplitView } from './widgets/overlay-split-view.native.js';
 export { AdwPasswordEntryRow } from './widgets/password-entry-row.native.js';
 export { AdwPreferencesGroup } from './widgets/preferences-group.native.js';
 export { AdwPreferencesPage } from './widgets/preferences-page.native.js';
@@ -53,6 +66,8 @@ export { AdwStatusPage } from './widgets/status-page.native.js';
 export { AdwSwitchRow } from './widgets/switch-row.native.js';
 export { AdwToastOverlay } from './widgets/toast-overlay.native.js';
 export { AdwToolbarView } from './widgets/toolbar-view.native.js';
+export { AdwViewStack } from './widgets/view-stack.native.js';
+export { AdwViewSwitcher } from './widgets/view-switcher.native.js';
 export { AdwWindowTitle } from './widgets/window-title.native.js';
 export { AdwWrapBox } from './widgets/wrap-box.native.js';
 
@@ -78,6 +93,10 @@ import { AdwComboRow as ComboRow } from './widgets/combo-row.native.js';
 import { AdwEntryRow as EntryRow } from './widgets/entry-row.native.js';
 import { AdwExpanderRow as ExpanderRow } from './widgets/expander-row.native.js';
 import { AdwHeaderBar as HeaderBar } from './widgets/header-bar.native.js';
+import { AdwNavigationPage as NavigationPage } from './widgets/navigation-page.native.js';
+import { AdwNavigationSplitView as NavigationSplitView } from './widgets/navigation-split-view.native.js';
+import { AdwNavigationView as NavigationView } from './widgets/navigation-view.native.js';
+import { AdwOverlaySplitView as OverlaySplitView } from './widgets/overlay-split-view.native.js';
 import { AdwPasswordEntryRow as PasswordEntryRow } from './widgets/password-entry-row.native.js';
 import { AdwPreferencesGroup as PreferencesGroup } from './widgets/preferences-group.native.js';
 import { AdwPreferencesPage as PreferencesPage } from './widgets/preferences-page.native.js';
@@ -87,6 +106,8 @@ import { AdwStatusPage as StatusPage } from './widgets/status-page.native.js';
 import { AdwSwitchRow as SwitchRow } from './widgets/switch-row.native.js';
 import { AdwToastOverlay as ToastOverlay } from './widgets/toast-overlay.native.js';
 import { AdwToolbarView as ToolbarView } from './widgets/toolbar-view.native.js';
+import { AdwViewStack as ViewStack } from './widgets/view-stack.native.js';
+import { AdwViewSwitcher as ViewSwitcher } from './widgets/view-switcher.native.js';
 import { AdwWindowTitle as WindowTitle } from './widgets/window-title.native.js';
 import { AdwWrapBox as WrapBox } from './widgets/wrap-box.native.js';
 
@@ -102,6 +123,10 @@ export const Adw = {
     EntryRow,
     ExpanderRow,
     HeaderBar,
+    NavigationPage,
+    NavigationSplitView,
+    NavigationView,
+    OverlaySplitView,
     PasswordEntryRow,
     PreferencesGroup,
     PreferencesPage,
@@ -111,6 +136,8 @@ export const Adw = {
     SwitchRow,
     ToastOverlay,
     ToolbarView,
+    ViewStack,
+    ViewSwitcher,
     WindowTitle,
     WrapBox,
 };

--- a/packages/framework/adwaita-react-native/src/index.ts
+++ b/packages/framework/adwaita-react-native/src/index.ts
@@ -21,10 +21,16 @@ export type {
     AdwEntryRowProps,
     AdwExpanderRowProps,
     AdwHeaderBarProps,
+    AdwNavigationPageProps,
+    AdwNavigationSplitViewProps,
+    AdwNavigationViewHandle,
+    AdwNavigationViewProps,
+    AdwOverlaySplitViewProps,
     AdwPasswordEntryRowProps,
     AdwPreferencesGroupProps,
     AdwPreferencesPageProps,
     AdwRowProps,
+    AdwSidebarWidthProps,
     AdwSpinRowProps,
     AdwSpinnerProps,
     AdwStatusPageProps,
@@ -32,6 +38,9 @@ export type {
     AdwToastOverlayHandle,
     AdwToastOverlayProps,
     AdwToolbarViewProps,
+    AdwViewStackPageProps,
+    AdwViewStackProps,
+    AdwViewSwitcherProps,
     AdwWidgetProps,
     AdwWindowTitleProps,
     AdwWrapBoxProps,
@@ -48,6 +57,10 @@ export { AdwComboRow } from './widgets/combo-row.js';
 export { AdwEntryRow } from './widgets/entry-row.js';
 export { AdwExpanderRow } from './widgets/expander-row.js';
 export { AdwHeaderBar } from './widgets/header-bar.js';
+export { AdwNavigationPage } from './widgets/navigation-page.js';
+export { AdwNavigationSplitView } from './widgets/navigation-split-view.js';
+export { AdwNavigationView } from './widgets/navigation-view.js';
+export { AdwOverlaySplitView } from './widgets/overlay-split-view.js';
 export { AdwPasswordEntryRow } from './widgets/password-entry-row.js';
 export { AdwPreferencesGroup } from './widgets/preferences-group.js';
 export { AdwPreferencesPage } from './widgets/preferences-page.js';
@@ -57,6 +70,8 @@ export { AdwStatusPage } from './widgets/status-page.js';
 export { AdwSwitchRow } from './widgets/switch-row.js';
 export { AdwToastOverlay } from './widgets/toast-overlay.js';
 export { AdwToolbarView } from './widgets/toolbar-view.js';
+export { AdwViewStack } from './widgets/view-stack.js';
+export { AdwViewSwitcher } from './widgets/view-switcher.js';
 export { AdwWindowTitle } from './widgets/window-title.js';
 export { AdwWrapBox } from './widgets/wrap-box.js';
 
@@ -82,6 +97,10 @@ import { AdwComboRow as ComboRow } from './widgets/combo-row.js';
 import { AdwEntryRow as EntryRow } from './widgets/entry-row.js';
 import { AdwExpanderRow as ExpanderRow } from './widgets/expander-row.js';
 import { AdwHeaderBar as HeaderBar } from './widgets/header-bar.js';
+import { AdwNavigationPage as NavigationPage } from './widgets/navigation-page.js';
+import { AdwNavigationSplitView as NavigationSplitView } from './widgets/navigation-split-view.js';
+import { AdwNavigationView as NavigationView } from './widgets/navigation-view.js';
+import { AdwOverlaySplitView as OverlaySplitView } from './widgets/overlay-split-view.js';
 import { AdwPasswordEntryRow as PasswordEntryRow } from './widgets/password-entry-row.js';
 import { AdwPreferencesGroup as PreferencesGroup } from './widgets/preferences-group.js';
 import { AdwPreferencesPage as PreferencesPage } from './widgets/preferences-page.js';
@@ -91,6 +110,8 @@ import { AdwStatusPage as StatusPage } from './widgets/status-page.js';
 import { AdwSwitchRow as SwitchRow } from './widgets/switch-row.js';
 import { AdwToastOverlay as ToastOverlay } from './widgets/toast-overlay.js';
 import { AdwToolbarView as ToolbarView } from './widgets/toolbar-view.js';
+import { AdwViewStack as ViewStack } from './widgets/view-stack.js';
+import { AdwViewSwitcher as ViewSwitcher } from './widgets/view-switcher.js';
 import { AdwWindowTitle as WindowTitle } from './widgets/window-title.js';
 import { AdwWrapBox as WrapBox } from './widgets/wrap-box.js';
 
@@ -106,6 +127,10 @@ export const Adw = {
     EntryRow,
     ExpanderRow,
     HeaderBar,
+    NavigationPage,
+    NavigationSplitView,
+    NavigationView,
+    OverlaySplitView,
     PasswordEntryRow,
     PreferencesGroup,
     PreferencesPage,
@@ -115,6 +140,8 @@ export const Adw = {
     SwitchRow,
     ToastOverlay,
     ToolbarView,
+    ViewStack,
+    ViewSwitcher,
     WindowTitle,
     WrapBox,
 };

--- a/packages/framework/adwaita-react-native/src/parity.spec.ts
+++ b/packages/framework/adwaita-react-native/src/parity.spec.ts
@@ -69,6 +69,18 @@ import type * as ExpanderRowNative from './widgets/expander-row.native.js';
 import type * as HeaderBarBase from './widgets/header-bar.js';
 import type * as HeaderBarGtk from './widgets/header-bar.gtk.js';
 import type * as HeaderBarNative from './widgets/header-bar.native.js';
+import type * as NavigationPageBase from './widgets/navigation-page.js';
+import type * as NavigationPageGtk from './widgets/navigation-page.gtk.js';
+import type * as NavigationPageNative from './widgets/navigation-page.native.js';
+import type * as NavigationSplitViewBase from './widgets/navigation-split-view.js';
+import type * as NavigationSplitViewGtk from './widgets/navigation-split-view.gtk.js';
+import type * as NavigationSplitViewNative from './widgets/navigation-split-view.native.js';
+import type * as NavigationViewBase from './widgets/navigation-view.js';
+import type * as NavigationViewGtk from './widgets/navigation-view.gtk.js';
+import type * as NavigationViewNative from './widgets/navigation-view.native.js';
+import type * as OverlaySplitViewBase from './widgets/overlay-split-view.js';
+import type * as OverlaySplitViewGtk from './widgets/overlay-split-view.gtk.js';
+import type * as OverlaySplitViewNative from './widgets/overlay-split-view.native.js';
 import type * as PasswordEntryRowBase from './widgets/password-entry-row.js';
 import type * as PasswordEntryRowGtk from './widgets/password-entry-row.gtk.js';
 import type * as PasswordEntryRowNative from './widgets/password-entry-row.native.js';
@@ -96,6 +108,12 @@ import type * as ToastOverlayNative from './widgets/toast-overlay.native.js';
 import type * as ToolbarViewBase from './widgets/toolbar-view.js';
 import type * as ToolbarViewGtk from './widgets/toolbar-view.gtk.js';
 import type * as ToolbarViewNative from './widgets/toolbar-view.native.js';
+import type * as ViewStackBase from './widgets/view-stack.js';
+import type * as ViewStackGtk from './widgets/view-stack.gtk.js';
+import type * as ViewStackNative from './widgets/view-stack.native.js';
+import type * as ViewSwitcherBase from './widgets/view-switcher.js';
+import type * as ViewSwitcherGtk from './widgets/view-switcher.gtk.js';
+import type * as ViewSwitcherNative from './widgets/view-switcher.native.js';
 import type * as WindowTitleBase from './widgets/window-title.js';
 import type * as WindowTitleGtk from './widgets/window-title.gtk.js';
 import type * as WindowTitleNative from './widgets/window-title.native.js';
@@ -228,6 +246,31 @@ export type PreferencesPageNativeSatisfiesBase = Assert<
 >;
 export type SpinRowGtkSatisfiesBase = Assert<SatisfiesBase<typeof SpinRowGtk, typeof SpinRowBase, 'AdwSpinRow'>>;
 export type SpinRowNativeSatisfiesBase = Assert<SatisfiesBase<typeof SpinRowNative, typeof SpinRowBase, 'AdwSpinRow'>>;
+
+export type NavigationPageGtkSatisfiesBase = Assert<
+    SatisfiesBase<typeof NavigationPageGtk, typeof NavigationPageBase, 'AdwNavigationPage'>
+>;
+export type NavigationPageNativeSatisfiesBase = Assert<
+    SatisfiesBase<typeof NavigationPageNative, typeof NavigationPageBase, 'AdwNavigationPage'>
+>;
+export type NavigationSplitViewGtkSatisfiesBase = Assert<
+    SatisfiesBase<typeof NavigationSplitViewGtk, typeof NavigationSplitViewBase, 'AdwNavigationSplitView'>
+>;
+export type NavigationSplitViewNativeSatisfiesBase = Assert<
+    SatisfiesBase<typeof NavigationSplitViewNative, typeof NavigationSplitViewBase, 'AdwNavigationSplitView'>
+>;
+export type NavigationViewGtkSatisfiesBase = Assert<
+    SatisfiesBase<typeof NavigationViewGtk, typeof NavigationViewBase, 'AdwNavigationView'>
+>;
+export type NavigationViewNativeSatisfiesBase = Assert<
+    SatisfiesBase<typeof NavigationViewNative, typeof NavigationViewBase, 'AdwNavigationView'>
+>;
+export type OverlaySplitViewGtkSatisfiesBase = Assert<
+    SatisfiesBase<typeof OverlaySplitViewGtk, typeof OverlaySplitViewBase, 'AdwOverlaySplitView'>
+>;
+export type OverlaySplitViewNativeSatisfiesBase = Assert<
+    SatisfiesBase<typeof OverlaySplitViewNative, typeof OverlaySplitViewBase, 'AdwOverlaySplitView'>
+>;
 export type SpinnerGtkSatisfiesBase = Assert<SatisfiesBase<typeof SpinnerGtk, typeof SpinnerBase, 'AdwSpinner'>>;
 export type SpinnerNativeSatisfiesBase = Assert<SatisfiesBase<typeof SpinnerNative, typeof SpinnerBase, 'AdwSpinner'>>;
 export type StatusPageGtkSatisfiesBase = Assert<
@@ -253,6 +296,18 @@ export type ToolbarViewGtkSatisfiesBase = Assert<
 >;
 export type ToolbarViewNativeSatisfiesBase = Assert<
     SatisfiesBase<typeof ToolbarViewNative, typeof ToolbarViewBase, 'AdwToolbarView'>
+>;
+export type ViewStackGtkSatisfiesBase = Assert<
+    SatisfiesBase<typeof ViewStackGtk, typeof ViewStackBase, 'AdwViewStack'>
+>;
+export type ViewStackNativeSatisfiesBase = Assert<
+    SatisfiesBase<typeof ViewStackNative, typeof ViewStackBase, 'AdwViewStack'>
+>;
+export type ViewSwitcherGtkSatisfiesBase = Assert<
+    SatisfiesBase<typeof ViewSwitcherGtk, typeof ViewSwitcherBase, 'AdwViewSwitcher'>
+>;
+export type ViewSwitcherNativeSatisfiesBase = Assert<
+    SatisfiesBase<typeof ViewSwitcherNative, typeof ViewSwitcherBase, 'AdwViewSwitcher'>
 >;
 export type WindowTitleGtkSatisfiesBase = Assert<
     SatisfiesBase<typeof WindowTitleGtk, typeof WindowTitleBase, 'AdwWindowTitle'>
@@ -302,6 +357,15 @@ export const PARITY_ASSERTIONS = [
     'PreferencesPageNativeSatisfiesBase',
     'SpinRowGtkSatisfiesBase',
     'SpinRowNativeSatisfiesBase',
+
+    'NavigationPageGtkSatisfiesBase',
+    'NavigationPageNativeSatisfiesBase',
+    'NavigationSplitViewGtkSatisfiesBase',
+    'NavigationSplitViewNativeSatisfiesBase',
+    'NavigationViewGtkSatisfiesBase',
+    'NavigationViewNativeSatisfiesBase',
+    'OverlaySplitViewGtkSatisfiesBase',
+    'OverlaySplitViewNativeSatisfiesBase',
     'SpinnerGtkSatisfiesBase',
     'SpinnerNativeSatisfiesBase',
     'StatusPageGtkSatisfiesBase',
@@ -312,6 +376,10 @@ export const PARITY_ASSERTIONS = [
     'ToastOverlayNativeSatisfiesBase',
     'ToolbarViewGtkSatisfiesBase',
     'ToolbarViewNativeSatisfiesBase',
+    'ViewStackGtkSatisfiesBase',
+    'ViewStackNativeSatisfiesBase',
+    'ViewSwitcherGtkSatisfiesBase',
+    'ViewSwitcherNativeSatisfiesBase',
     'WindowTitleGtkSatisfiesBase',
     'WindowTitleNativeSatisfiesBase',
     'WrapBoxGtkSatisfiesBase',
@@ -373,6 +441,15 @@ export default async () => {
                 'PreferencesPageNativeSatisfiesBase',
                 'SpinRowGtkSatisfiesBase',
                 'SpinRowNativeSatisfiesBase',
+
+                'NavigationPageGtkSatisfiesBase',
+                'NavigationPageNativeSatisfiesBase',
+                'NavigationSplitViewGtkSatisfiesBase',
+                'NavigationSplitViewNativeSatisfiesBase',
+                'NavigationViewGtkSatisfiesBase',
+                'NavigationViewNativeSatisfiesBase',
+                'OverlaySplitViewGtkSatisfiesBase',
+                'OverlaySplitViewNativeSatisfiesBase',
                 'SpinnerGtkSatisfiesBase',
                 'SpinnerNativeSatisfiesBase',
                 'StatusPageGtkSatisfiesBase',
@@ -383,6 +460,10 @@ export default async () => {
                 'ToastOverlayNativeSatisfiesBase',
                 'ToolbarViewGtkSatisfiesBase',
                 'ToolbarViewNativeSatisfiesBase',
+                'ViewStackGtkSatisfiesBase',
+                'ViewStackNativeSatisfiesBase',
+                'ViewSwitcherGtkSatisfiesBase',
+                'ViewSwitcherNativeSatisfiesBase',
                 'WindowTitleGtkSatisfiesBase',
                 'WindowTitleNativeSatisfiesBase',
                 'WrapBoxGtkSatisfiesBase',

--- a/packages/framework/adwaita-react-native/src/parity.spec.ts
+++ b/packages/framework/adwaita-react-native/src/parity.spec.ts
@@ -226,27 +226,6 @@ export type HeaderBarGtkSatisfiesBase = Assert<
 export type HeaderBarNativeSatisfiesBase = Assert<
     SatisfiesBase<typeof HeaderBarNative, typeof HeaderBarBase, 'AdwHeaderBar'>
 >;
-export type PasswordEntryRowGtkSatisfiesBase = Assert<
-    SatisfiesBase<typeof PasswordEntryRowGtk, typeof PasswordEntryRowBase, 'AdwPasswordEntryRow'>
->;
-export type PasswordEntryRowNativeSatisfiesBase = Assert<
-    SatisfiesBase<typeof PasswordEntryRowNative, typeof PasswordEntryRowBase, 'AdwPasswordEntryRow'>
->;
-export type PreferencesGroupGtkSatisfiesBase = Assert<
-    SatisfiesBase<typeof PreferencesGroupGtk, typeof PreferencesGroupBase, 'AdwPreferencesGroup'>
->;
-export type PreferencesGroupNativeSatisfiesBase = Assert<
-    SatisfiesBase<typeof PreferencesGroupNative, typeof PreferencesGroupBase, 'AdwPreferencesGroup'>
->;
-export type PreferencesPageGtkSatisfiesBase = Assert<
-    SatisfiesBase<typeof PreferencesPageGtk, typeof PreferencesPageBase, 'AdwPreferencesPage'>
->;
-export type PreferencesPageNativeSatisfiesBase = Assert<
-    SatisfiesBase<typeof PreferencesPageNative, typeof PreferencesPageBase, 'AdwPreferencesPage'>
->;
-export type SpinRowGtkSatisfiesBase = Assert<SatisfiesBase<typeof SpinRowGtk, typeof SpinRowBase, 'AdwSpinRow'>>;
-export type SpinRowNativeSatisfiesBase = Assert<SatisfiesBase<typeof SpinRowNative, typeof SpinRowBase, 'AdwSpinRow'>>;
-
 export type NavigationPageGtkSatisfiesBase = Assert<
     SatisfiesBase<typeof NavigationPageGtk, typeof NavigationPageBase, 'AdwNavigationPage'>
 >;
@@ -271,8 +250,28 @@ export type OverlaySplitViewGtkSatisfiesBase = Assert<
 export type OverlaySplitViewNativeSatisfiesBase = Assert<
     SatisfiesBase<typeof OverlaySplitViewNative, typeof OverlaySplitViewBase, 'AdwOverlaySplitView'>
 >;
+export type PasswordEntryRowGtkSatisfiesBase = Assert<
+    SatisfiesBase<typeof PasswordEntryRowGtk, typeof PasswordEntryRowBase, 'AdwPasswordEntryRow'>
+>;
+export type PasswordEntryRowNativeSatisfiesBase = Assert<
+    SatisfiesBase<typeof PasswordEntryRowNative, typeof PasswordEntryRowBase, 'AdwPasswordEntryRow'>
+>;
+export type PreferencesGroupGtkSatisfiesBase = Assert<
+    SatisfiesBase<typeof PreferencesGroupGtk, typeof PreferencesGroupBase, 'AdwPreferencesGroup'>
+>;
+export type PreferencesGroupNativeSatisfiesBase = Assert<
+    SatisfiesBase<typeof PreferencesGroupNative, typeof PreferencesGroupBase, 'AdwPreferencesGroup'>
+>;
+export type PreferencesPageGtkSatisfiesBase = Assert<
+    SatisfiesBase<typeof PreferencesPageGtk, typeof PreferencesPageBase, 'AdwPreferencesPage'>
+>;
+export type PreferencesPageNativeSatisfiesBase = Assert<
+    SatisfiesBase<typeof PreferencesPageNative, typeof PreferencesPageBase, 'AdwPreferencesPage'>
+>;
 export type SpinnerGtkSatisfiesBase = Assert<SatisfiesBase<typeof SpinnerGtk, typeof SpinnerBase, 'AdwSpinner'>>;
 export type SpinnerNativeSatisfiesBase = Assert<SatisfiesBase<typeof SpinnerNative, typeof SpinnerBase, 'AdwSpinner'>>;
+export type SpinRowGtkSatisfiesBase = Assert<SatisfiesBase<typeof SpinRowGtk, typeof SpinRowBase, 'AdwSpinRow'>>;
+export type SpinRowNativeSatisfiesBase = Assert<SatisfiesBase<typeof SpinRowNative, typeof SpinRowBase, 'AdwSpinRow'>>;
 export type StatusPageGtkSatisfiesBase = Assert<
     SatisfiesBase<typeof StatusPageGtk, typeof StatusPageBase, 'AdwStatusPage'>
 >;
@@ -433,15 +432,6 @@ export default async () => {
                 'ExpanderRowNativeSatisfiesBase',
                 'HeaderBarGtkSatisfiesBase',
                 'HeaderBarNativeSatisfiesBase',
-                'PasswordEntryRowGtkSatisfiesBase',
-                'PasswordEntryRowNativeSatisfiesBase',
-                'PreferencesGroupGtkSatisfiesBase',
-                'PreferencesGroupNativeSatisfiesBase',
-                'PreferencesPageGtkSatisfiesBase',
-                'PreferencesPageNativeSatisfiesBase',
-                'SpinRowGtkSatisfiesBase',
-                'SpinRowNativeSatisfiesBase',
-
                 'NavigationPageGtkSatisfiesBase',
                 'NavigationPageNativeSatisfiesBase',
                 'NavigationSplitViewGtkSatisfiesBase',
@@ -450,6 +440,14 @@ export default async () => {
                 'NavigationViewNativeSatisfiesBase',
                 'OverlaySplitViewGtkSatisfiesBase',
                 'OverlaySplitViewNativeSatisfiesBase',
+                'PasswordEntryRowGtkSatisfiesBase',
+                'PasswordEntryRowNativeSatisfiesBase',
+                'PreferencesGroupGtkSatisfiesBase',
+                'PreferencesGroupNativeSatisfiesBase',
+                'PreferencesPageGtkSatisfiesBase',
+                'PreferencesPageNativeSatisfiesBase',
+                'SpinRowGtkSatisfiesBase',
+                'SpinRowNativeSatisfiesBase',
                 'SpinnerGtkSatisfiesBase',
                 'SpinnerNativeSatisfiesBase',
                 'StatusPageGtkSatisfiesBase',

--- a/packages/framework/adwaita-react-native/src/props.ts
+++ b/packages/framework/adwaita-react-native/src/props.ts
@@ -23,8 +23,10 @@ import type {
     AdwBannerButtonStyle,
     AdwComboOptionInput,
     AdwLengthUnit,
+    AdwPackType,
     AdwToast,
     AdwToolbarStyle,
+    AdwViewSwitcherPolicy,
     AdwWrapBoxJustify,
     AdwWrapBoxOrientation,
     AdwWrapBoxPackDirection,
@@ -639,3 +641,291 @@ export interface AdwSpinRowProps extends AdwRowProps {
  * on a phone. Neither sibling renderer has them.
  */
 export interface AdwPasswordEntryRowProps extends AdwEntryRowProps {}
+
+// --- The navigation group ---
+//
+// `Adw.NavigationView`, the two split views, `Adw.ViewStack` and `Adw.ViewSwitcher`.
+// What separates them from everything above is that four of the five hold STATE a
+// caller does not own: which page is on top of a stack, which pane a collapsed split
+// view is showing, which page of a stack is selected. On GTK that state is
+// libadwaita's own C; on React Native it is `@gjsify/adwaita-core`'s port of the same
+// machine — `NavigationViewState`, `NavigationSplitViewState`, `OverlaySplitViewState`
+// and `ViewSwitcherState`, the classes `@gjsify/adwaita-web` and
+// `@gjsify/adwaita-nativescript` already run. Neither half re-derives the other's
+// answer, which is the rule `clamp.gtk.tsx` states for `clampAllocate`.
+
+/**
+ * `Adw.NavigationPage` — one page of an {@link AdwNavigationViewProps}.
+ *
+ * IT IS A WIDGET IN ITS OWN RIGHT ON GTK AND THAT IS WHY IT IS ONE HERE.
+ * `adw_navigation_view_add` takes an `AdwNavigationPage`, not a `GtkWidget`, and so do
+ * `adw_navigation_split_view_set_sidebar` / `_set_content` — a `Gtk.Box` handed to any
+ * of them is a rejected child. `@gjsify/adwaita-web` exposes it as its own element
+ * (`<adw-navigation-page>`) for the same reason; `@gjsify/adwaita-nativescript` does
+ * not, because a NativeScript `View` cannot carry the tag and it keeps the tag of
+ * record in the core instead.
+ */
+export interface AdwNavigationPageProps extends AdwWidgetProps {
+    /**
+     * `title` — this page's title, and the NEXT page's back-button tooltip. Default `''`.
+     *
+     * OPTIONAL IN THE TYPE AND EXPECTED IN PRACTICE, measured on libadwaita 1.9.3: a page
+     * with no title prints `AdwNavigationPage 0x… is missing a title. To hide a header bar
+     * title, consider using AdwHeaderBar:show-title instead.` — a real GTK diagnostic that
+     * the React Native half has no counterpart for, and one the GTK suite's
+     * `installDiagnosticsGate` fails on. It is not `g_return_if_fail`, so the widget still
+     * works; it is the difference between an omitted title and a deliberate one.
+     */
+    title?: string;
+    /**
+     * `tag` — the page's identity, unique within one view.
+     *
+     * `''` is a LEGAL tag and not "untagged": the C tag table is a plain `g_str_hash`
+     * table and only a NULL tag is skipped (`add_page`). An omitted prop is the NULL.
+     */
+    tag?: string;
+    /**
+     * `can-pop` — whether a shortcut or the back button may leave this page. Default true.
+     *
+     * It does NOT gate {@link AdwNavigationViewHandle.pop}, which is libadwaita's own
+     * split: `adw_navigation_view_pop` ignores it and only `pop_shortcut_cb` and
+     * `AdwBackButton` consult it.
+     */
+    canPop?: boolean;
+}
+
+/**
+ * What a caller does to an {@link AdwNavigationViewProps} through its `ref`.
+ *
+ * A PAGE IS PUSHED BY TAG, NEVER BY HANDLE, and that is the one place this surface is
+ * narrower than libadwaita's. `adw_navigation_view_push` takes an `AdwNavigationPage`
+ * and `pop_to_page` likewise; a page handle is an `Adw.NavigationPage` on GTK and a
+ * React element on React Native — two types with no shared spelling, the same wall
+ * `custom-image` hits on {@link AdwAvatarProps}. The tag overloads are strings on both
+ * halves, and a tag is what makes a page addressable at all, so those are the surface.
+ *
+ * `visiblePageTag`, `canGoBack` and `backButtonTooltip` are METHODS rather than
+ * properties because they are reads of live widget state: `Adw.NavigationView` answers
+ * them from its own stack, the React Native half from `NavigationViewState`, and a
+ * value snapshotted into an object at `useImperativeHandle` time would be stale by the
+ * first push.
+ */
+export interface AdwNavigationViewHandle {
+    /**
+     * `push_by_tag` — push the page carrying `tag`.
+     *
+     * Returns nothing, because `adw_navigation_view_push_by_tag` returns `void`: an
+     * unknown tag is a `g_critical`, not a `false`.
+     */
+    push(tag: string): void;
+    /** `pop` — pop the visible page. `false` when it was the root. */
+    pop(): boolean;
+    /** `pop_to_tag` — pop until the page carrying `tag` is visible. */
+    popToTag(tag: string): boolean;
+    /** `replace_with_tags` — replace the whole stack. The last tag becomes visible. */
+    replaceWithTags(tags: readonly string[]): void;
+    /** `visible-page`'s tag, or `null` — for an untagged page too. */
+    visiblePageTag(): string | null;
+    /** `AdwBackButton`'s visibility rule: a previous page exists AND the visible page `can-pop`. */
+    canGoBack(): boolean;
+    /** That button's tooltip — the revealed page's title, or `'Back'`. `null` when there is no button. */
+    backButtonTooltip(): string | null;
+}
+
+/**
+ * `Adw.NavigationView` — a stack of pages, one visible at a time.
+ *
+ * `children` ARE THE STATICALLY-ADDED PAGES, in `adw_navigation_view_add` order, and
+ * the first one is the root: `add_page` auto-pushes whenever the stack is EMPTY, so a
+ * declared page 0 becomes visible without anyone pushing it. Both other renderers
+ * snapshot their declared children exactly this way.
+ *
+ * Every mutation after that is a CALL through {@link AdwNavigationViewHandle}, not a
+ * prop, and that is libadwaita's shape rather than a React convenience:
+ * `Adw.NavigationView:visible-page` is READ-ONLY, and `push`/`pop` are methods. A
+ * `visiblePageTag={…}` prop would put the stack in the caller's hands on one half and
+ * in libadwaita's on the other.
+ */
+export interface AdwNavigationViewProps extends AdwWidgetProps {
+    /**
+     * `animate-transitions` — whether a push or a pop slides. Default true.
+     *
+     * CARRIED ON BOTH HALVES AND ANIMATED ONLY ON GTK, which is the same shape
+     * `@gjsify/adwaita-nativescript` records ("kept for API parity"): this package has
+     * no animation layer, so the swap is instant on React Native either way. The value
+     * still reaches `NavigationViewState`, whose `finishTransition()` seam is what a
+     * renderer with no animation settles immediately.
+     */
+    animateTransitions?: boolean;
+    /**
+     * `pop-on-escape` — whether Escape pops the visible page. Default true.
+     *
+     * Carried and inert on React Native, where there is no Escape key: the core's
+     * `popFromEscape()` is what it gates, and nothing on a phone calls it.
+     */
+    popOnEscape?: boolean;
+    /** The imperative surface — see {@link AdwNavigationViewHandle}. */
+    ref?: Ref<AdwNavigationViewHandle>;
+}
+
+/**
+ * The four sizing properties both split views share, under libadwaita's own names.
+ *
+ * They come as a QUARTET and not a single width because that is what the widgets are:
+ * a FRACTION of the view, clamped between a minimum and a maximum, with the two bounds
+ * written in a scale-aware unit. `@gjsify/adwaita-core` resolves them —
+ * `resolveSidebarBounds` then `resolveNavigationSidebarWidth` /
+ * `resolveOverlaySidebarWidth`, which answer the SAME input differently and both
+ * halves of this package run.
+ */
+export interface AdwSidebarWidthProps {
+    /** `min-sidebar-width`, in {@link sidebarWidthUnit}. Default 180. */
+    minSidebarWidth?: number;
+    /** `max-sidebar-width`, in {@link sidebarWidthUnit}. Default 280. Raised to the minimum when below it. */
+    maxSidebarWidth?: number;
+    /** `sidebar-width-fraction` — the share of the view the sidebar asks for. Default 0.25. */
+    sidebarWidthFraction?: number;
+    /** `sidebar-width-unit`. Default `sp`, which is a pixel passthrough at 96 dpi. */
+    sidebarWidthUnit?: AdwLengthUnit;
+}
+
+/**
+ * `Adw.NavigationSplitView` — a sidebar beside content, which becomes a navigation
+ * stack when collapsed.
+ *
+ * `children` IS THE CONTENT PANE and {@link sidebar} is a prop, the same split
+ * {@link AdwToolbarViewProps} makes and for the same reason — gtk-host routes a child
+ * by a `slot` prop on the CHILD, which a `ReactNode` handed in as a prop has nothing
+ * to carry.
+ *
+ * BOTH PANES ARE WRAPPED IN AN `Adw.NavigationPage` ON GTK, and that is not a
+ * convenience: `adw_navigation_split_view_set_sidebar` takes an `AdwNavigationPage`,
+ * so an unwrapped `Gtk.Box` is a rejected child. Hence the four `sidebar*` /
+ * `content*` page properties below — the tag pair is what
+ * `@gjsify/adwaita-nativescript` calls `sidebarTag`/`contentTag` for exactly this
+ * reason ("a `View` is not an `Adw.NavigationPage`"), and `@gjsify/adwaita-web` reads
+ * the same `tag` off its slotted pane.
+ */
+export interface AdwNavigationSplitViewProps extends AdwWidgetProps, AdwSidebarWidthProps {
+    /** `sidebar` — the sidebar pane's content. */
+    sidebar?: ReactNode;
+    /** The sidebar page's `Adw.NavigationPage:tag`. Colliding with {@link contentTag} is refused. */
+    sidebarTag?: string;
+    /** The content page's `Adw.NavigationPage:tag`. */
+    contentTag?: string;
+    /** The sidebar page's `Adw.NavigationPage:title`. */
+    sidebarTitle?: string;
+    /** The content page's `Adw.NavigationPage:title`. */
+    contentTitle?: string;
+    /** `collapsed` — one pane at a time. Default false. */
+    collapsed?: boolean;
+    /**
+     * `show-content` — which pane a COLLAPSED view shows. Default false (the sidebar).
+     *
+     * It is not the whole answer, which is the widget's entire point: a LONE child
+     * stays visible whatever this says, and with `sidebar-position: end` the CONTENT is
+     * the root page. That ordering table is `resolveNavigationStack` in the core, and
+     * both halves read `visiblePane` out of it rather than this flag.
+     */
+    showContent?: boolean;
+    /** `sidebar-position` — which side the sidebar is packed on. Default `start`. */
+    sidebarPosition?: AdwPackType;
+}
+
+/**
+ * `Adw.OverlaySplitView` — a sidebar beside content, which slides OVER it when
+ * collapsed instead of replacing it.
+ *
+ * Its panes are plain `GtkWidget`s, so unlike {@link AdwNavigationSplitViewProps}
+ * nothing is wrapped and there are no page properties.
+ */
+export interface AdwOverlaySplitViewProps extends AdwWidgetProps, AdwSidebarWidthProps {
+    /** `sidebar` — the sidebar pane's content. `children` is the content pane. */
+    sidebar?: ReactNode;
+    /** `collapsed` — the sidebar overlays rather than docks. Default false. */
+    collapsed?: boolean;
+    /**
+     * `show-sidebar` — whether the sidebar is revealed. Default TRUE.
+     *
+     * IT IS NOT PURELY A CALLER'S VALUE, and that is why {@link onNotifyShowSidebar}
+     * exists: unless {@link pinSidebar} is set, collapsing HIDES the sidebar and
+     * uncollapsing SHOWS it (`adw_overlay_split_view_set_collapsed`). Both halves
+     * report that back rather than silently disagreeing with the prop.
+     */
+    showSidebar?: boolean;
+    /** `pin-sidebar` — collapsing leaves {@link showSidebar} alone. Default false. */
+    pinSidebar?: boolean;
+    /** `sidebar-position`. Default `start`. */
+    sidebarPosition?: AdwPackType;
+    /** `enable-show-gesture` — edge-swipe to open. Default true. */
+    enableShowGesture?: boolean;
+    /** `enable-hide-gesture` — swipe to close. Default true. */
+    enableHideGesture?: boolean;
+    /** `notify::show-sidebar` — the value the widget settled on, the caller's or its own. */
+    onNotifyShowSidebar?: (showSidebar: boolean) => void;
+}
+
+/**
+ * One page of an {@link AdwViewStackProps}.
+ *
+ * IT IS A PROP OBJECT AND NOT A WIDGET, because `Adw.ViewStackPage` is not one: it is
+ * a GObject the stack hands back from `adw_view_stack_get_page (child)`, so it can be
+ * neither a JSX child nor a `slot`. Both other renderers reach the same shape from the
+ * other direction — `@gjsify/adwaita-web` consumes its `<adw-view-stack-page>`
+ * children into descriptors at connect, `@gjsify/adwaita-nativescript` takes
+ * `add(content, name, title, icon)` — and `@gjsify/adwaita-core`'s
+ * `AdwViewStackPageSpec` is the record both already build.
+ */
+export interface AdwViewStackPageProps {
+    /** `name` — the page's identity, and what `visible-child-name` selects. */
+    name: string;
+    /** `title` — falls back to {@link name} when absent, which is the core's own deviation from C. */
+    title?: string;
+    /** `icon-name` — carried on both halves, drawn only on GTK (no icon theme on a phone). */
+    iconName?: string;
+    /** `visible` — whether the page participates in selection at all. Default true. */
+    visible?: boolean;
+    /** `badge-number` — 0 is no badge; above 999 the label is `999+`. Default 0. */
+    badgeNumber?: number;
+    /** `needs-attention` — the bare dot, with or without a badge. Default false. */
+    needsAttention?: boolean;
+    /** `use-underline` — whether `_` marks a mnemonic in {@link title}. Default false. */
+    useUnderline?: boolean;
+    /** The page body. */
+    child?: ReactNode;
+}
+
+/**
+ * `Adw.ViewStack` — named pages, one visible at a time.
+ *
+ * `visibleChildName` is AUTHORED, not owned: an absent one leaves the stack on its own
+ * auto-pick (`adw_view_stack_add` selects the first VISIBLE page and notifies), and an
+ * unknown name is REFUSED rather than clamped — `adw_view_stack_set_visible_child_name`
+ * warns and leaves the selection alone. Both rules are `ViewStackState`'s, which is
+ * what `@gjsify/adwaita-web` and `@gjsify/adwaita-nativescript` run too.
+ */
+export interface AdwViewStackProps {
+    /** The pages, in `add` order. */
+    pages?: readonly AdwViewStackPageProps[];
+    /** `visible-child-name` — which page to show. */
+    visibleChildName?: string;
+    /** `notify::visible-child` — the name the stack settled on, including an auto-pick. */
+    onNotifyVisibleChild?: (name: string) => void;
+}
+
+/**
+ * `Adw.ViewSwitcher` — a row of buttons over an {@link AdwViewStackProps}.
+ *
+ * IT BUNDLES THE STACK LIBADWAITA KEEPS SEPARATE, and so do both other renderers.
+ * `Adw.ViewSwitcher:stack` is a WIDGET-valued property — the switcher points at an
+ * `Adw.ViewStack` somewhere else in the tree — and a React prop cannot hold a widget
+ * that does not exist yet on the half where widgets exist at all. So the switcher owns
+ * its pages here, exactly as `<adw-view-switcher>` and NativeScript's
+ * `AdwViewSwitcherBase` do; on GTK it still builds a real `Adw.ViewStack` and hands it
+ * to a real `Adw.ViewSwitcher` through that property, so nothing about the widget is
+ * simulated.
+ */
+export interface AdwViewSwitcherProps extends AdwViewStackProps {
+    /** `policy` — `narrow` stacks icon over label, `wide` puts them side by side. Default `narrow`. */
+    policy?: AdwViewSwitcherPolicy;
+}

--- a/packages/framework/adwaita-react-native/src/props.ts
+++ b/packages/framework/adwaita-react-native/src/props.ts
@@ -909,7 +909,18 @@ export interface AdwViewStackProps {
     pages?: readonly AdwViewStackPageProps[];
     /** `visible-child-name` — which page to show. */
     visibleChildName?: string;
-    /** `notify::visible-child` — the name the stack settled on, including an auto-pick. */
+    /**
+     * `notify::visible-child` — the name the stack settled on.
+     *
+     * WHAT REACHES IT IS NOT THE SAME SET ON THE TWO HALVES, measured. A press on the
+     * switcher reaches both. A change the CALLER made through {@link visibleChildName}
+     * reaches the React Native half only, because gtk-host drops the notify raised
+     * inside its own property write — the rule {@link AdwExpanderRowProps.onNotifyExpanded}
+     * records. And the mount AUTO-PICK reaches neither: libadwaita notifies it from
+     * inside `adw_view_stack_add_titled`, before React has committed the `ref` the name
+     * would be read off, and the core's own auto-pick lands before the subscription
+     * exists. The README carries the table.
+     */
     onNotifyVisibleChild?: (name: string) => void;
 }
 

--- a/packages/framework/adwaita-react-native/src/test.mts
+++ b/packages/framework/adwaita-react-native/src/test.mts
@@ -11,6 +11,7 @@ import { run } from '@gjsify/unit';
 import clampGtkSuite from './widgets/clamp.gtk.spec.js';
 import contentGtkSuite from './widgets/content.gtk.spec.js';
 import headerBarGtkSuite from './widgets/header-bar.gtk.spec.js';
+import navigationGtkSuite from './widgets/navigation.gtk.spec.js';
 import paritySuite from './parity.spec.js';
 import preferencesGtkSuite from './widgets/preferences.gtk.spec.js';
 import rowsGtkSuite from './widgets/rows.gtk.spec.js';
@@ -24,6 +25,7 @@ run({
     clampGtkSuite,
     contentGtkSuite,
     headerBarGtkSuite,
+    navigationGtkSuite,
     preferencesGtkSuite,
     rowsGtkSuite,
     statusPageGtkSuite,

--- a/packages/framework/adwaita-react-native/src/test.node.mts
+++ b/packages/framework/adwaita-react-native/src/test.node.mts
@@ -16,6 +16,10 @@ import buttonContentNativeSuite from './widgets/button-content.native.spec.js';
 import clampNativeSuite from './widgets/clamp.native.spec.js';
 import doubleSuite from './testing/react-native.spec.js';
 import headerBarNativeSuite from './widgets/header-bar.native.spec.js';
+import navigationPageNativeSuite from './widgets/navigation-page.native.spec.js';
+import navigationSplitViewNativeSuite from './widgets/navigation-split-view.native.spec.js';
+import navigationViewNativeSuite from './widgets/navigation-view.native.spec.js';
+import overlaySplitViewNativeSuite from './widgets/overlay-split-view.native.spec.js';
 import paritySuite from './parity.spec.js';
 import preferencesNativeSuite from './widgets/preferences.native.spec.js';
 import rowsNativeSuite from './widgets/rows.native.spec.js';
@@ -23,6 +27,8 @@ import spinnerNativeSuite from './widgets/spinner.native.spec.js';
 import statusPageNativeSuite from './widgets/status-page.native.spec.js';
 import toastOverlayNativeSuite from './widgets/toast-overlay.native.spec.js';
 import toolbarViewNativeSuite from './widgets/toolbar-view.native.spec.js';
+import viewStackNativeSuite from './widgets/view-stack.native.spec.js';
+import viewSwitcherNativeSuite from './widgets/view-switcher.native.spec.js';
 import windowTitleNativeSuite from './widgets/window-title.native.spec.js';
 import wrapBoxNativeSuite from './widgets/wrap-box.native.spec.js';
 
@@ -35,12 +41,18 @@ run({
     buttonContentNativeSuite,
     clampNativeSuite,
     headerBarNativeSuite,
+    navigationPageNativeSuite,
+    navigationSplitViewNativeSuite,
+    navigationViewNativeSuite,
+    overlaySplitViewNativeSuite,
     preferencesNativeSuite,
     rowsNativeSuite,
     spinnerNativeSuite,
     statusPageNativeSuite,
     toastOverlayNativeSuite,
     toolbarViewNativeSuite,
+    viewStackNativeSuite,
+    viewSwitcherNativeSuite,
     windowTitleNativeSuite,
     wrapBoxNativeSuite,
 });

--- a/packages/framework/adwaita-react-native/src/testing/render.spec.ts
+++ b/packages/framework/adwaita-react-native/src/testing/render.spec.ts
@@ -46,6 +46,30 @@ export function mount(element: React.ReactElement): ReactTestRenderer {
 export const mounted = (element: React.ReactElement): ReactTestRendererJSON =>
     mount(element).toJSON() as ReactTestRendererJSON;
 
+/**
+ * Mount, deliver ONE `onLayout` at `width`, and read the tree the widget settled on.
+ *
+ * Every size-aware widget in this package binds to the size of the VIEW rather than of
+ * the window, so its root node carries the `onLayout` and nothing downstream knows a size
+ * until one arrives. The missing-handler case is a THROW and not a skip: a widget that
+ * stopped emitting `onLayout` would otherwise leave every assertion below it reading the
+ * pre-layout tree and passing.
+ *
+ * ONE renderer, read twice — the reason is on {@link mount}.
+ */
+export function settled(element: React.ReactElement, width: number, height = 100): ReactTestRendererJSON {
+    const renderer = mount(element);
+    const before = renderer.toJSON() as ReactTestRendererJSON;
+    const onLayout = before.props.onLayout as ((event: unknown) => void) | undefined;
+    if (typeof onLayout !== 'function') {
+        throw new Error('the root view carries no onLayout, so no size can ever reach the widget');
+    }
+    act(() => {
+        onLayout({ nativeEvent: { layout: { x: 0, y: 0, width, height } } });
+    });
+    return renderer.toJSON() as ReactTestRendererJSON;
+}
+
 /** A node's element children, with text children refused rather than silently skipped. */
 export function childrenOf(node: ReactTestRendererJSON): ReactTestRendererJSON[] {
     const children = node.children ?? [];

--- a/packages/framework/adwaita-react-native/src/testing/render.spec.ts
+++ b/packages/framework/adwaita-react-native/src/testing/render.spec.ts
@@ -47,7 +47,8 @@ export const mounted = (element: React.ReactElement): ReactTestRendererJSON =>
     mount(element).toJSON() as ReactTestRendererJSON;
 
 /**
- * Mount, deliver ONE `onLayout` at `width`, and read the tree the widget settled on.
+ * Deliver ONE `onLayout` at `width` to the tree a MOUNTED renderer is showing, and read
+ * back what it settled on.
  *
  * Every size-aware widget in this package binds to the size of the VIEW rather than of
  * the window, so its root node carries the `onLayout` and nothing downstream knows a size
@@ -55,10 +56,11 @@ export const mounted = (element: React.ReactElement): ReactTestRendererJSON =>
  * stopped emitting `onLayout` would otherwise leave every assertion below it reading the
  * pre-layout tree and passing.
  *
- * ONE renderer, read twice — the reason is on {@link mount}.
+ * Separate from {@link settled} because an UPDATE needs the same delivery on a renderer
+ * that is already mounted — a widget re-reads no size on its own, so a tree read straight
+ * after `renderer.update` is still the pre-layout one.
  */
-export function settled(element: React.ReactElement, width: number, height = 100): ReactTestRendererJSON {
-    const renderer = mount(element);
+export function deliverLayout(renderer: ReactTestRenderer, width: number, height = 100): ReactTestRendererJSON {
     const before = renderer.toJSON() as ReactTestRendererJSON;
     const onLayout = before.props.onLayout as ((event: unknown) => void) | undefined;
     if (typeof onLayout !== 'function') {
@@ -69,6 +71,14 @@ export function settled(element: React.ReactElement, width: number, height = 100
     });
     return renderer.toJSON() as ReactTestRendererJSON;
 }
+
+/**
+ * Mount, deliver ONE `onLayout` at `width`, and read the tree the widget settled on.
+ *
+ * ONE renderer, read twice — the reason is on {@link mount}.
+ */
+export const settled = (element: React.ReactElement, width: number, height = 100): ReactTestRendererJSON =>
+    deliverLayout(mount(element), width, height);
 
 /** A node's element children, with text children refused rather than silently skipped. */
 export function childrenOf(node: ReactTestRendererJSON): ReactTestRendererJSON[] {

--- a/packages/framework/adwaita-react-native/src/widgets/clamp.native.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/clamp.native.spec.tsx
@@ -38,10 +38,9 @@
 // because the scheduler's `typeof navigator` probe is in both builds.
 
 import { describe, expect, it } from '@gjsify/unit';
-import { act, type ReactTestRendererJSON } from 'react-test-renderer';
 
 import { RCT_VIEW } from '../testing/react-native.js';
-import { mount, mounted, onlyChild, type Style } from '../testing/render.spec.js';
+import { mounted, onlyChild, settled, type Style } from '../testing/render.spec.js';
 import { AdwClamp } from './clamp.native.js';
 
 /** The frame the GTK half is photographed in, so both are asked the same question. */
@@ -49,24 +48,6 @@ const FRAME_WIDTH = 1000;
 
 /** Mount, and read the tree BEFORE any layout has been delivered. */
 const firstFrame = mounted;
-
-/**
- * Mount, deliver one `onLayout` at `width`, and read the tree the clamp settled on.
- *
- * ONE renderer, read twice — the reason is on `mount` in `../testing/render.spec.ts`.
- */
-function settled(element: React.ReactElement, width: number): ReactTestRendererJSON {
-    const renderer = mount(element);
-    const before = renderer.toJSON() as ReactTestRendererJSON;
-    const onLayout = before.props.onLayout as ((event: unknown) => void) | undefined;
-    if (typeof onLayout !== 'function') {
-        throw new Error('the outer view carries no onLayout, so no size can ever reach the clamp');
-    }
-    act(() => {
-        onLayout({ nativeEvent: { layout: { x: 0, y: 0, width, height: 100 } } });
-    });
-    return renderer.toJSON() as ReactTestRendererJSON;
-}
 
 export default async () => {
     await describe('AdwClamp on React Native — the tree it emits', async () => {

--- a/packages/framework/adwaita-react-native/src/widgets/navigation-page.gtk.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation-page.gtk.tsx
@@ -1,0 +1,28 @@
+/** @jsxImportSource @gjsify/gtk-host/react */
+// `AdwNavigationPage` on GTK — the real `Adw.NavigationPage`. (The pragma above is
+// required of every platform module; the reason is in `bin.gtk.tsx`.)
+//
+// THE PAGE IS A WIDGET HERE AND METADATA EVERYWHERE ELSE, which is the whole reason it
+// is a component rather than a prop object. `adw_navigation_view_add` and
+// `adw_navigation_split_view_set_sidebar` both take an `AdwNavigationPage` and reject a
+// bare `GtkWidget`, so on this half the three properties have to live on a real widget
+// in the tree. On React Native they are read off the element's props instead, because
+// there is no object to put them on.
+//
+// AN OMITTED PROP IS LEFT TO LIBADWAITA, not defaulted here: `title` is `''` and
+// `can-pop` is TRUE in `adw_navigation_page_init`, and passing those values back in
+// would make this file a second authority for a default the installed libadwaita
+// already owns. Same rule `clamp.gtk.tsx` states for `maximum-size`.
+
+import type { ReactElement } from 'react';
+
+import type { AdwNavigationPageProps } from '../props.js';
+
+/** {@link import('./navigation-page.js').AdwNavigationPage} on GTK. */
+export function AdwNavigationPage({ children, title, tag, canPop }: AdwNavigationPageProps): ReactElement | null {
+    return (
+        <adw-navigation-page title={title} tag={tag} can-pop={canPop}>
+            {children}
+        </adw-navigation-page>
+    );
+}

--- a/packages/framework/adwaita-react-native/src/widgets/navigation-page.native.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation-page.native.spec.tsx
@@ -1,0 +1,55 @@
+/** @jsxImportSource react */
+// The React Native half of `AdwNavigationPage`, rendered through React's real reconciler.
+//
+// THE WHOLE WIDGET IS ONE NODE AND THREE PROPERTIES THAT REACH NO NODE, so that is what
+// this file asserts — including the absence, in the shape the README's icon rule uses.
+// `title`, `tag` and `can-pop` are read by the page's HOLDER on this half
+// (`navigation-view.native.tsx` hands them to `NavigationViewState`), and a page that
+// started forwarding them onto its `View` would be inventing React Native props no
+// platform has. Asserting the absence is what makes the day one appears a decision.
+//
+// `flex: 1` IS ASSERTED, not assumed: a navigation page is the whole screen inside its
+// view, and a default-sized `View` would collapse to its content — a divergence from the
+// GTK half that renders as a page with a blank area under it, at exit 0.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { RCT_VIEW } from '../testing/react-native.js';
+import { mounted, onlyChild, type Style } from '../testing/render.spec.js';
+import { AdwNavigationPage } from './navigation-page.native.js';
+
+export default async () => {
+    await describe('AdwNavigationPage on React Native — the tree it emits', async () => {
+        await it('is one view that fills its holder', async () => {
+            const tree = mounted(
+                <AdwNavigationPage title="Home" tag="home">
+                    {null}
+                </AdwNavigationPage>,
+            );
+            expect(tree.type).toBe(RCT_VIEW);
+            expect(tree.props.style as Style).toStrictEqual({ flex: 1 });
+        });
+
+        await it('carries none of its three properties onto the view', async () => {
+            const tree = mounted(
+                <AdwNavigationPage title="Home" tag="home" canPop={false}>
+                    {null}
+                </AdwNavigationPage>,
+            );
+            // Named one by one rather than by counting keys: a key count passes when a
+            // prop is renamed as well as when it is absent.
+            expect(tree.props.title).toBe(undefined);
+            expect(tree.props.tag).toBe(undefined);
+            expect(tree.props.canPop).toBe(undefined);
+        });
+
+        await it('holds its child, which is the whole of what a bin does', async () => {
+            const tree = mounted(
+                <AdwNavigationPage title="Home">
+                    <AdwNavigationPage title="Nested">{null}</AdwNavigationPage>
+                </AdwNavigationPage>,
+            );
+            expect(onlyChild(tree).type).toBe(RCT_VIEW);
+        });
+    });
+};

--- a/packages/framework/adwaita-react-native/src/widgets/navigation-page.native.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation-page.native.tsx
@@ -1,0 +1,26 @@
+/** @jsxImportSource react */
+// `AdwNavigationPage` on React Native — a `View` holding the page body. (On the pragma,
+// see `bin.native.tsx`.)
+//
+// IT DRAWS NONE OF ITS THREE PROPERTIES, AND THAT IS THE WIDGET AND NOT A GAP.
+// `Adw.NavigationPage` is an `AdwBin` carrying a title, a tag and `can-pop`; the title
+// reaches a screen only because the VIEW puts it in a header bar, and the tag and
+// `can-pop` are never drawn at all. So on this half the three are read off the element's
+// props by whatever holds the page — `navigation-view.native.tsx` hands them straight to
+// `NavigationViewState` — and the page itself is the bin.
+//
+// `flex: 1` RATHER THAN NOTHING: a navigation page is the whole screen inside its view,
+// which is what `Adw.NavigationView` allocates it and what `@gjsify/adwaita-web`'s
+// `.adw-navigation-page` and NativeScript's full-span grid cell both give it. A
+// default-sized `View` would collapse to its content and leave the rest of the view
+// blank — a divergence nobody would see until a page had a background.
+
+import type { ReactElement } from 'react';
+import { View } from 'react-native';
+
+import type { AdwNavigationPageProps } from '../props.js';
+
+/** {@link import('./navigation-page.js').AdwNavigationPage} on React Native. */
+export function AdwNavigationPage({ children }: AdwNavigationPageProps): ReactElement | null {
+    return <View style={{ flex: 1 }}>{children}</View>;
+}

--- a/packages/framework/adwaita-react-native/src/widgets/navigation-page.ts
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation-page.ts
@@ -1,0 +1,20 @@
+// `AdwNavigationPage` — the base module. See `../refuse.ts` for who reaches this and
+// why it throws instead of resolving to something.
+
+import type { ReactElement } from 'react';
+
+import type { AdwNavigationPageProps } from '../props.js';
+import { refuseBaseModule } from '../refuse.js';
+
+/**
+ * One page of a navigation view, or one pane of a navigation split view.
+ *
+ * IT CARRIES THREE VALUES AND DRAWS NONE OF THEM. `title`, `tag` and `can-pop` are
+ * read by whatever holds the page — the view's stack machine on both halves — and the
+ * page itself is a container. That is libadwaita's own shape: `AdwNavigationPage` is an
+ * `AdwBin` with three properties, and the title appears on screen only because the
+ * view puts it in a header bar.
+ */
+export function AdwNavigationPage(_props: AdwNavigationPageProps): ReactElement | null {
+    return refuseBaseModule('AdwNavigationPage');
+}

--- a/packages/framework/adwaita-react-native/src/widgets/navigation-split-view.gtk.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation-split-view.gtk.tsx
@@ -1,0 +1,72 @@
+/** @jsxImportSource @gjsify/gtk-host/react */
+// `AdwNavigationSplitView` on GTK — the real `Adw.NavigationSplitView`. (On the pragma,
+// see `bin.gtk.tsx`.)
+//
+// NEITHER THE WIDTH NOR THE ORDERING IS COMPUTED HERE. `resolveNavigationSidebarWidth`
+// and `resolveNavigationStack` are `@gjsify/adwaita-core`'s ports of
+// `allocate_uncollapsed` and `update_navigation_stack`; on this half the C originals are
+// right there, and computing the same answer twice would give the widget two
+// authorities for its own layout. That is the rule `clamp.gtk.tsx` states for
+// `clampAllocate`, and the core's value on this path is as the oracle
+// `navigation-split-view.native.spec.tsx` is measured against.
+//
+// BOTH PANES ARE WRAPPED IN AN `Adw.NavigationPage`, AND THAT IS NOT A CONVENIENCE.
+// `adw_navigation_split_view_set_sidebar` is typed `AdwNavigationPage*`; handing it a
+// `GtkBox` is a rejected child, so the wrap is what makes a `ReactNode` sidebar
+// expressible at all. The two other renderers wrap too — `@gjsify/adwaita-web` moves
+// each slotted pane into its own `.adw-nsv-sidebar` / `.adw-nsv-content` box and reads
+// `tag` off the child, `@gjsify/adwaita-nativescript` keeps `sidebarTag`/`contentTag`
+// on the widget because "a `View` is not an `Adw.NavigationPage`". The four page props
+// on this surface are that wrap's properties, named where the caller can reach them.
+//
+// A PANE IS OMITTED WHEN ITS PROP IS, and the distinction is load-bearing rather than
+// tidy: `update_navigation_stack` branches on which children EXIST, so a split view
+// with only a sidebar keeps that sidebar visible whatever `show-content` says. Always
+// emitting an empty content page would make `hasContent` true and collapse that rule to
+// a blank pane — measured as the exact bug `@gjsify/adwaita-nativescript` names in
+// `_applyLayout` ("keying it on `showSidebar` alone rendered a split view holding only
+// a sidebar blank").
+
+import type { ReactElement } from 'react';
+
+import type { AdwNavigationSplitViewProps } from '../props.js';
+
+/** {@link import('./navigation-split-view.js').AdwNavigationSplitView} on GTK. */
+export function AdwNavigationSplitView({
+    children,
+    sidebar,
+    sidebarTag,
+    contentTag,
+    sidebarTitle,
+    contentTitle,
+    collapsed,
+    showContent,
+    sidebarPosition,
+    minSidebarWidth,
+    maxSidebarWidth,
+    sidebarWidthFraction,
+    sidebarWidthUnit,
+}: AdwNavigationSplitViewProps): ReactElement | null {
+    return (
+        <adw-navigation-split-view
+            collapsed={collapsed}
+            show-content={showContent}
+            sidebar-position={sidebarPosition}
+            min-sidebar-width={minSidebarWidth}
+            max-sidebar-width={maxSidebarWidth}
+            sidebar-width-fraction={sidebarWidthFraction}
+            sidebar-width-unit={sidebarWidthUnit}
+        >
+            {sidebar === undefined ? null : (
+                <adw-navigation-page slot="sidebar" tag={sidebarTag} title={sidebarTitle}>
+                    {sidebar}
+                </adw-navigation-page>
+            )}
+            {children === undefined ? null : (
+                <adw-navigation-page slot="content" tag={contentTag} title={contentTitle}>
+                    {children}
+                </adw-navigation-page>
+            )}
+        </adw-navigation-split-view>
+    );
+}

--- a/packages/framework/adwaita-react-native/src/widgets/navigation-split-view.native.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation-split-view.native.spec.tsx
@@ -1,0 +1,133 @@
+/** @jsxImportSource react */
+// The React Native half of `AdwNavigationSplitView`, rendered through React's real
+// reconciler.
+//
+// THE NUMBERS IN THIS FILE ARE THE NUMBERS THE GTK HALF IS ASSERTED WITH.
+// `navigation.gtk.spec.tsx` puts the real `Adw.NavigationSplitView` in a 1000-point
+// window, photographs it, and reads the two panes back at 250 and 750 off the live GTK
+// tree. This suite renders the React Native module at the same width and asserts the same
+// pair as two style objects — neither renderer invented them,
+// `resolveNavigationSidebarWidth` and `layoutNavigationSplitView` did.
+//
+// EVERY PANE CARRIES A `Text` THAT NAMES IT, and that is not decoration. A pane is a bare
+// `View`, so "one pane is on screen" is true of the sidebar and of the content alike —
+// measured: an assertion that counted the panes passed with `resolveNavigationStack`
+// replaced by `showContent ? 'content' : 'sidebar'`, which is precisely the rule this
+// widget exists to get right. Reading the text back is what makes the count a statement
+// about WHICH pane.
+//
+// WHAT IS ABSENT IS YOGA, exactly as for `AdwClamp`: a `width` in a style object is an
+// INSTRUCTION to a layout engine that is not in this process, so every assertion here is
+// about what the widget ASKS FOR. The matching "and it got it" is the GTK photograph.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { RCT_VIEW, Text } from '../testing/react-native.js';
+import { at, childrenOf, mounted, onlyChild, settled, textOf, type Style } from '../testing/render.spec.js';
+import { AdwNavigationSplitView } from './navigation-split-view.native.js';
+
+/** The frame the GTK half is photographed in, so both are asked the same question. */
+const FRAME_WIDTH = 1000;
+
+/** A split view whose two panes name themselves. */
+function splitView(props: Record<string, unknown> = {}) {
+    return (
+        <AdwNavigationSplitView sidebar={<Text>sidebar</Text>} sidebarWidthUnit="px" {...props}>
+            <Text>content</Text>
+        </AdwNavigationSplitView>
+    );
+}
+
+/** The name the pane at `index` is carrying. */
+function paneName(panes: ReturnType<typeof childrenOf>, index: number): string {
+    return textOf(onlyChild(at(panes, index)));
+}
+
+export default async () => {
+    await describe('AdwNavigationSplitView on React Native — the allocation it asks for', async () => {
+        await it('splits a 1000-point frame 250 / 750, where GTK reads the same pair', async () => {
+            const panes = childrenOf(settled(splitView(), FRAME_WIDTH));
+            expect(panes.length).toBe(2);
+            expect(paneName(panes, 0)).toBe('sidebar');
+            expect(at(panes, 0).props.style as Style).toStrictEqual({ width: 250 });
+            expect(paneName(panes, 1)).toBe('content');
+            expect(at(panes, 1).props.style as Style).toStrictEqual({ width: 750 });
+        });
+
+        await it('puts the sidebar LAST for sidebar-position: end, following the rects', async () => {
+            const panes = childrenOf(settled(splitView({ sidebarPosition: 'end' }), FRAME_WIDTH));
+            // Draw ORDER, taken from the rects rather than from a second predicate: the
+            // core returned `content.x = 0` and `sidebar.x = 750`.
+            expect(paneName(panes, 0)).toBe('content');
+            expect(at(panes, 0).props.style as Style).toStrictEqual({ width: 750 });
+            expect(paneName(panes, 1)).toBe('sidebar');
+            expect(at(panes, 1).props.style as Style).toStrictEqual({ width: 250 });
+        });
+
+        await it('leaves both panes unsized before the first layout', async () => {
+            const tree = mounted(splitView());
+            expect(tree.type).toBe(RCT_VIEW);
+            expect(typeof tree.props.onLayout).toBe('function');
+            for (const pane of childrenOf(tree)) expect(pane.props.style as Style).toBe(undefined);
+        });
+
+        await it('truncates the fraction, as the C’s (int) cast does', async () => {
+            // 0.333 of 1000 is 333.0 and `Math.trunc` is what the C does; the value is
+            // then clamped into 180…280, so the truncation is only VISIBLE with the
+            // maximum raised — which is why both halves of the rule are asserted.
+            const clamped = childrenOf(settled(splitView({ sidebarWidthFraction: 0.333 }), FRAME_WIDTH));
+            expect(at(clamped, 0).props.style as Style).toStrictEqual({ width: 280 });
+
+            const wider = childrenOf(
+                settled(splitView({ sidebarWidthFraction: 0.333, maxSidebarWidth: 500 }), FRAME_WIDTH),
+            );
+            expect(at(wider, 0).props.style as Style).toStrictEqual({ width: 333 });
+        });
+    });
+
+    await describe('AdwNavigationSplitView on React Native — the ordering table', async () => {
+        await it('shows the SIDEBAR when collapsed and show-content is false', async () => {
+            const tree = settled(splitView({ collapsed: true }), FRAME_WIDTH);
+            expect(childrenOf(tree).length).toBe(1);
+            expect(paneName(childrenOf(tree), 0)).toBe('sidebar');
+            expect(onlyChild(tree).props.style as Style).toStrictEqual({ flex: 1 });
+        });
+
+        await it('shows the CONTENT when collapsed and show-content is true', async () => {
+            const tree = settled(splitView({ collapsed: true, showContent: true }), FRAME_WIDTH);
+            expect(paneName(childrenOf(tree), 0)).toBe('content');
+        });
+
+        await it('keeps a LONE child visible whatever show-content says', async () => {
+            // The rule two CSS classes cannot express: `show-content` asks for a content
+            // pane that is not mounted, so the sidebar stays on screen. Keying the swap on
+            // the flag renders this case with an EMPTY pane — the bug
+            // `@gjsify/adwaita-nativescript` records against its own `_applyLayout`, and
+            // the reason this assertion reads the pane's name rather than counting panes.
+            const tree = settled(
+                <AdwNavigationSplitView sidebar={<Text>sidebar</Text>} collapsed={true} showContent={true} />,
+                FRAME_WIDTH,
+            );
+            expect(childrenOf(tree).length).toBe(1);
+            expect(paneName(childrenOf(tree), 0)).toBe('sidebar');
+        });
+
+        // `sidebar-position: end` IS NOT ASSERTED IN THIS DESCRIBE, and that is a
+        // measurement rather than an oversight. `resolveNavigationStack`'s `end` branch
+        // builds the stack the other way round — the CONTENT is the root page and the
+        // sidebar is pushed on top of it — but the LAST entry, which is the pane on
+        // screen, is the same for both positions at every value of `show-content`. What
+        // actually differs is the push/pop DIRECTION, which a renderer spends on a slide
+        // and this one has none of (`props.ts` names the absent animation). Measured: a
+        // test written here passed with `setSidebarPosition` pinned to `'start'`, which
+        // is the shape of an assertion that asserts nothing. The position IS asserted,
+        // where it is observable — on the docked draw order, above.
+
+        await it('renders no pane at all when neither is mounted', async () => {
+            const tree = settled(<AdwNavigationSplitView collapsed={true} />, FRAME_WIDTH);
+            // Not "renders something empty": an empty stack has no visible pane, so the
+            // view is one node with no children.
+            expect(tree.children).toBe(null);
+        });
+    });
+};

--- a/packages/framework/adwaita-react-native/src/widgets/navigation-split-view.native.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation-split-view.native.tsx
@@ -1,0 +1,167 @@
+/** @jsxImportSource react */
+// `AdwNavigationSplitView` on React Native — `@gjsify/adwaita-core`'s ports of
+// `allocate_uncollapsed` and `update_navigation_stack`. (On the pragma, see
+// `bin.native.tsx`.)
+//
+// TWO CORE ANSWERS, AND NEITHER IS APPROXIMATED HERE. `resolveNavigationSidebarWidth` is
+// the C's own arithmetic — the fraction truncated with `(int)`, the max bound capped by
+// `width - content_min`, and GLib's `CLAMP`, which tests the HIGH bound first and
+// therefore disagrees with `Math.min(max, Math.max(min, x))` exactly where the bounds
+// invert. `resolveNavigationStack` is the ordering table: a LONE child stays visible
+// whatever `show-content` says, and under `sidebar-position: end` the CONTENT is the
+// root page. A `width: '25%'` and an `if (showContent)` would agree with libadwaita in
+// the easy cases and nowhere else.
+//
+// THE SIZE SOURCE IS `onLayout`, NOT `useWindowDimensions()`, for the reason
+// `clamp.native.tsx` gives: every renderer of this design binds to the size of the VIEW.
+// A split view nested in a pane has to divide the pane.
+//
+// `contentMin` AND `sidebarChildMin` ARE PASSED AS 0 BECAUSE REACT NATIVE HAS NO MEASURE
+// PASS — the same one-directional divergence `AdwClamp` carries and the README names.
+// libadwaita protects the content pane by capping the sidebar's max bound with the
+// content's own minimum; `onLayout` reports a size AFTER layout and never a child's
+// intrinsic minimum, so that protection is absent here and the sidebar can take its full
+// share of a view too narrow for both.
+//
+// THE STATE IS IN A `useRef` AND THE PANES ARE MOUNTED BY IDENTITY.
+// `NavigationSplitViewState.setSidebar` compares the page ref by IDENTITY and emits on
+// every change, so handing it a fresh `{ tag }` each commit would emit each commit —
+// which, with the repaint this file subscribes, is a render loop rather than a
+// divergence. One ref object per pane, mounted once and RETAGGED through `setTag`, is
+// what makes mounting idempotent; it is also libadwaita's own split, where mounting a
+// colliding tag REFUSES the assignment and retagging a mounted page CLEARS the tag.
+//
+// THE READING DIRECTION IS `ltr` HERE. `isSidebarAtVisualStart` takes one, GTK resolves
+// it from the widget, and React Native's is on `I18nManager` — which is not a host
+// component and therefore not something `testing/react-native.ts` may stand in for. The
+// README names it; the core call still takes the parameter, so closing it is one
+// argument.
+
+import { useEffect, useRef, useState, type ReactElement, type ReactNode } from 'react';
+import { View, type LayoutChangeEvent } from 'react-native';
+
+import {
+    NavigationSplitViewState,
+    layoutNavigationSplitView,
+    resolveNavigationSidebarWidth,
+    type NavigationPageRef,
+    type SplitViewPane,
+} from '@gjsify/adwaita-core';
+
+import type { AdwNavigationSplitViewProps } from '../props.js';
+
+/** What survives every render: the ordering machine and one mountable ref per pane. */
+interface SplitViewStore {
+    state: NavigationSplitViewState;
+    sidebarPage: NavigationPageRef;
+    contentPage: NavigationPageRef;
+}
+
+/**
+ * {@link import('./navigation-split-view.js').AdwNavigationSplitView} on React Native.
+ *
+ * BEFORE THE FIRST LAYOUT there is no available width, so both panes render unsized for
+ * exactly one frame — the same one-frame case `AdwClamp` has, and for the same reason.
+ */
+export function AdwNavigationSplitView({
+    children,
+    sidebar,
+    sidebarTag,
+    contentTag,
+    collapsed,
+    showContent,
+    sidebarPosition,
+    minSidebarWidth,
+    maxSidebarWidth,
+    sidebarWidthFraction,
+    sidebarWidthUnit,
+}: AdwNavigationSplitViewProps): ReactElement | null {
+    const [available, setAvailable] = useState<number | null>(null);
+    const [, repaint] = useState(0);
+
+    const store = useRef<SplitViewStore | null>(null);
+    store.current ??= {
+        state: new NavigationSplitViewState({
+            sidebarPosition: sidebarPosition ?? 'start',
+            collapsed: collapsed ?? false,
+            showContent: showContent ?? false,
+        }),
+        sidebarPage: { tag: sidebarTag ?? null },
+        contentPage: { tag: contentTag ?? null },
+    };
+    const { state, sidebarPage, contentPage } = store.current;
+
+    useEffect(() => state.subscribe(() => repaint((count) => count + 1)), [state]);
+
+    useEffect(() => {
+        // The tag has to be current BEFORE the pane is mounted: `setSidebar` reads it off
+        // the ref and refuses the whole assignment on a collision.
+        sidebarPage.tag = sidebarTag ?? null;
+        contentPage.tag = contentTag ?? null;
+        if ((sidebar !== undefined) !== (state.sidebar !== null)) {
+            state.setSidebar(sidebar === undefined ? null : sidebarPage);
+        } else if (state.sidebar !== null && state.sidebarTag !== (sidebarTag ?? null)) {
+            state.setTag('sidebar', sidebarTag ?? null);
+        }
+        if ((children !== undefined) !== (state.content !== null)) {
+            state.setContent(children === undefined ? null : contentPage);
+        } else if (state.content !== null && state.contentTag !== (contentTag ?? null)) {
+            state.setTag('content', contentTag ?? null);
+        }
+        state.setSidebarPosition(sidebarPosition ?? 'start');
+        state.setCollapsed(collapsed ?? false);
+        state.setShowContent(showContent ?? false);
+    });
+
+    const onLayout = (event: LayoutChangeEvent): void => setAvailable(event.nativeEvent.layout.width);
+
+    const pane = (which: SplitViewPane, body: ReactNode, style: Record<string, number> | undefined): ReactElement => (
+        <View key={which} style={style}>
+            {body}
+        </View>
+    );
+
+    // Collapsed, the visible pane fills the view — and WHICH pane that is comes out of
+    // the ordering table, never out of `showContent`. Keying it on the flag renders a
+    // split view holding only a sidebar blank, which is the bug
+    // `@gjsify/adwaita-nativescript` records against its own `_applyLayout`.
+    if (state.collapsed) {
+        const visible = state.visiblePane;
+        if (visible === null) return <View onLayout={onLayout} style={{ flex: 1 }} />;
+        return (
+            <View onLayout={onLayout} style={{ flex: 1 }}>
+                {pane(visible, visible === 'sidebar' ? sidebar : children, { flex: 1 })}
+            </View>
+        );
+    }
+
+    const layout =
+        available === null
+            ? null
+            : layoutNavigationSplitView({
+                  totalWidth: available,
+                  sidebarWidth: resolveNavigationSidebarWidth({
+                      totalWidth: available,
+                      minSidebarWidth,
+                      maxSidebarWidth,
+                      sidebarWidthFraction,
+                      sidebarWidthUnit,
+                  }),
+                  sidebarPosition: state.sidebarPosition,
+              });
+    const sidebarStyle = layout === null ? undefined : { width: layout.sidebar.width };
+    const contentStyle = layout === null ? undefined : { width: layout.content.width };
+
+    const sidebarPane = sidebar === undefined ? null : pane('sidebar', sidebar, sidebarStyle);
+    const contentPane = children === undefined ? null : pane('content', children, contentStyle);
+    // Draw order follows the rects the core returned, so `sidebar-position: end` puts the
+    // sidebar last rather than needing a second predicate here.
+    const sidebarFirst = layout === null || layout.sidebar.x <= layout.content.x;
+
+    return (
+        <View onLayout={onLayout} style={{ flex: 1, flexDirection: 'row' }}>
+            {sidebarFirst ? sidebarPane : contentPane}
+            {sidebarFirst ? contentPane : sidebarPane}
+        </View>
+    );
+}

--- a/packages/framework/adwaita-react-native/src/widgets/navigation-split-view.ts
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation-split-view.ts
@@ -1,0 +1,23 @@
+// `AdwNavigationSplitView` — the base module. See `../refuse.ts` for who reaches this
+// and why it throws instead of resolving to something.
+
+import type { ReactElement } from 'react';
+
+import type { AdwNavigationSplitViewProps } from '../props.js';
+import { refuseBaseModule } from '../refuse.js';
+
+/**
+ * A sidebar beside content, which becomes a navigation stack when collapsed.
+ *
+ * THE SHARED HALF IS TWO THINGS, and both are `@gjsify/adwaita-core`'s. The WIDTH is
+ * `resolveNavigationSidebarWidth`, a port of the C that caps the sidebar's MAX BOUND by
+ * `width - content_min` and then clamps with GLib's `CLAMP` — which tests the high
+ * bound first and therefore disagrees with `Math.min(max, Math.max(min, x))` exactly
+ * where the bounds invert. The ORDERING is `resolveNavigationStack`, the table that
+ * keeps a LONE child visible whatever `show-content` says and makes the CONTENT the
+ * root page under `sidebar-position: end`. libadwaita runs the originals on GTK; the
+ * React Native half runs the ports, and the suites assert the same numbers on both.
+ */
+export function AdwNavigationSplitView(_props: AdwNavigationSplitViewProps): ReactElement | null {
+    return refuseBaseModule('AdwNavigationSplitView');
+}

--- a/packages/framework/adwaita-react-native/src/widgets/navigation-view.gtk.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation-view.gtk.tsx
@@ -1,0 +1,83 @@
+/** @jsxImportSource @gjsify/gtk-host/react */
+// `AdwNavigationView` on GTK — the real `Adw.NavigationView`, and libadwaita's own
+// stack. (On the pragma, see `bin.gtk.tsx`.)
+//
+// `NavigationViewState` IS NOT USED HERE, and that is the design rather than an
+// omission — the same rule `clamp.gtk.tsx` states for `clampAllocate` and
+// `toast-overlay.gtk.tsx` for `AdwToastQueue`. The core's port of the stack machine
+// exists for a renderer with no libadwaita; this half has the original, and running
+// both would give one widget two authorities for which page is on top. The core's value
+// on this path is as the oracle `navigation-view.native.spec.tsx` is measured against.
+//
+// TWO CONSTANTS ARE STILL SHARED, because they are not a second computation: the
+// back-button DERIVATION below is libadwaita's own rule (`adw-back-button.c`'s
+// `update_page` and `query_tooltip`) read off the real widget, and the fallback string
+// it lands on is `BACK_BUTTON_FALLBACK_TOOLTIP` — the same constant the React Native
+// half's `backButtonTooltip()` defaults to. Retyping `'Back'` here would be the drift.
+//
+// THE MUTATORS ARE CALLS, REACHED THROUGH A `ref`, for the reason `props.ts` gives:
+// `Adw.NavigationView:visible-page` is READ-ONLY and `push`/`pop` are methods, so a
+// prop-driven stack would be this package inventing a shape libadwaita does not have.
+// gtk-host's `getPublicInstance` hands back the author's own widget, so the ref is the
+// real `Adw.NavigationView`.
+
+import type Adw from 'gi://Adw?version=1';
+import { useImperativeHandle, useRef, type ReactElement } from 'react';
+
+import { BACK_BUTTON_FALLBACK_TOOLTIP } from '@gjsify/adwaita-core';
+
+import type { AdwNavigationViewProps } from '../props.js';
+
+/**
+ * `AdwBackButton`'s visibility rule, read off the live widget.
+ *
+ * `get_previous_page(visible) !== null && visible.can_pop` — the ONLY place `can-pop`
+ * decides anything, and deliberately not `get_navigation_stack().n_items > 1`: the
+ * stack is a `Gio.ListModel`, so that spelling would pull a second typelib into this
+ * module for a question two calls already answer.
+ */
+function canGoBack(view: Adw.NavigationView | null): boolean {
+    const page = view?.get_visible_page() ?? null;
+    if (view === null || page === null || !page.canPop) return false;
+    return view.get_previous_page(page) !== null;
+}
+
+/** `AdwBackButton`'s `query_tooltip`: the revealed page's title, or the fallback. */
+function backButtonTooltip(view: Adw.NavigationView | null): string | null {
+    if (!canGoBack(view) || view === null) return null;
+    const previous = view.get_previous_page(view.get_visible_page() as Adw.NavigationPage);
+    if (previous === null) return null;
+    return previous.title.length > 0 ? previous.title : BACK_BUTTON_FALLBACK_TOOLTIP;
+}
+
+/** {@link import('./navigation-view.js').AdwNavigationView} on GTK. */
+export function AdwNavigationView({
+    children,
+    animateTransitions,
+    popOnEscape,
+    ref,
+}: AdwNavigationViewProps): ReactElement | null {
+    const view = useRef<Adw.NavigationView | null>(null);
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            push: (tag: string): void => view.current?.push_by_tag(tag),
+            pop: (): boolean => view.current?.pop() ?? false,
+            popToTag: (tag: string): boolean => view.current?.pop_to_tag(tag) ?? false,
+            // A COPY, because `replace_with_tags` takes a mutable `string[]` through the
+            // introspection binding and the prop is a `readonly string[]`.
+            replaceWithTags: (tags: readonly string[]): void => view.current?.replace_with_tags([...tags]),
+            visiblePageTag: (): string | null => view.current?.get_visible_page_tag() ?? null,
+            canGoBack: (): boolean => canGoBack(view.current),
+            backButtonTooltip: (): string | null => backButtonTooltip(view.current),
+        }),
+        [],
+    );
+
+    return (
+        <adw-navigation-view ref={view} animate-transitions={animateTransitions} pop-on-escape={popOnEscape}>
+            {children}
+        </adw-navigation-view>
+    );
+}

--- a/packages/framework/adwaita-react-native/src/widgets/navigation-view.native.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation-view.native.spec.tsx
@@ -1,0 +1,169 @@
+/** @jsxImportSource react */
+// The React Native half of `AdwNavigationView`, rendered through React's real reconciler.
+//
+// EVERY TAG AND EVERY TOOLTIP IN THIS FILE HAS A TWIN IN `navigation.gtk.spec.tsx`, run
+// against libadwaita's own stack instead of `@gjsify/adwaita-core`'s port of it. That is
+// what "one API surface, two implementations" has to mean on a widget whose state is a
+// stack rather than a number: not that both files compile, but that a three-page chain
+// answers `home` / `detail` / `Home` / `Back` identically on a desktop and on a phone.
+//
+// ONE ROW IS ASSERTED HERE AND NOT THERE, and it is a measurement rather than a gap. The
+// `'Back'` fallback needs a page whose title is EMPTY, and libadwaita 1.9.3 prints
+// `AdwNavigationPage 0x… is missing a title.` for exactly that page — a diagnostic the
+// GTK suite's `installDiagnosticsGate` fails on, and correctly. Both halves still share
+// the STRING: `BACK_BUTTON_FALLBACK_TOOLTIP` is what `navigation-view.gtk.tsx` falls back
+// to and what `NavigationViewState.backButtonTooltip` defaults to.
+//
+// WHAT IS AND IS NOT MEASURED. `react-test-renderer` runs React's own reconciler and hook
+// dispatcher, so the effects that register the pages and the `useImperativeHandle` that
+// exposes the stack are real. What is absent is Yoga: `display: 'none'` is an INSTRUCTION
+// to a layout engine that is not in this process, so "the other pages are hidden" is
+// asserted as what the widget ASKS FOR.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { act } from 'react-test-renderer';
+
+import { BACK_BUTTON_FALLBACK_TOOLTIP } from '@gjsify/adwaita-core';
+
+import type { AdwNavigationViewHandle } from '../props.js';
+import { RCT_VIEW } from '../testing/react-native.js';
+import { at, childrenOf, mount, type Style } from '../testing/render.spec.js';
+import { AdwNavigationPage } from './navigation-page.native.js';
+import { AdwNavigationView } from './navigation-view.native.js';
+
+/** The three declared pages `navigation.gtk.spec.tsx` uses, with one title left empty. */
+function pages() {
+    return [
+        <AdwNavigationPage key="home" title="Home" tag="home">
+            {null}
+        </AdwNavigationPage>,
+        <AdwNavigationPage key="detail" title="Detail" tag="detail">
+            {null}
+        </AdwNavigationPage>,
+        <AdwNavigationPage key="settings" title="Settings" tag="settings">
+            {null}
+        </AdwNavigationPage>,
+    ];
+}
+
+/** Mount the three-page view and hand back its handle plus a reader for the tree. */
+function mountView(options: { detailCanPop?: boolean; untitledRoot?: boolean } = {}) {
+    const ref: { current: AdwNavigationViewHandle | null } = { current: null };
+    const declared = pages();
+    const renderer = mount(
+        <AdwNavigationView ref={ref}>
+            {options.untitledRoot ? (
+                <AdwNavigationPage key="home" title="" tag="home">
+                    {null}
+                </AdwNavigationPage>
+            ) : (
+                declared[0]
+            )}
+            <AdwNavigationPage key="detail" title="Detail" tag="detail" canPop={options.detailCanPop}>
+                {null}
+            </AdwNavigationPage>
+            {declared[2]}
+        </AdwNavigationView>,
+    );
+    if (ref.current === null) throw new Error('the view exposed no handle');
+    return { handle: ref.current, renderer };
+}
+
+/** Which declared page the tree is showing, by the style the wrappers carry. */
+function displayedIndexes(renderer: ReturnType<typeof mount>): number[] {
+    const tree = renderer.toJSON();
+    if (tree === null || Array.isArray(tree)) throw new Error('the view rendered no single root');
+    return childrenOf(tree)
+        .map((child, index) => ((child.props.style as { display?: string }).display === undefined ? index : -1))
+        .filter((index) => index >= 0);
+}
+
+export default async () => {
+    await describe('AdwNavigationView on React Native — the tree it emits', async () => {
+        await it('keeps every registered page mounted and shows exactly one', async () => {
+            const { renderer } = mountView();
+            const tree = renderer.toJSON();
+            if (tree === null || Array.isArray(tree)) throw new Error('the view rendered no single root');
+            expect(tree.type).toBe(RCT_VIEW);
+            // Three pages in the tree, and only page 0 displayed — the auto-push.
+            expect(childrenOf(tree).length).toBe(3);
+            expect(displayedIndexes(renderer)).toStrictEqual([0]);
+            expect(at(childrenOf(tree), 0).props.style as Style).toStrictEqual({ flex: 1 });
+            expect(at(childrenOf(tree), 1).props.style as Style).toStrictEqual({ display: 'none' });
+        });
+
+        await it('moves the displayed page on a push, without unmounting the others', async () => {
+            const { handle, renderer } = mountView();
+            act(() => handle.push('settings'));
+            expect(displayedIndexes(renderer)).toStrictEqual([2]);
+            const tree = renderer.toJSON();
+            if (tree === null || Array.isArray(tree)) throw new Error('the view rendered no single root');
+            // STILL three: a renderer that dropped the hidden pages would lose their
+            // component state on every push, which no other Adwaita renderer does.
+            expect(childrenOf(tree).length).toBe(3);
+        });
+    });
+
+    await describe('AdwNavigationView on React Native — the stack machine both halves answer alike', async () => {
+        await it('starts on the root page, with no way back', async () => {
+            const { handle } = mountView();
+            expect(handle.visiblePageTag()).toBe('home');
+            expect(handle.canGoBack()).toBe(false);
+            expect(handle.backButtonTooltip()).toBe(null);
+        });
+
+        await it('pushes by tag and names the revealed page in the tooltip', async () => {
+            const { handle } = mountView();
+            act(() => handle.push('detail'));
+            expect(handle.visiblePageTag()).toBe('detail');
+            expect(handle.canGoBack()).toBe(true);
+            // The title of the page the button would REVEAL, not of the one on screen.
+            expect(handle.backButtonTooltip()).toBe('Home');
+        });
+
+        await it('pops back to the root and refuses to pop the root', async () => {
+            const { handle } = mountView();
+            act(() => handle.push('detail'));
+            let popped = false;
+            act(() => {
+                popped = handle.pop();
+            });
+            expect(popped).toBe(true);
+            expect(handle.visiblePageTag()).toBe('home');
+            expect(handle.pop()).toBe(false);
+        });
+
+        await it('replaces the whole stack, last tag visible', async () => {
+            const { handle } = mountView();
+            act(() => handle.replaceWithTags(['home', 'detail', 'settings']));
+            expect(handle.visiblePageTag()).toBe('settings');
+            act(() => {
+                handle.popToTag('home');
+            });
+            expect(handle.visiblePageTag()).toBe('home');
+        });
+
+        await it('hides the back button for a page that cannot be popped', async () => {
+            const { handle } = mountView({ detailCanPop: false });
+            act(() => handle.push('detail'));
+            expect(handle.visiblePageTag()).toBe('detail');
+            // `can-pop` gates the BUTTON and the shortcuts, never `pop()`.
+            expect(handle.canGoBack()).toBe(false);
+            expect(handle.backButtonTooltip()).toBe(null);
+            let popped = false;
+            act(() => {
+                popped = handle.pop();
+            });
+            expect(popped).toBe(true);
+        });
+
+        await it('falls back to “Back” when the revealed page has an empty title', async () => {
+            const { handle } = mountView({ untitledRoot: true });
+            act(() => handle.push('detail'));
+            // The constant, not the literal: `navigation-view.gtk.tsx` imports the same
+            // one, so the two halves cannot drift apart on the string.
+            expect(handle.backButtonTooltip()).toBe(BACK_BUTTON_FALLBACK_TOOLTIP);
+            expect(BACK_BUTTON_FALLBACK_TOOLTIP).toBe('Back');
+        });
+    });
+};

--- a/packages/framework/adwaita-react-native/src/widgets/navigation-view.native.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation-view.native.spec.tsx
@@ -26,8 +26,8 @@ import { act } from 'react-test-renderer';
 import { BACK_BUTTON_FALLBACK_TOOLTIP } from '@gjsify/adwaita-core';
 
 import type { AdwNavigationViewHandle } from '../props.js';
-import { RCT_VIEW } from '../testing/react-native.js';
-import { at, childrenOf, mount, type Style } from '../testing/render.spec.js';
+import { RCT_VIEW, Text } from '../testing/react-native.js';
+import { at, childrenOf, mount, onlyChild, textOf, type Style } from '../testing/render.spec.js';
 import { AdwNavigationPage } from './navigation-page.native.js';
 import { AdwNavigationView } from './navigation-view.native.js';
 
@@ -67,6 +67,32 @@ function mountView(options: { detailCanPop?: boolean; untitledRoot?: boolean } =
     );
     if (ref.current === null) throw new Error('the view exposed no handle');
     return { handle: ref.current, renderer };
+}
+
+/** The same three pages, with the ROOT behind a condition and each body named. */
+function conditionalView(showRoot: boolean, ref: { current: AdwNavigationViewHandle | null }) {
+    return (
+        <AdwNavigationView ref={ref}>
+            {showRoot ? (
+                <AdwNavigationPage key="home" title="Home" tag="home">
+                    <Text>home</Text>
+                </AdwNavigationPage>
+            ) : null}
+            <AdwNavigationPage key="detail" title="Detail" tag="detail">
+                <Text>detail</Text>
+            </AdwNavigationPage>
+            <AdwNavigationPage key="settings" title="Settings" tag="settings">
+                <Text>settings</Text>
+            </AdwNavigationPage>
+        </AdwNavigationView>
+    );
+}
+
+/** The name each rendered page is carrying, in tree order. */
+function bodyNames(renderer: ReturnType<typeof mount>): string[] {
+    const tree = renderer.toJSON();
+    if (tree === null || Array.isArray(tree)) throw new Error('the view rendered no single root');
+    return childrenOf(tree).map((wrapper) => textOf(onlyChild(onlyChild(wrapper))));
 }
 
 /** Which declared page the tree is showing, by the style the wrappers carry. */
@@ -155,6 +181,41 @@ export default async () => {
                 popped = handle.pop();
             });
             expect(popped).toBe(true);
+        });
+
+        await it('survives a page disappearing from the middle of the declared list', async () => {
+            // THE TOKEN IS KEYED, NOT INDEXED, and this is the case that proves it.
+            // `Children.toArray` COMPACTS, so a `{cond ? … : null}` root that goes false
+            // moves every page after it down one index. Measured with a position-keyed
+            // token: the sync effect unregistered the LAST page instead of the vanished
+            // one, the survivors inherited their neighbours' tags, and the visible token
+            // resolved to no element at all — every page `display: 'none'`, a blank
+            // screen at exit 0. Each assertion below reads a page's NAME, because a count
+            // of three `View`s is true of the corrupted tree too.
+            const ref: { current: AdwNavigationViewHandle | null } = { current: null };
+            const renderer = mount(conditionalView(true, ref));
+            if (ref.current === null) throw new Error('the view exposed no handle');
+            const handle = ref.current;
+            act(() => handle.push('settings'));
+            expect(displayedIndexes(renderer)).toStrictEqual([2]);
+
+            act(() => {
+                renderer.update(conditionalView(false, ref));
+            });
+            // The root is UNDECLARED and still on the view's stack, which is
+            // `adw_navigation_view_remove`'s own rule: a page on the stack is marked
+            // remove-on-pop and destroyed when it is popped, not before.
+            expect(bodyNames(renderer)).toStrictEqual(['home', 'detail', 'settings']);
+            expect(handle.visiblePageTag()).toBe('settings');
+            // The tooltip still names the page the button would REVEAL. With the tags
+            // shifted it read `Detail`.
+            expect(handle.backButtonTooltip()).toBe('Home');
+
+            act(() => {
+                handle.pop();
+            });
+            expect(handle.visiblePageTag()).toBe('home');
+            expect(displayedIndexes(renderer)).toStrictEqual([0]);
         });
 
         await it('falls back to “Back” when the revealed page has an empty title', async () => {

--- a/packages/framework/adwaita-react-native/src/widgets/navigation-view.native.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation-view.native.tsx
@@ -21,10 +21,21 @@
 // A PAGE'S IDENTITY IS A TOKEN, NOT ITS ELEMENT. `NavigationViewState<P>` keys its
 // registry on `P` by identity, and React rebuilds every child element on every render —
 // so registering the elements would re-register the whole view each time and lose the
-// stack. The token is the page's position in the declared list, allocated once, and the
-// CURRENT element for that position is looked up at render. `@gjsify/adwaita-web` has
-// the same problem and solves it the other way round, because a DOM node survives a
-// re-render and a React element does not.
+// stack. `@gjsify/adwaita-web` has the same problem and solves it the other way round,
+// because a DOM node survives a re-render and a React element does not.
+//
+// AND THE TOKEN IS KEYED BY THE CHILD'S KEY, NOT BY ITS POSITION IN THE DECLARED LIST.
+// `Children.toArray` COMPACTS: a `{cond && <Page/>}` branch that goes false is dropped
+// from the array, so every page after it moves down one index. Measured with a
+// position-keyed token, on the exact case this widget is for — three declared pages,
+// `push('settings')`, then the root conditionally removed: the sync effect unregistered
+// the LAST token instead of the vanished one, the survivors were retagged with their
+// neighbours' tags, the visible token no longer resolved to an element, and the view
+// rendered with EVERY page `display: 'none'` — a blank screen at exit 0, which is the
+// failure signature this package exists to remove. The key does not move: `toArray`
+// stamps `.$<key>` on an authored one and `.N` on an unkeyed child where N is the index
+// in the ORIGINAL child list, holes included (measured: `[a, false, c]` yields
+// `['.1', '.2']`, not `['.0', '.1']`).
 //
 // DECLARED CHILDREN ARE THE STATICALLY-ADDED PAGES, in order, and page 0 becomes visible
 // with nobody pushing it: `add_page` auto-pushes whenever the stack is EMPTY. Both other
@@ -51,10 +62,33 @@ import { NavigationViewState, type AdwNavigationPageProps as CoreNavigationPageP
 
 import type { AdwNavigationPageProps, AdwNavigationViewProps } from '../props.js';
 
-/** A declared page's identity, allocated once per position and never re-created. */
+/** A declared page's identity, allocated once per key and never re-created. */
 interface PageToken {
-    /** Index into the declared child list — how the element for this page is found again. */
-    readonly index: number;
+    /** The key `Children.toArray` stamped on the child — see the head of this file. */
+    readonly key: string;
+    /**
+     * The element last declared for this page.
+     *
+     * KEPT ON THE TOKEN so a page that stops being declared while it is still on the
+     * stack goes on rendering until it is popped. That is `remove_page`'s own rule —
+     * `NavigationViewState.remove` defers the unregistration for a page on the stack, as
+     * `adw_navigation_view_remove` does — and looking the element up in the current
+     * declared list instead would draw nothing for exactly those pages.
+     */
+    element: ReactElement<AdwNavigationPageProps>;
+}
+
+/**
+ * The key `Children.toArray` gave this child.
+ *
+ * A LOUD FAILURE rather than a fallback: two pages sharing a synthesised key would share
+ * a token, and the view would then lose one of them somewhere far from here. `toArray`
+ * keys every child it returns, so this throw is unreachable — and the type is
+ * `string | null`, so leaving it to `??` would be the silent version.
+ */
+function keyOf(element: ReactElement): string {
+    if (element.key === null) throw new Error('Children.toArray returned a page with no key');
+    return element.key;
 }
 
 /** The three headless page properties, off the element's own props. */
@@ -66,10 +100,10 @@ function corePropsOf(element: ReactElement<AdwNavigationPageProps>): CoreNavigat
     };
 }
 
-/** What survives every render: the stack machine and one token per declared position. */
+/** What survives every render: the stack machine and one token per declared key. */
 interface PageStore {
     state: NavigationViewState<PageToken>;
-    tokens: PageToken[];
+    tokens: Map<string, PageToken>;
 }
 
 /** {@link import('./navigation-view.js').AdwNavigationView} on React Native. */
@@ -79,8 +113,8 @@ export function AdwNavigationView({
     popOnEscape,
     ref,
 }: AdwNavigationViewProps): ReactElement | null {
-    // `Children.toArray` drops `null`/`false` branches and flattens fragments, so a
-    // conditionally-rendered page does not shift the positions of the ones after it.
+    // `Children.toArray` flattens fragments and drops `null`/`false` branches — the
+    // DROP is why a token is keyed rather than indexed; see the head of this file.
     const declared = Children.toArray(children).filter((child) =>
         isValidElement(child),
     ) as ReactElement<AdwNavigationPageProps>[];
@@ -89,10 +123,12 @@ export function AdwNavigationView({
     const store = useRef<PageStore | null>(null);
     if (store.current === null) {
         const state = new NavigationViewState<PageToken>();
-        const tokens = declared.map((_, index) => ({ index }));
-        tokens.forEach((token, index) =>
-            state.add(token, corePropsOf(declared[index] as ReactElement<AdwNavigationPageProps>)),
-        );
+        const tokens = new Map<string, PageToken>();
+        for (const element of declared) {
+            const token: PageToken = { key: keyOf(element), element };
+            tokens.set(token.key, token);
+            state.add(token, corePropsOf(element));
+        }
         store.current = { state, tokens };
     }
     const { state, tokens } = store.current;
@@ -117,22 +153,31 @@ export function AdwNavigationView({
     useEffect(() => {
         state.setAnimateTransitions(animateTransitions ?? true);
         state.setPopOnEscape(popOnEscape ?? true);
-        while (tokens.length < declared.length) {
-            const token: PageToken = { index: tokens.length };
-            tokens.push(token);
-            state.add(token, corePropsOf(declared[token.index] as ReactElement<AdwNavigationPageProps>));
-        }
-        while (tokens.length > declared.length) {
-            state.remove(tokens.pop() as PageToken);
-        }
-        declared.forEach((element, index) => {
-            const token = tokens[index];
-            if (token === undefined) return;
+        const stillDeclared = new Set<string>();
+        for (const element of declared) {
+            const key = keyOf(element);
+            stillDeclared.add(key);
+            const existing = tokens.get(key);
+            if (existing === undefined) {
+                const token: PageToken = { key, element };
+                tokens.set(key, token);
+                state.add(token, corePropsOf(element));
+                continue;
+            }
+            existing.element = element;
             const props = corePropsOf(element);
-            state.setTag(token, props.tag ?? null);
-            state.setTitle(token, props.title ?? '');
-            state.setCanPop(token, props.canPop ?? true);
-        });
+            state.setTag(existing, props.tag ?? null);
+            state.setTitle(existing, props.title ?? '');
+            state.setCanPop(existing, props.canPop ?? true);
+        }
+        // Iterated over a COPY: this loop deletes from the same map it walks, and
+        // `state.remove` can unregister immediately on top of that.
+        // oxlint-disable-next-line unicorn/no-useless-spread -- the copy IS the point: a live Map iterator would skip an entry after the delete below
+        for (const [key, token] of [...tokens]) {
+            if (stillDeclared.has(key)) continue;
+            tokens.delete(key);
+            state.remove(token);
+        }
     });
 
     useImperativeHandle(
@@ -157,15 +202,11 @@ export function AdwNavigationView({
     const visible = state.visiblePage;
     return (
         <View style={{ flex: 1 }}>
-            {state.pages.map((token) => {
-                const element = declared[token.index];
-                if (element === undefined) return null;
-                return (
-                    <View key={token.index} style={token === visible ? { flex: 1 } : { display: 'none' }}>
-                        {element}
-                    </View>
-                );
-            })}
+            {state.pages.map((token) => (
+                <View key={token.key} style={token === visible ? { flex: 1 } : { display: 'none' }}>
+                    {token.element}
+                </View>
+            ))}
         </View>
     );
 }

--- a/packages/framework/adwaita-react-native/src/widgets/navigation-view.native.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation-view.native.tsx
@@ -1,0 +1,171 @@
+/** @jsxImportSource react */
+// `AdwNavigationView` on React Native — `@gjsify/adwaita-core`'s port of libadwaita's
+// stack machine. (On the pragma, see `bin.native.tsx`.)
+//
+// WHERE THE STATE LIVES, AND WHY IT IS NOT IN REACT. `NavigationViewState` is in a
+// `useRef` and is never re-created: it owns the page registry, the tag index, the
+// static-versus-dynamic `remove_on_pop` lifecycle and the six mutators. Rebuilding it on
+// a render would reset a stack the user had already pushed onto; putting it in
+// `useState` would additionally make React decide when it exists. It is the authority,
+// so it outlives every render — exactly as `Adw.NavigationView` does on the other half,
+// where the authority is libadwaita's own C. Same reasoning, and the same shape, as
+// `AdwToastQueue` in `toast-overlay.native.tsx`.
+//
+// REACT'S ONLY JOB IS THE REPAINT, which is what the `useState` counter is: the
+// subscription bumps it, and the render reads the settled stack back out of the core.
+// The subscription is installed in an EFFECT rather than beside the construction, and
+// that ordering is load-bearing: the initial `add()` calls auto-push the root page and
+// therefore EMIT, and a listener that called `setState` there would be updating a
+// component while it renders.
+//
+// A PAGE'S IDENTITY IS A TOKEN, NOT ITS ELEMENT. `NavigationViewState<P>` keys its
+// registry on `P` by identity, and React rebuilds every child element on every render —
+// so registering the elements would re-register the whole view each time and lose the
+// stack. The token is the page's position in the declared list, allocated once, and the
+// CURRENT element for that position is looked up at render. `@gjsify/adwaita-web` has
+// the same problem and solves it the other way round, because a DOM node survives a
+// re-render and a React element does not.
+//
+// DECLARED CHILDREN ARE THE STATICALLY-ADDED PAGES, in order, and page 0 becomes visible
+// with nobody pushing it: `add_page` auto-pushes whenever the stack is EMPTY. Both other
+// renderers snapshot their declared children exactly this way — and the auto-push is
+// also what re-arms the view after `replaceWithTags([])`.
+//
+// EVERY REGISTERED PAGE STAYS MOUNTED and the hidden ones are `display: 'none'`, which
+// is `hidden` on the browser half and `visibility: 'collapse'` on the NativeScript one.
+// Rendering only the visible page would unmount the rest and lose their component state
+// on every push — a divergence from all three other renderers, on the widget whose whole
+// point is that you can go back to where you were.
+//
+// THERE IS NO AUTOMATIC BACK BUTTON, which is `@gjsify/adwaita-nativescript`'s decision
+// and for its reason: the browser renderer can find an `<adw-header-bar>` inside the page
+// and inject one, and neither NativeScript nor this package has a header bar it can
+// identify inside an opaque child. `canGoBack()` and `backButtonTooltip()` on the handle
+// are the two derivations a caller wires its own button to, and they are libadwaita's
+// own rules rather than this file's.
+
+import { Children, isValidElement, useEffect, useImperativeHandle, useRef, useState, type ReactElement } from 'react';
+import { View } from 'react-native';
+
+import { NavigationViewState, type AdwNavigationPageProps as CoreNavigationPageProps } from '@gjsify/adwaita-core';
+
+import type { AdwNavigationPageProps, AdwNavigationViewProps } from '../props.js';
+
+/** A declared page's identity, allocated once per position and never re-created. */
+interface PageToken {
+    /** Index into the declared child list — how the element for this page is found again. */
+    readonly index: number;
+}
+
+/** The three headless page properties, off the element's own props. */
+function corePropsOf(element: ReactElement<AdwNavigationPageProps>): CoreNavigationPageProps {
+    return {
+        tag: element.props.tag ?? null,
+        title: element.props.title ?? '',
+        canPop: element.props.canPop ?? true,
+    };
+}
+
+/** What survives every render: the stack machine and one token per declared position. */
+interface PageStore {
+    state: NavigationViewState<PageToken>;
+    tokens: PageToken[];
+}
+
+/** {@link import('./navigation-view.js').AdwNavigationView} on React Native. */
+export function AdwNavigationView({
+    children,
+    animateTransitions,
+    popOnEscape,
+    ref,
+}: AdwNavigationViewProps): ReactElement | null {
+    // `Children.toArray` drops `null`/`false` branches and flattens fragments, so a
+    // conditionally-rendered page does not shift the positions of the ones after it.
+    const declared = Children.toArray(children).filter((child) =>
+        isValidElement(child),
+    ) as ReactElement<AdwNavigationPageProps>[];
+
+    const [, repaint] = useState(0);
+    const store = useRef<PageStore | null>(null);
+    if (store.current === null) {
+        const state = new NavigationViewState<PageToken>();
+        const tokens = declared.map((_, index) => ({ index }));
+        tokens.forEach((token, index) =>
+            state.add(token, corePropsOf(declared[index] as ReactElement<AdwNavigationPageProps>)),
+        );
+        store.current = { state, tokens };
+    }
+    const { state, tokens } = store.current;
+
+    useEffect(
+        () =>
+            state.subscribe(() => {
+                // No animation on this half, so the deferred destroy settles at once —
+                // what `adw_animation_skip` does in the C when `animate` is FALSE, and
+                // what both other renderers call this seam for.
+                state.finishTransition();
+                repaint((count) => count + 1);
+            }),
+        [state],
+    );
+
+    // The web half's `syncPageProperty`: the props are the authoring surface, and the
+    // tag index, the title chain and the back-button rule read the CORE's copy. Without
+    // this, a page's `can-pop` would be frozen at whatever it was when the view mounted.
+    // No dependency list — the declared list is rebuilt on every render, so any
+    // dependency over it would be a second copy of the same three values.
+    useEffect(() => {
+        state.setAnimateTransitions(animateTransitions ?? true);
+        state.setPopOnEscape(popOnEscape ?? true);
+        while (tokens.length < declared.length) {
+            const token: PageToken = { index: tokens.length };
+            tokens.push(token);
+            state.add(token, corePropsOf(declared[token.index] as ReactElement<AdwNavigationPageProps>));
+        }
+        while (tokens.length > declared.length) {
+            state.remove(tokens.pop() as PageToken);
+        }
+        declared.forEach((element, index) => {
+            const token = tokens[index];
+            if (token === undefined) return;
+            const props = corePropsOf(element);
+            state.setTag(token, props.tag ?? null);
+            state.setTitle(token, props.title ?? '');
+            state.setCanPop(token, props.canPop ?? true);
+        });
+    });
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            // `pushByTag` returns a boolean here and `adw_navigation_view_push_by_tag`
+            // returns void, so the boolean is dropped rather than widening the surface
+            // past what both halves can answer.
+            push: (tag: string): void => {
+                state.pushByTag(tag);
+            },
+            pop: (): boolean => state.pop(),
+            popToTag: (tag: string): boolean => state.popToTag(tag),
+            replaceWithTags: (tags: readonly string[]): void => state.replaceWithTags(tags),
+            visiblePageTag: (): string | null => state.visiblePageTag,
+            canGoBack: (): boolean => state.canGoBack(),
+            backButtonTooltip: (): string | null => state.backButtonTooltip(),
+        }),
+        [state],
+    );
+
+    const visible = state.visiblePage;
+    return (
+        <View style={{ flex: 1 }}>
+            {state.pages.map((token) => {
+                const element = declared[token.index];
+                if (element === undefined) return null;
+                return (
+                    <View key={token.index} style={token === visible ? { flex: 1 } : { display: 'none' }}>
+                        {element}
+                    </View>
+                );
+            })}
+        </View>
+    );
+}

--- a/packages/framework/adwaita-react-native/src/widgets/navigation-view.ts
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation-view.ts
@@ -1,0 +1,24 @@
+// `AdwNavigationView` — the base module. See `../refuse.ts` for who reaches this and
+// why it throws instead of resolving to something.
+
+import type { ReactElement } from 'react';
+
+import type { AdwNavigationViewProps } from '../props.js';
+import { refuseBaseModule } from '../refuse.js';
+
+/**
+ * A stack of pages, one visible at a time.
+ *
+ * THE TWO IMPLEMENTATIONS SHARE THE STACK MACHINE AND NOTHING ELSE, and unlike every
+ * widget above this one that machine is real state rather than arithmetic: a page
+ * registry, a tag index, the static-versus-dynamic `remove_on_pop` lifecycle, six
+ * mutators and the back-button derivation. On GTK it is libadwaita's own C; on React
+ * Native it is `@gjsify/adwaita-core`'s `NavigationViewState`, the same class
+ * `@gjsify/adwaita-web` and `@gjsify/adwaita-nativescript` already run — so the three
+ * renderers answer one question about a given page chain, and the suites assert the
+ * same tag and the same tooltip on both halves rather than each side's own idea of
+ * "the top of the stack".
+ */
+export function AdwNavigationView(_props: AdwNavigationViewProps): ReactElement | null {
+    return refuseBaseModule('AdwNavigationView');
+}

--- a/packages/framework/adwaita-react-native/src/widgets/navigation.gtk.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation.gtk.spec.tsx
@@ -217,6 +217,45 @@ export default async () => {
                 );
             });
 
+            await it('never reports a visible-child name no page carries', async () => {
+                // THE AUTO-PICK NOTIFY ARRIVES BEFORE THE REF DOES. libadwaita selects the
+                // first visible page from inside `adw_view_stack_add_titled`, and child
+                // insertion sits OUTSIDE gtk-host's host-write window, so the handler runs
+                // — while React has not yet committed the `ref` it would read the name
+                // off. Measured before `visibleChildNotifier`: `['']`, a name no page has,
+                // on a callback whose contract is to name the page that is showing.
+                //
+                // AND A CHANGE THE CALLER MADE REPORTS NOTHING HERE, which the second
+                // `rerender` pins: gtk-host drops the notify raised inside its own
+                // property write. That is a real divergence from the React Native half,
+                // which re-applies the prop through `selectName` and reports what it
+                // settled on — the README names it, and this row is what makes it a
+                // measurement rather than a claim. A change the USER made reaches both;
+                // driving a real switcher press is not something this suite can do.
+                const seen: string[] = [];
+                const pages = [
+                    { name: 'home', title: 'Home', child: <gtk-label label="home" /> },
+                    { name: 'detail', title: 'Detail', child: <gtk-label label="detail" /> },
+                ];
+                laidOut(
+                    <AdwViewStack pages={pages} onNotifyVisibleChild={(name) => seen.push(name)} />,
+                    (container, _window, rerender) => {
+                        const stack = find(container, 'AdwViewStack') as Adw.ViewStack;
+                        expect(stack.visibleChildName).toBe('home');
+                        expect(seen).toStrictEqual([]);
+                        rerender(
+                            <AdwViewStack
+                                pages={pages}
+                                visibleChildName="detail"
+                                onNotifyVisibleChild={(name) => seen.push(name)}
+                            />,
+                        );
+                        expect(stack.visibleChildName).toBe('detail');
+                        expect(seen).toStrictEqual([]);
+                    },
+                );
+            });
+
             await it('points a real Adw.ViewSwitcher at the real Adw.ViewStack it built', async () => {
                 laidOut(
                     <AdwViewSwitcher

--- a/packages/framework/adwaita-react-native/src/widgets/navigation.gtk.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation.gtk.spec.tsx
@@ -36,7 +36,7 @@ import Adw from 'gi://Adw?version=1';
 import type Gtk from 'gi://Gtk?version=4.0';
 import { expect, it } from '@gjsify/unit';
 import { blankReason, shotEvidence } from '@gjsify/gtk-host';
-import { measureSplitViewHorizontal, resolveSidebarBounds } from '@gjsify/adwaita-core';
+import { measureSplitViewHorizontal, resolveOverlaySidebarWidth, resolveSidebarBounds } from '@gjsify/adwaita-core';
 
 import type { AdwNavigationViewHandle } from '../props.js';
 import { FRAME_WIDTH, capture, find, laidOut, typeOf, withGtk } from '../testing/gtk.spec.js';
@@ -145,6 +145,41 @@ export default async () => {
                         expect(view.showSidebar).toBe(true);
                         // No `Adw.NavigationPage` here: these two slots take `GtkWidget`.
                         expect(typeOf(view.sidebar as Gtk.Widget)).toBe('GtkBox');
+                    },
+                );
+            });
+
+            await it('pins and collapses in ONE commit without losing the sidebar', async () => {
+                // THE WRITE ORDER, AS A THING THAT GOES RED, and the twin of the row of
+                // the same name in `overlay-split-view.native.spec.tsx`.
+                // `adw_overlay_split_view_set_collapsed` calls `set_show_sidebar (self,
+                // !collapsed, …)` for an UNPINNED sidebar, so `collapsed` has to be
+                // written after `pin-sidebar` — and gtk-host writes props in ELEMENT
+                // order, on the update path from `Object.keys(newProps)` and at mount
+                // from the insertion order `g_object_new_with_properties` preserves. The
+                // mount case is covered by the row above, which authors both flags at
+                // once; this one changes both in a single commit, which is the case that
+                // depends on nothing but the order two JSX attributes are written in.
+                laidOut(
+                    <AdwOverlaySplitView sidebar={<gtk-label label="sidebar" />}>
+                        <gtk-label label="content" />
+                    </AdwOverlaySplitView>,
+                    (container, _window, rerender) => {
+                        const view = find(container, 'AdwOverlaySplitView') as Adw.OverlaySplitView;
+                        expect(view.showSidebar).toBe(true);
+                        rerender(
+                            <AdwOverlaySplitView
+                                sidebar={<gtk-label label="sidebar" />}
+                                pinSidebar={true}
+                                collapsed={true}
+                            >
+                                <gtk-label label="content" />
+                            </AdwOverlaySplitView>,
+                        );
+                        expect(view.collapsed).toBe(true);
+                        expect(view.pinSidebar).toBe(true);
+                        // Pinned BEFORE collapsing, so the collapse left it alone.
+                        expect(view.showSidebar).toBe(true);
                     },
                 );
             });
@@ -366,24 +401,35 @@ export default async () => {
                 });
             });
 
-            await gated('the container minimum, which is also the core\u2019s', async () => {
-                // WHAT THIS DESCRIBE REPLACED, AND WHY IT COULD NOT BE WRITTEN.
+            await gated('the container minimum and the overlay cap, both the core\u2019s', async () => {
+                // WHAT THIS DESCRIBE REPLACED, AND HOW MUCH OF IT COULD NOT BE WRITTEN.
                 // `resolveNavigationSidebarWidth` and `resolveOverlaySidebarWidth` are
                 // genuinely different rules — the first caps the sidebar's MAX BOUND by
                 // `width - content_min`, the second caps the RESULT — and the core's own
-                // header names a 300-point vector where they answer 180 and 100. That
-                // vector is unreachable through a GTK window, measured: `measure` reports
-                // `sidebar_min + content_min` as the view's own minimum, GTK never
-                // allocates a widget below its minimum, and the two rules agree at every
-                // width from that minimum upwards. The 300-point frame below is allocated
-                // 380. So the disagreement is a property of the two FUNCTIONS, held by
-                // `@gjsify/adwaita-core`'s own vectors, and asserting it here would have
-                // meant asserting a number the widget cannot produce.
+                // header names a 300-point vector where they answer 180 and 100. The PAIR
+                // is unreachable through GTK windows, measured, but only because of the
+                // NAVIGATION half: `measure_uncollapsed` reports `sidebar_min +
+                // content_min`, GTK never allocates below a widget's minimum, and from
+                // that minimum upwards `width - content_min` never falls under
+                // `sidebar_min`, so the bound cap never inverts. The 300-point frame in
+                // the first row below is allocated 380. Asserting the two answers side by
+                // side would therefore mean asserting a number one of the widgets cannot
+                // produce; the disagreement itself is held by `@gjsify/adwaita-core`'s own
+                // vectors and by its `the two widgets disagree on the SAME input`.
                 //
-                // What IS reachable is the minimum itself, and it is the same arithmetic:
-                // `measureSplitViewHorizontal` computes it, and this reads GTK's answer
-                // back. The React Native half cannot be asked — a component there is
-                // handed an already-laid-out size and never reports a minimum upwards,
+                // THE OVERLAY'S OWN ANSWER IS NOT UNREACHABLE, and the second row is it.
+                // Its minimum is `(int) (sidebar_min * show_progress) + content_min`
+                // (adw-overlay-split-view.c), so a HIDDEN sidebar takes the whole
+                // `sidebar_min` term out and 300 points is a width GTK will give it —
+                // measured on libadwaita 1.9.3, no diagnostic, the sidebar allocated 100.
+                // Without that row the result-cap, which is one of the two documented
+                // differences between the widgets, had no GTK-side measurement at all:
+                // both other overlay rows sit where the two rules agree.
+                //
+                // The MINIMUM is the same arithmetic on the other side:
+                // `measureSplitViewHorizontal` computes it and the first row reads GTK's
+                // answer back. The React Native half cannot be asked — a component there
+                // is handed an already-laid-out size and never reports a minimum upwards,
                 // which is the `childMin` divergence `AdwClamp` already carries.
                 await it('refuses to be narrower than sidebar minimum plus content minimum', async () => {
                     const bounds = resolveSidebarBounds({ sidebarWidthUnit: 'px' }, 0);
@@ -413,6 +459,39 @@ export default async () => {
                             expect(view.get_width()).toBe(measured.minimum);
                             // And at that width both rules answer 180, the lower bound.
                             expect(allocatedWidth(view.sidebar as Gtk.Widget, view)).toBe(bounds.min);
+                        },
+                        { frameWidth: SQUEEZED_FRAME_WIDTH },
+                    );
+                });
+
+                await it('caps the OVERLAY sidebar by the content minimum, where its sibling caps the bound', async () => {
+                    // 100, and the navigation widget answers 180 for the same input —
+                    // see the head of this describe for which half of that pair a GTK
+                    // window can be asked about and why. Written as the core's own call
+                    // AND as the literal, so a changed default falls here rather than
+                    // letting both sides move together.
+                    const capped = resolveOverlaySidebarWidth({
+                        totalWidth: SQUEEZED_FRAME_WIDTH,
+                        contentMin: CONTENT_MINIMUM,
+                        sidebarWidthUnit: 'px',
+                    });
+                    expect(capped).toBe(100);
+
+                    laidOut(
+                        // `show-sidebar: false` is what takes the view's minimum down to
+                        // the content's own; the sidebar is still ALLOCATED, off the
+                        // leading edge, which is what makes the width readable.
+                        <AdwOverlaySplitView
+                            sidebar={<gtk-label label="s" />}
+                            showSidebar={false}
+                            sidebarWidthUnit="px"
+                        >
+                            <gtk-label label="c" width-request={CONTENT_MINIMUM} />
+                        </AdwOverlaySplitView>,
+                        (container) => {
+                            const view = find(container, 'AdwOverlaySplitView') as Adw.OverlaySplitView;
+                            expect(view.get_width()).toBe(SQUEEZED_FRAME_WIDTH);
+                            expect(allocatedWidth(view.sidebar as Gtk.Widget, view)).toBe(capped);
                         },
                         { frameWidth: SQUEEZED_FRAME_WIDTH },
                     );

--- a/packages/framework/adwaita-react-native/src/widgets/navigation.gtk.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation.gtk.spec.tsx
@@ -1,0 +1,423 @@
+/** @jsxImportSource @gjsify/gtk-host/react */
+// The GTK half of the NAVIGATION group, against the libadwaita that is installed.
+//
+// ONE FILE FOR SIX WIDGETS, for the reason `content.gtk.spec.tsx` gives: what every GTK
+// spec here needs before it can assert anything — the realised sized window, the tree
+// search, the diagnostics gate — is `../testing/gtk.spec.tsx`, and what is per-widget is
+// the reasoning at each `describe`.
+//
+// THE NUMBERS ARE SHARED WITH THE FOUR `*.native.spec.tsx` FILES OF THIS GROUP, which is
+// what makes each widget one widget rather than two that compile. A 1000-point frame
+// gives both split views a 250-point sidebar and a 750-point content pane; a COLLAPSED
+// overlay in a 360-point frame gives a 280-point sidebar where a quarter would be 90.
+// Neither renderer invented those — `resolveNavigationSidebarWidth`,
+// `resolveOverlaySidebarWidth` and `layoutOverlaySplitView` are ports of the C, and this
+// file reads the answers off the live GTK tree.
+//
+// AND ONE NUMBER IS DELIBERATELY GTK-ONLY: the view's own MINIMUM, `sidebar_min +
+// content_min`, which `measureSplitViewHorizontal` computes and only a renderer with a
+// measure pass can be asked for. The React Native half has none — that is the `childMin`
+// divergence `AdwClamp` already carries — so a component there never reports a minimum
+// upwards and can be squeezed where GTK refuses.
+//
+// `sidebar-width-unit` IS WRITTEN AS `px` IN EVERY SIZED CASE, and that is a measurement
+// decision rather than a style. The property defaults to `sp`, which
+// `adw_length_unit_to_px` scales by `gtk-xft-dpi` — so at any text scale other than 96
+// dpi the SAME authored 180/280 is a different number of pixels, and the pair with the
+// React Native suite would fail on a machine with large text rather than on a bug.
+//
+// THE TREE ASSERTIONS READ THE PROPERTY, NOT A CHILD SEARCH, wherever libadwaita offers
+// one. `Adw.NavigationSplitView:sidebar` IS the page that was installed, so reading it
+// back proves `set_sidebar` was called with the wrapped page — where `find(…,
+// 'AdwNavigationPage')` would return whichever page the breadth-first walk reached first
+// and pass with the panes swapped.
+
+import Adw from 'gi://Adw?version=1';
+import type Gtk from 'gi://Gtk?version=4.0';
+import { expect, it } from '@gjsify/unit';
+import { blankReason, shotEvidence } from '@gjsify/gtk-host';
+import { measureSplitViewHorizontal, resolveSidebarBounds } from '@gjsify/adwaita-core';
+
+import type { AdwNavigationViewHandle } from '../props.js';
+import { FRAME_WIDTH, capture, find, laidOut, typeOf, withGtk } from '../testing/gtk.spec.js';
+import { AdwNavigationPage } from './navigation-page.gtk.js';
+import { AdwNavigationSplitView } from './navigation-split-view.gtk.js';
+import { AdwNavigationView } from './navigation-view.gtk.js';
+import { AdwOverlaySplitView } from './overlay-split-view.gtk.js';
+import { AdwViewStack } from './view-stack.gtk.js';
+import { AdwViewSwitcher } from './view-switcher.gtk.js';
+
+/** The narrow frame a collapsed overlay is measured in — a phone, in points. */
+const PHONE_FRAME_WIDTH = 360;
+
+/** The frame the two width rules disagree in. */
+const SQUEEZED_FRAME_WIDTH = 300;
+
+/** A content pane wide enough to squeeze the sidebar — the `content_min` of the C. */
+const CONTENT_MINIMUM = 200;
+
+/** The allocated width of `widget`, in the coordinate space of `within`. */
+function allocatedWidth(widget: Gtk.Widget, within: Gtk.Widget): number {
+    const bounds = widget.compute_bounds(within);
+    // `compute_bounds` returns `[ok, rect]`; a false `ok` means the two widgets share no
+    // common ancestor, which would otherwise read as a width of whatever the stale rect
+    // held.
+    expect(bounds[0]).toBe(true);
+    return Math.round(bounds[1].get_width());
+}
+
+export default async () => {
+    await withGtk(async ({ gated, display }) => {
+        await gated('the widgets are the real libadwaita ones', async () => {
+            await it('renders AdwNavigationPage as an Adw.NavigationPage carrying its three properties', async () => {
+                laidOut(
+                    <AdwNavigationPage title="Home" tag="home" canPop={false}>
+                        <gtk-label label="inside" />
+                    </AdwNavigationPage>,
+                    (container) => {
+                        const page = find(container, 'AdwNavigationPage') as Adw.NavigationPage;
+                        expect(page.title).toBe('Home');
+                        expect(page.tag).toBe('home');
+                        expect(page.canPop).toBe(false);
+                        expect(typeOf(page.get_child() as Gtk.Widget)).toBe('GtkLabel');
+                    },
+                );
+            });
+
+            await it('adds the declared pages and auto-pushes the first one', async () => {
+                laidOut(
+                    <AdwNavigationView animateTransitions={false}>
+                        <AdwNavigationPage title="Home" tag="home">
+                            <gtk-label label="home" />
+                        </AdwNavigationPage>
+                        <AdwNavigationPage title="Detail" tag="detail">
+                            <gtk-label label="detail" />
+                        </AdwNavigationPage>
+                    </AdwNavigationView>,
+                    (container) => {
+                        const view = find(container, 'AdwNavigationView') as Adw.NavigationView;
+                        // `add_page` auto-pushes into an EMPTY stack, so page 0 is
+                        // visible with nobody having pushed it — and page 1 is reachable
+                        // by tag without being on screen.
+                        expect(view.get_visible_page_tag()).toBe('home');
+                        expect(view.find_page('detail')).not.toBe(null);
+                        expect(view.animateTransitions).toBe(false);
+                    },
+                );
+            });
+
+            await it('wraps both split-view panes in an Adw.NavigationPage carrying the tag', async () => {
+                laidOut(
+                    <AdwNavigationSplitView
+                        sidebar={<gtk-label label="sidebar" />}
+                        sidebarTag="sidebar"
+                        sidebarTitle="Sidebar"
+                        contentTag="content"
+                        contentTitle="Content"
+                    >
+                        <gtk-label label="content" />
+                    </AdwNavigationSplitView>,
+                    (container) => {
+                        const view = find(container, 'AdwNavigationSplitView') as Adw.NavigationSplitView;
+                        const sidebar = view.sidebar as Adw.NavigationPage;
+                        const content = view.content as Adw.NavigationPage;
+                        expect(typeOf(sidebar)).toBe('AdwNavigationPage');
+                        expect(typeOf(content)).toBe('AdwNavigationPage');
+                        expect(sidebar.tag).toBe('sidebar');
+                        expect(content.tag).toBe('content');
+                        expect(sidebar.title).toBe('Sidebar');
+                        expect(typeOf(sidebar.get_child() as Gtk.Widget)).toBe('GtkLabel');
+                    },
+                );
+            });
+
+            await it('gives Adw.OverlaySplitView plain widgets and its own properties', async () => {
+                laidOut(
+                    <AdwOverlaySplitView sidebar={<gtk-label label="sidebar" />} pinSidebar={true} collapsed={true}>
+                        <gtk-label label="content" />
+                    </AdwOverlaySplitView>,
+                    (container) => {
+                        const view = find(container, 'AdwOverlaySplitView') as Adw.OverlaySplitView;
+                        expect(view.collapsed).toBe(true);
+                        expect(view.pinSidebar).toBe(true);
+                        // PINNED, so collapsing did NOT hide it — the coupling the
+                        // React Native half runs through `OverlaySplitViewState`.
+                        expect(view.showSidebar).toBe(true);
+                        // No `Adw.NavigationPage` here: these two slots take `GtkWidget`.
+                        expect(typeOf(view.sidebar as Gtk.Widget)).toBe('GtkBox');
+                    },
+                );
+            });
+
+            await it('writes the seven Adw.ViewStackPage properties add_titled cannot carry', async () => {
+                laidOut(
+                    <AdwViewStack
+                        pages={[
+                            { name: 'home', title: 'Home', child: <gtk-label label="home" /> },
+                            {
+                                name: 'detail',
+                                title: 'Detail',
+                                iconName: 'go-next-symbolic',
+                                badgeNumber: 3,
+                                needsAttention: true,
+                                child: <gtk-label label="detail" />,
+                            },
+                        ]}
+                    />,
+                    (container) => {
+                        const stack = find(container, 'AdwViewStack') as Adw.ViewStack;
+                        // The auto-pick: the first VISIBLE page, selected by libadwaita
+                        // itself, which is what `ViewStackState` reproduces.
+                        expect(stack.visibleChildName).toBe('home');
+                        const detail = stack.get_page(stack.get_child_by_name('detail') as Gtk.Widget);
+                        expect(detail.title).toBe('Detail');
+                        expect(detail.iconName).toBe('go-next-symbolic');
+                        expect(detail.badgeNumber).toBe(3);
+                        expect(detail.needsAttention).toBe(true);
+                        // An omitted title settles on the NAME, because `add_titled`
+                        // received it — the same answer `resolvePageTitle` gives.
+                        const home = stack.get_page(stack.get_child_by_name('home') as Gtk.Widget);
+                        expect(home.title).toBe('Home');
+                    },
+                );
+            });
+
+            await it('points a real Adw.ViewSwitcher at the real Adw.ViewStack it built', async () => {
+                laidOut(
+                    <AdwViewSwitcher
+                        policy="wide"
+                        pages={[
+                            { name: 'home', title: 'Home', child: <gtk-label label="home" /> },
+                            { name: 'detail', title: 'Detail', child: <gtk-label label="detail" /> },
+                        ]}
+                    />,
+                    (container) => {
+                        const switcher = find(container, 'AdwViewSwitcher') as Adw.ViewSwitcher;
+                        const stack = find(container, 'AdwViewStack') as Adw.ViewStack;
+                        // THE BINDING, not merely both widgets existing: a switcher whose
+                        // `stack` stayed null renders an empty row at exit 0, which is
+                        // this host's whole failure signature.
+                        expect(switcher.get_stack()).toBe(stack);
+                        expect(switcher.policy).toBe(Adw.ViewSwitcherPolicy.WIDE);
+                        expect(stack.visibleChildName).toBe('home');
+                    },
+                );
+            });
+        });
+
+        await gated('the stack machine both halves answer alike', async () => {
+            // Every assertion here has a twin in `navigation-view.native.spec.tsx`, run
+            // against `NavigationViewState` instead of against libadwaita. The tags and
+            // the tooltip are the whole cross-renderer claim: `push_by_tag` /
+            // `pop_to_tag` / `replace_with_tags` are string-addressed on both halves, and
+            // the back-button rule is `get_previous_page(visible) !== null &&
+            // visible.can_pop` in both places.
+            const withHandle = (
+                body: (handle: AdwNavigationViewHandle) => void,
+                options: { detailCanPop?: boolean } = {},
+            ): void => {
+                const ref: { current: AdwNavigationViewHandle | null } = { current: null };
+                laidOut(
+                    <AdwNavigationView animateTransitions={false} ref={ref}>
+                        <AdwNavigationPage title="Home" tag="home">
+                            <gtk-label label="home" />
+                        </AdwNavigationPage>
+                        <AdwNavigationPage title="Detail" tag="detail" canPop={options.detailCanPop}>
+                            <gtk-label label="detail" />
+                        </AdwNavigationPage>
+                        <AdwNavigationPage title="Settings" tag="settings">
+                            <gtk-label label="settings" />
+                        </AdwNavigationPage>
+                    </AdwNavigationView>,
+                    () => {
+                        if (ref.current === null) throw new Error('the view exposed no handle');
+                        body(ref.current);
+                    },
+                );
+            };
+
+            await it('starts on the root page, with no way back', async () => {
+                withHandle((handle) => {
+                    expect(handle.visiblePageTag()).toBe('home');
+                    expect(handle.canGoBack()).toBe(false);
+                    expect(handle.backButtonTooltip()).toBe(null);
+                });
+            });
+
+            await it('pushes by tag and names the revealed page in the tooltip', async () => {
+                withHandle((handle) => {
+                    handle.push('detail');
+                    expect(handle.visiblePageTag()).toBe('detail');
+                    expect(handle.canGoBack()).toBe(true);
+                    // The tooltip is the title of the page the button would REVEAL, not
+                    // of the one on screen.
+                    expect(handle.backButtonTooltip()).toBe('Home');
+                });
+            });
+
+            // THE `'Back'` FALLBACK IS ASSERTED ON THE REACT NATIVE HALF ONLY, and that is a
+            // measurement rather than an omission. It needs a page whose title is EMPTY,
+            // and libadwaita 1.9.3 prints `AdwNavigationPage 0x… is missing a title. To
+            // hide a header bar title, consider using AdwHeaderBar:show-title instead.`
+            // for exactly that page — a diagnostic `installDiagnosticsGate` fails on, and
+            // correctly: this suite's whole premise is that GTK's failure mode is exit 0.
+            // `navigation-view.native.spec.tsx` asserts the fallback against
+            // `BACK_BUTTON_FALLBACK_TOOLTIP`, the constant `navigation-view.gtk.tsx`
+            // imports from the same module, so the two halves still share the string.
+
+            await it('pops back to the root and refuses to pop the root', async () => {
+                withHandle((handle) => {
+                    handle.push('detail');
+                    expect(handle.pop()).toBe(true);
+                    expect(handle.visiblePageTag()).toBe('home');
+                    expect(handle.pop()).toBe(false);
+                });
+            });
+
+            await it('replaces the whole stack, last tag visible', async () => {
+                withHandle((handle) => {
+                    handle.replaceWithTags(['home', 'detail', 'settings']);
+                    expect(handle.visiblePageTag()).toBe('settings');
+                    expect(handle.popToTag('home')).toBe(true);
+                    expect(handle.visiblePageTag()).toBe('home');
+                });
+            });
+
+            await it('hides the back button for a page that cannot be popped', async () => {
+                withHandle(
+                    (handle) => {
+                        handle.push('detail');
+                        expect(handle.visiblePageTag()).toBe('detail');
+                        // `can-pop` gates the BUTTON and the shortcuts, never `pop()` —
+                        // libadwaita's own split, and the core's.
+                        expect(handle.canGoBack()).toBe(false);
+                        expect(handle.backButtonTooltip()).toBe(null);
+                        expect(handle.pop()).toBe(true);
+                    },
+                    { detailCanPop: false },
+                );
+            });
+        });
+
+        if (display !== null) {
+            await gated('the allocation, not only the setter', async () => {
+                await it('splits a 1000-point frame 250 / 750, as the core does', async () => {
+                    laidOut(
+                        <AdwNavigationSplitView
+                            sidebar={<gtk-label label="sidebar" />}
+                            sidebarTitle="Sidebar"
+                            contentTitle="Content"
+                            sidebarWidthUnit="px"
+                        >
+                            <gtk-label label="content" hexpand={true} />
+                        </AdwNavigationSplitView>,
+                        (container) => {
+                            const view = find(container, 'AdwNavigationSplitView');
+                            const evidence = shotEvidence(view, capture);
+                            expect(blankReason(evidence)).toBe(null);
+                            expect(view.get_width()).toBe(FRAME_WIDTH);
+                            // The same pair `navigation-split-view.native.spec.tsx`
+                            // asserts as two style objects.
+                            expect(allocatedWidth((view as Adw.NavigationSplitView).sidebar as Gtk.Widget, view)).toBe(
+                                250,
+                            );
+                            expect(allocatedWidth((view as Adw.NavigationSplitView).content as Gtk.Widget, view)).toBe(
+                                750,
+                            );
+                        },
+                    );
+                });
+
+                await it('gives a COLLAPSED overlay sidebar 280 on a 360-point phone', async () => {
+                    laidOut(
+                        <AdwOverlaySplitView
+                            sidebar={<gtk-label label="sidebar" />}
+                            collapsed={true}
+                            pinSidebar={true}
+                            sidebarWidthUnit="px"
+                        >
+                            <gtk-label label="content" hexpand={true} />
+                        </AdwOverlaySplitView>,
+                        (container) => {
+                            const view = find(container, 'AdwOverlaySplitView') as Adw.OverlaySplitView;
+                            const evidence = shotEvidence(view, capture);
+                            expect(blankReason(evidence)).toBe(null);
+                            expect(view.get_width()).toBe(PHONE_FRAME_WIDTH);
+                            // 280, not 90: a collapsed overlay IGNORES the fraction and
+                            // clamps the VIEW width instead. The React Native suite
+                            // asserts the same number off `resolveOverlaySidebarWidth`.
+                            expect(allocatedWidth(view.sidebar as Gtk.Widget, view)).toBe(280);
+                        },
+                        { frameWidth: PHONE_FRAME_WIDTH },
+                    );
+                });
+
+                await it('splits an UNCOLLAPSED overlay 250 / 750 in the same 1000-point frame', async () => {
+                    laidOut(
+                        <AdwOverlaySplitView sidebar={<gtk-label label="sidebar" />} sidebarWidthUnit="px">
+                            <gtk-label label="content" hexpand={true} />
+                        </AdwOverlaySplitView>,
+                        (container) => {
+                            const view = find(container, 'AdwOverlaySplitView') as Adw.OverlaySplitView;
+                            expect(allocatedWidth(view.sidebar as Gtk.Widget, view)).toBe(250);
+                            expect(allocatedWidth(view.content as Gtk.Widget, view)).toBe(750);
+                        },
+                    );
+                });
+            });
+
+            await gated('the container minimum, which is also the core\u2019s', async () => {
+                // WHAT THIS DESCRIBE REPLACED, AND WHY IT COULD NOT BE WRITTEN.
+                // `resolveNavigationSidebarWidth` and `resolveOverlaySidebarWidth` are
+                // genuinely different rules — the first caps the sidebar's MAX BOUND by
+                // `width - content_min`, the second caps the RESULT — and the core's own
+                // header names a 300-point vector where they answer 180 and 100. That
+                // vector is unreachable through a GTK window, measured: `measure` reports
+                // `sidebar_min + content_min` as the view's own minimum, GTK never
+                // allocates a widget below its minimum, and the two rules agree at every
+                // width from that minimum upwards. The 300-point frame below is allocated
+                // 380. So the disagreement is a property of the two FUNCTIONS, held by
+                // `@gjsify/adwaita-core`'s own vectors, and asserting it here would have
+                // meant asserting a number the widget cannot produce.
+                //
+                // What IS reachable is the minimum itself, and it is the same arithmetic:
+                // `measureSplitViewHorizontal` computes it, and this reads GTK's answer
+                // back. The React Native half cannot be asked — a component there is
+                // handed an already-laid-out size and never reports a minimum upwards,
+                // which is the `childMin` divergence `AdwClamp` already carries.
+                await it('refuses to be narrower than sidebar minimum plus content minimum', async () => {
+                    const bounds = resolveSidebarBounds({ sidebarWidthUnit: 'px' }, 0);
+                    const measured = measureSplitViewHorizontal({
+                        bounds,
+                        sidebarNatural: bounds.max,
+                        contentMin: CONTENT_MINIMUM,
+                        contentNatural: CONTENT_MINIMUM,
+                    });
+                    // 180 + 200. Written as the core's own call rather than as `380`, so a
+                    // change to either default falls here instead of drifting.
+                    expect(measured.minimum).toBe(380);
+
+                    laidOut(
+                        <AdwNavigationSplitView
+                            sidebar={<gtk-label label="s" />}
+                            sidebarTitle="Sidebar"
+                            contentTitle="Content"
+                            sidebarWidthUnit="px"
+                        >
+                            <gtk-label label="c" width-request={CONTENT_MINIMUM} />
+                        </AdwNavigationSplitView>,
+                        (container) => {
+                            const view = find(container, 'AdwNavigationSplitView') as Adw.NavigationSplitView;
+                            // The window asked for 300 and GTK gave the widget its own
+                            // minimum instead — which is the number the core computes.
+                            expect(view.get_width()).toBe(measured.minimum);
+                            // And at that width both rules answer 180, the lower bound.
+                            expect(allocatedWidth(view.sidebar as Gtk.Widget, view)).toBe(bounds.min);
+                        },
+                        { frameWidth: SQUEEZED_FRAME_WIDTH },
+                    );
+                });
+            });
+        }
+    });
+};

--- a/packages/framework/adwaita-react-native/src/widgets/navigation.gtk.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/navigation.gtk.spec.tsx
@@ -373,6 +373,56 @@ export default async () => {
             });
         });
 
+        await gated('the ordering table both halves answer alike', async () => {
+            // The twin of `navigation-split-view.native.spec.tsx`'s describe of the same
+            // subject, which reads the pane NAME off `resolveNavigationStack`. Until this
+            // one existed, the ordering table — the thing that makes a collapsed split
+            // view a navigation stack rather than an `if (showContent)` — was asserted
+            // against the CORE on one half and against nothing on the other, so
+            // "libadwaita answers the same" was a claim.
+            //
+            // The visible page is read off the internal `AdwNavigationView`. There is no
+            // getter for it, and `show-content` alone would not do: for the lone-child row
+            // the property STAYS true (`set_show_content` takes its early return when
+            // either pane is missing) while the sidebar is what is on screen, which is
+            // precisely the case a flag-keyed renderer gets wrong.
+            const visibleTag = (view: Gtk.Widget): string | null =>
+                (find(view, 'AdwNavigationView') as Adw.NavigationView).get_visible_page()?.tag ?? null;
+
+            const collapsed = (showContent: boolean, lone: boolean, body: (view: Gtk.Widget) => void): void =>
+                laidOut(
+                    <AdwNavigationSplitView
+                        sidebar={<gtk-label label="sidebar" />}
+                        sidebarTag="sidebar"
+                        sidebarTitle="Sidebar"
+                        contentTag="content"
+                        contentTitle="Content"
+                        collapsed={true}
+                        showContent={showContent}
+                    >
+                        {lone ? undefined : <gtk-label label="content" />}
+                    </AdwNavigationSplitView>,
+                    (container) => body(find(container, 'AdwNavigationSplitView')),
+                );
+
+            await it('shows the SIDEBAR when collapsed and show-content is false', async () => {
+                collapsed(false, false, (view) => expect(visibleTag(view)).toBe('sidebar'));
+            });
+
+            await it('shows the CONTENT when collapsed and show-content is true', async () => {
+                collapsed(true, false, (view) => expect(visibleTag(view)).toBe('content'));
+            });
+
+            await it('keeps a LONE child visible whatever show-content says', async () => {
+                collapsed(true, true, (view) => {
+                    // The property the caller authored is still true …
+                    expect((view as Adw.NavigationSplitView).showContent).toBe(true);
+                    // … and the sidebar is the page on screen anyway.
+                    expect(visibleTag(view)).toBe('sidebar');
+                });
+            });
+        });
+
         if (display !== null) {
             await gated('the allocation, not only the setter', async () => {
                 await it('splits a 1000-point frame 250 / 750, as the core does', async () => {

--- a/packages/framework/adwaita-react-native/src/widgets/overlay-split-view.gtk.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/overlay-split-view.gtk.tsx
@@ -1,0 +1,87 @@
+/** @jsxImportSource @gjsify/gtk-host/react */
+// `AdwOverlaySplitView` on GTK — the real `Adw.OverlaySplitView`. (On the pragma, see
+// `bin.gtk.tsx`.)
+//
+// NO `Adw.NavigationPage` HERE, unlike its navigation sibling: `Adw.OverlaySplitView:sidebar`
+// and `:content` are plain `GtkWidget`, so neither pane needs the page wrap that file
+// explains. That is the only structural difference between the two, and it is a property
+// of the C rather than a choice.
+//
+// The sidebar still gets one `GtkBox`, for the reason spelled out in `header-bar.gtk.tsx`:
+// gtk-host routes a child by the `slot` prop on the CHILD, a prop of this component is an
+// arbitrary `ReactNode`, and `cloneElement` cannot put a `slot` on a composite component.
+// `children` needs none — it goes to the descriptor's `defaultSlot`, which is `content`.
+//
+// `OverlaySplitViewState` IS NOT USED HERE. The core's port of the collapse coupling —
+// collapsing hides an unpinned sidebar, uncollapsing shows it again, without animating —
+// is for a renderer with no libadwaita; on this half `adw_overlay_split_view_set_collapsed`
+// does it, and `onNotifyShowSidebar` below is how the caller learns what it decided.
+// Running both would give one widget two authorities for its own `show-sidebar`.
+//
+// `collapsed` IS WRITTEN LAST, AND THAT ORDER IS MEASURED RATHER THAN REASONED. gtk-host
+// applies props in the order they appear on the element, and
+// `adw_overlay_split_view_set_collapsed` HIDES an unpinned sidebar on its way through —
+// so with `collapsed` first, `<AdwOverlaySplitView pinSidebar collapsed>` reached
+// `set_collapsed` while `pin-sidebar` was still FALSE and read back `show-sidebar: false`
+// on libadwaita 1.9.3, with no diagnostic and a sidebar simply not on screen. Writing the
+// two flags it CONSULTS before it is the fix, and it is the same ordering
+// `overlay-split-view.native.tsx`'s effect applies for the same reason —
+// `@gjsify/adwaita-web`'s `_readAttribute` says so in a comment ("Last: it can change
+// `show-sidebar`").
+//
+// THE NOTIFY HANDLER READS THE WIDGET BACK RATHER THAN TAKING THE VALUE FROM THE SIGNAL,
+// because a `notify::` handler in this host receives the ParamSpec alone (`attrs.ts`
+// strips the emitting object). A ref is therefore not optional decoration: without it
+// the callback knows THAT `show-sidebar` moved and not what to.
+
+import type Adw from 'gi://Adw?version=1';
+import { useRef, type ReactElement } from 'react';
+
+import type { AdwOverlaySplitViewProps } from '../props.js';
+
+/** {@link import('./overlay-split-view.js').AdwOverlaySplitView} on GTK. */
+export function AdwOverlaySplitView({
+    children,
+    sidebar,
+    collapsed,
+    showSidebar,
+    pinSidebar,
+    sidebarPosition,
+    enableShowGesture,
+    enableHideGesture,
+    minSidebarWidth,
+    maxSidebarWidth,
+    sidebarWidthFraction,
+    sidebarWidthUnit,
+    onNotifyShowSidebar,
+}: AdwOverlaySplitViewProps): ReactElement | null {
+    const view = useRef<Adw.OverlaySplitView | null>(null);
+
+    return (
+        <adw-overlay-split-view
+            ref={view}
+            pin-sidebar={pinSidebar}
+            show-sidebar={showSidebar}
+            sidebar-position={sidebarPosition}
+            enable-show-gesture={enableShowGesture}
+            enable-hide-gesture={enableHideGesture}
+            min-sidebar-width={minSidebarWidth}
+            max-sidebar-width={maxSidebarWidth}
+            sidebar-width-fraction={sidebarWidthFraction}
+            sidebar-width-unit={sidebarWidthUnit}
+            collapsed={collapsed}
+            onNotifyShowSidebar={
+                onNotifyShowSidebar === undefined
+                    ? undefined
+                    : () => onNotifyShowSidebar(view.current?.showSidebar ?? false)
+            }
+        >
+            {sidebar === undefined ? null : (
+                <gtk-box slot="sidebar" orientation="vertical">
+                    {sidebar}
+                </gtk-box>
+            )}
+            {children}
+        </adw-overlay-split-view>
+    );
+}

--- a/packages/framework/adwaita-react-native/src/widgets/overlay-split-view.gtk.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/overlay-split-view.gtk.tsx
@@ -19,15 +19,22 @@
 // Running both would give one widget two authorities for its own `show-sidebar`.
 //
 // `collapsed` IS WRITTEN LAST, AND THAT ORDER IS MEASURED RATHER THAN REASONED. gtk-host
-// applies props in the order they appear on the element, and
-// `adw_overlay_split_view_set_collapsed` HIDES an unpinned sidebar on its way through —
-// so with `collapsed` first, `<AdwOverlaySplitView pinSidebar collapsed>` reached
-// `set_collapsed` while `pin-sidebar` was still FALSE and read back `show-sidebar: false`
-// on libadwaita 1.9.3, with no diagnostic and a sidebar simply not on screen. Writing the
-// two flags it CONSULTS before it is the fix, and it is the same ordering
+// applies props in the order they appear on the element — at mount through the insertion
+// order `g_object_new_with_properties` preserves, on an update through
+// `Object.keys(newProps)` — and `adw_overlay_split_view_set_collapsed` HIDES an unpinned
+// sidebar on its way through (`set_show_sidebar (self, !collapsed, FALSE, 0)`). So with
+// `collapsed` first, `<AdwOverlaySplitView pinSidebar collapsed>` reached `set_collapsed`
+// while `pin-sidebar` was still FALSE and read back `show-sidebar: false` on libadwaita
+// 1.9.3, with no diagnostic and a sidebar simply not on screen. Writing the two flags it
+// CONSULTS before it is the fix, and it is the same ordering
 // `overlay-split-view.native.tsx`'s effect applies for the same reason —
 // `@gjsify/adwaita-web`'s `_readAttribute` says so in a comment ("Last: it can change
 // `show-sidebar`").
+//
+// IT IS A RULE ABOUT THE ORDER OF TWO JSX ATTRIBUTES, so it needs a row that fails when
+// they move. Two do, both in `navigation.gtk.spec.tsx`: the MOUNT case authors both flags
+// at once, and `pins and collapses in ONE commit without losing the sidebar` changes both
+// in one `rerender`. The React Native half carries the same pair of rows.
 //
 // THE NOTIFY HANDLER READS THE WIDGET BACK RATHER THAN TAKING THE VALUE FROM THE SIGNAL,
 // because a `notify::` handler in this host receives the ParamSpec alone (`attrs.ts`

--- a/packages/framework/adwaita-react-native/src/widgets/overlay-split-view.native.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/overlay-split-view.native.spec.tsx
@@ -24,7 +24,16 @@ import { describe, expect, it } from '@gjsify/unit';
 import { act } from 'react-test-renderer';
 
 import { Text } from '../testing/react-native.js';
-import { at, childrenOf, mount, onlyChild, settled, textOf, type Style } from '../testing/render.spec.js';
+import {
+    at,
+    childrenOf,
+    deliverLayout,
+    mount,
+    onlyChild,
+    settled,
+    textOf,
+    type Style,
+} from '../testing/render.spec.js';
 import { AdwOverlaySplitView } from './overlay-split-view.native.js';
 
 /** The frame the GTK half is photographed in, so both are asked the same question. */
@@ -126,6 +135,38 @@ export default async () => {
             expect((at(nodes, 1).props.style as Record<string, unknown>).opacity).toBe(0);
             // Off the leading edge by its full width, not merely transparent.
             expect((at(nodes, 1).props.style as Record<string, unknown>).left).toBe(-280);
+        });
+
+        await it('pins and collapses in ONE commit without losing the sidebar', async () => {
+            // THE WRITE ORDER, AS A THING THAT GOES RED. `setCollapsed` hides an
+            // UNPINNED sidebar itself, so the effect has to push `pin-sidebar` first —
+            // and on a commit that changes both, "first" is nothing but the order of two
+            // lines in one function body. Measured with those two lines swapped: the
+            // sidebar came back at `left: -280, opacity: 0` and every other test in this
+            // package stayed green, because they all reach the two flags either at mount
+            // or in separate commits. This is the row that fails.
+            //
+            // Its twin is in `navigation.gtk.spec.tsx`, where the same two props change
+            // in one `rerender` and gtk-host writes them in ELEMENT order.
+            const view = (pinned: boolean) => overlay({ pinSidebar: pinned, collapsed: pinned });
+            const renderer = mount(view(false));
+            deliverLayout(renderer, PHONE_FRAME_WIDTH);
+            act(() => {
+                renderer.update(view(true));
+            });
+            const nodes = childrenOf(deliverLayout(renderer, PHONE_FRAME_WIDTH));
+            // Content, shield, sidebar — the shield is there only while collapsed AND
+            // revealed, so its presence is half the assertion.
+            expect(nodes.length).toBe(3);
+            expect(paneName(nodes, 2)).toBe('sidebar');
+            expect(at(nodes, 2).props.style as Style).toStrictEqual({
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                left: 0,
+                width: 280,
+                opacity: 1,
+            });
         });
 
         await it('reports the value the widget settled on, not the one it was given', async () => {

--- a/packages/framework/adwaita-react-native/src/widgets/overlay-split-view.native.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/overlay-split-view.native.spec.tsx
@@ -1,0 +1,153 @@
+/** @jsxImportSource react */
+// The React Native half of `AdwOverlaySplitView`, rendered through React's real
+// reconciler.
+//
+// THE NUMBERS ARE THE GTK HALF'S. `navigation.gtk.spec.tsx` reads 250 / 750 off a real
+// `Adw.OverlaySplitView` in a 1000-point window and 280 off a COLLAPSED one in a
+// 360-point window; this suite asserts the same three numbers as style objects, because
+// `resolveOverlaySidebarWidth` and `layoutOverlaySplitView` are the C's arithmetic and
+// neither renderer invented it. 280 on a 360-point phone is the one worth naming: a
+// collapsed overlay IGNORES `sidebar-width-fraction` and clamps the VIEW width instead,
+// so a `width: '25%'` would draw 90.
+//
+// THE PANE RECTS ARE ASSERTED AS `left` AND `width`, which is what the core returns and
+// what this half writes. A hidden docked sidebar is at `left: -250` — it is placed OFF
+// the leading edge rather than removed, which is what makes the reveal a continuum, and
+// `opacity: 0` is the snapshot gate the C applies at zero progress.
+//
+// EACH PANE CARRIES A `Text` THAT NAMES IT, for the reason
+// `navigation-split-view.native.spec.tsx` gives: three bare `View`s in paint order are
+// indistinguishable, so an index-based assertion would survive the content and the
+// sidebar swapping places.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { act } from 'react-test-renderer';
+
+import { Text } from '../testing/react-native.js';
+import { at, childrenOf, mount, onlyChild, settled, textOf, type Style } from '../testing/render.spec.js';
+import { AdwOverlaySplitView } from './overlay-split-view.native.js';
+
+/** The frame the GTK half is photographed in, so both are asked the same question. */
+const FRAME_WIDTH = 1000;
+
+/** The narrow frame the collapsed case is measured in — a phone, in points. */
+const PHONE_FRAME_WIDTH = 360;
+
+/** An overlay split view whose two panes name themselves. */
+function overlay(props: Record<string, unknown> = {}) {
+    return (
+        <AdwOverlaySplitView sidebar={<Text>sidebar</Text>} sidebarWidthUnit="px" {...props}>
+            <Text>content</Text>
+        </AdwOverlaySplitView>
+    );
+}
+
+/** The name the pane at `index` is carrying. */
+function paneName(nodes: ReturnType<typeof childrenOf>, index: number): string {
+    return textOf(onlyChild(at(nodes, index)));
+}
+
+export default async () => {
+    await describe('AdwOverlaySplitView on React Native — the docked allocation', async () => {
+        await it('splits a 1000-point frame 250 / 750, where GTK reads the same pair', async () => {
+            const nodes = childrenOf(settled(overlay(), FRAME_WIDTH));
+            // Content, then sidebar: no shield while docked, and the paint order is
+            // content < shield < sidebar.
+            expect(nodes.length).toBe(2);
+            expect(paneName(nodes, 0)).toBe('content');
+            expect(paneName(nodes, 1)).toBe('sidebar');
+            expect(at(nodes, 0).props.style as Style).toStrictEqual({
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                left: 250,
+                width: 750,
+            });
+            expect(at(nodes, 1).props.style as Style).toStrictEqual({
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                left: 0,
+                width: 250,
+                opacity: 1,
+            });
+        });
+
+        await it('slides a hidden docked sidebar off the leading edge rather than dropping it', async () => {
+            const nodes = childrenOf(settled(overlay({ showSidebar: false }), FRAME_WIDTH));
+            expect(nodes.length).toBe(2);
+            expect(paneName(nodes, 1)).toBe('sidebar');
+            // The content takes the whole frame…
+            expect((at(nodes, 0).props.style as Record<string, unknown>).width).toBe(FRAME_WIDTH);
+            // …and the sidebar is at -250, unpainted. Its NODE is still there, which is
+            // what makes "hidden" different from "never rendered".
+            expect(at(nodes, 1).props.style as Style).toStrictEqual({
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                left: -250,
+                width: 250,
+                opacity: 0,
+            });
+        });
+    });
+
+    await describe('AdwOverlaySplitView on React Native — the collapsed overlay', async () => {
+        await it('gives the sidebar 280 on a 360-point phone, where a quarter would be 90', async () => {
+            const nodes = childrenOf(settled(overlay({ collapsed: true, pinSidebar: true }), PHONE_FRAME_WIDTH));
+            // Content, shield, sidebar — the shield exists only while collapsed AND
+            // revealed, so its presence is itself the assertion, and the third node is
+            // read by NAME rather than by index.
+            expect(nodes.length).toBe(3);
+            expect(paneName(nodes, 0)).toBe('content');
+            expect(paneName(nodes, 2)).toBe('sidebar');
+            expect(at(nodes, 1).children).toBe(null);
+            expect((at(nodes, 0).props.style as Record<string, unknown>).width).toBe(PHONE_FRAME_WIDTH);
+            // `shadowProgress` is 0 at full reveal, so the shield is fully opaque.
+            expect((at(nodes, 1).props.style as Record<string, unknown>).opacity).toBe(1);
+            expect(at(nodes, 2).props.style as Style).toStrictEqual({
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                left: 0,
+                width: 280,
+                opacity: 1,
+            });
+        });
+
+        await it('drops the shield and the reveal when an unpinned sidebar is collapsed', async () => {
+            // The collapse COUPLING: `set_collapsed` hides an unpinned sidebar itself, so
+            // this case authors no `showSidebar` at all and still ends up hidden. Applying
+            // the props in any other order leaves it shown — which is the ordering
+            // measurement both halves of this widget carry at their head.
+            const nodes = childrenOf(settled(overlay({ collapsed: true }), PHONE_FRAME_WIDTH));
+            expect(nodes.length).toBe(2);
+            expect(paneName(nodes, 1)).toBe('sidebar');
+            expect((at(nodes, 1).props.style as Record<string, unknown>).opacity).toBe(0);
+            // Off the leading edge by its full width, not merely transparent.
+            expect((at(nodes, 1).props.style as Record<string, unknown>).left).toBe(-280);
+        });
+
+        await it('reports the value the widget settled on, not the one it was given', async () => {
+            // AN UPDATE, NOT A MOUNT, and that is the honest question. The subscription is
+            // installed in an effect, so a change the CONSTRUCTOR made has no listener yet
+            // — on both halves, where gtk-host likewise writes the widget's properties
+            // before anything is bound. What a caller can observe is every change after
+            // that, which is where the collapse coupling actually bites.
+            const seen: boolean[] = [];
+            const view = (collapsed: boolean) =>
+                overlay({ collapsed, onNotifyShowSidebar: (value: boolean) => seen.push(value) });
+            const renderer = mount(view(false));
+            expect(seen).toStrictEqual([]);
+            act(() => {
+                renderer.update(view(true));
+            });
+            // Nobody authored `showSidebar`: collapsing an UNPINNED sidebar hides it.
+            expect(seen).toStrictEqual([false]);
+            act(() => {
+                renderer.update(view(false));
+            });
+            expect(seen).toStrictEqual([false, true]);
+        });
+    });
+};

--- a/packages/framework/adwaita-react-native/src/widgets/overlay-split-view.native.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/overlay-split-view.native.tsx
@@ -41,6 +41,20 @@
 // ("a blanket re-read would clobber that decision with the stale attribute"). React has
 // no per-prop callback, so the previously-applied values live in a ref and this effect is
 // the diff.
+//
+// THE REF HOLDS PROPS, NEVER THE WIDGET'S STATE, and nothing invalidates it — which is
+// the point rather than an omission. It is prop-versus-prop exactly as gtk-host's own
+// `diffProps` is, so both halves answer a re-render with an unchanged `showSidebar` the
+// same way: the widget's own decision stands. The cost is the same on both too — a
+// caller whose `showSidebar` was already `true` when the collapse hid the sidebar has no
+// prop change left to express "show it", which is what `onNotifyShowSidebar` is for.
+//
+// AND THE ORDER INSIDE THIS EFFECT IS A RULE, so it needs a row that fails when the lines
+// move. `pins and collapses in ONE commit without losing the sidebar` in
+// `overlay-split-view.native.spec.tsx` is it: measured with `setCollapsed` moved above
+// `setPinSidebar`, the sidebar came back at `left: -280, opacity: 0` and every other test
+// in this package stayed green, because they all reach the two flags at mount or in
+// separate commits.
 
 import { useEffect, useRef, useState, type ReactElement } from 'react';
 import { View, type LayoutChangeEvent } from 'react-native';

--- a/packages/framework/adwaita-react-native/src/widgets/overlay-split-view.native.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/overlay-split-view.native.tsx
@@ -1,0 +1,196 @@
+/** @jsxImportSource react */
+// `AdwOverlaySplitView` on React Native — `@gjsify/adwaita-core`'s `OverlaySplitViewState`
+// plus `layoutOverlaySplitView`. (On the pragma, see `bin.native.tsx`.)
+//
+// THE WIDTH RULE IS NOT ITS SIBLING'S, and that is the whole reason the two widgets are
+// two files rather than one with a flag. `resolveOverlaySidebarWidth` caps the RESULT by
+// `width - content_min` where `resolveNavigationSidebarWidth` caps the BOUND, and a
+// COLLAPSED overlay ignores the fraction entirely and clamps the VIEW width instead — 280
+// on a 360-point phone, where a quarter would be 180. Both are the C's, ported once.
+//
+// BOTH PANES ARE PLACED AT THE RECTS THE CORE RETURNS, and one code path covers docked
+// and overlaid. `@gjsify/adwaita-web` keeps the docked case in flex flow with a negative
+// margin and places only the collapsed one absolutely; the rects are the same numbers
+// either way, and one path is one place for them to be wrong. `layoutOverlaySplitView`
+// answers for ANY progress, overshoot included, which is what makes the reveal a
+// continuum rather than two end states.
+//
+// THE REVEAL IS INSTANT HERE. The core's default is `INSTANT_SPLIT_VIEW_ANIMATOR`, and
+// this file does not replace it: libadwaita animates with a spring `(1, 0.5, 500)`, the
+// browser renderer approximates it from `requestAnimationFrame` and NativeScript from
+// `View.animate()`, and React Native's own answer is `Animated` — a COMPOSITE surface
+// this package's test double may not stand in for (`testing/react-native.ts` names the
+// rule and `spinner.native.tsx` the precedent). So `show-progress` steps 0 → 1 and the
+// gesture properties are carried and inert. The README names it.
+//
+// `showSidebar` IS NOT PURELY THE CALLER'S, and that costs this file two rules rather
+// than one. Unless `pin-sidebar` is set, collapsing HIDES the sidebar and uncollapsing
+// SHOWS it, and `setCollapsed` does that itself.
+//
+// FIRST: `collapsed` IS APPLIED LAST, at construction as well as on update. It is
+// deliberately not a constructor option here — the constructor ASSIGNS its options and
+// runs no coupling, so a `collapsed` passed in would leave an unpinned sidebar shown,
+// where the GTK half (whose props gtk-host writes in element order, `collapsed` last)
+// reads back `show-sidebar: false`. Measured on libadwaita 1.9.3, and the reason
+// `overlay-split-view.gtk.tsx` carries the same ordering note.
+//
+// SECOND: ONLY A PROP THAT CHANGED IS PUSHED. A blanket re-apply on every commit would
+// take the auto-hide the widget just performed and overwrite it with the caller's stale
+// `showSidebar`, one render later and with no diagnostic — which is exactly why
+// `@gjsify/adwaita-web` pushes ONE attribute per `attributeChangedCallback` and says so
+// ("a blanket re-read would clobber that decision with the stale attribute"). React has
+// no per-prop callback, so the previously-applied values live in a ref and this effect is
+// the diff.
+
+import { useEffect, useRef, useState, type ReactElement } from 'react';
+import { View, type LayoutChangeEvent } from 'react-native';
+
+import { OverlaySplitViewState, layoutOverlaySplitView, resolveOverlaySidebarWidth } from '@gjsify/adwaita-core';
+
+import type { AdwOverlaySplitViewProps } from '../props.js';
+
+/** {@link import('./overlay-split-view.js').AdwOverlaySplitView} on React Native. */
+export function AdwOverlaySplitView({
+    children,
+    sidebar,
+    collapsed,
+    showSidebar,
+    pinSidebar,
+    sidebarPosition,
+    enableShowGesture,
+    enableHideGesture,
+    minSidebarWidth,
+    maxSidebarWidth,
+    sidebarWidthFraction,
+    sidebarWidthUnit,
+    onNotifyShowSidebar,
+}: AdwOverlaySplitViewProps): ReactElement | null {
+    const [available, setAvailable] = useState<number | null>(null);
+    const [, repaint] = useState(0);
+
+    const state = useRef<OverlaySplitViewState | null>(null);
+    if (state.current === null) {
+        const created = new OverlaySplitViewState({
+            showSidebar: showSidebar ?? true,
+            pinSidebar: pinSidebar ?? false,
+            sidebarPosition: sidebarPosition ?? 'start',
+            enableShowGesture: enableShowGesture ?? true,
+            enableHideGesture: enableHideGesture ?? true,
+        });
+        // LAST, and through the SETTER — see the second paragraph at the head.
+        created.setCollapsed(collapsed ?? false);
+        state.current = created;
+    }
+    const view = state.current;
+
+    /** What was last pushed into the state, so the effect can push only what moved. */
+    const applied = useRef({
+        collapsed,
+        showSidebar,
+        pinSidebar,
+        sidebarPosition,
+        enableShowGesture,
+        enableHideGesture,
+    });
+
+    // The callback is read out of a ref rather than closed over, so the subscription is
+    // installed once: re-subscribing whenever a caller passes a fresh arrow would drop
+    // and re-add a listener on every render, and the core snapshots its listener set
+    // during a fan-out.
+    const notify = useRef(onNotifyShowSidebar);
+    notify.current = onNotifyShowSidebar;
+
+    useEffect(
+        () =>
+            view.subscribe((change) => {
+                if (change.property === 'show-sidebar') notify.current?.(view.showSidebar);
+                repaint((count) => count + 1);
+            }),
+        [view],
+    );
+
+    useEffect(() => {
+        const previous = applied.current;
+        if (pinSidebar !== previous.pinSidebar) view.setPinSidebar(pinSidebar ?? false);
+        if (sidebarPosition !== previous.sidebarPosition) view.setSidebarPosition(sidebarPosition ?? 'start');
+        if (enableShowGesture !== previous.enableShowGesture) view.setEnableShowGesture(enableShowGesture ?? true);
+        if (enableHideGesture !== previous.enableHideGesture) view.setEnableHideGesture(enableHideGesture ?? true);
+        if (showSidebar !== previous.showSidebar) view.setShowSidebar(showSidebar ?? true, { animate: false });
+        // LAST: it can change `show-sidebar` on its own.
+        if (collapsed !== previous.collapsed) view.setCollapsed(collapsed ?? false);
+        applied.current = { collapsed, showSidebar, pinSidebar, sidebarPosition, enableShowGesture, enableHideGesture };
+    });
+
+    const onLayout = (event: LayoutChangeEvent): void => setAvailable(event.nativeEvent.layout.width);
+
+    const layout =
+        available === null
+            ? null
+            : layoutOverlaySplitView({
+                  totalWidth: available,
+                  sidebarWidth: resolveOverlaySidebarWidth({
+                      totalWidth: available,
+                      collapsed: view.collapsed,
+                      minSidebarWidth,
+                      maxSidebarWidth,
+                      sidebarWidthFraction,
+                      sidebarWidthUnit,
+                  }),
+                  showProgress: view.showProgress,
+                  collapsed: view.collapsed,
+                  sidebarPosition: view.sidebarPosition,
+              });
+
+    // Paint order is content, shield, sidebar — the order `@gjsify/adwaita-nativescript`
+    // re-raises its children into on every layout, because a shield under the content
+    // shields nothing and a sidebar under the shield is unreachable.
+    return (
+        <View onLayout={onLayout} style={{ flex: 1 }}>
+            <View
+                style={
+                    layout === null ? undefined : { position: 'absolute', top: 0, bottom: 0, ...rect(layout.content) }
+                }
+            >
+                {children}
+            </View>
+            {layout === null || !layout.shieldVisible ? null : (
+                <View
+                    style={{
+                        position: 'absolute',
+                        top: 0,
+                        bottom: 0,
+                        left: 0,
+                        right: 0,
+                        // `shadowProgress` is INVERTED relative to the reveal: 1 is no
+                        // shadow, 0 is fully shadowed.
+                        opacity: 1 - layout.shadowProgress,
+                    }}
+                />
+            )}
+            {sidebar === undefined ? null : (
+                <View
+                    style={
+                        layout === null
+                            ? undefined
+                            : {
+                                  position: 'absolute',
+                                  top: 0,
+                                  bottom: 0,
+                                  ...rect(layout.sidebar),
+                                  // The snapshot gate: below zero progress nothing is
+                                  // painted, and what is not painted takes no input.
+                                  opacity: layout.sidebarPainted ? 1 : 0,
+                              }
+                    }
+                >
+                    {sidebar}
+                </View>
+            )}
+        </View>
+    );
+}
+
+/** A core pane rect as the two style keys React Native places a box with. */
+function rect(pane: { x: number; width: number }): { left: number; width: number } {
+    return { left: pane.x, width: pane.width };
+}

--- a/packages/framework/adwaita-react-native/src/widgets/overlay-split-view.ts
+++ b/packages/framework/adwaita-react-native/src/widgets/overlay-split-view.ts
@@ -1,0 +1,21 @@
+// `AdwOverlaySplitView` — the base module. See `../refuse.ts` for who reaches this and
+// why it throws instead of resolving to something.
+
+import type { ReactElement } from 'react';
+
+import type { AdwOverlaySplitViewProps } from '../props.js';
+import { refuseBaseModule } from '../refuse.js';
+
+/**
+ * A sidebar beside content, which slides OVER it when collapsed.
+ *
+ * IT IS NOT `AdwNavigationSplitView` WITH A DIFFERENT PAINT, and the width is where
+ * that shows: `resolveOverlaySidebarWidth` caps the RESULT by `width - content_min`
+ * where the navigation widget caps the BOUND, and a COLLAPSED overlay ignores the
+ * fraction entirely and clamps the VIEW width instead — 280 on a 360-point phone where
+ * a quarter would be 180. Both rules are `@gjsify/adwaita-core`'s port of the C, run by
+ * the React Native half and by libadwaita itself on GTK.
+ */
+export function AdwOverlaySplitView(_props: AdwOverlaySplitViewProps): ReactElement | null {
+    return refuseBaseModule('AdwOverlaySplitView');
+}

--- a/packages/framework/adwaita-react-native/src/widgets/view-stack.gtk.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/view-stack.gtk.tsx
@@ -80,6 +80,35 @@ export function useViewStackPageProperties(stack: Adw.ViewStack | null, pages: r
     });
 }
 
+/**
+ * The `notify::visible-child` handler both stack-owning components install.
+ *
+ * IT REPORTS NOTHING UNTIL THE WIDGET IS READABLE. libadwaita's auto-pick notifies from
+ * inside `adw_view_stack_add_titled` — child insertion is deliberately OUTSIDE gtk-host's
+ * host-write window, so the notify is delivered — and at that moment React has not yet
+ * committed the `ref`, so there is no stack to read the settled name off. Measured, the
+ * inline `stack?.visibleChildName ?? ''` this replaces reported `''` at mount: a name no
+ * page carries, on a callback whose whole contract is to name the page that is showing.
+ * The React Native half reports nothing there, because its subscription is installed in
+ * an effect after the pages are filled in.
+ *
+ * A change the CALLER made does not come back through here either — gtk-host drops the
+ * notify raised inside its own property write, the same rule `AdwExpanderRowProps`
+ * records for `onNotifyExpanded`. That one IS a divergence from the React Native half,
+ * which re-applies `visibleChildName` through `selectName` and reports what it settled
+ * on; the README names it. What both halves report is a change the USER made.
+ */
+export function visibleChildNotifier(
+    stack: Adw.ViewStack | null,
+    notify: ((name: string) => void) | undefined,
+): (() => void) | undefined {
+    if (notify === undefined) return undefined;
+    return () => {
+        if (stack === null) return;
+        notify(stack.visibleChildName ?? '');
+    };
+}
+
 /** {@link import('./view-stack.js').AdwViewStack} on GTK. */
 export function AdwViewStack({
     pages,
@@ -96,11 +125,7 @@ export function AdwViewStack({
         <adw-view-stack
             ref={setStack}
             visible-child-name={visibleChildName}
-            onNotifyVisibleChild={
-                onNotifyVisibleChild === undefined
-                    ? undefined
-                    : () => onNotifyVisibleChild(stack?.visibleChildName ?? '')
-            }
+            onNotifyVisibleChild={visibleChildNotifier(stack, onNotifyVisibleChild)}
         >
             {viewStackChildren(pages ?? [])}
         </adw-view-stack>

--- a/packages/framework/adwaita-react-native/src/widgets/view-stack.gtk.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/view-stack.gtk.tsx
@@ -1,0 +1,108 @@
+/** @jsxImportSource @gjsify/gtk-host/react */
+// `AdwViewStack` on GTK — the real `Adw.ViewStack`. (On the pragma, see `bin.gtk.tsx`.)
+//
+// `ViewStackState` IS NOT USED HERE, for the reason `clamp.gtk.tsx` gives about
+// `clampAllocate`: the core's port of the selection guards is for a renderer with no
+// libadwaita, and this half has the original. What the core still owns on BOTH paths is
+// the page RECORD — `AdwViewStackPageSpec`'s eight fields are the eight properties set
+// below, in the same order and with the same defaults.
+//
+// THE NAME TRAVELS AS `slot` AND THE OTHER SEVEN PROPERTIES DO NOT TRAVEL AT ALL, which
+// is what `useViewStackPageProperties` exists for. gtk-host's `keyed` policy calls
+// `add_titled(child, name, title)` and reads the name from `child.layout?.name ??
+// child.slot` (`policies.ts`) — `slot` is the spelling this host's React surface types,
+// since `layout` is not one of the per-element attributes `ReactWidgetAttributes`
+// declares. Everything else a page carries lives on `Adw.ViewStackPage`, a GObject the
+// stack hands back from `get_page (child)` — NOT a widget, so it can be neither a JSX
+// child nor a prop of one. The effect below is the only way to reach it, and it is why
+// `AdwViewStackPageProps` is a prop object rather than a component.
+//
+// THE TITLE IS WRITTEN TWICE ON PURPOSE. `add_titled` receives the NAME as the title
+// (the policy's `title ?? name ?? ''` fallback), and the effect then writes the authored
+// one. An omitted `title` therefore settles on the name — which is exactly
+// `resolvePageTitle`'s deviation from C, so both halves of this package answer alike
+// where libadwaita alone would leave the title NULL and draw no label.
+
+import type Adw from 'gi://Adw?version=1';
+import { useEffect, useState, type ReactElement } from 'react';
+
+import type { AdwViewStackPageProps, AdwViewStackProps } from '../props.js';
+
+/**
+ * The page bodies, as children of an `<adw-view-stack>`.
+ *
+ * Exported because `view-switcher.gtk.tsx` builds the same stack; `parity.spec.ts`
+ * allows a platform-only export beside the widget, and the second copy is where a
+ * `slot`-versus-`layout` decision would drift.
+ *
+ * Each body gets its own `GtkBox` rather than being handed to `add_titled` directly:
+ * `child` is an arbitrary `ReactNode` with nothing to write a `slot` on, the same wall
+ * `header-bar.gtk.tsx` documents.
+ */
+export function viewStackChildren(pages: readonly AdwViewStackPageProps[]): ReactElement[] {
+    return pages.map((page) => (
+        <gtk-box key={page.name} slot={page.name} orientation="vertical">
+            {page.child}
+        </gtk-box>
+    ));
+}
+
+/**
+ * Write the seven `Adw.ViewStackPage` properties `add_titled` cannot carry.
+ *
+ * IT RUNS AFTER EVERY COMMIT, WITH NO DEPENDENCY LIST, and that is deliberate: the page
+ * list is a prop array whose identity a caller has no reason to keep stable, so a
+ * dependency list over its contents would be a second hand-maintained copy of the same
+ * record. A redundant `g_object_set` with an unchanged value emits no `notify` and
+ * nothing else, so the cost is a property read per page per commit.
+ *
+ * AN OMITTED PROP IS LEFT ALONE rather than written as libadwaita's default — the rule
+ * `clamp.gtk.tsx` states — so the installed libadwaita stays the authority for its own
+ * defaults and a drift against `@gjsify/adwaita-core`'s transcription of them is visible
+ * instead of silent.
+ */
+export function useViewStackPageProperties(stack: Adw.ViewStack | null, pages: readonly AdwViewStackPageProps[]): void {
+    useEffect(() => {
+        if (stack === null) return;
+        for (const page of pages) {
+            const child = stack.get_child_by_name(page.name);
+            // A page whose body has not been adopted yet is not an error: the effect
+            // runs again on the commit that adopts it.
+            if (child === null) continue;
+            const stackPage = stack.get_page(child);
+            if (page.title !== undefined) stackPage.title = page.title;
+            if (page.iconName !== undefined) stackPage.iconName = page.iconName;
+            if (page.visible !== undefined) stackPage.visible = page.visible;
+            if (page.badgeNumber !== undefined) stackPage.badgeNumber = page.badgeNumber;
+            if (page.needsAttention !== undefined) stackPage.needsAttention = page.needsAttention;
+            if (page.useUnderline !== undefined) stackPage.useUnderline = page.useUnderline;
+        }
+    });
+}
+
+/** {@link import('./view-stack.js').AdwViewStack} on GTK. */
+export function AdwViewStack({
+    pages,
+    visibleChildName,
+    onNotifyVisibleChild,
+}: AdwViewStackProps): ReactElement | null {
+    // A `useState` callback ref rather than a `useRef`: `view-switcher.gtk.tsx` needs
+    // the same widget as a PROP VALUE, which only a render-visible binding can be, and
+    // the two files stay one shape.
+    const [stack, setStack] = useState<Adw.ViewStack | null>(null);
+    useViewStackPageProperties(stack, pages ?? []);
+
+    return (
+        <adw-view-stack
+            ref={setStack}
+            visible-child-name={visibleChildName}
+            onNotifyVisibleChild={
+                onNotifyVisibleChild === undefined
+                    ? undefined
+                    : () => onNotifyVisibleChild(stack?.visibleChildName ?? '')
+            }
+        >
+            {viewStackChildren(pages ?? [])}
+        </adw-view-stack>
+    );
+}

--- a/packages/framework/adwaita-react-native/src/widgets/view-stack.native.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/view-stack.native.spec.tsx
@@ -1,0 +1,144 @@
+/** @jsxImportSource react */
+// The React Native half of `AdwViewStack`, rendered through React's real reconciler.
+//
+// THE SELECTION IS THE CLAIM, and every rule asserted below is one `ViewStackState`
+// answers for all three Adwaita renderers — the same class `@gjsify/adwaita-web`'s
+// `<adw-view-stack>` and `@gjsify/adwaita-nativescript`'s `AdwViewStack` run.
+// `navigation.gtk.spec.tsx` reads the first two off the real `Adw.ViewStack`: the
+// auto-pick lands on `home`, and an authored `visible-child-name` moves it.
+//
+// AN UNKNOWN NAME IS REFUSED AND NOT CLAMPED, which is the row a hand-written selection
+// would get wrong in the expensive direction: `adw_view_stack_set_visible_child_name`
+// warns and leaves the selection where it was, so a typo'd prop shows the PREVIOUS page
+// rather than page 0 or nothing. Asserting the refusal is what stops a "helpful" fallback
+// being added later.
+//
+// EVERY PAGE STAYS MOUNTED. The unselected ones carry `display: 'none'`, which is what
+// both other renderers do (`hidden`, `visibility: 'collapse'`); a stack that rendered
+// only the selected page would lose the others' component state on every switch. What is
+// absent is Yoga, as everywhere in this package: `display` is an instruction to a layout
+// engine that is not in this process.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { act } from 'react-test-renderer';
+
+import { Text } from '../testing/react-native.js';
+import { at, childrenOf, mount, mounted, onlyChild, textOf } from '../testing/render.spec.js';
+import { AdwViewStack } from './view-stack.native.js';
+
+/** Which page index the tree is showing. */
+function displayed(node: ReturnType<typeof mounted>): number[] {
+    return childrenOf(node)
+        .map((child, index) => ((child.props.style as { display?: string }).display === undefined ? index : -1))
+        .filter((index) => index >= 0);
+}
+
+// Each body names itself, so an assertion can say WHICH page is on screen rather than
+// only how many are — three bare `View`s are otherwise indistinguishable.
+const PAGES = [
+    { name: 'home', title: 'Home', child: <Text>home</Text> },
+    { name: 'detail', title: 'Detail', child: <Text>detail</Text> },
+    { name: 'settings', title: 'Settings', child: <Text>settings</Text> },
+];
+
+/** The name of the page the tree is showing. */
+function shownName(node: ReturnType<typeof mounted>): string {
+    const index = displayed(node)[0];
+    if (index === undefined) throw new Error('no page is displayed');
+    return textOf(onlyChild(at(childrenOf(node), index)));
+}
+
+export default async () => {
+    await describe('AdwViewStack on React Native — the selection', async () => {
+        await it('auto-picks the first visible page, as add() does on GTK', async () => {
+            const tree = mounted(<AdwViewStack pages={PAGES} />);
+            expect(childrenOf(tree).length).toBe(3);
+            expect(displayed(tree)).toStrictEqual([0]);
+        });
+
+        await it('shows the page an authored visible-child-name names', async () => {
+            const tree = mounted(<AdwViewStack pages={PAGES} visibleChildName="settings" />);
+            expect(displayed(tree)).toStrictEqual([2]);
+            expect(shownName(tree)).toBe('settings');
+        });
+
+        await it('refuses an unknown name instead of clamping it', async () => {
+            const tree = mounted(<AdwViewStack pages={PAGES} visibleChildName="nowhere" />);
+            // The auto-pick still holds — NOT page 0 by accident: `home` IS page 0, so the
+            // second half of this assertion is the one that carries the claim, and it is
+            // made with a stack whose auto-pick is page 1.
+            expect(displayed(tree)).toStrictEqual([0]);
+
+            const hiddenFirst = mounted(
+                <AdwViewStack
+                    pages={[{ name: 'home', title: 'Home', visible: false }, ...PAGES.slice(1)]}
+                    visibleChildName="nowhere"
+                />,
+            );
+            // The auto-pick skipped the invisible page 0, and the unknown name did not
+            // move it back.
+            expect(displayed(hiddenFirst)).toStrictEqual([1]);
+        });
+
+        await it('skips a page that is not visible when picking', async () => {
+            const tree = mounted(
+                <AdwViewStack pages={[{ name: 'home', title: 'Home', visible: false }, ...PAGES.slice(1)]} />,
+            );
+            expect(displayed(tree)).toStrictEqual([1]);
+            expect(shownName(tree)).toBe('detail');
+        });
+
+        await it('refuses to select a page that is not visible', async () => {
+            const tree = mounted(
+                <AdwViewStack
+                    pages={[
+                        { name: 'home', title: 'Home' },
+                        { name: 'detail', title: 'Detail', visible: false },
+                    ]}
+                    visibleChildName="detail"
+                />,
+            );
+            // `adw_view_stack_pages_select_item` simply returns FALSE for a hidden page,
+            // so the auto-pick keeps page 0 — it does not select the hidden one and it
+            // does not fall through to nothing.
+            expect(displayed(tree)).toStrictEqual([0]);
+        });
+    });
+
+    await describe('AdwViewStack on React Native — the tree it emits', async () => {
+        await it('mounts every page and displays only the selected one', async () => {
+            const tree = mounted(<AdwViewStack pages={PAGES.slice(0, 2)} />);
+            const bodies = childrenOf(tree);
+            expect(bodies.length).toBe(2);
+            expect(at(bodies, 0).props.style).toStrictEqual({ flex: 1 });
+            expect(at(bodies, 1).props.style).toStrictEqual({ display: 'none' });
+            // The hidden page is MOUNTED, carrying its own body — a stack that rendered
+            // only the selected page would lose the others' state on every switch.
+            expect(textOf(onlyChild(at(bodies, 1)))).toBe('detail');
+        });
+
+        await it('reports the name it settled on when the selection moves', async () => {
+            const seen: string[] = [];
+            const stack = (name: string) => (
+                <AdwViewStack pages={PAGES} visibleChildName={name} onNotifyVisibleChild={(n) => seen.push(n)} />
+            );
+            // MOUNTED ON A PAGE THAT IS NOT THE AUTO-PICK, on purpose: an authored name
+            // equal to the auto-pick would make this row pass whether the initial
+            // selection happened before the subscription or after it. `settings` is page
+            // 2, so a selection made in the effect instead would arrive as a notification.
+            const renderer = mount(stack('settings'));
+            expect(shownName(renderer.toJSON() as ReturnType<typeof mounted>)).toBe('settings');
+            expect(seen).toStrictEqual([]);
+            act(() => {
+                renderer.update(stack('home'));
+            });
+            expect(seen).toStrictEqual(['home']);
+            act(() => {
+                renderer.update(stack('nowhere'));
+            });
+            // Refused, so nothing moved and nothing was reported — a renderer that echoed
+            // the prop back would report a name it is not showing.
+            expect(seen).toStrictEqual(['home']);
+        });
+    });
+};

--- a/packages/framework/adwaita-react-native/src/widgets/view-stack.native.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/view-stack.native.tsx
@@ -1,0 +1,128 @@
+/** @jsxImportSource react */
+// `AdwViewStack` on React Native — `@gjsify/adwaita-core`'s selection machine. (On the
+// pragma, see `bin.native.tsx`.)
+//
+// THE STATE CLASS IS `ViewSwitcherState` AND THAT IS NOT A MISNOMER. Core's own header
+// says its selection is DELEGATED to `ViewStackState` — the integer/range/hidden guards,
+// the by-name lookup, the first-VISIBLE-page auto-pick and the hide-fallback all come
+// from there, with their conformance vectors. What it adds on top is `setPages`, a
+// name-preserving wholesale replace, and that is exactly the seam a React renderer needs:
+// the page list here is a PROP ARRAY that a caller rebuilds on every render, where the
+// browser and NativeScript renderers hold long-lived page nodes and can add and remove
+// them one at a time. Diffing the array into `ViewStackState.addPage`/`removePage` would
+// be a second, private copy of `setPages` — and libadwaita's selection follows the page
+// OBJECT across such a rebuild, not the index, which is the part a hand-written diff gets
+// wrong.
+//
+// `visibleChildName` IS AUTHORED, NOT OWNED, and both halves answer that the same way. An
+// absent one leaves the stack on its auto-pick, which NOTIFIES — `adw_view_stack_add`
+// selects the first VISIBLE page and a switcher that is not told would need a manual
+// refresh. An unknown one is REFUSED and not clamped, so the notification a caller gets
+// back may not be the name it asked for. Re-applying it on every commit is what makes a
+// controlled stack controlled; `selectName(…, false)` marks it non-interactive, because a
+// prop is not a click.
+//
+// EVERY PAGE STAYS MOUNTED and the unselected ones are `display: 'none'` — `hidden` on
+// the browser half, `visibility: 'collapse'` on the NativeScript one. Rendering only the
+// selected page would unmount the others and lose their state on every switch.
+
+import { useEffect, useRef, useState, type ReactElement } from 'react';
+import { View } from 'react-native';
+
+import { ViewSwitcherState, type AdwViewSwitcherPageInit } from '@gjsify/adwaita-core';
+
+import type { AdwViewStackPageProps, AdwViewStackProps } from '../props.js';
+
+/**
+ * One page prop object as the core's page record, with this surface's defaults applied.
+ *
+ * `title` and `iconName` collapse to `null` and NOT to `''`, which is load-bearing rather
+ * than tidy: `isViewSwitcherButtonVisible` tests `title != NULL`, so an EMPTY title keeps
+ * its button and an absent one does not. `createViewSwitcherPage` applies the same rule to
+ * the fields left out here.
+ */
+function pageSpec(page: AdwViewStackPageProps): AdwViewSwitcherPageInit {
+    return {
+        name: page.name,
+        title: page.title ?? null,
+        iconName: page.iconName ?? null,
+        visible: page.visible ?? true,
+        badgeNumber: page.badgeNumber ?? 0,
+        needsAttention: page.needsAttention ?? false,
+        useUnderline: page.useUnderline ?? false,
+    };
+}
+
+/**
+ * The page model and its selection, shared with `view-switcher.native.tsx`.
+ *
+ * Exported because the switcher bundles the same stack; `parity.spec.ts` allows a
+ * platform-only export beside the widget, and a second copy of this wiring is where the
+ * two would come to disagree about what an unknown name does.
+ */
+export function useViewStackSelection(
+    pages: readonly AdwViewStackPageProps[],
+    visibleChildName: string | undefined,
+    onNotifyVisibleChild: ((name: string) => void) | undefined,
+): ViewSwitcherState {
+    const [, repaint] = useState(0);
+    const store = useRef<ViewSwitcherState | null>(null);
+    if (store.current === null) {
+        // Built AND filled before anything subscribes: the auto-pick emits, and a
+        // listener that called `setState` there would be updating a component while it
+        // renders. The effect below is what installs it.
+        const created = new ViewSwitcherState();
+        created.setPages(pages.map(pageSpec));
+        if (visibleChildName !== undefined) created.selectName(visibleChildName, false);
+        store.current = created;
+    }
+    const state = store.current;
+
+    // The callback lives in a ref so the subscription is installed once — re-subscribing
+    // for every fresh arrow a caller passes would drop and re-add a listener per render.
+    const notify = useRef(onNotifyVisibleChild);
+    notify.current = onNotifyVisibleChild;
+
+    useEffect(
+        () =>
+            state.subscribe((change) => {
+                notify.current?.(change.name);
+                repaint((count) => count + 1);
+            }),
+        [state],
+    );
+
+    // No dependency list: the page array is rebuilt on every render, so any dependency
+    // over its contents would be a second hand-maintained copy of the same record.
+    // `setPages` emits only when the SELECTION moved, so this settles in one pass.
+    useEffect(() => {
+        state.setPages(pages.map(pageSpec));
+        if (visibleChildName !== undefined) state.selectName(visibleChildName, false);
+    });
+
+    return state;
+}
+
+/**
+ * The page bodies, one per page, with only the selected one displayed.
+ *
+ * Shared with the switcher for the reason {@link useViewStackSelection} gives.
+ */
+export function viewStackBodies(pages: readonly AdwViewStackPageProps[], selected: number): ReactElement[] {
+    return pages.map((page, index) => (
+        <View key={page.name} style={index === selected ? { flex: 1 } : { display: 'none' }}>
+            {page.child}
+        </View>
+    ));
+}
+
+/** {@link import('./view-stack.js').AdwViewStack} on React Native. */
+export function AdwViewStack({
+    pages,
+    visibleChildName,
+    onNotifyVisibleChild,
+}: AdwViewStackProps): ReactElement | null {
+    const list = pages ?? [];
+    const state = useViewStackSelection(list, visibleChildName, onNotifyVisibleChild);
+    return <View style={{ flex: 1 }}>{viewStackBodies(list, state.selected)}</View>;
+}

--- a/packages/framework/adwaita-react-native/src/widgets/view-stack.ts
+++ b/packages/framework/adwaita-react-native/src/widgets/view-stack.ts
@@ -1,0 +1,21 @@
+// `AdwViewStack` — the base module. See `../refuse.ts` for who reaches this and why it
+// throws instead of resolving to something.
+
+import type { ReactElement } from 'react';
+
+import type { AdwViewStackProps } from '../props.js';
+import { refuseBaseModule } from '../refuse.js';
+
+/**
+ * Named pages, one visible at a time.
+ *
+ * THE SELECTION IS THE SHARED HALF. Which page an omitted `visible-child-name` shows
+ * (the first VISIBLE one, and the auto-pick NOTIFIES), what an unknown name does
+ * (nothing — refused, not clamped), and where the selection goes when the visible page
+ * is hidden are `@gjsify/adwaita-core`'s `ViewStackState`, held to conformance vectors
+ * and already run by both other renderers. On GTK the original answers instead, and
+ * the suites assert the same name on both halves.
+ */
+export function AdwViewStack(_props: AdwViewStackProps): ReactElement | null {
+    return refuseBaseModule('AdwViewStack');
+}

--- a/packages/framework/adwaita-react-native/src/widgets/view-switcher.gtk.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/view-switcher.gtk.tsx
@@ -24,7 +24,7 @@ import type Adw from 'gi://Adw?version=1';
 import { useState, type ReactElement } from 'react';
 
 import type { AdwViewSwitcherProps } from '../props.js';
-import { useViewStackPageProperties, viewStackChildren } from './view-stack.gtk.js';
+import { useViewStackPageProperties, viewStackChildren, visibleChildNotifier } from './view-stack.gtk.js';
 
 /** {@link import('./view-switcher.js').AdwViewSwitcher} on GTK. */
 export function AdwViewSwitcher({
@@ -43,11 +43,7 @@ export function AdwViewSwitcher({
                 ref={setStack}
                 vexpand={true}
                 visible-child-name={visibleChildName}
-                onNotifyVisibleChild={
-                    onNotifyVisibleChild === undefined
-                        ? undefined
-                        : () => onNotifyVisibleChild(stack?.visibleChildName ?? '')
-                }
+                onNotifyVisibleChild={visibleChildNotifier(stack, onNotifyVisibleChild)}
             >
                 {viewStackChildren(pages ?? [])}
             </adw-view-stack>

--- a/packages/framework/adwaita-react-native/src/widgets/view-switcher.gtk.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/view-switcher.gtk.tsx
@@ -1,0 +1,56 @@
+/** @jsxImportSource @gjsify/gtk-host/react */
+// `AdwViewSwitcher` on GTK — the real `Adw.ViewSwitcher` over a real `Adw.ViewStack`.
+// (On the pragma, see `bin.gtk.tsx`.)
+//
+// THE STACK IS BUILT HERE AND POINTED AT, WHICH IS THE ONE THING THAT MAKES THE BUNDLED
+// SURFACE HONEST. `Adw.ViewSwitcher:stack` is a widget-valued property, so this file
+// renders both widgets and binds one to the other; nothing about the switcher is
+// simulated and `buildViewSwitcherButtons` is not run on this half at all — libadwaita
+// derives its own buttons from the stack's pages model. `props.ts` carries why the two
+// are bundled and that both other renderers bundle them too.
+//
+// THE BINDING NEEDS A RENDER, NOT A REF, and that is why the stack lands in `useState`.
+// A `useRef` is populated during commit and never re-renders, so `stack={ref.current}`
+// would be `null` on the first pass and stay null forever — the switcher would be a row
+// of nothing, at exit 0, which is this host's whole failure signature. The state costs
+// one extra render at mount and makes the property write happen.
+//
+// THE PAGE PROPERTIES COME FROM `view-stack.gtk.tsx`, imported rather than repeated:
+// seven `Adw.ViewStackPage` writes and one `slot`-carrying child are exactly what a
+// second copy would drift on, and `parity.spec.ts` allows a platform-only export beside
+// the widget for this.
+
+import type Adw from 'gi://Adw?version=1';
+import { useState, type ReactElement } from 'react';
+
+import type { AdwViewSwitcherProps } from '../props.js';
+import { useViewStackPageProperties, viewStackChildren } from './view-stack.gtk.js';
+
+/** {@link import('./view-switcher.js').AdwViewSwitcher} on GTK. */
+export function AdwViewSwitcher({
+    pages,
+    policy,
+    visibleChildName,
+    onNotifyVisibleChild,
+}: AdwViewSwitcherProps): ReactElement | null {
+    const [stack, setStack] = useState<Adw.ViewStack | null>(null);
+    useViewStackPageProperties(stack, pages ?? []);
+
+    return (
+        <gtk-box orientation="vertical">
+            <adw-view-switcher policy={policy} stack={stack} />
+            <adw-view-stack
+                ref={setStack}
+                vexpand={true}
+                visible-child-name={visibleChildName}
+                onNotifyVisibleChild={
+                    onNotifyVisibleChild === undefined
+                        ? undefined
+                        : () => onNotifyVisibleChild(stack?.visibleChildName ?? '')
+                }
+            >
+                {viewStackChildren(pages ?? [])}
+            </adw-view-stack>
+        </gtk-box>
+    );
+}

--- a/packages/framework/adwaita-react-native/src/widgets/view-switcher.native.spec.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/view-switcher.native.spec.tsx
@@ -1,0 +1,117 @@
+/** @jsxImportSource react */
+// The React Native half of `AdwViewSwitcher`, rendered through React's real reconciler.
+//
+// WHAT IS ASSERTED IS THE DERIVATION, because that is the half both renderers share.
+// `buildViewSwitcherButtons` decides whether a button exists at all, what its label
+// reads after mnemonic stripping, what its badge reads above the limit and which way it
+// arranges itself; libadwaita computes the same on GTK from the stack's pages model, and
+// `navigation.gtk.spec.tsx` asserts that the real `Adw.ViewSwitcher` is pointed at the
+// real `Adw.ViewStack` so those buttons are libadwaita's own.
+//
+// A HIDDEN BUTTON IS ASSERTED AS A NODE WITH `display: 'none'`, never as an absence: a
+// missing node cannot tell "this page has no button" from "this page is not in the model
+// at all", and the first is a C rule while the second would be a bug in this file.
+//
+// PRESSING IS ASSERTED THROUGH THE HANDLER THE TREE CARRIES, which is as far as a
+// `react-test-renderer` tree goes: what a spec here can show is that the widget ASKS for
+// a press and what it does when one arrives, never that a tap on a device reaches it.
+// `testing/react-native.ts` carries that gap, and it is why the tap target is a `Text` —
+// React Native's tappable primitives are composites the double may not stand in for.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { act } from 'react-test-renderer';
+
+import { VIEW_SWITCHER_BADGE_LIMIT } from '@gjsify/adwaita-core';
+
+import { RCT_TEXT } from '../testing/react-native.js';
+import { at, childrenOf, mount, mounted, textOf } from '../testing/render.spec.js';
+import { AdwViewSwitcher } from './view-switcher.native.js';
+
+const PAGES = [
+    { name: 'home', title: 'Home' },
+    { name: 'detail', title: 'Detail' },
+];
+
+/** The button row — always the switcher's first child, with the page bodies after it. */
+function buttonRow(tree: ReturnType<typeof mounted>) {
+    return childrenOf(at(childrenOf(tree), 0));
+}
+
+export default async () => {
+    await describe('AdwViewSwitcher on React Native — the buttons it derives', async () => {
+        await it('gives every page a button, above the page bodies', async () => {
+            const tree = mounted(<AdwViewSwitcher pages={PAGES} />);
+            // One row plus one body per page.
+            expect(childrenOf(tree).length).toBe(3);
+            const buttons = buttonRow(tree);
+            expect(buttons.length).toBe(2);
+            expect(textOf(at(childrenOf(at(buttons, 0)), 0))).toBe('Home');
+            expect(at(childrenOf(at(buttons, 1)), 0).type).toBe(RCT_TEXT);
+        });
+
+        await it('strips the mnemonic marker libadwaita underlines', async () => {
+            const tree = mounted(<AdwViewSwitcher pages={[{ name: 'home', title: '_Home', useUnderline: true }]} />);
+            // `_Home` with `use-underline` is the label `Home` with H marked — a renderer
+            // with no accelerator layer wants the plain text, and `stripMnemonic` is where
+            // that lives.
+            expect(textOf(at(childrenOf(at(buttonRow(tree), 0)), 0))).toBe('Home');
+        });
+
+        await it('hides the button of a page with NEITHER a title NOR an icon', async () => {
+            const tree = mounted(<AdwViewSwitcher pages={[{ name: 'home', title: 'Home' }, { name: 'ghost' }]} />);
+            const buttons = buttonRow(tree);
+            // The node exists — the page is in the model — and is not displayed.
+            expect(buttons.length).toBe(2);
+            expect((at(buttons, 1).props.style as { display?: string }).display).toBe('none');
+            // And an EMPTY title is NOT that case: `''` is not NULL, so it keeps a button.
+            const empty = mounted(<AdwViewSwitcher pages={[{ name: 'home', title: '' }]} />);
+            expect((at(buttonRow(empty), 0).props.style as { display?: string }).display).toBe('flex');
+        });
+
+        await it('caps the badge at 999+, and draws none at zero', async () => {
+            const tree = mounted(
+                <AdwViewSwitcher
+                    pages={[
+                        { name: 'home', title: 'Home', badgeNumber: VIEW_SWITCHER_BADGE_LIMIT + 1 },
+                        { name: 'detail', title: 'Detail' },
+                    ]}
+                />,
+            );
+            const buttons = buttonRow(tree);
+            expect(childrenOf(at(buttons, 0)).length).toBe(2);
+            expect(textOf(at(childrenOf(at(buttons, 0)), 1))).toBe('999+');
+            // Badge 0 is no badge at all — one child, not a child holding ''.
+            expect(childrenOf(at(buttons, 1)).length).toBe(1);
+        });
+
+        await it('arranges the button along the axis the policy names', async () => {
+            const narrow = mounted(<AdwViewSwitcher pages={PAGES} />);
+            expect((at(buttonRow(narrow), 0).props.style as { flexDirection?: string }).flexDirection).toBe('column');
+            const wide = mounted(<AdwViewSwitcher pages={PAGES} policy="wide" />);
+            expect((at(buttonRow(wide), 0).props.style as { flexDirection?: string }).flexDirection).toBe('row');
+        });
+    });
+
+    await describe('AdwViewSwitcher on React Native — pressing one', async () => {
+        await it('switches the visible page and reports the name it moved to', async () => {
+            const seen: string[] = [];
+            const renderer = mount(<AdwViewSwitcher pages={PAGES} onNotifyVisibleChild={(n) => seen.push(n)} />);
+            const tree = renderer.toJSON();
+            if (tree === null || Array.isArray(tree)) throw new Error('the switcher rendered no single root');
+            const label = at(childrenOf(at(buttonRow(tree), 1)), 0);
+            act(() => {
+                (label.props.onPress as () => void)();
+            });
+            expect(seen).toStrictEqual(['detail']);
+
+            const after = renderer.toJSON();
+            if (after === null || Array.isArray(after)) throw new Error('the switcher rendered no single root');
+            const bodies = childrenOf(after).slice(1);
+            expect((at(bodies, 0).props.style as { display?: string }).display).toBe('none');
+            expect(at(bodies, 1).props.style).toStrictEqual({ flex: 1 });
+            // The button that was pressed now reports itself selected — the model's own
+            // flag, so a renderer that painted selection from its own memory would differ.
+            expect((at(buttonRow(after), 1).props.accessibilityState as { selected?: boolean }).selected).toBe(true);
+        });
+    });
+};

--- a/packages/framework/adwaita-react-native/src/widgets/view-switcher.native.tsx
+++ b/packages/framework/adwaita-react-native/src/widgets/view-switcher.native.tsx
@@ -1,0 +1,81 @@
+/** @jsxImportSource react */
+// `AdwViewSwitcher` on React Native — `buildViewSwitcherButtons` over the same stack
+// `view-stack.native.tsx` runs. (On the pragma, see `bin.native.tsx`.)
+//
+// NOT ONE BUTTON DECISION IS MADE IN THIS FILE. `buildViewSwitcherButtons` returns one
+// model per PAGE — libadwaita's `populate_switcher` adds a button for every page and
+// `update_button` merely hides the ones that fail the visibility rule, so the index
+// spaces line up — carrying whether the button exists at all (a page with NEITHER a
+// title NOR an icon has none, and an EMPTY title is not that case), the mnemonic-stripped
+// label, the badge text (`999+` above the limit), the needs-attention dot and the
+// screen-reader description. libadwaita derives the same on GTK from the stack's pages
+// model, so the two halves differ in what they can DRAW and never in which buttons exist.
+//
+// A HIDDEN BUTTON IS RENDERED AND NOT DISPLAYED, which is what both other renderers do
+// (`button.hidden` on the browser half, `visibility` on the NativeScript one) and what
+// libadwaita does itself. Dropping the node instead would make "this page has no button"
+// indistinguishable from "this page is not in the model", which is the assertion
+// `view-switcher.native.spec.tsx` needs to be able to make.
+//
+// THE TAP TARGET IS A `Text`, AND BOTH TEXTS CARRY THE HANDLER. React Native's tappable
+// primitives — `Pressable`, `TouchableOpacity` — are COMPOSITES, and this package's test
+// double may only stand in for a component that IS a host element with its props
+// forwarded (`testing/react-native.ts` states the rule; `spinner.native.tsx` is the
+// precedent for refusing one). `Text` has `onPress` on its own props, so the button is a
+// `View` in the model's orientation holding a label `Text` and, when there is one, a badge
+// `Text` — each with the same handler, so the whole button is tappable rather than only
+// its left half.
+//
+// NO ICON IS DRAWN, so a page with an icon and no title gets a button with an empty
+// label. That is the icon-theme divergence the README already names for `AdwStatusPage`,
+// `AdwAvatar` and `AdwButtonContent`: `iconName` names an entry in a theme React Native
+// has none of, and drawing the name as text would put `folder-symbolic` on screen. The
+// ORIENTATION is still applied, because it is what arranges the label and the badge.
+
+import { type ReactElement } from 'react';
+import { Text, View } from 'react-native';
+
+import { buildViewSwitcherButtons } from '@gjsify/adwaita-core';
+
+import type { AdwViewSwitcherProps } from '../props.js';
+import { useViewStackSelection, viewStackBodies } from './view-stack.native.js';
+
+/** {@link import('./view-switcher.js').AdwViewSwitcher} on React Native. */
+export function AdwViewSwitcher({
+    pages,
+    policy,
+    visibleChildName,
+    onNotifyVisibleChild,
+}: AdwViewSwitcherProps): ReactElement | null {
+    const list = pages ?? [];
+    const state = useViewStackSelection(list, visibleChildName, onNotifyVisibleChild);
+    const buttons = buildViewSwitcherButtons(state.pages, state.selected, policy ?? 'narrow');
+
+    return (
+        <View style={{ flex: 1 }}>
+            <View style={{ flexDirection: 'row' }}>
+                {buttons.map((button) => {
+                    const press = (): void => {
+                        state.setSelected(button.pageIndex);
+                    };
+                    return (
+                        <View
+                            key={button.name}
+                            accessible={true}
+                            accessibilityRole="button"
+                            accessibilityState={{ selected: button.selected }}
+                            style={{
+                                flexDirection: button.orientation === 'horizontal' ? 'row' : 'column',
+                                display: button.visible ? 'flex' : 'none',
+                            }}
+                        >
+                            <Text onPress={press}>{button.label}</Text>
+                            {button.badgeLabel.length === 0 ? null : <Text onPress={press}>{button.badgeLabel}</Text>}
+                        </View>
+                    );
+                })}
+            </View>
+            {viewStackBodies(list, state.selected)}
+        </View>
+    );
+}

--- a/packages/framework/adwaita-react-native/src/widgets/view-switcher.ts
+++ b/packages/framework/adwaita-react-native/src/widgets/view-switcher.ts
@@ -1,0 +1,21 @@
+// `AdwViewSwitcher` — the base module. See `../refuse.ts` for who reaches this and why
+// it throws instead of resolving to something.
+
+import type { ReactElement } from 'react';
+
+import type { AdwViewSwitcherProps } from '../props.js';
+import { refuseBaseModule } from '../refuse.js';
+
+/**
+ * A row of buttons over a view stack.
+ *
+ * WHAT EACH BUTTON SHOWS IS DERIVED, NOT AUTHORED, and that derivation is
+ * `@gjsify/adwaita-core`'s `buildViewSwitcherButtons`: a page with NEITHER a title NOR
+ * an icon has no button at all, a page with no icon gets `image-missing` rather than
+ * nothing, a badge above 999 reads `999+`, and the button's orientation follows the
+ * policy. libadwaita computes the same on GTK, so this widget's two halves differ in
+ * what they can DRAW and never in which buttons exist.
+ */
+export function AdwViewSwitcher(_props: AdwViewSwitcherProps): ReactElement | null {
+    return refuseBaseModule('AdwViewSwitcher');
+}


### PR DESCRIPTION
## What lands

The navigation group — six widgets, each a base module that refuses, a `.gtk.tsx` over the
real `Adw.*` through `@gjsify/gtk-host`, a `.native.tsx` over React Native primitives, and
specs on both sides:

| widget | GTK | React Native |
|---|---|---|
| `AdwNavigationPage` | `Adw.NavigationPage` | a `View` and three properties its holder reads |
| `AdwNavigationView` | libadwaita's own stack, reached through a `ref` | `NavigationViewState` |
| `AdwNavigationSplitView` | `Adw.NavigationSplitView`, both panes wrapped in a page | `NavigationSplitViewState` + `resolveNavigationSidebarWidth` + `layoutNavigationSplitView` |
| `AdwOverlaySplitView` | `Adw.OverlaySplitView` | `OverlaySplitViewState` + `resolveOverlaySidebarWidth` + `layoutOverlaySplitView` |
| `AdwViewStack` | `Adw.ViewStack`, page properties written onto `Adw.ViewStackPage` | `ViewSwitcherState` over `ViewStackState` |
| `AdwViewSwitcher` | a real `Adw.ViewSwitcher` bound to a real `Adw.ViewStack` | `buildViewSwitcherButtons` |

`AdwNavigationPage` is here because the two navigation slots take nothing else:
`adw_navigation_view_add` and `adw_navigation_split_view_set_sidebar` are typed
`AdwNavigationPage*`, and `@gjsify/adwaita-web` exposes the same element for the same
reason.

This is the first group whose widgets hold STATE rather than compute a number, and the
split is the one every widget in this package makes: on GTK libadwaita's own C owns the
stack, the collapse coupling and the selection; on React Native `@gjsify/adwaita-core`'s
ports of them do — the classes both other Adwaita renderers already run. Neither half
re-derives the other's answer.

## The numbers both halves are asserted with

- a 1000-point frame splits **250 / 750** on both split views — read off the live GTK tree
  and asserted as style objects on React Native;
- a **COLLAPSED** overlay sidebar is **280** on a 360-point phone, where a quarter would be
  90: `get_sidebar_width` ignores the fraction while collapsed and clamps the VIEW width;
- a three-page chain answers the same tags (`home` → `detail` → `home`) and the same
  back-button tooltip (`Home`, and `Back` for an untitled page) through libadwaita and
  through `NavigationViewState`;
- the split view's own minimum is **380** = `sidebar_min + content_min`, asserted against
  `measureSplitViewHorizontal` and read back off GTK.

## Three defects the measurement found

1. **`collapsed` written before `pin-sidebar`.** gtk-host applies props in element order
   and `adw_overlay_split_view_set_collapsed` hides an unpinned sidebar on its way through,
   so `<AdwOverlaySplitView pinSidebar collapsed>` reached `set_collapsed` with
   `pin-sidebar` still FALSE and read back `show-sidebar: false` — no diagnostic, sidebar
   simply not on screen. Both halves now apply it last.
2. **A blanket re-apply clobbered the widget's own auto-hide.** The React Native half was
   pushing every prop into the state on every commit, which takes the `show-sidebar` the
   widget had just decided and overwrites it with the caller's stale value one render
   later. It now diffs against the last-applied values, the way
   `attributeChangedCallback` pushes ONE attribute.
3. **The core's 300-point vector is unreachable through a GTK window.**
   `resolveNavigationSidebarWidth` and `resolveOverlaySidebarWidth` genuinely differ (180
   versus 100 at 300 points), but `measure` makes `sidebar_min + content_min` the view's
   own minimum and GTK never allocates below it — from there upwards the two rules agree.
   The suite asserts the minimum instead, and the README records why the pair is not
   asserted here.

## A/B

Every assertion was shown to go RED by reverting the behaviour it claims to check: 38
mutations on the React Native half and 29 on the GTK half, applied one at a time with the
tree restored after each. Two vacuous rows and one untested path were found that way and
fixed before landing — an ordering-table assertion that counted panes without saying WHICH
(every pane is a bare `View`, so it passed with `resolveNavigationStack` replaced by
`showContent ? 'content' : 'sidebar'`; the panes now carry a `Text` that names them), a
`sidebar-position: end` row that asserted nothing (the visible pane is the same for both
positions — only the push/pop DIRECTION differs, and this renderer has no animation to
spend it on), and a mount-time `selectName` no assertion reached. The `blankReason` guard
on the GTK photograph was falsified too: with both panes emptied it reports *"the container
is allocated 1000×0: its 2 widget(s) exist and occupy nothing"*.

## Also here

- `settled(element, width)` lifted out of `clamp.native.spec.tsx` into
  `testing/render.spec.ts` — two more suites needed it, and the second copy is where you
  lift.
- Ten named divergences added to the README, including the absent measure pass on both
  split views, the instant reveal (`Animated` is a composite the test double may not stand
  in for), `ltr`-only direction resolution, and the GTK warning for an untitled
  `Adw.NavigationPage`.

## Gates

`gjsify format --check`, `gjsify lint`, `gjsify tsc`, both test legs (Node 316, GJS 216),
`check-gi-import-versions`, `check-adwaita-rn-platform-split` (18 widgets),
`check-vocabulary-alignment` (18 React Native widgets, 18 sharing a spelling, 0 undecided),
`check-storybook-widget-coverage`, `check-generated-website-data`, `check-doc-revert`,
`check-agent-context-size --check` — all exit 0 against the committed tree. No gtk-host
descriptor needed a change: all five container widgets were already curated.
