### PR TITLE
fix(react-native): stop retrying a tab page the stack has not got

### DIFF
--- a/packages/framework/react-native/src/router/router.spec.ts
+++ b/packages/framework/react-native/src/router/router.spec.ts
@@ -892,6 +892,10 @@ export default async () => {
                 // gate can object, and `assertQuiet()` fails on its own with `Child name
                 // 'page-not-committed-yet' not found in AdwViewStack`. The boolean is the
                 // readable half; the gate catches the same defect reached by another route.
+                //
+                // The hidden-page leg at the end is a THIRD net for a THIRD condition, and
+                // it has only the boolean: measured, that no-op prints nothing, so there is
+                // no gate leg to have. Drop `!page.get_visible()` and it fails on its own.
                 const Stack = lookupWidget('AdwViewStack').ctor() as unknown as new () => Adw.ViewStack;
                 const stack = new Stack();
                 stack.add_named(new Gtk.Label({ label: 'here' }), 'page-here');
@@ -906,6 +910,18 @@ export default async () => {
 
                 // Already there: no call, still true.
                 expect(showFocusedPage(stack, 'page-later')).toBe(true);
+
+                // THE OTHER SILENT NO-OP, which a presence check alone does not cover. A
+                // page can be there and HIDDEN, and `adw_view_stack_set_visible_child_name`
+                // then changes nothing, emits no notify AND prints nothing — measured, so
+                // the suite's gate cannot see this one at all. Answering `true` would be the
+                // same non-terminating state this function exists to end, by the road where
+                // no log disagrees.
+                const unmapped = new Gtk.Label({ label: 'hidden' });
+                unmapped.set_visible(false);
+                stack.add_named(unmapped, 'page-hidden');
+                expect(showFocusedPage(stack, 'page-hidden')).toBe(false);
+                expect(stack.get_visible_child_name()).toBe('page-later');
             });
 
             await it('follows the USER when the switcher changes the visible child', async () => {

--- a/packages/framework/react-native/src/router/router.spec.ts
+++ b/packages/framework/react-native/src/router/router.spec.ts
@@ -38,7 +38,7 @@ import { RouterRoot } from './root.js';
 import type { RouteManifest } from './routes.js';
 import { Stack } from './stack.js';
 import { advanceTracking, applyStack, coalesce, initialTracking, releaseFrom, type Tracking } from './stack.js';
-import { Tabs } from './tabs.js';
+import { showFocusedPage, Tabs } from './tabs.js';
 
 /** Named identities, not a capability: a probe that answers "no" stands the suite DOWN, and a suite that ran zero tests reports success. */
 const GTK_HOSTS: Runtime[] = ['Gjs', 'Node.js', 'Bun', 'Deno'];
@@ -874,6 +874,38 @@ export default async () => {
                     expect(turns >= 0).toBe(true);
                     expect(stack.get_page(stack.get_visible_child() as Gtk.Widget).get_title()).toBe('Two');
                 });
+            });
+
+            await it('leaves the stack alone when the focused page is not there yet', async () => {
+                // THE CONDITION DIRECTLY, not through a render race. A focused route whose
+                // page React has not committed yet is an ordinary intermediate state, and
+                // the effect that follows React has no dependency array precisely so that a
+                // later commit gets another try. What must not happen is a call into Adw for
+                // a name it does not hold: measured, `set_visible_child_name` then changes
+                // nothing, emits no notify, and prints `Adwaita-WARNING: Child name '…' not
+                // found in AdwViewStack` — so the naive guard never terminates and warns once
+                // per render for a state that is not a fault.
+                //
+                // TWO INDEPENDENT NETS, each proven by breaking the fix on its own. Drop the
+                // presence check in `showFocusedPage` and the return value below fails first
+                // (false becomes true, exit 1). Loosen that assertion as well, so only the
+                // gate can object, and `assertQuiet()` fails on its own with `Child name
+                // 'page-not-committed-yet' not found in AdwViewStack`. The boolean is the
+                // readable half; the gate catches the same defect reached by another route.
+                const Stack = lookupWidget('AdwViewStack').ctor() as unknown as new () => Adw.ViewStack;
+                const stack = new Stack();
+                stack.add_named(new Gtk.Label({ label: 'here' }), 'page-here');
+
+                expect(showFocusedPage(stack, 'page-not-committed-yet')).toBe(false);
+                expect(stack.get_visible_child_name()).toBe('page-here');
+
+                // And the other direction, so the false above is not simply "it never sets".
+                stack.add_named(new Gtk.Label({ label: 'later' }), 'page-later');
+                expect(showFocusedPage(stack, 'page-later')).toBe(true);
+                expect(stack.get_visible_child_name()).toBe('page-later');
+
+                // Already there: no call, still true.
+                expect(showFocusedPage(stack, 'page-later')).toBe(true);
             });
 
             await it('follows the USER when the switcher changes the visible child', async () => {

--- a/packages/framework/react-native/src/router/tabs.ts
+++ b/packages/framework/react-native/src/router/tabs.ts
@@ -87,8 +87,8 @@ type TabDescriptor = Pick<
  *     if (stack.get_visible_child_name() !== focused) stack.set_visible_child_name(focused);
  *
  * reads as "set it unless it is already set", and it terminates only when the set TAKES.
- * Measured on Adw 1.x: `set_visible_child_name` with a name the stack does not hold changes
- * nothing, emits NO `notify::visible-child-name`, and prints
+ * MEASURED on libadwaita 1.9.3: `set_visible_child_name` with a name the stack does not hold
+ * changes nothing, emits NO `notify::visible-child-name`, and prints
  * `Adwaita-WARNING: Child name '…' not found in AdwViewStack`. So `get_visible_child_name()`
  * still answers the old page, the comparison is still unequal, and the effect — which has no
  * dependency array on purpose, because a page can materialise on a render where `focused` did
@@ -100,11 +100,22 @@ type TabDescriptor = Pick<
  * which is what "not there yet" deserves — and one warning per render for a normal state is
  * how a log stops being read.
  *
+ * AND THE SET HAS A SECOND WAY TO DO NOTHING, which is why presence alone is not the whole
+ * gate. `adw_view_stack_set_visible_child_name` ends on
+ * `if (gtk_widget_get_visible (page->widget)) set_visible_child (...)`, so a page that is
+ * there but HIDDEN changes nothing, emits no notify and — unlike the missing name — prints
+ * NOTHING AT ALL (measured). That is the same non-terminating state by the quieter road: the
+ * caller would be told the stack shows `focused` while it shows the other page, and no log
+ * anywhere would disagree. Both no-op paths are therefore asked about BEFORE the write, which
+ * is also what keeps each one attributable to its own failing assertion.
+ *
  * @returns whether the stack now shows `focused`.
  */
 export function showFocusedPage(stack: Adw.ViewStack, focused: string): boolean {
     if (stack.get_visible_child_name() === focused) return true;
-    if (stack.get_child_by_name(focused) === null) return false;
+    const page = stack.get_child_by_name(focused);
+    if (page === null) return false; // not committed yet — the branch that would warn
+    if (!page.get_visible()) return false; // there, but the set would silently skip it
     stack.set_visible_child_name(focused);
     return true;
 }
@@ -176,7 +187,11 @@ function TabsView(props: TabsViewProps): ReactElement {
         }
         const event = navigation.emit({ type: 'tabPress', target: route.key, canPreventDefault: true });
         if (event.defaultPrevented) {
-            stack.set_visible_child_name(current.routes[current.index]?.key ?? name);
+            // Through the same guard, not a raw set: putting the widget BACK is the same
+            // operation with the same two silent no-ops, and this is the one caller React
+            // does not re-run afterwards — a prevented press changes no state, so no render
+            // follows to try again.
+            showFocusedPage(stack, current.routes[current.index]?.key ?? name);
             return;
         }
         navigation.dispatch({ ...TabActions.jumpTo(route.name, route.params), target: current.key });

--- a/packages/framework/react-native/src/router/tabs.ts
+++ b/packages/framework/react-native/src/router/tabs.ts
@@ -78,6 +78,37 @@ type TabDescriptor = Pick<
     'route' | 'options' | 'render'
 >;
 
+/**
+ * Put the stack on the focused page, or leave it alone because that page is not there yet.
+ *
+ * THE PRESENCE CHECK IS THE TERMINATING CONDITION, and the reason it has to be explicit is
+ * that the obvious guard is a bet rather than a test. Writing
+ *
+ *     if (stack.get_visible_child_name() !== focused) stack.set_visible_child_name(focused);
+ *
+ * reads as "set it unless it is already set", and it terminates only when the set TAKES.
+ * Measured on Adw 1.x: `set_visible_child_name` with a name the stack does not hold changes
+ * nothing, emits NO `notify::visible-child-name`, and prints
+ * `Adwaita-WARNING: Child name '…' not found in AdwViewStack`. So `get_visible_child_name()`
+ * still answers the old page, the comparison is still unequal, and the effect — which has no
+ * dependency array on purpose, because a page can materialise on a render where `focused` did
+ * not change — repeats the failing call on every render for as long as the mismatch lasts.
+ *
+ * A focused route whose page React has not committed yet is an ORDINARY intermediate state,
+ * not a fault: the effect runs after the commit that added the OTHER pages, and the missing
+ * one arrives on a later commit. So the answer is to do nothing and let the next render try,
+ * which is what "not there yet" deserves — and one warning per render for a normal state is
+ * how a log stops being read.
+ *
+ * @returns whether the stack now shows `focused`.
+ */
+export function showFocusedPage(stack: Adw.ViewStack, focused: string): boolean {
+    if (stack.get_visible_child_name() === focused) return true;
+    if (stack.get_child_by_name(focused) === null) return false;
+    stack.set_visible_child_name(focused);
+    return true;
+}
+
 function TabsView(props: TabsViewProps): ReactElement {
     const { state, descriptors, navigation, NavigationContent } = useNavigationBuilder<
         TabState,
@@ -111,7 +142,7 @@ function TabsView(props: TabsViewProps): ReactElement {
     useLayoutEffect(() => {
         const stack = stackRef.current;
         if (stack === null || focused === undefined) return;
-        if (stack.get_visible_child_name() !== focused) stack.set_visible_child_name(focused);
+        showFocusedPage(stack, focused);
     });
 
     /**


### PR DESCRIPTION
## The defect

`<Tabs>` drove the visible child with a guard that reads as "set it unless it is already set":

```ts
if (stack.get_visible_child_name() !== focused) stack.set_visible_child_name(focused);
```

It terminates only when the set **takes**. MEASURED on libadwaita 1.9.3:

```
set_visible_child_name('page-missing')
  → visible child unchanged, changed=false, notifies=0
  → Adwaita-WARNING: Child name 'page-missing' not found in AdwViewStack
guard would retry: true
```

No `notify::visible-child-name`, so nothing re-renders from it; the comparison stays unequal, and the effect repeats the failing call on every render for as long as the mismatch lasts.

## Why the state is normal

A focused route whose page React has not committed yet is an ordinary intermediate state, not a fault. The effect deliberately has **no dependency array** so that a later commit gets another try — a page can materialise on a render where `focused` did not change. So the right answer is to do nothing and let the next render try. One warning per render for a normal state is how a log stops being read.

## The change

The condition is now `showFocusedPage()`, a named exported function, so the test can reach it directly: one stack, one page, a name that is not there. No timing, no render race, no application.

## A/B — two independent nets, each proven on its own

1. Remove the presence check → the return value assertion fails first (`false` becomes `true`), exit 1.
2. Remove the presence check **and** loosen that assertion, so only the gate can object → `assertQuiet()` fails by itself with `Child name 'page-not-committed-yet' not found in AdwViewStack`, exit 1.

Both legs green with the fix in place: 1220 tests, exit 0.

## Scope

This does **not** explain the `gtk_widget_set_child_visible: assertion 'GTK_IS_WIDGET (widget)' failed` criticals reported from the same application. Those are a separate defect in how `Adw.ViewStack` handles a removed page, fixed in #1484. Two defects, not one — the probe that found this one produced a different diagnostic on a different path, which is what said so.

---

## Review addendum (independent review, second commit on this branch)

Verified here: the missing-name measurement exactly as quoted (`changed=false`, `notifies=0`, `Adwaita-WARNING: Child name 'page-missing' not found in AdwViewStack`), and both A/B legs — each breaks one net, each fails one test.

Found and fixed: **the set has a SECOND way to do nothing, and the presence check does not cover it.** `adw_view_stack_set_visible_child_name` ends on `if (gtk_widget_get_visible (page->widget)) set_visible_child (...)`, so a page that is present but HIDDEN changes nothing, emits no notify and — unlike the missing name — prints nothing at all (measured). `showFocusedPage` answered `true` there while the stack still showed the other page: the same non-terminating state, by the road where no log disagrees, on the one function whose `@returns` promises to know. Both no-op paths are now asked about before the write, each with its own failing assertion (three nets, all three A/B'd).

The prevented-press path in `onVisibleChildChanged` had the identical raw `set_visible_child_name` and now goes through the same guard. It is the one caller React does not re-run afterwards, since a prevented press changes no state.
