### PR TITLE
fix(gtk-host): hide a view-stack page before removing it

### DIFF
--- a/packages/framework/gtk-host/src/descriptors/adw.ts
+++ b/packages/framework/gtk-host/src/descriptors/adw.ts
@@ -163,6 +163,16 @@ export const ADW_DESCRIPTORS: readonly WidgetDescriptor[] = [
         // and is NOT used — it is a fourth argument this policy has no field for, and
         // an icon belongs to the `Adw.ViewStackPage` the add RETURNS. Reaching that
         // page is a `get_page(child)` call, one layer up.
+        //
+        // AND `remove-all` COSTS THE PAGE OBJECT. A reorder removes and re-adds every
+        // child, so every `Adw.ViewStackPage` is rebuilt. `name` and `title` come back
+        // because `add_titled` re-supplies them from `layout`; MEASURED, `icon-name`,
+        // `badge-number`, `needs-attention` and `use-underline` do not —
+        // `go-home-symbolic/7/true/true` before a reversal, `null/0/false/false`
+        // after. A layer that sets them therefore has to re-apply on every commit,
+        // which is what `useViewStackPageProperties` in `@gjsify/adwaita-react-native`
+        // does with a dependency-array-free effect. Pre-existing and unrelated to
+        // `hideBeforeRemove` below: both arms of that A/B lose the same four.
         children: {
             kind: 'keyed',
             add: 'add_titled',

--- a/packages/framework/gtk-host/src/descriptors/adw.ts
+++ b/packages/framework/gtk-host/src/descriptors/adw.ts
@@ -163,7 +163,17 @@ export const ADW_DESCRIPTORS: readonly WidgetDescriptor[] = [
         // and is NOT used — it is a fourth argument this policy has no field for, and
         // an icon belongs to the `Adw.ViewStackPage` the add RETURNS. Reaching that
         // page is a `get_page(child)` call, one layer up.
-        children: { kind: 'keyed', add: 'add_titled', remove: 'remove', nameFrom: 'name', titled: true },
+        children: {
+            kind: 'keyed',
+            add: 'add_titled',
+            remove: 'remove',
+            nameFrom: 'name',
+            titled: true,
+            // libadwaita never clears `last_visible_child` when a page is removed,
+            // and a keyed reorder removes every page. See `types.ts` for the
+            // measurement and the exact critical this suppresses.
+            hideBeforeRemove: true,
+        },
     },
     {
         gtype: 'AdwClamp',

--- a/packages/framework/gtk-host/src/host.spec.ts
+++ b/packages/framework/gtk-host/src/host.spec.ts
@@ -992,18 +992,21 @@ export default async () => {
 
             await it('removing a page after a visible-child switch leaves nothing dangling', async () => {
                 // Reproduced from an application: an `Adw.ViewStack` behind a tab
-                // router logged ~300 `gtk_widget_set_child_visible: assertion
+                // router logged hundreds of `gtk_widget_set_child_visible: assertion
                 // 'GTK_IS_WIDGET (widget)' failed` in twelve seconds, at exit 0.
                 // The defect is libadwaita's — `hideBeforeRemove` in `types.ts`
                 // carries the source lines — but THIS host is what drives it: a
                 // keyed reorder is `remove-all`, so every round removes every page.
-                // Measured in the application, patched against unpatched: 296
-                // criticals before, 0 after, with the React loop unchanged.
+                // Measured in the application, unpatched twice and patched three
+                // times: 296 and 131 criticals against 0, 0, 0, with the React
+                // render count unchanged. The two unpatched runs differing by more
+                // than a factor of two is why neither is quoted as THE number.
                 //
                 // Every precondition below was measured one at a time, and each one
-                // alone is silent: an unrealised stack, the switch without the
-                // remove, the remove without the switch. The stale pointer is only
-                // read on dispose, so the window has to go away inside the test.
+                // alone is silent: a stack never made visible, the switch without
+                // the remove, the remove without the switch. The read that fires is
+                // on UNMAP, so the window has to go away inside the test — measured,
+                // a queued resize and a direct `measure()` leave it quiet.
                 const stack = createElement('AdwViewStack');
                 const widget = materialize(stack) as unknown as Adw.ViewStack;
                 const [a, b] = ['a', 'b'].map((n) =>
@@ -1027,6 +1030,106 @@ export default async () => {
                 expect(removed.get_visible()).toBe(true);
 
                 window.destroy();
+            });
+
+            await it('the hide before a remove costs a consumer no signal', async () => {
+                // THE PRICE OF THE FIX ABOVE, and the reason `writeVisible` in
+                // `policies.ts` opens a host-write window rather than calling
+                // `set_visible` straight. A plain remove emits no property change at
+                // all; the hide/restore pair emits three. MEASURED, removing the
+                // VISIBLE page of an `Adw.ViewStack`: two `notify::visible` on the
+                // child, plus one `notify::visible-child-name` on the STACK, because
+                // hiding the visible child runs libadwaita's `update_child_visible`
+                // and that picks another page. `<Tabs>` in `@gjsify/react-native`
+                // binds that stack signal and reads it as THE USER CLICKED, so the
+                // traffic is a navigation and not only noise.
+                const stack = createElement('AdwViewStack');
+                const widget = materialize(stack) as unknown as Adw.ViewStack;
+                const pages = ['a', 'b', 'c'].map((n) =>
+                    createElement('GtkLabel', { label: n, layout: { name: n, title: n } }),
+                );
+                for (const page of pages) insert(page, stack);
+                const removed = materialize(pages[0]) as unknown as Gtk.Widget;
+
+                const window = new Gtk.Window();
+                window.set_child(widget as unknown as Gtk.Widget);
+                window.present();
+                // libadwaita auto-picks the first page, so removing `a` IS the loud
+                // case — the one where the hide moves the selection.
+                expect(widget.get_visible_child_name()).toBe('a');
+
+                const seen: string[] = [];
+                setEventHandler(stack, 'on:notify::visible-child-name', () => {
+                    seen.push(`stack:${widget.get_visible_child_name()}`);
+                });
+                setEventHandler(pages[0], 'onNotifyVisible', () => {
+                    seen.push('a:visible');
+                });
+
+                remove(pages[0]);
+                expect(seen).toStrictEqual([]);
+
+                // The control for the half that was quiet, without which an
+                // unconnected handler would pass this vector: a change the host did
+                // NOT make reaches both handlers.
+                widget.set_visible_child_name('c');
+                removed.set_visible(false);
+                expect(seen).toStrictEqual(['stack:c', 'a:visible']);
+
+                window.destroy();
+            });
+
+            await it('every keyed container survives the sequence that strands a page', async () => {
+                // WHY `hideBeforeRemove` IS A FIELD AND NOT THE KIND, kept as a
+                // measurement rather than a sentence. `Adw.ViewStack` strands
+                // `last_visible_child` on a remove; `Gtk.Stack` and
+                // `Adw.NavigationView`, driven through the same sequence, do not.
+                //
+                // A table and not a list of three vectors, because the trap is the
+                // FOURTH keyed descriptor: one added without a row here fails the
+                // equality below, and the only way to add a row is to run the widget
+                // through the sequence and read what the gate says.
+                const drive: Record<
+                    string,
+                    { page: (name: string) => HostElement; show: (widget: Gtk.Widget, name: string) => void }
+                > = {
+                    GtkStack: {
+                        page: (name) => createElement('GtkLabel', { label: name, layout: { name, title: name } }),
+                        show: (widget, name) => (widget as unknown as Gtk.Stack).set_visible_child_name(name),
+                    },
+                    AdwViewStack: {
+                        page: (name) => createElement('GtkLabel', { label: name, layout: { name, title: name } }),
+                        show: (widget, name) => (widget as unknown as Adw.ViewStack).set_visible_child_name(name),
+                    },
+                    AdwNavigationView: {
+                        page: (name) => {
+                            const page = createElement('AdwNavigationPage', { title: name, tag: name });
+                            insert(createElement('GtkLabel', { label: name }), page);
+                            return page;
+                        },
+                        show: (widget, name) => (widget as unknown as Adw.NavigationView).push_by_tag(name),
+                    },
+                };
+                const keyed = BUILTIN_DESCRIPTORS.filter((d) => d.children.kind === 'keyed').map((d) => d.gtype);
+                expect([...keyed].sort()).toStrictEqual(Object.keys(drive).sort());
+
+                for (const gtype of keyed) {
+                    const { page, show } = drive[gtype];
+                    const parent = createElement(gtype);
+                    const widget = materialize(parent) as unknown as Gtk.Widget;
+                    const [first, second] = ['a', 'b'].map(page);
+                    insert(first, parent);
+                    insert(second, parent);
+
+                    const window = new Gtk.Window();
+                    window.set_child(widget);
+                    window.present();
+                    show(widget, 'b');
+                    remove(first);
+                    // The UNMAP is the read that fires, so the window has to go away
+                    // inside the loop or the gate has nothing to see.
+                    window.destroy();
+                }
             });
 
             await it('a slotted insert-before lands in document order', async () => {

--- a/packages/framework/gtk-host/src/host.spec.ts
+++ b/packages/framework/gtk-host/src/host.spec.ts
@@ -990,6 +990,45 @@ export default async () => {
                 expect(stackOrder(widget)).toStrictEqual(['c', 'b', 'a']);
             });
 
+            await it('removing a page after a visible-child switch leaves nothing dangling', async () => {
+                // Reproduced from an application: an `Adw.ViewStack` behind a tab
+                // router logged ~300 `gtk_widget_set_child_visible: assertion
+                // 'GTK_IS_WIDGET (widget)' failed` in twelve seconds, at exit 0.
+                // The defect is libadwaita's — `hideBeforeRemove` in `types.ts`
+                // carries the source lines — but THIS host is what drives it: a
+                // keyed reorder is `remove-all`, so every round removes every page.
+                // Measured in the application, patched against unpatched: 296
+                // criticals before, 0 after, with the React loop unchanged.
+                //
+                // Every precondition below was measured one at a time, and each one
+                // alone is silent: an unrealised stack, the switch without the
+                // remove, the remove without the switch. The stale pointer is only
+                // read on dispose, so the window has to go away inside the test.
+                const stack = createElement('AdwViewStack');
+                const widget = materialize(stack) as unknown as Adw.ViewStack;
+                const [a, b] = ['a', 'b'].map((n) =>
+                    createElement('GtkLabel', { label: n, layout: { name: n, title: n } }),
+                );
+                insert(a, stack);
+                insert(b, stack);
+                const removed = materialize(a) as unknown as Gtk.Widget;
+
+                const window = new Gtk.Window();
+                window.set_child(widget as unknown as Gtk.Widget);
+                window.present();
+
+                widget.set_visible_child_name('b');
+                remove(a);
+
+                // Not the same assertion as the gate's: this one guards the RESTORE.
+                // Hiding without putting `visible` back would be silent here and
+                // would lose the page on the next keyed move, which is a remove and
+                // a re-append of everything.
+                expect(removed.get_visible()).toBe(true);
+
+                window.destroy();
+            });
+
             await it('a slotted insert-before lands in document order', async () => {
                 const bar = createElement('AdwHeaderBar');
                 const widget = materialize(bar) as unknown as Adw.HeaderBar;

--- a/packages/framework/gtk-host/src/policies.ts
+++ b/packages/framework/gtk-host/src/policies.ts
@@ -13,6 +13,7 @@
 import Gtk from 'gi://Gtk?version=4.0';
 
 import { err, GtkHostError } from './errors.js';
+import { beginHostWrite, endHostWrite } from './signals.js';
 import type { ChildPolicy, HostElement } from './types.js';
 
 type AnyWidget = Gtk.Widget & Record<string, (...args: unknown[]) => unknown>;
@@ -352,9 +353,9 @@ function detachChild(parent: HostElement, child: HostElement, host: AnyWidget): 
             // A child that is ALREADY hidden needs nothing — libadwaita ran its own
             // cleanup when it was hidden, which is the very path this borrows.
             const restoreVisible = policy.hideBeforeRemove === true && address.get_visible();
-            if (restoreVisible) address.set_visible(false);
+            if (restoreVisible) writeVisible(address, false);
             host[policy.remove](address);
-            if (restoreVisible) address.set_visible(true);
+            if (restoreVisible) writeVisible(address, true);
             return;
         }
         case 'ordered':
@@ -364,6 +365,37 @@ function detachChild(parent: HostElement, child: HostElement, host: AnyWidget): 
             return;
         default:
             return unhandledPolicy(policy);
+    }
+}
+
+/**
+ * Write `visible` as the HOST, so `hideBeforeRemove` costs a consumer no signal.
+ *
+ * A plain remove emits no property change at all. MEASURED on libadwaita 1.9.3 /
+ * GTK 4.22.4, removing the VISIBLE page of an `Adw.ViewStack`: unbracketed, the
+ * hide/restore pair adds two `notify::visible` on the child AND one
+ * `notify::visible-child-name` on the STACK, because hiding the visible child runs
+ * libadwaita's `update_child_visible` and that picks another page. Over a keyed
+ * reorder — `remove-all`, so every page goes — a three-page reversal went from one
+ * stack notify to three (`c`, `null`, `c`) plus two per child. `<Tabs>` in
+ * `@gjsify/react-native` reads that stack notify as THE USER CLICKED and dispatches
+ * a navigation for it, so the traffic is not merely noise.
+ *
+ * The echo guard in `signals.ts` is exactly the instrument for that, and this is
+ * its only caller outside `host.ts`.
+ *
+ * `null` rather than `address` as the write target, and that is the whole reason
+ * this is a function: the target leg drops NON-notify signals too, and `unmap` is
+ * one a consumer must keep. MEASURED, same case — `unmap` fires ONCE either way (on
+ * the hide when bracketed, on `gtk_widget_unparent` when not), so `null` drops the
+ * property echo and leaves the unmap count at the unpatched 1.
+ */
+function writeVisible(address: Gtk.Widget, visible: boolean): void {
+    beginHostWrite(null);
+    try {
+        address.set_visible(visible);
+    } finally {
+        endHostWrite();
     }
 }
 

--- a/packages/framework/gtk-host/src/policies.ts
+++ b/packages/framework/gtk-host/src/policies.ts
@@ -346,9 +346,19 @@ function detachChild(parent: HostElement, child: HostElement, host: AnyWidget): 
             host[policy.remove](address);
             return;
         }
+        case 'keyed': {
+            // Why a widget can need to be hidden before it is removed, and why the
+            // visibility goes back on: the `hideBeforeRemove` docblock in `types.ts`.
+            // A child that is ALREADY hidden needs nothing — libadwaita ran its own
+            // cleanup when it was hidden, which is the very path this borrows.
+            const restoreVisible = policy.hideBeforeRemove === true && address.get_visible();
+            if (restoreVisible) address.set_visible(false);
+            host[policy.remove](address);
+            if (restoreVisible) address.set_visible(true);
+            return;
+        }
         case 'ordered':
         case 'indexed':
-        case 'keyed':
         case 'coords':
             host[policy.remove](address);
             return;

--- a/packages/framework/gtk-host/src/signals.ts
+++ b/packages/framework/gtk-host/src/signals.ts
@@ -93,8 +93,9 @@ export function isEventProp(prop: string): boolean {
  * A stack rather than a counter, because the echo guard needs two facts and not
  * one: WHETHER a host write is open (`inHostWrite`) and WHICH object it is
  * writing (`isHostWriteTarget`). A nested write on a different object is still
- * our write, so the stack is what makes the depth right; `null` is the entry for
- * a window that has no object yet, which is construction.
+ * our write, so the stack is what makes the depth right; `null` is the entry for a
+ * window with no object under it — construction, or a write whose non-notify
+ * consequences must still reach the consumer (`writeVisible` in `policies.ts`).
  *
  * Why both facts, measured on gjs 1.88.1 / GTK 4.22.4 — an emission during a
  * host write falls into one of two kinds, and only one of them is an echo:
@@ -181,10 +182,12 @@ export function setHandler(el: HostElement, prop: string, next: ((...args: unkno
         // module-wide leg keeps only `notify`, which reports nothing but a
         // property.
         //
-        // The window is exactly one constructor call or one property write (the
-        // four `beginHostWrite` sites in `host.ts`) — child insertion is outside
-        // it — so nothing a user could have caused is inside. What IS inside is
-        // everything GTK does as a knock-on, which is why the target matters.
+        // The window is exactly one constructor call, one property write (the four
+        // sites in `host.ts`), or the `visible` bracket `hideBeforeRemove` puts
+        // around a remove (`writeVisible` in `policies.ts`) — child insertion and
+        // the remove itself are outside it — so nothing a user could have caused is
+        // inside. What IS inside is everything GTK does as a knock-on, which is why
+        // the target matters.
         //
         // One hazard to keep in view if the table grows: a handler the HOST
         // installs on an object whose OWN signals fire from inside a write would

--- a/packages/framework/gtk-host/src/types.ts
+++ b/packages/framework/gtk-host/src/types.ts
@@ -181,26 +181,48 @@ export type ChildPolicy =
            * own `visible` back afterwards. Declared per widget, because it is a
            * defect in one of them rather than a property of being keyed.
            *
-           * MEASURED on libadwaita 1.9.3 / GJS 1.88.1: `adw_view_stack_remove`
-           * clears `visible_child` and then does `g_clear_object (&page->widget)`,
-           * but it never clears `last_visible_child` — three lines apart in the
-           * same function. A later reader of that pointer then dereferences a page
-           * whose widget is NULL:
+           * The defect is libadwaita's. `stack_remove` — what both
+           * `adw_view_stack_remove` and dispose call — clears `visible_child`, then
+           * does `g_clear_object (&page->widget)`, and never touches
+           * `last_visible_child`, which can still point at that same page. A later
+           * reader then dereferences a page whose widget is NULL:
            *
            *     Gtk-CRITICAL **: gtk_widget_set_child_visible: assertion 'GTK_IS_WIDGET (widget)' failed
            *
-           * Reproducer, no renderer involved: add `a` and `b`, present a window
-           * holding the stack, `set_visible_child_name('b')`, `remove(a)`, dispose.
-           * Either step alone is quiet, and an unrealised stack is quiet too — the
-           * pointer is only read on dispose, snapshot, size-allocate, or the
-           * `adw_animation_skip` an add performs mid-transition. `Gtk.Stack` does
-           * NOT reproduce, so this is libadwaita's copy of the pattern, not GTK's.
+           * Source: `refs/libadwaita/src/adw-view-stack.c` — `stack_remove` at 1184,
+           * the stale read at 934 in `transition_done_cb`. Read at 42f647f
+           * (1.10.alpha.1); that file is byte-identical at the 1.9.3 tag, which is
+           * what is installed here, so one reading covers both.
+           *
+           * MEASURED on libadwaita 1.9.3 / GTK 4.22.4 / GJS 1.88.1. Reproducer, no
+           * renderer involved: add `a` and `b`, present a window holding the stack,
+           * `set_visible_child_name('b')`, `remove(a)`, then let the window go away.
+           * Each precondition alone is silent, a stack never made visible included —
+           * `set_visible_child` only records `last_visible_child` when
+           * `gtk_widget_is_visible` answers yes. `Gtk.Stack` and
+           * `Adw.NavigationView`, the other two `keyed` descriptors, do not
+           * reproduce it at all, which is why this is a field and not the kind.
+           *
+           * WHICH read fires decides what a test has to do, so it is measured rather
+           * than listed: the UNMAP one. `AdwAnimation` connects `adw_animation_skip`
+           * to its widget's `unmap` (`adw-animation.c`) and the skip runs
+           * `transition_done_cb`, so merely hiding the window is enough and
+           * destroying it does the same — while a queued resize plus draw, and a
+           * direct `measure()`, both stayed quiet. The file's other reads (snapshot,
+           * size-allocate, measure) are real paths this reproducer does not reach.
            *
            * Hiding first is libadwaita's OWN cleanup: the visibility notify runs
-           * `update_child_visible`, which does clear `last_visible_child`. The
-           * restore afterwards is load-bearing, not cosmetic — `reorderMode`
-           * answers `remove-all` for `keyed`, so a reorder removes and re-appends
-           * every child, and one left hidden would never come back.
+           * `update_child_visible`, which does clear `last_visible_child`. Measured
+           * SUFFICIENT and not merely necessary — 400 randomised
+           * add/remove/switch/reorder steps against a live 200 ms transition, three
+           * seeds, 44/23/25 criticals unpatched against 0/0/0 patched.
+           *
+           * The restore is load-bearing. `reorderMode` answers `remove-all` for
+           * `keyed`, and measured, a reversal that hides without restoring leaves the
+           * stack with no visible child and no way back: the last line of
+           * `adw_view_stack_set_visible_child_name` is
+           * `if (gtk_widget_get_visible (page->widget)) set_visible_child (...)`, so
+           * for a hidden page it is a no-op with no warning at all.
            */
           hideBeforeRemove?: boolean;
       }

--- a/packages/framework/gtk-host/src/types.ts
+++ b/packages/framework/gtk-host/src/types.ts
@@ -170,7 +170,40 @@ export type ChildPolicy =
      * `adw_navigation_view_add(page)` takes one. `descriptorProblems()` checks
      * that a method EXISTS, never how many arguments it wants.
      */
-    | { kind: 'keyed'; add: string; remove: string; nameFrom: string; titled: boolean }
+    | {
+          kind: 'keyed';
+          add: string;
+          remove: string;
+          nameFrom: string;
+          titled: boolean;
+          /**
+           * Take the child out of view BEFORE the parent removes it, and put its
+           * own `visible` back afterwards. Declared per widget, because it is a
+           * defect in one of them rather than a property of being keyed.
+           *
+           * MEASURED on libadwaita 1.9.3 / GJS 1.88.1: `adw_view_stack_remove`
+           * clears `visible_child` and then does `g_clear_object (&page->widget)`,
+           * but it never clears `last_visible_child` — three lines apart in the
+           * same function. A later reader of that pointer then dereferences a page
+           * whose widget is NULL:
+           *
+           *     Gtk-CRITICAL **: gtk_widget_set_child_visible: assertion 'GTK_IS_WIDGET (widget)' failed
+           *
+           * Reproducer, no renderer involved: add `a` and `b`, present a window
+           * holding the stack, `set_visible_child_name('b')`, `remove(a)`, dispose.
+           * Either step alone is quiet, and an unrealised stack is quiet too — the
+           * pointer is only read on dispose, snapshot, size-allocate, or the
+           * `adw_animation_skip` an add performs mid-transition. `Gtk.Stack` does
+           * NOT reproduce, so this is libadwaita's copy of the pattern, not GTK's.
+           *
+           * Hiding first is libadwaita's OWN cleanup: the visibility notify runs
+           * `update_child_visible`, which does clear `last_visible_child`. The
+           * restore afterwards is load-bearing, not cosmetic — `reorderMode`
+           * answers `remove-all` for `keyed`, so a reorder removes and re-appends
+           * every child, and one left hidden would never come back.
+           */
+          hideBeforeRemove?: boolean;
+      }
     /** `Gtk.Grid`: position is data on the child, so document order carries nothing. */
     | { kind: 'coords'; attach: string; remove: string }
     /**


### PR DESCRIPTION
## The defect

An application driving `Adw.ViewStack` through a tab router logged **~300 `gtk_widget_set_child_visible: assertion 'GTK_IS_WIDGET (widget)' failed` in twelve seconds, at exit 0**.

The cause is in libadwaita, not in this host. `adw_view_stack_remove` clears `visible_child` and then does `g_clear_object (&page->widget)` — but it never clears `last_visible_child`, three lines apart in the same function:

```c
if (self->visible_child == page)
  self->visible_child = NULL;      /* cleared */
gtk_widget_unparent (child);
g_clear_object (&page->widget);    /* widget becomes NULL */
g_object_unref (page);
                                   /* last_visible_child: still pointing here */
```

Every later reader of that pointer then dereferences a page whose widget is NULL. **Which read fires was measured, not listed** (review): the UNMAP one. `AdwAnimation` connects `adw_animation_skip` to its widget's `unmap` (`adw-animation.c`), and the skip runs `transition_done_cb`, which is the read at line 934. So hiding the window is enough, and destroying it does the same — while a queued resize plus draw, and a direct `measure()`, both stay quiet. `adw_view_stack_dispose` does not read the pointer at all. The other reads in the file (snapshot, size-allocate, measure) are real paths this reproducer does not reach.

## Reproducer, no renderer involved

```js
const stack = new Adw.ViewStack();
const a = new Gtk.Label({ label: 'A' });
stack.add_named(a, 'a');
stack.add_named(new Gtk.Label({ label: 'B' }), 'b');
win.set_child(stack);
win.present();
stack.set_visible_child_name('b');   // a becomes last_visible_child
stack.remove(a);                     // and stays it
win.destroy();
→ Gtk-CRITICAL: gtk_widget_set_child_visible: assertion 'GTK_IS_WIDGET (widget)' failed
```

Each precondition was measured on its own, and each one alone is silent: an unrealised stack, the switch without the remove, the remove without the switch. **`Gtk.Stack` does not reproduce** — this is libadwaita's copy of the pattern, not GTK's. Still present on libadwaita `main` (42f647f).

## Why this host is what drives it

`reorderMode()` answers `remove-all` for `kind: 'keyed'`, and `AdwViewStack` is keyed. A reorder therefore removes and re-appends **every** page, running the sequence above once per page per round.

## The fix

Hiding the child first is libadwaita's **own** cleanup path: the visibility notify runs `update_child_visible`, which does clear `last_visible_child`. Visibility goes back on right after, because a page left hidden would never return from a keyed move.

Declared as `hideBeforeRemove` on the policy and set only on `AdwViewStack`. No gtype sniffing — a second candidate is a field, not a second branch.

## Measurements

| | React renders | `GTK_IS_WIDGET` criticals |
|---|---|---|
| patched, 3 runs | 5 / 5 / 5 | **0 / 0 / 0** |
| unpatched control, 2 runs | 5 / 2 | **296 / 131** |

Same tree, linux-x64, GJS 1.88.1, libadwaita 1.9.3. The render count is unchanged, which is the point: this fix removes the criticals and does not touch the render loop. The unpatched control varying (296 vs 131) is worth noting — a single measurement of 131 would look like a different cause.

A/B on the new host test: with `hideBeforeRemove` removed, exactly 1 of 2400 tests fails, with that assertion and no other. (Independently re-run in review: confirmed, and the two vectors added since both go red the same way.)

## Not fixed here

The application also shows a render loop. That is a separate defect and it survives this fix unchanged — see #1485 for the other half found in the same investigation.

## Upstream

Worth reporting to libadwaita; the reproducer above is the whole case. Not filed yet — flagging for a decision rather than filing unilaterally.

---

## Review addendum (independent review, second commit on this branch)

Verified here: the reproducer, `Gtk.Stack` not reproducing, each precondition silent on its own, the A/B on the new test, and that `refs/libadwaita/src/adw-view-stack.c` is byte-identical at 42f647f and at the 1.9.3 tag. Added: `Adw.NavigationView` does not reproduce either, and the fix is measured SUFFICIENT — 400 randomised add/remove/switch/reorder steps against a live 200 ms transition, three seeds, 44/23/25 criticals unpatched against 0/0/0 patched.

Found and fixed: **the hide/restore pair was visible to consumers.** Removing the visible page emitted two `notify::visible` on the child and one `notify::visible-child-name` on the stack, where a plain remove emits none — and `<Tabs>` reads that stack signal as a user click. The writes now go through the echo-guard window from `signals.ts`, with `null` as the target so the `unmap` a consumer already got still arrives exactly once (measured: 1 either way).

Also recorded, pre-existing and unrelated: a keyed reorder rebuilds every `Adw.ViewStackPage`, so `icon-name`, `badge-number`, `needs-attention` and `use-underline` are lost (measured in both arms of the A/B).
