### PR TITLE
docs(status): one field, two questions in gjsify.app

### DIFF
--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -1035,6 +1035,42 @@ misled. These are the upstream source of that claim, and a stale comment is how 
 grows back. Left for a commit of its own because both files path-filter CI job
 selection, and editing them from a docs branch is churn where it is riskiest.
 
+### `gjsify.app` answers two questions on one field, so a per-OS runtime split is not expressible
+
+**Measured on a real project rather than derived from the schema.** A GTK4 application
+whose Linux target runs on GJS and whose macOS/Windows targets run on Node — the exact
+split ADR 0024 § 4 argues for, since there is no relocatable GJS for either — cannot say
+so. `gjsify ship darwin --stage` and `ship windows --stage` both assemble a layout and
+then report `formats (none — macos-app and macos-app-zip need gjsify.app: "node")`. Set
+that field and the two OSes produce their formats, and the LINUX deb changes with them:
+`Depends: gjs (>= 1.86)` becomes `Depends: nodejs (>= 24)`.
+
+**The field carries two questions.** Which runtime the application needs, and which
+package formats a target can build. They are the same answer for a single-OS project and
+different answers for a cross-OS one, and today only the first can be stated. The deb
+generator reads the PROJECT field rather than the resolved runtime of ITS target, which
+is why the Linux arm changes when a macOS decision is made.
+
+**The shape a fix would take**, recorded because the smaller-looking alternative is the
+wrong one: make `gjsify.app` the DEFAULT and let each ship target override it, then have
+every generator read the resolved runtime of its own target and never the project field.
+The tempting alternative — simply offering `macos-app`/`windows-dir` under
+`app: "gjs"` — makes the output richer and leaves the question unanswered: it would stage
+a bundle whose runtime assumption nobody stated, and the next finding is an artifact that
+finds no GJS on the target machine. Better to make the field resolvable than to decouple
+its effect.
+
+**The test that pins it is cheaper than the discussion**, and it guards the class rather
+than the fix: a project with `app: "gjs"` and a windows target on `node`, asserting that
+the deb carries NO `Depends: nodejs` and that `windows-dir` appears anyway. Red today,
+and red again the next time some generator reads a project-wide field where a per-target
+one was meant.
+
+**What already works, so the gap is exactly this and not more:** all three layouts stage
+from one Linux host, the runtime packages exist (`@gjsify/node-runtime-{darwin-x64,
+win32-x64}` and the matching `gtk-runtime-*`, 119/89/73/77 MiB unpacked at 0.45.0), and
+every missing piece is named by the command itself rather than guessed.
+
 ### `gjsify ship --sign`: three things M6 did not prove, each with what WAS measured
 
 The signing interface landed whole (ADR 0024 § A12-§ A17) and its darwin half is


### PR DESCRIPTION
Files a measured gap rather than fixing it, because the fix touches ADR 0024 and that decision is the project owner's.

## What was measured

A GTK4 application whose **Linux** target runs on GJS and whose **macOS/Windows** targets run on Node — the split ADR 0024 § 4 argues for, there being no relocatable GJS for either — cannot say so.

| | |
|---|---|
| `ship darwin --stage`, `ship windows --stage` | both assemble a layout, then report `formats (none — macos-app and macos-app-zip need gjsify.app: "node")` |
| with `gjsify.app: "node"` | both produce their formats — **and the Linux deb changes with them**, `Depends: gjs (>= 1.86)` → `Depends: nodejs (>= 24)` |

## The field carries two questions

*Which runtime the application needs*, and *which package formats a target can build*. Same answer for a single-OS project, different answers for a cross-OS one — and only the first can be stated today. The deb generator reads the **project** field rather than the resolved runtime of **its own** target, which is why a macOS decision moves the Linux dependency.

## The shape a fix would take, and the alternative it rejects

Make `gjsify.app` the default and let each ship target override it; every generator then reads the resolved runtime of its own target and never the project field.

The tempting smaller change — simply offering `macos-app`/`windows-dir` under `app: "gjs"` — makes the output richer and leaves the question unanswered. It would stage a bundle whose runtime assumption nobody stated, and the next finding is an artifact that finds no GJS on the target machine. Better to make the field resolvable than to decouple its effect.

The test that pins it guards the class rather than the fix: a project with `app: "gjs"` and a windows target on `node`, asserting the deb carries **no** `Depends: nodejs` and that `windows-dir` appears anyway. Red today, and red again the next time a generator reads a project-wide field where a per-target one was meant.

## What already works

Recorded so the gap is exactly this and not more: all three layouts stage from one Linux host, the runtime packages exist at 0.45.0 (`node-runtime-darwin-x64` 119 MiB, `node-runtime-win32-x64` 89, `gtk-runtime-darwin-x64` 73, `gtk-runtime-win32-x64` 77, unpacked), and every missing piece is named by the command itself rather than guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nfw9Fn8QNoJmH6DYZ1Gwy2