### PR TITLE
feat: resolve the ship runtime per target

### DIFF
--- a/docs/adr/0024-ship-installable-artifacts.md
+++ b/docs/adr/0024-ship-installable-artifacts.md
@@ -143,6 +143,13 @@ preference.
 | `--app browser` | — | no OS-package question |
 | `--app nativescript` | — | APK/IPA is a different pipeline; out of scope |
 
+**Amended 2026-09-02 (§ A22).** This table has a row per OS and the implementation had ONE field to
+read it with — `gjsify.app` — so the split it argues for was not expressible: a project could not be
+GJS on Linux and Node on macOS. It is `gjsify.ship.app.<os>` over `gjsify.app` now, resolved once
+per target. The heading's *"not chosen per app"* keeps its meaning and narrows its scope: nothing
+here is DERIVED from the layout, an author states it per OS, and this table is what they are
+choosing between.
+
 **GJS on macOS is a real option and deliberately not the first one.** It works: the macOS CI
 leg runs `test:gjs` on both architectures, which the Windows leg cannot. What is missing is a
 *relocatable* GJS — `packages/node-gi/scripts/build-gtk-runtime-darwin.mjs` says so in its own
@@ -1315,3 +1322,77 @@ blob DIFFERS; without it a correct run could report every image `identical` and 
 additionally blocked by something measurable on our side — the payload round trip is bytes plus mode
 and carries no extended attributes, which is where a script main-executable's signature would have
 to live.
+
+## Amendment, 2026-09-02 — one field answered two questions, so § 4's own table was unstatable
+
+§ 4 has a row per operating system and argues the split hard: Linux takes GJS from the
+distribution, macOS and Windows take Node because there is no relocatable GJS for either. The
+implementation had ONE field to read that table with, `gjsify.app`, and a project therefore could
+not say what § 4 derives.
+
+### A22. `gjsify.app` is the DEFAULT; each ship target resolves its own runtime
+
+**Measured on a GTK4 application rather than derived from the schema.** `gjsify ship darwin
+--stage` and `ship windows --stage` both assembled a layout and then reported
+`formats (none — macos-app and macos-app-zip need gjsify.app: "node")`. Setting that field produced
+the two formats — **and moved the Linux dependency with them**, `Depends: gjs (>= 1.86)` becoming
+`Depends: nodejs (>= 24)`, which apt refuses on trixie, Ubuntu 24.04 and Ubuntu 26.04. A macOS
+decision made the Linux package uninstallable, because the deb generator read the PROJECT field
+rather than the resolved runtime of ITS OWN target.
+
+The field carried two questions: *which runtime the application needs*, and *which package formats
+a target can build*. Same answer for a single-OS project, different answers for the cross-OS one
+§ 4 describes — and only the first could be stated.
+
+**The decision.** `gjsify.app` becomes the DEFAULT and every ship target may override it:
+`gjsify.ship.app.{linux,darwin,win32}`, keyed in the `process.platform` spelling because the value
+that resolves is chosen by the LAYOUT being assembled and never by the host doing the assembling —
+the same rule § A12 gives for `gjsify.ship.sign`. One resolver (`resolveShipApp`,
+`utils/ship/settings.ts`) turns the pair into a runtime — `commands/ship.ts`'s free
+`assertShippableTarget` folds into it, so the `browser`/`nativescript` refusal names the KEY that
+carried the value rather than saying *"this project declares"*, which with two keys no longer
+locates it — and every generator reads that result:
+the launcher, `deriveDepends`, the carried `@gjsify/node-runtime-*`/`gtk-runtime-*` closure, the
+format-availability filter, and `resolveShipSettings`, whose input is the already-resolved value
+and typed `'gjs' | 'node'` so that handing it the project field does not compile. `--from-stage` is
+untouched and needs to be: the stage manifest has always recorded the RESOLVED value, so the
+packing host reads an answer rather than a default.
+
+**There is deliberately no per-layout DEFAULT**, and this is the trap the layout axis already fell
+into once. An absent override means `gjsify.app` and never `Layout.shippedRuntime`: defaulting
+darwin to Node is exactly the measured defect that paragraph records — a project with no
+`gjsify.app` key staged `exec node …/gjs.js` in front of a bundle opening with
+`import Gtk from 'gi://Gtk?version=4.0'`, at exit 0. § 4 derives what an artifact CARRIES; what it
+RUNS is what its author says.
+
+**The alternative that looks smaller is the wrong one**, recorded because it will be proposed
+again: simply offering `macos-app`/`windows-dir` under `app: "gjs"`. It makes the output richer and
+leaves the question unanswered — it would stage a bundle whose runtime assumption nobody stated,
+and the next finding is an artifact that finds no GJS on the target machine. Better to make the
+field resolvable than to decouple its effect.
+
+**A mis-keyed override is the silent failure, so it is a rule and not a convention.**
+`manifest-conformance`'s `ship` rule refuses a key outside `{linux,darwin,win32}` and a value
+outside `{gjs,node}` — `gjsify.ship.app.windows`, the `gjsify ship <os>` POSITIONAL's spelling,
+resolves to nothing, so that target quietly keeps the project-wide answer and the author reads it
+as gjsify not supporting the split, with every gate green. That is § A12's *"an identity under a key
+nothing reads ships UNSIGNED with nothing to say so"*, one table over. The override is also PRINTED
+at stage time: one that silently changes the launcher, the dependency and the format list is one
+nobody can tell from the default.
+
+**The test guards the CLASS — a generator reading a project-wide field where a per-target one was
+meant — and needs two directions to do it.** `tests/e2e/ship` asserts (a) a project with
+`app: "gjs"` and `ship.app.win32: "node"` whose Linux `.deb`/`.rpm` carries NO Node dependency while
+`windows-dir` is offered anyway, and (b) the mirror: `app: "node"` with `ship.app.linux: "gjs"`,
+whose Linux package must depend on `gjs`. (a) alone is not discriminating — there the project field
+and the Linux answer agree, so a generator that regressed to reading the project field would still
+emit `Depends: gjs` and the assertion would distinguish nothing. Both were red before the fix, (a)
+on `windows-dir must be offered, got: (none)` and (b) on a staged launcher reading `exec node
+"$prefix"/lib/ship-demo/gjs.js`.
+
+**What this does NOT do, stated so the amendment is not read as more than it is.** The runtime is
+per target; the BUNDLE is still one path (`gjsify.ship.bundle`, falling back to `gjsify.main`). A
+project that is GJS on Linux and Node on Windows builds two bundles — `dist/<name>.gjs.js` beside
+`dist/<name>.node.mjs` is the layout this tree documents as normal, and `discoverPayload` stages
+both — but every layout's launcher names the same one of them. That is the next axis, and it is a
+separate question with a separate config surface; `status/open-todos.md` carries it.

--- a/docs/adr/0024-ship-installable-artifacts.md
+++ b/docs/adr/0024-ship-installable-artifacts.md
@@ -1371,14 +1371,17 @@ leaves the question unanswered — it would stage a bundle whose runtime assumpt
 and the next finding is an artifact that finds no GJS on the target machine. Better to make the
 field resolvable than to decouple its effect.
 
-**A mis-keyed override is the silent failure, so it is a rule and not a convention.**
-`manifest-conformance`'s `ship` rule refuses a key outside `{linux,darwin,win32}` and a value
-outside `{gjs,node}` — `gjsify.ship.app.windows`, the `gjsify ship <os>` POSITIONAL's spelling,
+**A mis-keyed override is the silent failure, so it is a rule and not a convention — and it is
+refused on BOTH surfaces.** `gjsify.ship.app.windows`, the `gjsify ship <os>` POSITIONAL's spelling,
 resolves to nothing, so that target quietly keeps the project-wide answer and the author reads it
 as gjsify not supporting the split, with every gate green. That is § A12's *"an identity under a key
-nothing reads ships UNSIGNED with nothing to say so"*, one table over. The override is also PRINTED
-at stage time: one that silently changes the launcher, the dependency and the format list is one
-nobody can tell from the default.
+nothing reads ships UNSIGNED with nothing to say so"*, one table over. `resolveShipApp` therefore
+refuses an unknown KEY on every `gjsify ship` run — the WHOLE table, not this run's key, because
+`gjsify ship linux` is the run most likely to be sitting in front of the typo and a check that fires
+only on the mis-keyed OS never fires at all — and the value that resolves must be `gjs` or `node`.
+`manifest-conformance`'s `ship` rule refuses the same two shapes over the whole table, for the tree
+nobody has shipped from yet. The override is also PRINTED at stage time: one that silently changes
+the launcher, the dependency and the format list is one nobody can tell from the default.
 
 **The test guards the CLASS — a generator reading a project-wide field where a per-target one was
 meant — and needs two directions to do it.** `tests/e2e/ship` asserts (a) a project with
@@ -1388,7 +1391,13 @@ whose Linux package must depend on `gjs`. (a) alone is not discriminating — th
 and the Linux answer agree, so a generator that regressed to reading the project field would still
 emit `Depends: gjs` and the assertion would distinguish nothing. Both were red before the fix, (a)
 on `windows-dir must be offered, got: (none)` and (b) on a staged launcher reading `exec node
-"$prefix"/lib/ship-demo/gjs.js`.
+"$prefix"/lib/ship-demo/gjs.js`. Re-measured on review, one regression at a time rather than only
+against the whole revert: a format filter reading the project field reddens (a) alone, and a
+settings hand-off reading it reddens both — so neither direction is carried by the other.
+
+The conformance half is held by `tests/e2e/ship-declaration`, which drives the rule over synthetic
+roots for the mis-keyed OS, the unshippable runtime and the scalar written where the table goes. A
+rule with no red case looks exactly like a rule that passes.
 
 **What this does NOT do, stated so the amendment is not read as more than it is.** The runtime is
 per target; the BUNDLE is still one path (`gjsify.ship.bundle`, falling back to `gjsify.main`). A

--- a/docs/release-notes/next.md
+++ b/docs/release-notes/next.md
@@ -244,6 +244,32 @@ itself.
 See [#1354](https://github.com/gjsify/gjsify/issues/1354) and
 `docs/adr/0024-ship-installable-artifacts.md`.
 
+### One project, GJS on Linux and Node on macOS and Windows
+
+Everything above needs a Node runtime, and until now saying so said it about the whole project.
+`gjsify ship darwin --stage` reported `formats (none — macos-app and macos-app-zip need
+gjsify.app: "node")`, and setting that field produced the bundle **and moved the Linux dependency
+with it**: `Depends: gjs (>= 1.86)` became `Depends: nodejs (>= 24)`, which apt refuses on Debian
+trixie, Ubuntu 24.04 and Ubuntu 26.04. Asking for a `.app` made the `.deb` uninstallable.
+
+One field was answering two questions — which runtime the application needs, and which formats a
+target can build. It is per target now:
+
+```jsonc
+{
+  "gjsify": {
+    "app": "gjs",
+    "ship": { "app": { "darwin": "node", "win32": "node" } }
+  }
+}
+```
+
+`gjsify.app` stays the default and each target may override it, keyed `linux` / `darwin` / `win32`.
+Every generator reads the runtime of its own target — the launcher, the emitted `Depends:`, the
+carried interpreter and GTK closure, the format list — so the Linux package of that project still
+depends on `gjs` and still execs `gjs -m`. An override is printed at stage time, and a key outside
+those three is refused by name rather than silently leaving the target on the project default.
+
 ---
 
 ### Lists no framework owns

--- a/docs/ship-formats.md
+++ b/docs/ship-formats.md
@@ -362,8 +362,9 @@ Ubuntu 26.04. Every generator now reads the runtime of ITS OWN target — the la
 already-resolved value, typed `'gjs' | 'node'`, so handing it the project field does not compile.
 There is deliberately no per-LAYOUT default: an absent override means `gjsify.app` and never
 `Layout.shippedRuntime`, which is the mirror-image defect two paragraphs down. A key outside
-`{linux,darwin,win32}` is refused by `manifest-conformance`'s `ship` rule for `gjsify.ship.sign`'s
-reason — `gjsify.ship.app.windows` resolves to nothing and leaves the target silently on the
+`{linux,darwin,win32}` is refused by NAME, by `resolveShipApp` on every `gjsify ship` run and by
+`manifest-conformance`'s `ship` rule in a tree nobody has shipped from yet — `gjsify.ship.sign`'s
+reason: `gjsify.ship.app.windows` resolves to nothing and would leave that target silently on the
 project-wide answer.
 
 `utils/ship/payload.ts`'s `readLauncherInterpreters` strips a surrounding shell quote before taking
@@ -409,14 +410,14 @@ of guessing is not silence but naming whichever token landed in the program posi
 interpreter and there is no relocatable GJS to put in one. The two windows rows say the same thing
 for a harder reason (#1354 M3): there is no GJS host on Windows AT ALL — not a system one to depend
 on and not a relocatable one to carry — so a `--app gjs` payload has nothing anywhere that could run
-it. So the two questions are asked in two
-places and give two different answers for one project: the launcher execs what the payload was built
-for, and the FORMAT says what its runtime can provide. A project whose darwin target resolves to `gjs` therefore stages the
-darwin layout and cannot pack it — and the distinction between those is load-bearing rather than
-pedantic. Since #1486 that is a statement the author can change for darwin ALONE
-(`gjsify.ship.app.darwin`), which is what the refusal now names. A DERIVED default set is filtered by the interpreter, with the dropped formats and the
-reason printed; a typed `--target macos-app` is refused by name. The first cut refused both, which
-made `gjsify ship darwin --stage` exit 1 for every project this command has.
+it. So the two questions are asked in two places and give two different answers for one project: the
+launcher execs what the payload was built for, and the FORMAT says what its runtime can provide. A
+project whose darwin target resolves to `gjs` therefore stages the darwin layout and cannot pack it
+— and the distinction between those is load-bearing rather than pedantic. Since #1486 that is a
+statement the author can change for darwin ALONE (`gjsify.ship.app.darwin`), which is what the
+refusal now names. A DERIVED default set is filtered by the interpreter, with the dropped formats
+and the reason printed; a typed `--target macos-app` is refused by name. The first cut refused both,
+which made `gjsify ship darwin --stage` exit 1 for every project this command has.
 
 That is the SECOND time this pair of questions has been collapsed into one, and the first is worth
 keeping beside it because the two failures are mirror images. The first cut of the LAYOUT axis read

--- a/docs/ship-formats.md
+++ b/docs/ship-formats.md
@@ -343,13 +343,28 @@ out — a hardened-runtime, Developer-ID-signed main executable IS restricted, s
 on `DYLD_*` works unsigned and breaks the day the bundle is signed. ADR 0024 § 3 puts that half
 in-process instead.
 
-All three exec whatever `gjsify.app` names — `gjs -m`, or `node` for a `--app node` project.
-ADR 0024 § 4 derives Node for macOS and Windows, and that answer lives on
-`Layout.shippedRuntime` as DATA: it describes the runtime a SHIPPED ARTIFACT carries, which
+All three exec THIS TARGET's runtime — `gjs -m`, or `node`. That runtime is resolved once, by
+`resolveShipApp` (`utils/ship/settings.ts`), out of `gjsify.ship.app.<os>` falling back to
+`gjsify.app`, and it is the same function that guarantees the answer is `gjs` or `node` rather than
+`browser` or `nativescript`. ADR 0024 § 4 derives Node for macOS and Windows, and that answer lives
+on `Layout.shippedRuntime` as DATA: it describes the runtime a SHIPPED ARTIFACT carries, which
 #1354 M0 implements by bundling one and **#1354 M2b stages** — the macOS launcher execs
 `"$here/node"` when the stage carries one, and the bare name when it does not. The only interpreter
-that can read the payload is still the one it was BUILT for, and `assertShippableTarget`
-(layout-independent) guarantees that is `gjs` or `node`.
+that can read the payload is still the one it was BUILT for.
+
+**PER TARGET, and the project field is only its default** (#1486, ADR 0024 § A22). One field
+answered two questions — which runtime the app needs, and which formats a target can build — so
+§ 4's own table was unstatable: `gjsify ship darwin --stage` reported `formats (none — macos-app and
+macos-app-zip need gjsify.app: "node")`, and setting that field flipped the LINUX `.deb` from
+`Depends: gjs (>= 1.86)` to `Depends: nodejs (>= 24)`, which apt refuses on trixie, Ubuntu 24.04 and
+Ubuntu 26.04. Every generator now reads the runtime of ITS OWN target — the launcher,
+`deriveDepends`, `resolveCarriedRuntime`, the format filter — and `resolveShipSettings` takes the
+already-resolved value, typed `'gjs' | 'node'`, so handing it the project field does not compile.
+There is deliberately no per-LAYOUT default: an absent override means `gjsify.app` and never
+`Layout.shippedRuntime`, which is the mirror-image defect two paragraphs down. A key outside
+`{linux,darwin,win32}` is refused by `manifest-conformance`'s `ship` rule for `gjsify.ship.sign`'s
+reason — `gjsify.ship.app.windows` resolves to nothing and leaves the target silently on the
+project-wide answer.
 
 `utils/ship/payload.ts`'s `readLauncherInterpreters` strips a surrounding shell quote before taking
 the basename, and that is not tidiness: without it `"$here/node"` read back as `node"`, which is
@@ -396,9 +411,10 @@ for a harder reason (#1354 M3): there is no GJS host on Windows AT ALL — not a
 on and not a relocatable one to carry — so a `--app gjs` payload has nothing anywhere that could run
 it. So the two questions are asked in two
 places and give two different answers for one project: the launcher execs what the payload was built
-for, and the FORMAT says what its runtime can provide. A `--app gjs` project therefore stages the
+for, and the FORMAT says what its runtime can provide. A project whose darwin target resolves to `gjs` therefore stages the
 darwin layout and cannot pack it — and the distinction between those is load-bearing rather than
-pedantic. A DERIVED default set is filtered by the interpreter, with the dropped formats and the
+pedantic. Since #1486 that is a statement the author can change for darwin ALONE
+(`gjsify.ship.app.darwin`), which is what the refusal now names. A DERIVED default set is filtered by the interpreter, with the dropped formats and the
 reason printed; a typed `--target macos-app` is refused by name. The first cut refused both, which
 made `gjsify ship darwin --stage` exit 1 for every project this command has.
 

--- a/packages/infra/cli/src/commands/ship.ts
+++ b/packages/infra/cli/src/commands/ship.ts
@@ -90,7 +90,12 @@ import {
 } from '../utils/ship/signing.js';
 import { renderLauncher } from '../utils/ship/launcher.js';
 import { buildRpm } from '../utils/ship/rpm.js';
-import { declaredBundlePath, resolveShipSettings, type ShipPackageManifest } from '../utils/ship/settings.js';
+import {
+    declaredBundlePath,
+    resolveShipApp,
+    resolveShipSettings,
+    type ShipPackageManifest,
+} from '../utils/ship/settings.js';
 import {
     assertExpectedTarget,
     assertFormatsStaged,
@@ -264,13 +269,27 @@ async function assemble(args: ShipOptions): Promise<void> {
     const configData = await config.forCommand(projectDir);
     const ship = configData.ship ?? {};
     const flatpak = configData.flatpak ?? {};
-    assertShippableTarget(configData.app);
-    // Resolved HERE and not from `settings`, because the format list is decided
-    // before anything is built and `resolveShipSettings` runs after. The
-    // defaulting rule is the one `resolveShipSettings` states and must stay the
-    // same one: an undeclared target means `gjs`, never the host runtime this
-    // command happens to run under.
-    const interpreter: 'gjs' | 'node' = configData.app === 'node' ? 'node' : 'gjs';
+    // THE ONE RESOLUTION, and it runs HERE because the format list is decided
+    // before anything is built while `resolveShipSettings` runs after. Its result
+    // is threaded into the settings rather than re-derived there: two defaulting
+    // rules for one question is how the format list and the emitted `Depends:`
+    // came to answer for different targets.
+    //
+    // PER LAYOUT, which is the whole of #1486's fix. `gjsify.app` is the project
+    // DEFAULT and `gjsify.ship.app.<os>` overrides it for this run's target, so a
+    // GTK4 app can be GJS on Linux and Node on macOS and Windows — the split ADR
+    // 0024 § 4 argues for — without the macOS answer moving the Linux `Depends:`.
+    const resolvedApp = resolveShipApp({ project: configData.app, perTarget: ship.app, layoutOs: layout.os });
+    const interpreter = resolvedApp.app;
+    // SAID, not swallowed, like every other narrowing in this function. An
+    // override that changed the launcher, the dependency and the format list
+    // without a line of output is one nobody can tell from the project default.
+    if (resolvedApp.overridden) {
+        console.log(
+            `${LOG} runtime for ${layout.name}: ${interpreter} — \`${resolvedApp.key}\` overrides ` +
+                `\`gjsify.app${configData.app === undefined ? '' : `: "${configData.app}"`}\`.`,
+        );
+    }
     const pkg = (readPackageJson(join(projectDir, 'package.json')) ?? {}) as ShipPackageManifest;
 
     // Resolved before anything is built or written: a typo'd `--target`
@@ -322,8 +341,11 @@ async function assemble(args: ShipOptions): Promise<void> {
         if (unusable.length > 0) {
             console.log(
                 `${LOG} ${unusable.map((format) => format.id).join(', ')} wrap the ${layout.name} layout but ` +
-                    `cannot run \`gjsify.app: "${interpreter}"\` — ${unusable[0]?.interpreterGap ?? ''}. ` +
-                    'Assembling the layout only; pass --target to be told the same thing as an error.',
+                    `cannot run \`${interpreter}\`, which \`${resolvedApp.key}\` resolves to — ` +
+                    `${unusable[0]?.interpreterGap ?? ''}. Set \`gjsify.ship.app.${layout.os}\` to ` +
+                    `"${unusable[0]?.interpreters.join('" / "')}" to ship this OS on that runtime; it leaves every ` +
+                    'other target on `gjsify.app`. Assembling the layout only; pass --target to be told the same ' +
+                    'thing as an error.',
             );
         }
     }
@@ -368,7 +390,11 @@ async function assemble(args: ShipOptions): Promise<void> {
         flatpak,
         cli: { outDir: args.out, arch: args.arch, layoutOs: layout.os },
         discovered,
-        app: configData.app,
+        // The RESOLVED runtime, never `configData.app`. Everything downstream —
+        // the launcher, `deriveDepends`, the carried runtime, the stage manifest —
+        // reads `settings.app`, so this is the one hand-off that decides whether
+        // those generators speak about this target or about the project.
+        app: interpreter,
     });
     for (const warning of warnings) console.warn(`${LOG} ${warning}`);
     // BEFORE anything is staged, and NOT under `assertCanPack` (which `--stage`
@@ -621,7 +647,11 @@ async function assemble(args: ShipOptions): Promise<void> {
         // above has already SAID in its own words rather than repeating here.
         const none =
             unusable.length > 0
-                ? `(none — ${unusable.map((format) => format.id).join(' and ')} need \`gjsify.app: "node"\`)`
+                ? // The key that fixes it, which used to be `gjsify.app` and is now
+                  // this target's own: naming the project field here is how a macOS
+                  // stage came to move the Linux `Depends:` (#1486).
+                  `(none — ${unusable.map((format) => format.id).join(' and ')} need ` +
+                  `\`gjsify.ship.app.${layout.os}: "node"\`)`
                 : formatIdsFor(layout.os).length === 0
                   ? `(none — no format wraps the ${layout.name} layout)`
                   : '(none asked for)';
@@ -1252,8 +1282,10 @@ function assertPackable(
         throw new Error(
             `gjsify ship: ${unusable.map((format) => format.id).join(' and ')} wrap the ${layout.name} ` +
                 `layout, and neither can run this project — ${unusable[0]?.interpreterGap ?? ''}.\n` +
-                `    \`gjsify ship ${layout.name} --stage\` assembles the tree anyway; packing it is what ` +
-                'the milestone that stages an interpreter is for (#1354 M2b).',
+                `    Set \`gjsify.ship.app.${layout.os}\` to ` +
+                `"${unusable[0]?.interpreters.join('" / "')}" — it overrides \`gjsify.app\` for THIS target and\n` +
+                '    leaves every other one alone, which is what lets one project be GJS on Linux and Node here.\n' +
+                `    \`gjsify ship ${layout.name} --stage\` assembles the tree either way.`,
         );
     }
     // A THIRD emptiness, and the one the last throw in this function used to
@@ -1320,67 +1352,12 @@ function assertPackable(
 }
 
 /**
- * Refuse a build target this command cannot package correctly.
- *
- * `gjs` and `node` are packageable: `renderLauncher` execs the one
- * `settings.app` names and `deriveDepends` declares the same one — `gjs >= …`,
- * or `nodejs (>= 24)` / `nodejs(engine) >= 24`. Until #1354's M0 this said "only
- * `gjs` can be packaged today", which was true: the launcher execed gjs
- * unconditionally, so a `--app node` package would have installed and died at
- * startup.
- *
- * `browser` and `nativescript` stay refused, and not for want of a launcher
- * line: a browser bundle has no process to start, and NativeScript ships as an
- * APK/IPA through a different pipeline entirely (ADR 0024 § 4).
- *
- * DELIBERATELY NOT PER LAYOUT, and the first cut of the layout axis got this
- * exactly backwards. Reading ADR § 4's runtime table as a per-layout `app`
- * requirement refused `gjsify.app: "gjs"` for the macOS layout — i.e. refused the
- * entire audience of this command from assembling a `.app` — while a project with
- * no `gjsify.app` key sailed through and staged a launcher naming `node` in front
- * of a GJS bundle. Both halves came from the same mistake: § 4 derives the runtime
- * a SHIPPED ARTIFACT carries, which is `Layout.shippedRuntime` and is printed as
- * `Layout.runtimeGap`. What the launcher execs is what the PAYLOAD was built for,
- * and that is `settings.app` on every layout.
- *
- * An undeclared target is the common case for a GJS app and is allowed. It must
- * NOT be resolved through `Config.forBuild`, whose fallback is the HOST runtime
- * — that would refuse, or worse silently re-target, a perfectly good GJS project
- * merely for running this command under Node.
- *
- * WHY THIS REFUSES AND `Layout.runtimeGap` ONLY WARNS, since the two describe
- * neighbouring predicaments and get opposite treatment. A target this command
- * cannot package would leave here as an ARTIFACT — a `.deb` a stranger installs,
- * which then fails at startup, with no gate between here and their machine. The
- * `runtimeGap` warns about something that is not an artifact: it is printed over a
- * staged tree, and only when that tree carries no interpreter of its own.
- *
- * This paragraph used to end "the day a Windows format exists, that warning has to
- * become this refusal". #1354 M3 is that day, and the refusal it became is
- * {@link assertFormatCanRunInterpreter} — per FORMAT rather than per layout,
- * because what a runtime can execute is a property of the container and not of the
- * tree it wraps. This function stayed exactly as wide as it was.
- *
- * Phase one only. Phase two does not re-read `gjsify.app` — it has no project —
- * but it is not unchecked either: `assertLauncherMatchesInterpreter` compares
- * the staged `bin/<name>`'s own `exec` line against the dependency about to be
- * written.
- */
-function assertShippableTarget(app: string | undefined): void {
-    if (app === undefined || app === 'gjs' || app === 'node') return;
-    throw new Error(
-        `gjsify ship: this project declares \`gjsify.app: "${app}"\`, and only \`gjs\` and \`node\` can be ` +
-            'packaged. A browser bundle has no process to launch, and a NativeScript app ships as an APK/IPA ' +
-            'through a different pipeline. ADR 0024 § 4 has the runtime-per-OS table.',
-    );
-}
-
-/**
  * Refuse a format whose runtime cannot provide the interpreter the launcher execs.
  *
  * THE HOLE THIS CLOSES, and it was opened by the commit that made `--app node`
- * packageable. `assertShippableTarget` used to refuse `app: 'node'` outright, so
- * no format ever saw one. Lifting that made deb and rpm correct and left Flatpak
+ * packageable. The shippable-target refusal — `resolveShipApp` in
+ * `utils/ship/settings.ts`, a free function in this file until #1486 — used to
+ * refuse `app: 'node'` outright, so no format ever saw one. Lifting that made deb and rpm correct and left Flatpak
  * silently wrong: measured at exit 0, a `--target flatpak --stage` with
  * `app: 'node'` emitted a manifest with `runtime: org.gnome.Platform`,
  * `runtime-version: 50`, no `sdk-extensions` and no `append-path`, beside a
@@ -1398,14 +1375,18 @@ function assertShippableTarget(app: string | undefined): void {
 function assertFormatCanRunInterpreter(format: FormatDescriptor, app: 'gjs' | 'node'): void {
     if (format.interpreters.includes(app)) return;
     throw new Error(
-        `gjsify ship: this project is \`gjsify.app: "${app}"\`, and the ${format.id} runtime cannot run it — ` +
-            `it provides ${format.interpreters.join(', ')}.\n` +
+        // The TARGET's runtime, not "this project is": since #1486 the two can
+        // differ, and a message naming `gjsify.app` for a per-target answer sends
+        // the reader to the key whose edit moves every OTHER target's `Depends:`.
+        `gjsify ship: this ${format.layoutOs} target runs \`${app}\`, and the ${format.id} runtime cannot ` +
+            `run it — it provides ${format.interpreters.join(', ')}.\n` +
             // The ROW's own sentence, not one written here. Hardcoded, this
             // paragraph told the first `.app` author about
             // `org.freedesktop.Sdk.Extension.node2x` and the GNOME runtime.
             `    ${format.interpreterGap}.\n` +
-            '    Build the formats that wrap this layout and can run it, or ship this app as ' +
-            `\`gjsify.app: "${format.interpreters.join('" / "')}"\`.`,
+            '    Build the formats that wrap this layout and can run it, or set ' +
+            `\`gjsify.ship.app.${format.layoutOs}: "${format.interpreters.join('" / "')}"\` ` +
+            '(which overrides `gjsify.app` for this target alone).',
     );
 }
 

--- a/packages/infra/cli/src/commands/ship.ts
+++ b/packages/infra/cli/src/commands/ship.ts
@@ -273,12 +273,8 @@ async function assemble(args: ShipOptions): Promise<void> {
     // before anything is built while `resolveShipSettings` runs after. Its result
     // is threaded into the settings rather than re-derived there: two defaulting
     // rules for one question is how the format list and the emitted `Depends:`
-    // came to answer for different targets.
-    //
-    // PER LAYOUT, which is the whole of #1486's fix. `gjsify.app` is the project
-    // DEFAULT and `gjsify.ship.app.<os>` overrides it for this run's target, so a
-    // GTK4 app can be GJS on Linux and Node on macOS and Windows — the split ADR
-    // 0024 § 4 argues for — without the macOS answer moving the Linux `Depends:`.
+    // came to answer for different targets (#1486). Why the runtime is per target
+    // at all, and why an absent override means the project field: `resolveShipApp`.
     const resolvedApp = resolveShipApp({ project: configData.app, perTarget: ship.app, layoutOs: layout.os });
     const interpreter = resolvedApp.app;
     // SAID, not swallowed, like every other narrowing in this function. An

--- a/packages/infra/cli/src/types/config-data.ts
+++ b/packages/infra/cli/src/types/config-data.ts
@@ -425,6 +425,37 @@ export interface ConfigDataShip extends AppMetadata {
     /** `Maintainer:` / `Packager:` as `Name <email>`. Default: `package.json#author`. */
     maintainer?: string;
     /**
+     * The runtime a shipped artifact runs, PER TARGET — `gjsify.app` is the
+     * default and a key here overrides it for one layout.
+     *
+     * WHY THE PROJECT FIELD COULD NOT ANSWER THIS ALONE. `gjsify.app` carried two
+     * questions on one field: which runtime the application needs, and which
+     * package formats a target can build. Same answer for a single-OS project,
+     * different answers for the cross-OS split ADR 0024 § 4 argues for — Linux on
+     * GJS from the distribution, macOS and Windows on Node because there is no
+     * relocatable GJS for either. Measured before this key existed: `gjsify ship
+     * darwin --stage` reported `formats (none — macos-app and macos-app-zip need
+     * gjsify.app: "node")`, and setting that field to satisfy it flipped the LINUX
+     * `.deb` from `Depends: gjs (>= 1.86)` to `Depends: nodejs (>= 24)` — a macOS
+     * decision moving a Linux dependency, because the deb generator read the
+     * project field rather than the resolved runtime of its own target.
+     *
+     * KEYED IN THE `process.platform` SPELLING, like {@link ShipSignOptions} and
+     * for the same reason: the value that resolves is chosen by the LAYOUT being
+     * assembled — `FormatDescriptor.layoutOs` and the stage manifest's `target.os`
+     * — never by the host doing the assembling. `macos` and `windows` are the
+     * `gjsify ship <os>` POSITIONAL's spelling and are refused by name
+     * (`manifest-conformance`'s `ship` rule), because a runtime under a key
+     * nothing reads is a target that silently keeps the project-wide answer.
+     *
+     * There is deliberately NO per-layout default here — an absent key means
+     * `gjsify.app`, and never `Layout.shippedRuntime`. Defaulting darwin to `node`
+     * is the measured defect `Layout.shippedRuntime`'s own doc records: a project
+     * with no `gjsify.app` key staged `exec node …/gjs.js` in front of a bundle
+     * opening with `import Gtk from 'gi://Gtk?version=4.0'`.
+     */
+    app?: ShipAppOptions;
+    /**
      * Formats to build when `--target` is not given. Default `['deb', 'rpm']`.
      *
      * A project-level DEFAULT, so it is filtered to the layout `gjsify ship <os>`
@@ -534,6 +565,28 @@ export interface ConfigDataShip extends AppMetadata {
      * is the default path and a legitimate output (ADR 0024 § A13).
      */
     sign?: ShipSignOptions;
+}
+
+/**
+ * `gjsify.ship.app` — the shipped runtime per OS, overriding `gjsify.app`.
+ *
+ * All three keys are present, which is where this differs from
+ * {@link ShipSignOptions}: `linux` is absent there because a `.deb` carries no
+ * per-file signature, while a Linux artifact very much has a runtime — it is the
+ * one that emits `Depends: gjs (>= 1.86)` or `Depends: nodejs (>= 24)`, and the
+ * whole point of this table is that stating darwin's answer must not move it.
+ *
+ * Only `gjs` and `node` are shippable. `browser` has no process to launch and
+ * `nativescript` ships as an APK/IPA through another pipeline (ADR 0024 § 4), so
+ * either one is refused here exactly as it is on `gjsify.app`.
+ */
+export interface ShipAppOptions {
+    /** What a `.deb`/`.rpm`/Flatpak depends on and what its launcher execs. */
+    linux?: 'gjs' | 'node';
+    /** What a `<App>.app` carries. `node` is the only value the macOS formats accept. */
+    darwin?: 'gjs' | 'node';
+    /** What a Windows program directory carries. `node` is the only value its formats accept. */
+    win32?: 'gjs' | 'node';
 }
 
 /**

--- a/packages/infra/cli/src/types/config-data.ts
+++ b/packages/infra/cli/src/types/config-data.ts
@@ -428,31 +428,19 @@ export interface ConfigDataShip extends AppMetadata {
      * The runtime a shipped artifact runs, PER TARGET — `gjsify.app` is the
      * default and a key here overrides it for one layout.
      *
-     * WHY THE PROJECT FIELD COULD NOT ANSWER THIS ALONE. `gjsify.app` carried two
-     * questions on one field: which runtime the application needs, and which
-     * package formats a target can build. Same answer for a single-OS project,
-     * different answers for the cross-OS split ADR 0024 § 4 argues for — Linux on
-     * GJS from the distribution, macOS and Windows on Node because there is no
-     * relocatable GJS for either. Measured before this key existed: `gjsify ship
-     * darwin --stage` reported `formats (none — macos-app and macos-app-zip need
-     * gjsify.app: "node")`, and setting that field to satisfy it flipped the LINUX
-     * `.deb` from `Depends: gjs (>= 1.86)` to `Depends: nodejs (>= 24)` — a macOS
-     * decision moving a Linux dependency, because the deb generator read the
-     * project field rather than the resolved runtime of its own target.
-     *
      * KEYED IN THE `process.platform` SPELLING, like {@link ShipSignOptions} and
      * for the same reason: the value that resolves is chosen by the LAYOUT being
      * assembled — `FormatDescriptor.layoutOs` and the stage manifest's `target.os`
      * — never by the host doing the assembling. `macos` and `windows` are the
-     * `gjsify ship <os>` POSITIONAL's spelling and are refused by name
-     * (`manifest-conformance`'s `ship` rule), because a runtime under a key
-     * nothing reads is a target that silently keeps the project-wide answer.
+     * `gjsify ship <os>` POSITIONAL's spelling, and both `gjsify ship` and
+     * `manifest-conformance`'s `ship` rule refuse them BY NAME, because a runtime
+     * under a key nothing reads is a target that silently keeps the project-wide
+     * answer.
      *
-     * There is deliberately NO per-layout default here — an absent key means
-     * `gjsify.app`, and never `Layout.shippedRuntime`. Defaulting darwin to `node`
-     * is the measured defect `Layout.shippedRuntime`'s own doc records: a project
-     * with no `gjsify.app` key staged `exec node …/gjs.js` in front of a bundle
-     * opening with `import Gtk from 'gi://Gtk?version=4.0'`.
+     * `resolveShipApp` (`utils/ship/settings.ts`) is the only reader of this key
+     * or of `gjsify.app`, and holds the rest: what one field could not answer,
+     * the measurement behind it, and why an absent key means `gjsify.app` and
+     * never `Layout.shippedRuntime`.
      */
     app?: ShipAppOptions;
     /**

--- a/packages/infra/cli/src/utils/ship/launcher.spec.ts
+++ b/packages/infra/cli/src/utils/ship/launcher.spec.ts
@@ -71,7 +71,7 @@ function settings(execArgs: string[]): ShipSettings {
 export default async () => {
     await describe('ship launcher interpreter', async () => {
         await it("execs the payload's own runtime on every layout", () => {
-            // `assertShippableTarget` allows only a `--app gjs` bundle, so `gjs -m`
+            // This fixture's target resolves to `gjs` (`resolveShipApp`), so `gjs -m`
             // is the only interpreter that can read what is staged. ADR 0024 § 4's
             // Node answer is about a SHIPPED ARTIFACT and arrives with #1354 M0's
             // bundled interpreter; naming it here put `exec node` in front of a

--- a/packages/infra/cli/src/utils/ship/launcher.ts
+++ b/packages/infra/cli/src/utils/ship/launcher.ts
@@ -417,11 +417,10 @@ function windowsPath(rel: string): string {
  * interpreter that can read the payload is the one the payload was BUILT for,
  * and that is `settings.app` on all three.
  *
- * Since #1486 `settings.app` is itself resolved PER TARGET — `gjsify.ship.app.<os>`
- * over `gjsify.app` — so "NOT the layout" keeps meaning what it always meant and no
- * more: the layout does not DERIVE the runtime, an author STATES it per OS and this
- * field carries the statement. Deriving it here would still stage `exec node` in
- * front of a GJS bundle for everyone who said nothing.
+ * Since #1486 `settings.app` is itself resolved per target (`resolveShipApp`), so
+ * "NOT the layout" keeps meaning exactly what it meant: the layout does not DERIVE
+ * the runtime, an author STATES it per OS. Deriving it here would still stage
+ * `exec node` in front of a GJS bundle for everyone who said nothing.
  *
  * `Layout.runtimeGap` is where the honest half of that lives: it says, per OS,
  * why the staged launcher does not yet name what § 4 derives, and `gjsify ship`

--- a/packages/infra/cli/src/utils/ship/launcher.ts
+++ b/packages/infra/cli/src/utils/ship/launcher.ts
@@ -417,6 +417,12 @@ function windowsPath(rel: string): string {
  * interpreter that can read the payload is the one the payload was BUILT for,
  * and that is `settings.app` on all three.
  *
+ * Since #1486 `settings.app` is itself resolved PER TARGET — `gjsify.ship.app.<os>`
+ * over `gjsify.app` — so "NOT the layout" keeps meaning what it always meant and no
+ * more: the layout does not DERIVE the runtime, an author STATES it per OS and this
+ * field carries the statement. Deriving it here would still stage `exec node` in
+ * front of a GJS bundle for everyone who said nothing.
+ *
  * `Layout.runtimeGap` is where the honest half of that lives: it says, per OS,
  * why the staged launcher does not yet name what § 4 derives, and `gjsify ship`
  * prints it.

--- a/packages/infra/cli/src/utils/ship/layout.ts
+++ b/packages/infra/cli/src/utils/ship/layout.ts
@@ -115,7 +115,7 @@ export interface Layout {
      * M1 may honestly claim. A layout with no packer produces no installable
      * artifact, so writing `exec node` into a stage assembled from a `--app gjs`
      * bundle would put a runtime that cannot read the payload in front of it —
-     * the exact defect `assertShippableTarget` exists to prevent, produced by the
+     * the exact defect `resolveShipApp`'s refusal exists to prevent, produced by the
      * code meant to prevent it. Measured before this was data: `gjsify ship
      * darwin --stage` on a project with no `gjsify.app` key exited 0 and staged
      * `exec node "$contents/Resources/lib/gjs.js"` in front of a bundle whose

--- a/packages/infra/cli/src/utils/ship/payload.ts
+++ b/packages/infra/cli/src/utils/ship/payload.ts
@@ -504,7 +504,15 @@ export function assertLauncherMatchesInterpreter(
             '    An installed package that depends on one interpreter and runs another installs cleanly and ' +
             'fails\n' +
             "    at first launch, on the user's machine.\n" +
-            `    Either set \`gjsify.app\` to "${other}", or fix the launcher — if it comes from ` +
+            // THIS TARGET's key, and not `gjsify.app`. Since #1486 the runtime is
+            // resolved per target, so sending the reader to the project field to
+            // fix ONE layout's launcher moves every other layout's `Depends:` with
+            // it — the defect § A22 exists to close, reintroduced by the message
+            // that reports it. Named as a project edit because `--from-stage`
+            // reaches here too, and that host has no config to change.
+            `    Either set \`gjsify.ship.app.${layout.os}\` to "${other}" in the project this was staged ` +
+            'from — it overrides\n' +
+            '    `gjsify.app` for that target alone — or fix the launcher: if it comes from ' +
             '`gjsify.ship.extraFiles`,\n' +
             '    that override is what decides which interpreter runs and it must match the declaration.',
     );

--- a/packages/infra/cli/src/utils/ship/plan.spec.ts
+++ b/packages/infra/cli/src/utils/ship/plan.spec.ts
@@ -170,7 +170,7 @@ export default async () => {
         // `LAYOUTS.linux`, because these two cases are about the INTERPRETER, which
         // `settings.app` decides on every layout — the three FORMS have their own
         // suite in `launcher.spec.ts`.
-        await it('execs the interpreter `gjsify.app` names, and only that one', async () => {
+        await it('execs the interpreter this target resolved to, and only that one', async () => {
             // `gjs` needs `-m` for an ES module; `node` decides from the
             // extension and REJECTS the flag, so this is not a name swap.
             expect(renderLauncher(settings(), 'app.gjs.js', LAYOUTS.linux)).toContain(

--- a/packages/infra/cli/src/utils/ship/settings.spec.ts
+++ b/packages/infra/cli/src/utils/ship/settings.spec.ts
@@ -9,7 +9,14 @@
 
 import { describe, expect, it } from '@gjsify/unit';
 
-import { descriptionParagraphs, deriveBinaryName, resolveShipSettings, type SettingsInput } from './settings.js';
+import {
+    descriptionParagraphs,
+    deriveBinaryName,
+    resolveShipApp,
+    resolveShipSettings,
+    type SettingsInput,
+} from './settings.js';
+import type { ShipAppOptions } from '../../types/config-data.js';
 import { normaliseVersion } from './version.js';
 
 function input(overrides: Partial<SettingsInput> = {}): SettingsInput {
@@ -18,6 +25,9 @@ function input(overrides: Partial<SettingsInput> = {}): SettingsInput {
         pkg: { name: 'hello-app', version: '1.2.3', license: 'MIT', author: 'Dev <dev@example.org>' },
         ship: { appId: 'org.example.Hello' },
         flatpak: {},
+        // Already RESOLVED, which is the contract: `resolveShipSettings` does no
+        // defaulting of its own, so every caller has been through `resolveShipApp`.
+        app: 'gjs',
         cli: { layoutOs: 'linux' },
         discovered: {
             bundlePath: '/project/dist/gjs.js',
@@ -141,6 +151,56 @@ export default async () => {
 
         await it('refuses a version no package manager can order', async () => {
             expect(() => normaliseVersion('not-a-version')).toThrow('not a usable package version');
+        });
+    });
+
+    await describe('resolveShipApp', async () => {
+        await it('defaults to gjs, and to the project field when one is declared', async () => {
+            // An undeclared target is the common case for a GJS app and it means
+            // GJS — never the host runtime this command happens to run under.
+            expect(resolveShipApp({ layoutOs: 'linux' }).app).toBe('gjs');
+            expect(resolveShipApp({ project: 'node', layoutOs: 'linux' }).app).toBe('node');
+            expect(resolveShipApp({ project: 'node', layoutOs: 'darwin' }).key).toBe('gjsify.app');
+        });
+
+        await it('lets ONE target override the project default and leaves the others alone', async () => {
+            // The split ADR 0024 § 4 argues for: GJS on Linux from the
+            // distribution, Node where no relocatable GJS exists. Before #1486
+            // saying the second half said the first half too.
+            const perTarget = { darwin: 'node', win32: 'node' } as const;
+            expect(resolveShipApp({ project: 'gjs', perTarget, layoutOs: 'linux' }).app).toBe('gjs');
+            expect(resolveShipApp({ project: 'gjs', perTarget, layoutOs: 'darwin' }).app).toBe('node');
+            expect(resolveShipApp({ project: 'gjs', perTarget, layoutOs: 'win32' }).app).toBe('node');
+        });
+
+        await it('reports which key answered, so the override is never silent', async () => {
+            const overridden = resolveShipApp({ project: 'gjs', perTarget: { win32: 'node' }, layoutOs: 'win32' });
+            expect(overridden.key).toBe('gjsify.ship.app.win32');
+            expect(overridden.overridden).toBe(true);
+            const inherited = resolveShipApp({ project: 'gjs', perTarget: { win32: 'node' }, layoutOs: 'linux' });
+            expect(inherited.key).toBe('gjsify.app');
+            expect(inherited.overridden).toBe(false);
+        });
+
+        await it('refuses a runtime that cannot be packaged, and names the key that carried it', async () => {
+            // A browser bundle has no process to launch and a NativeScript app
+            // ships as an APK/IPA. WHICH key said so matters now that two can:
+            // "this project declares" no longer locates the value to edit.
+            expect(() => resolveShipApp({ project: 'browser', layoutOs: 'linux' })).toThrow(
+                '`gjsify.app` is "browser"',
+            );
+            // The cast is the POINT, not a workaround: this value arrives from a
+            // JSON config file that TypeScript never sees, so the type is a
+            // statement about our callers and the refusal is the only real check.
+            const fromJson = { darwin: 'browser' } as unknown as ShipAppOptions;
+            expect(() => resolveShipApp({ project: 'gjs', perTarget: fromJson, layoutOs: 'darwin' })).toThrow(
+                '`gjsify.ship.app.darwin` is "browser"',
+            );
+            // And an unshippable PROJECT default is not reached when the target
+            // overrides it: what ships is what the target says.
+            expect(
+                resolveShipApp({ project: 'nativescript', perTarget: { darwin: 'node' }, layoutOs: 'darwin' }).app,
+            ).toBe('node');
         });
     });
 

--- a/packages/infra/cli/src/utils/ship/settings.spec.ts
+++ b/packages/infra/cli/src/utils/ship/settings.spec.ts
@@ -202,6 +202,23 @@ export default async () => {
                 resolveShipApp({ project: 'nativescript', perTarget: { darwin: 'node' }, layoutOs: 'darwin' }).app,
             ).toBe('node');
         });
+
+        await it('refuses a key it does not read, on the run that does not read it either', async () => {
+            // THE SILENT ONE. `windows` is the `gjsify ship <os>` POSITIONAL's
+            // spelling, so a runtime under it resolves to nothing, that target
+            // quietly keeps `gjsify.app`, and the author reads the unchanged output
+            // as gjsify not supporting the split — with every gate green.
+            const misKeyed = { windows: 'node' } as unknown as ShipAppOptions;
+            expect(() => resolveShipApp({ project: 'gjs', perTarget: misKeyed, layoutOs: 'win32' })).toThrow(
+                '`gjsify.ship.app.windows` is not an OS',
+            );
+            // The WHOLE table is checked, not this run's key: `gjsify ship linux`
+            // is the run most likely to be sitting in front of the typo, and a
+            // check that only fires on the mis-keyed OS never fires at all.
+            expect(() => resolveShipApp({ project: 'gjs', perTarget: misKeyed, layoutOs: 'linux' })).toThrow(
+                '`gjsify.ship.app.windows` is not an OS',
+            );
+        });
     });
 
     await describe('descriptionParagraphs', async () => {

--- a/packages/infra/cli/src/utils/ship/settings.ts
+++ b/packages/infra/cli/src/utils/ship/settings.ts
@@ -73,13 +73,12 @@ export interface SettingsInput {
     cli: { outDir?: string; arch?: string; layoutOs: HostOs };
     discovered: DiscoveredPayload;
     /**
-     * The runtime {@link resolveShipApp} resolved for THIS run's target.
+     * THIS TARGET's runtime, as {@link resolveShipApp} resolved it — never the
+     * raw `gjsify.app`.
      *
-     * Already resolved and already narrowed, never the raw `gjsify.app`. The type
-     * is what enforces it: a caller handing the project field straight through
-     * does not compile, which is the defect this field used to carry — every
-     * generator downstream reads `settings.app`, so a project-wide value arriving
-     * here made a macOS decision move the Linux `Depends:`.
+     * The TYPE is the enforcement: a caller handing the project field straight
+     * through no longer compiles. That is exactly the regression this field used
+     * to carry in silence, since every generator downstream reads `settings.app`.
      */
     app: 'gjs' | 'node';
 }
@@ -95,23 +94,27 @@ export interface ResolvedShipApp {
 }
 
 /**
+ * The OS keys `gjsify.ship.app` may carry — {@link HostOs}, the
+ * `process.platform` spelling.
+ *
+ * `satisfies Record<HostOs, true>` rather than a bare list: a fourth layout
+ * cannot arrive without this object failing to compile, so the accepted set
+ * stays total without a second place to remember to update.
+ */
+const SHIP_APP_OSES = { linux: true, darwin: true, win32: true } as const satisfies Record<HostOs, true>;
+
+/**
  * The ONE place a ship target's runtime is decided: `gjsify.app` as the DEFAULT,
  * `gjsify.ship.app.<os>` as this target's override.
  *
- * Every generator reads the result and none reads the project field, because the
- * two are not the same question. `gjsify.app` says what the application was
- * BUILT as; a shipped artifact's runtime is per OS (ADR 0024 § 4), and stating
- * darwin's must not move Linux's. It did: with one field, `gjsify ship darwin`
- * refused its formats until `gjsify.app` was set to `"node"`, and setting it
- * turned the Linux `.deb`'s `Depends: gjs (>= 1.86)` into `Depends: nodejs
- * (>= 24)` — a package that then refuses to install on trixie, Ubuntu 24.04 and
- * Ubuntu 26.04, for a macOS decision.
- *
- * `browser` and `nativescript` are refused here rather than deeper down, and not
- * for want of a launcher line: a browser bundle has no process to start, and a
- * NativeScript app ships as an APK/IPA through a different pipeline entirely
- * (ADR 0024 § 4). The refusal names the KEY that carried the value, because with
- * two keys "this project declares" no longer locates it.
+ * WHY IT IS PER TARGET, measured on a GTK4 application rather than derived from
+ * the schema: with one field, `gjsify ship darwin` refused its formats until
+ * `gjsify.app` was `"node"` — and setting it turned the LINUX `.deb`'s
+ * `Depends: gjs (>= 1.86)` into `Depends: nodejs (>= 24)`, which apt refuses on
+ * trixie, Ubuntu 24.04 and Ubuntu 26.04. A macOS decision made the Linux package
+ * uninstallable, because every generator read the PROJECT field instead of the
+ * resolved runtime of its OWN target (#1486, ADR 0024 § A22). Nothing downstream
+ * reads either key; they all read `settings.app`, which is this result.
  *
  * NOT PER LAYOUT BY DEFAULT, and the first cut of the layout axis got this
  * exactly backwards. Reading ADR § 4's runtime table as a per-layout
@@ -130,26 +133,25 @@ export interface ResolvedShipApp {
  * whose launcher execs `node`. An undeclared target is the common case for a GJS
  * app, and it means GJS.
  *
- * WHY THIS REFUSES WHERE `Layout.runtimeGap` ONLY WARNS, since the two describe
- * neighbouring predicaments and get opposite treatment. A runtime this command
- * cannot package would leave here as an ARTIFACT — a `.deb` a stranger installs,
- * which then fails at startup, with no gate between here and their machine. The
- * `runtimeGap` warns about something that is not an artifact: it is printed over
- * a staged tree, and only when that tree carries no interpreter of its own. The
- * per-FORMAT half of the same question is `assertFormatCanRunInterpreter`, which
- * asks what a container can EXECUTE rather than what an author declared.
+ * TWO REFUSALS, and each is here because the alternative to refusing is SILENT.
+ * A `browser` or `nativescript` value has no artifact to be — no process to
+ * start, an APK/IPA through another pipeline (§ 4) — and would otherwise leave
+ * here as a `.deb` a stranger installs and cannot run, with no gate between here
+ * and their machine; `Layout.runtimeGap` only WARNS because what it describes is
+ * a staged tree rather than an artifact, and the per-FORMAT half of the question
+ * is `assertFormatCanRunInterpreter`, which asks what a container can EXECUTE.
+ * A key outside {@link SHIP_APP_OSES} — `windows`, the `gjsify ship <os>`
+ * POSITIONAL's spelling — would resolve to nothing and leave that target on the
+ * project-wide answer with every gate green, which is why the author who typed
+ * it reads the result as gjsify not supporting the split at all. Both refusals
+ * name the KEY that carried the value: with two keys, "this project declares" no
+ * longer locates it.
  *
- * Until #1354 M0 the refusal read "only `gjs` can be packaged today", and that
- * was true: the launcher execed gjs unconditionally, so a `--app node` package
- * would have installed and died at startup. Both are packageable now —
- * `renderLauncher` execs the one this resolves to and `deriveDepends` declares
- * the same one, `gjs >= …` or `nodejs (>= 24)` / `nodejs(engine) >= 24`.
- *
- * Phase one only. `gjsify ship --from-stage` has no project to read either key
- * from and does not need one: the resolved value is what the stage manifest
- * records, so the packing host reads an answer rather than a default — and
- * `assertLauncherMatchesInterpreter` still compares the staged `bin/<name>`'s own
- * `exec` line against the dependency about to be written.
+ * `gjsify ship --from-stage` reads neither key and needs neither: the stage
+ * manifest records the RESOLVED value, so the packing host reads an answer
+ * rather than a default, and `assertLauncherMatchesInterpreter` still compares
+ * the staged `bin/<name>`'s own `exec` line against the dependency about to be
+ * written.
  */
 export function resolveShipApp(input: {
     /** `gjsify.app` as DECLARED — `undefined` when the project declares nothing. */
@@ -159,7 +161,21 @@ export function resolveShipApp(input: {
     /** The layout this run assembles. */
     layoutOs: HostOs;
 }): ResolvedShipApp {
-    const override = input.perTarget?.[input.layoutOs];
+    const perTarget = input.perTarget ?? {};
+    // The WHOLE table, not only this run's key: a mis-keyed override is silent by
+    // construction, so `gjsify ship linux` is the run that has to say `windows` is
+    // not a key. Checking only the resolving key would leave the typo to be found
+    // by the `gjsify ship windows` that already reads as unsupported.
+    for (const os of Object.keys(perTarget)) {
+        if (Object.hasOwn(SHIP_APP_OSES, os)) continue;
+        throw new Error(
+            `gjsify ship: \`gjsify.ship.app.${os}\` is not an OS this command assembles for. Known: ` +
+                `${Object.keys(SHIP_APP_OSES).join(', ')} — the \`process.platform\` spelling, not the ` +
+                "`gjsify ship <os>` positional's. A runtime under a key nothing reads leaves that target on " +
+                '`gjsify.app` with nothing to say so.',
+        );
+    }
+    const override = perTarget[input.layoutOs];
     const overridden = override !== undefined;
     const key = overridden ? `gjsify.ship.app.${input.layoutOs}` : 'gjsify.app';
     const declared = overridden ? override : input.project;
@@ -219,11 +235,9 @@ export function resolveShipSettings(input: SettingsInput): ResolvedSettings {
     const appId = ship.appId ?? flatpak.appId ?? reverseDnsOrThrow(pkg.name, binaryName);
     const name = metadata.name ?? titleCase(binaryName);
     const kind = metadata.kind ?? 'app';
-    // NOT resolved here. `resolveShipApp` above is the one place that turns
-    // `gjsify.app` plus `gjsify.ship.app.<os>` into a runtime, and this function
-    // is reached AFTER the format list has already been decided from it — a
-    // second defaulting rule here would be the second path the two could disagree
-    // on, which is precisely what a per-target runtime cannot afford.
+    // NOT resolved here: `resolveShipApp` already did, before the format list was
+    // decided from it. A second defaulting rule in this function would be the
+    // second path those two answers could come apart on.
     const app = input.app;
 
     const rawVersion = ship.version ?? pkg.version;

--- a/packages/infra/cli/src/utils/ship/settings.ts
+++ b/packages/infra/cli/src/utils/ship/settings.ts
@@ -13,7 +13,13 @@
 import { validateMimeTypes } from './mime.js';
 import { basename } from 'node:path';
 
-import type { AppMetadata, ConfigDataFlatpak, ConfigDataShip, DescriptionBlock } from '../../types/config-data.js';
+import type {
+    AppMetadata,
+    ConfigDataFlatpak,
+    ConfigDataShip,
+    DescriptionBlock,
+    ShipAppOptions,
+} from '../../types/config-data.js';
 import { DEFAULT_GJS_FLOOR, DEFAULT_NODE_FLOOR } from './depends.js';
 import { resolveShipFlatpakSettings } from './flatpak-config.js';
 import { assertRelease, normaliseVersion } from './version.js';
@@ -67,12 +73,104 @@ export interface SettingsInput {
     cli: { outDir?: string; arch?: string; layoutOs: HostOs };
     discovered: DiscoveredPayload;
     /**
-     * `gjsify.app` as DECLARED — `undefined` when the project declares nothing.
+     * The runtime {@link resolveShipApp} resolved for THIS run's target.
      *
-     * Deliberately the raw config value and not `Config.forBuild`'s resolved one:
-     * see where it is defaulted below.
+     * Already resolved and already narrowed, never the raw `gjsify.app`. The type
+     * is what enforces it: a caller handing the project field straight through
+     * does not compile, which is the defect this field used to carry — every
+     * generator downstream reads `settings.app`, so a project-wide value arriving
+     * here made a macOS decision move the Linux `Depends:`.
      */
-    app?: string;
+    app: 'gjs' | 'node';
+}
+
+/** The runtime one ship target runs, and which key decided it. */
+export interface ResolvedShipApp {
+    /** What the launcher execs, what the package depends on, and which formats can wrap it. */
+    app: 'gjs' | 'node';
+    /** The config key the answer came from — named in the refusal and in the notice. */
+    key: string;
+    /** Whether a per-target key overrode the project default. */
+    overridden: boolean;
+}
+
+/**
+ * The ONE place a ship target's runtime is decided: `gjsify.app` as the DEFAULT,
+ * `gjsify.ship.app.<os>` as this target's override.
+ *
+ * Every generator reads the result and none reads the project field, because the
+ * two are not the same question. `gjsify.app` says what the application was
+ * BUILT as; a shipped artifact's runtime is per OS (ADR 0024 § 4), and stating
+ * darwin's must not move Linux's. It did: with one field, `gjsify ship darwin`
+ * refused its formats until `gjsify.app` was set to `"node"`, and setting it
+ * turned the Linux `.deb`'s `Depends: gjs (>= 1.86)` into `Depends: nodejs
+ * (>= 24)` — a package that then refuses to install on trixie, Ubuntu 24.04 and
+ * Ubuntu 26.04, for a macOS decision.
+ *
+ * `browser` and `nativescript` are refused here rather than deeper down, and not
+ * for want of a launcher line: a browser bundle has no process to start, and a
+ * NativeScript app ships as an APK/IPA through a different pipeline entirely
+ * (ADR 0024 § 4). The refusal names the KEY that carried the value, because with
+ * two keys "this project declares" no longer locates it.
+ *
+ * NOT PER LAYOUT BY DEFAULT, and the first cut of the layout axis got this
+ * exactly backwards. Reading ADR § 4's runtime table as a per-layout
+ * REQUIREMENT refused `gjsify.app: "gjs"` for the macOS layout — the entire
+ * audience of that command — while a project with no `gjsify.app` key sailed
+ * through and staged a launcher naming `node` in front of a GJS bundle. § 4
+ * derives the runtime a shipped artifact CARRIES, which is
+ * `Layout.shippedRuntime`; what an artifact runs is what its author says, which
+ * is this. So an absent override means the project field and never the layout's
+ * derived answer.
+ *
+ * MUST NOT be fed `Config.forBuild`'s resolution, whose fallback is the HOST
+ * runtime. That fallback is right for a build (`gjsify build` under Node should
+ * produce a Node bundle by default) and catastrophic for a package: running this
+ * command under Node would silently turn every undeclared GJS project into one
+ * whose launcher execs `node`. An undeclared target is the common case for a GJS
+ * app, and it means GJS.
+ *
+ * WHY THIS REFUSES WHERE `Layout.runtimeGap` ONLY WARNS, since the two describe
+ * neighbouring predicaments and get opposite treatment. A runtime this command
+ * cannot package would leave here as an ARTIFACT — a `.deb` a stranger installs,
+ * which then fails at startup, with no gate between here and their machine. The
+ * `runtimeGap` warns about something that is not an artifact: it is printed over
+ * a staged tree, and only when that tree carries no interpreter of its own. The
+ * per-FORMAT half of the same question is `assertFormatCanRunInterpreter`, which
+ * asks what a container can EXECUTE rather than what an author declared.
+ *
+ * Until #1354 M0 the refusal read "only `gjs` can be packaged today", and that
+ * was true: the launcher execed gjs unconditionally, so a `--app node` package
+ * would have installed and died at startup. Both are packageable now —
+ * `renderLauncher` execs the one this resolves to and `deriveDepends` declares
+ * the same one, `gjs >= …` or `nodejs (>= 24)` / `nodejs(engine) >= 24`.
+ *
+ * Phase one only. `gjsify ship --from-stage` has no project to read either key
+ * from and does not need one: the resolved value is what the stage manifest
+ * records, so the packing host reads an answer rather than a default — and
+ * `assertLauncherMatchesInterpreter` still compares the staged `bin/<name>`'s own
+ * `exec` line against the dependency about to be written.
+ */
+export function resolveShipApp(input: {
+    /** `gjsify.app` as DECLARED — `undefined` when the project declares nothing. */
+    project?: string;
+    /** `gjsify.ship.app`, the per-layout override table. */
+    perTarget?: ShipAppOptions;
+    /** The layout this run assembles. */
+    layoutOs: HostOs;
+}): ResolvedShipApp {
+    const override = input.perTarget?.[input.layoutOs];
+    const overridden = override !== undefined;
+    const key = overridden ? `gjsify.ship.app.${input.layoutOs}` : 'gjsify.app';
+    const declared = overridden ? override : input.project;
+    if (declared !== undefined && declared !== 'gjs' && declared !== 'node') {
+        throw new Error(
+            `gjsify ship: \`${key}\` is "${declared}", and only \`gjs\` and \`node\` can be ` +
+                'packaged. A browser bundle has no process to launch, and a NativeScript app ships as an APK/IPA ' +
+                'through a different pipeline. ADR 0024 § 4 has the runtime-per-OS table.',
+        );
+    }
+    return { app: declared === 'node' ? 'node' : 'gjs', key, overridden };
 }
 
 export interface ResolvedSettings {
@@ -121,14 +219,12 @@ export function resolveShipSettings(input: SettingsInput): ResolvedSettings {
     const appId = ship.appId ?? flatpak.appId ?? reverseDnsOrThrow(pkg.name, binaryName);
     const name = metadata.name ?? titleCase(binaryName);
     const kind = metadata.kind ?? 'app';
-    // `gjsify.app`, defaulted HERE to `'gjs'` rather than taken from
-    // `Config.forBuild`'s resolution, which falls back to the HOST runtime. That
-    // fallback is right for a build (`gjsify build` under Node should produce a
-    // Node bundle by default) and catastrophic for a package: running this
-    // command under Node would silently turn every undeclared GJS project into
-    // one whose launcher execs `node`. An undeclared target is the common case
-    // for a GJS app, and it means GJS.
-    const app: 'gjs' | 'node' = input.app === 'node' ? 'node' : 'gjs';
+    // NOT resolved here. `resolveShipApp` above is the one place that turns
+    // `gjsify.app` plus `gjsify.ship.app.<os>` into a runtime, and this function
+    // is reached AFTER the format list has already been decided from it — a
+    // second defaulting rule here would be the second path the two could disagree
+    // on, which is precisely what a per-target runtime cannot afford.
+    const app = input.app;
 
     const rawVersion = ship.version ?? pkg.version;
     if (!rawVersion) {

--- a/packages/infra/cli/src/utils/ship/types.ts
+++ b/packages/infra/cli/src/utils/ship/types.ts
@@ -374,13 +374,10 @@ export interface PackSettings {
      * depends on. THIS TARGET's runtime, resolved once by `resolveShipApp` out of
      * `gjsify.ship.app.<os>` falling back to `gjsify.app`; default `'gjs'`.
      *
-     * PER TARGET and never the project field, which is #1486's fix. With one
-     * field, `gjsify ship darwin` refused its formats until `gjsify.app` was
-     * `"node"` — and setting it flipped the LINUX `.deb` from `Depends: gjs
-     * (>= 1.86)` to `Depends: nodejs (>= 24)`, unsatisfiable on trixie, Ubuntu
-     * 24.04 and Ubuntu 26.04, for a macOS decision. That the stage manifest
-     * carries the RESOLVED value is what keeps `--from-stage` honest: the packing
-     * host has no project and needs none.
+     * PER TARGET and never the project field, which is #1486's fix and whose
+     * measurement `resolveShipApp` carries. That the stage manifest records the
+     * RESOLVED value is what keeps `--from-stage` honest: the packing host has no
+     * project and needs none.
      *
      * ON `PackSettings`, not on `ShipSettings` alone, because BOTH halves need it
      * and they must not answer it differently: `renderLauncher` writes

--- a/packages/infra/cli/src/utils/ship/types.ts
+++ b/packages/infra/cli/src/utils/ship/types.ts
@@ -371,7 +371,16 @@ export interface PackSettings {
     typelibPackages: Record<string, Record<DistroFormatId, string>>;
     /**
      * The interpreter the launcher execs, and therefore the one the package
-     * depends on. From `gjsify.app`; default `'gjs'`.
+     * depends on. THIS TARGET's runtime, resolved once by `resolveShipApp` out of
+     * `gjsify.ship.app.<os>` falling back to `gjsify.app`; default `'gjs'`.
+     *
+     * PER TARGET and never the project field, which is #1486's fix. With one
+     * field, `gjsify ship darwin` refused its formats until `gjsify.app` was
+     * `"node"` — and setting it flipped the LINUX `.deb` from `Depends: gjs
+     * (>= 1.86)` to `Depends: nodejs (>= 24)`, unsatisfiable on trixie, Ubuntu
+     * 24.04 and Ubuntu 26.04, for a macOS decision. That the stage manifest
+     * carries the RESOLVED value is what keeps `--from-stage` honest: the packing
+     * host has no project and needs none.
      *
      * ON `PackSettings`, not on `ShipSettings` alone, because BOTH halves need it
      * and they must not answer it differently: `renderLauncher` writes

--- a/packages/infra/manifest-conformance/lib/rules/ship.mjs
+++ b/packages/infra/manifest-conformance/lib/rules/ship.mjs
@@ -96,6 +96,26 @@ const PATH_KEYS = ['icon', 'schemas', 'licenseFile'];
  */
 const SIGN_OSES = new Set(['darwin', 'win32']);
 
+/**
+ * The OSes `gjsify.ship.app` may be keyed on, and the runtimes it may name.
+ *
+ * The `process.platform` spelling again, for the reason `SIGN_OSES` gives: the
+ * value that resolves is chosen by the LAYOUT being assembled. All three are in,
+ * unlike signing — a Linux artifact very much has a runtime, and it is the one
+ * that emits `Depends: gjs (>= 1.86)` or `Depends: nodejs (>= 24)`.
+ *
+ * THE FAILURE THIS CATCHES IS THE SILENT ONE, and it is worse here than for an
+ * identity. `gjsify.ship.app.windows: "node"` — the `gjsify ship <os>`
+ * POSITIONAL's spelling — resolves to nothing, so that target quietly keeps the
+ * project-wide `gjsify.app`: the Windows formats stay unavailable and the author
+ * reads it as gjsify not supporting the split, with every gate green. An
+ * unrecognised RUNTIME is the same shape one level down; `browser` and
+ * `nativescript` are refused for ADR 0024 § 4's reason — no process to launch,
+ * and an APK/IPA pipeline that is not this one.
+ */
+const APP_OSES = new Set(['linux', 'darwin', 'win32']);
+const APP_RUNTIMES = new Set(['gjs', 'node']);
+
 export function auditShip(ctx) {
     const failures = [];
     let declared = 0;
@@ -152,6 +172,36 @@ export function auditShip(ctx) {
                     `${pkg.rel}/package.json: \`gjsify.ship.targets\` names "${target}", which \`gjsify ship\` cannot ` +
                         `build. Known targets: ${[...TARGETS].join(', ')}.`,
                 );
+            }
+        }
+
+        const app = block.app;
+        if (app !== undefined) {
+            if (app === null || typeof app !== 'object' || Array.isArray(app)) {
+                failures.push(
+                    `${pkg.rel}/package.json: \`gjsify.ship.app\` must be an object keyed by OS — it is the ` +
+                        `PER-TARGET override of \`gjsify.app\`, not a second spelling of it.`,
+                );
+            } else {
+                for (const [os, runtime] of Object.entries(app)) {
+                    if (!APP_OSES.has(os)) {
+                        failures.push(
+                            `${pkg.rel}/package.json: \`gjsify.ship.app.${os}\` is not an OS \`gjsify ship\` ` +
+                                `assembles for. Known: ${[...APP_OSES].join(', ')} — the \`process.platform\` ` +
+                                `spelling, not the \`gjsify ship <os>\` positional's. A runtime under a key nothing ` +
+                                `reads leaves that target on \`gjsify.app\` with nothing to say so.`,
+                        );
+                        continue;
+                    }
+                    if (!APP_RUNTIMES.has(runtime)) {
+                        failures.push(
+                            `${pkg.rel}/package.json: \`gjsify.ship.app.${os}\` is "${runtime}", and only ` +
+                                `${[...APP_RUNTIMES].join(' and ')} can be packaged. A browser bundle has no ` +
+                                `process to launch, and a NativeScript app ships as an APK/IPA through a different ` +
+                                `pipeline (ADR 0024 § 4).`,
+                        );
+                    }
+                }
             }
         }
 

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -1035,41 +1035,31 @@ misled. These are the upstream source of that claim, and a stale comment is how 
 grows back. Left for a commit of its own because both files path-filter CI job
 selection, and editing them from a docs branch is churn where it is riskiest.
 
-### `gjsify.app` answers two questions on one field, so a per-OS runtime split is not expressible
+### `gjsify ship`: the RUNTIME is per target, the BUNDLE is still one path
 
-**Measured on a real project rather than derived from the schema.** A GTK4 application
-whose Linux target runs on GJS and whose macOS/Windows targets run on Node — the exact
-split ADR 0024 § 4 argues for, since there is no relocatable GJS for either — cannot say
-so. `gjsify ship darwin --stage` and `ship windows --stage` both assemble a layout and
-then report `formats (none — macos-app and macos-app-zip need gjsify.app: "node")`. Set
-that field and the two OSes produce their formats, and the LINUX deb changes with them:
-`Depends: gjs (>= 1.86)` becomes `Depends: nodejs (>= 24)`.
+The runtime half is closed (#1486, ADR 0024 § A22): `gjsify.ship.app.{linux,darwin,win32}`
+overrides `gjsify.app` per target, one resolver answers, and every generator reads the
+runtime of ITS OWN target — so stating macOS's answer no longer moves the Linux
+`Depends:`. What that makes askable is the next question, and it is genuinely a different
+one.
 
-**The field carries two questions.** Which runtime the application needs, and which
-package formats a target can build. They are the same answer for a single-OS project and
-different answers for a cross-OS one, and today only the first can be stated. The deb
-generator reads the PROJECT field rather than the resolved runtime of ITS target, which
-is why the Linux arm changes when a macOS decision is made.
+**`gjsify.ship.bundle` is a single path**, falling back to `gjsify.main` then
+`package.json#main`, and every layout's launcher names the file it resolves to. A project
+that is GJS on Linux and Node on Windows has TWO bundles — `dist/<name>.gjs.js` beside
+`dist/<name>.node.mjs` is the layout `resolve-gjs-entry.ts` documents as normal — and
+`discoverPayload` already stages both, because it takes the whole directory beside the
+bundle. So the payload is right and the launcher's exec line is not: the Windows `.cmd`
+runs `node` over whichever single file the project declared.
 
-**The shape a fix would take**, recorded because the smaller-looking alternative is the
-wrong one: make `gjsify.app` the DEFAULT and let each ship target override it, then have
-every generator read the resolved runtime of its own target and never the project field.
-The tempting alternative — simply offering `macos-app`/`windows-dir` under
-`app: "gjs"` — makes the output richer and leaves the question unanswered: it would stage
-a bundle whose runtime assumption nobody stated, and the next finding is an artifact that
-finds no GJS on the target machine. Better to make the field resolvable than to decouple
-its effect.
-
-**The test that pins it is cheaper than the discussion**, and it guards the class rather
-than the fix: a project with `app: "gjs"` and a windows target on `node`, asserting that
-the deb carries NO `Depends: nodejs` and that `windows-dir` appears anyway. Red today,
-and red again the next time some generator reads a project-wide field where a per-target
-one was meant.
-
-**What already works, so the gap is exactly this and not more:** all three layouts stage
-from one Linux host, the runtime packages exist (`@gjsify/node-runtime-{darwin-x64,
-win32-x64}` and the matching `gtk-runtime-*`, 119/89/73/77 MiB unpacked at 0.45.0), and
-every missing piece is named by the command itself rather than guessed.
+**What makes it non-obvious rather than a five-line follow-up.** The bundle path is read
+before the settings are resolved (`declaredBundlePath` feeds `discoverPayload`), several
+other keys are addressed relative to it, and `assertLauncherMatchesInterpreter` compares
+the launcher with the DEPENDENCY — never with the bundle's dialect, which nothing reads.
+So the failure mode is silent in exactly the way the runtime one was: a `.app` or a
+program directory that assembles, packs and installs, and dies at first launch on a
+machine nobody here owns. A fix wants the same shape as § A22 — one resolver, per target,
+with the resolved value in the stage manifest — plus a discriminator that can tell a GJS
+bundle from a Node one, which is the part that does not exist yet.
 
 ### `gjsify ship --sign`: three things M6 did not prove, each with what WAS measured
 

--- a/tests/e2e/ship-declaration/run.mjs
+++ b/tests/e2e/ship-declaration/run.mjs
@@ -158,6 +158,50 @@ describe('ship declaration invariant', { timeout: 5 * 60 * 1000 }, () => {
         assert.match(run(root).failures.join('\n'), /must be an object/);
     });
 
+    // `gjsify.ship.app` — the PER-TARGET runtime override (ADR 0024 § A22). The
+    // failure this rule exists for is the SILENT one: a runtime under a key
+    // nothing reads leaves that target on the project-wide `gjsify.app`, so the
+    // formats stay unavailable and the author reads it as gjsify not supporting
+    // the split, with every gate green. `gjsify ship` refuses the same mis-key
+    // (`resolveShipApp`); this is the half that fires in a tree nobody has run
+    // `ship` in yet.
+    describe('the per-target runtime override', () => {
+        it('passes all three keys, which is what distinguishes it from `sign`', () => {
+            const root = makeRoot('app-ok');
+            addPackage(root, 'app', {
+                name: '@fixture/app',
+                gjsify: { ship: { app: { linux: 'gjs', darwin: 'node', win32: 'node' } } },
+            });
+            assert.deepEqual(run(root).failures, []);
+        });
+
+        it('FAILS the `gjsify ship <os>` positional spelling', () => {
+            const root = makeRoot('app-poskey');
+            addPackage(root, 'app', {
+                name: '@fixture/app',
+                gjsify: { ship: { app: { windows: 'node' } } },
+            });
+            assert.match(run(root).failures.join('\n'), /`gjsify\.ship\.app\.windows` is not an OS/);
+        });
+
+        it('FAILS a runtime no format can wrap', () => {
+            const root = makeRoot('app-runtime');
+            addPackage(root, 'app', {
+                name: '@fixture/app',
+                gjsify: { ship: { app: { darwin: 'browser' } } },
+            });
+            assert.match(run(root).failures.join('\n'), /`gjsify\.ship\.app\.darwin` is "browser"/);
+        });
+
+        it('FAILS the project field written here by mistake', () => {
+            // `"app": "node"` is what a reader of `gjsify.app` types first, and it
+            // is not a second spelling of that field — it is the table over it.
+            const root = makeRoot('app-scalar');
+            addPackage(root, 'app', { name: '@fixture/app', gjsify: { ship: { app: 'node' } } });
+            assert.match(run(root).failures.join('\n'), /`gjsify\.ship\.app` must be an object keyed by OS/);
+        });
+    });
+
     // `TARGETS` in the rule above is the ONE copy of the ship format vocabulary the
     // compiler cannot bind: it lives in a package that must not import the CLI,
     // because the rule is `scope: 'portable'` and runs where `@gjsify/cli` is not a

--- a/tests/e2e/ship/run.mjs
+++ b/tests/e2e/ship/run.mjs
@@ -659,8 +659,9 @@ describe('CLI ship E2E', { timeout: 10 * 60 * 1000 }, () => {
     });
 
     it('refuses `--app node` for a runtime that has no node, before anything is staged', () => {
-        // The hole the `--app node` support opened. `assertShippableTarget` used
-        // to refuse `app: node` outright, so no format ever saw one; lifting that
+        // The hole the `--app node` support opened. The shippable-target refusal
+        // (`resolveShipApp`) used to refuse `app: node` outright, so no format ever
+        // saw one; lifting that
         // made deb and rpm correct and left Flatpak silently wrong. Measured at
         // exit 0 before this refusal: a manifest with `runtime: org.gnome.Platform`
         // and no `sdk-extensions`, beside a launcher that execs `node`.
@@ -721,6 +722,94 @@ describe('CLI ship E2E', { timeout: 10 * 60 * 1000 }, () => {
             ['-qp', '--requires', join(dir, 'ship', 'out', 'ship-demo-1.2.3-1.noarch.rpm')],
             { encoding: 'utf-8' },
         );
+        assert.match(requires, /^gjs >= 1\.86$/m);
+        assert.doesNotMatch(requires, /nodejs/);
+    });
+
+    it('resolves the runtime PER TARGET, so a windows override leaves the Linux package on gjs', () => {
+        // THE CLASS THIS GUARDS is not the override — it is a generator reading a
+        // PROJECT-wide field where a per-target one was meant. `gjsify.app`
+        // carried two questions on one field: which runtime the app needs, and
+        // which formats a target can build. Measured before #1486, on exactly this
+        // project shape: `gjsify ship darwin --stage` and `ship windows --stage`
+        // reported `formats (none — … need gjsify.app: "node")`, and setting that
+        // field to get them flipped the LINUX deb from `Depends: gjs (>= 1.86)` to
+        // `Depends: nodejs (>= 24)` — which apt refuses on trixie, Ubuntu 24.04 and
+        // Ubuntu 26.04. A macOS decision made a Linux package uninstallable.
+        //
+        // Both halves in ONE test, because either alone passes for the wrong
+        // reason: the Linux half alone passes on a project that never mentions
+        // windows, and the windows half alone passes under `gjsify.app: "node"`,
+        // which is the state the defect forced.
+        const dir = scaffold(join(tmpDir, 'per-target-runtime'), (pkg, at) => {
+            pkg.gjsify.app = 'gjs';
+            pkg.gjsify.ship.app = { win32: 'node' };
+            // The sibling a cross-OS project really builds. Staged either way —
+            // `discoverPayload` takes the whole directory — and which one the
+            // launcher NAMES is a separate axis (`gjsify.ship.bundle` is still one
+            // path), so this test says nothing about it.
+            writeFileSync(join(at, 'dist', 'app.node.mjs'), NODE_BUNDLE);
+        });
+
+        // ── the target that said NOTHING, and must therefore have changed nothing
+        runCliSync(CLI_ENTRY, ['ship', 'linux', '--skip-build', '--out', 'ship-linux'], { cwd: dir });
+        assert.match(readFileSync(join(dir, 'ship-linux', 'stage', 'bin', 'ship-demo'), 'utf-8'), /exec gjs -m /);
+
+        if (probe('ar') && probe('tar')) {
+            const extracted = join(tmpDir, 'per-target-deb');
+            mkdirSync(extracted, { recursive: true });
+            execFileSync('ar', ['x', join(dir, 'ship-linux', 'out', 'ship-demo_1.2.3-1_all.deb')], { cwd: extracted });
+            execFileSync('tar', ['xzf', 'control.tar.gz'], { cwd: extracted });
+            const control = readFileSync(join(extracted, 'control'), 'utf-8');
+            assert.match(control, /^Depends: .*gjs \(>= 1\.86\)/m);
+            // `nodejs` and not `nodejs \(>= 24\)`: ANY Node dependency here is the
+            // defect, whatever floor it carries.
+            assert.doesNotMatch(control, /nodejs/);
+        }
+        if (probe('rpm')) {
+            const requires = execFileSync(
+                'rpm',
+                ['-qp', '--requires', join(dir, 'ship-linux', 'out', 'ship-demo-1.2.3-1.noarch.rpm')],
+                { encoding: 'utf-8' },
+            );
+            assert.match(requires, /^gjs >= 1\.86$/m);
+            assert.doesNotMatch(requires, /nodejs/);
+        }
+
+        // ── and the target that DID say node, which is why its formats exist
+        const staged = runCliSync(CLI_ENTRY, ['ship', 'windows', '--skip-build', '--stage', '--out', 'ship-windows'], {
+            cwd: dir,
+        });
+        const manifest = JSON.parse(readFileSync(join(dir, 'ship-windows', 'stage', STAGE_MANIFEST_FILE), 'utf-8'));
+        assert.ok(
+            manifest.formats.includes('windows-dir'),
+            `windows-dir must be offered, got: ${manifest.formats.join(', ') || '(none)'}`,
+        );
+        // The RESOLVED value is what crosses to the packing host: `--from-stage`
+        // has no project and must not have to resolve anything again.
+        assert.equal(manifest.settings.app, 'node');
+        // And the override is SAID. One that silently changes the launcher, the
+        // dependency and the format list is one nobody can tell from the default.
+        assert.match(staged, /`gjsify\.ship\.app\.win32` overrides `gjsify\.app: "gjs"`/);
+    });
+
+    it('the Linux package follows its OWN target, and not the project-wide field', () => {
+        // THE DISCRIMINATING DIRECTION, and the test above does not have it. There,
+        // `gjsify.app` is `gjs` and so is the Linux answer, so a generator that
+        // regressed to reading the project field would still emit `Depends: gjs`
+        // and the assertion would pass having distinguished nothing. Here the two
+        // DISAGREE: the project says node, this target says gjs, and only a
+        // generator reading its own target's resolved runtime can get it right.
+        const dir = scaffold(join(tmpDir, 'linux-overrides-project'), (pkg, at) => {
+            pkg.gjsify.app = 'node';
+            pkg.gjsify.ship.app = { linux: 'gjs' };
+            writeFileSync(join(at, 'dist', 'app.node.mjs'), NODE_BUNDLE);
+        });
+        runCliSync(CLI_ENTRY, ['ship', '--skip-build'], { cwd: dir });
+
+        assert.match(readFileSync(join(dir, 'ship', 'stage', 'bin', 'ship-demo'), 'utf-8'), /exec gjs -m /);
+        if (!probe('rpm')) return;
+        const requires = execFileSync('rpm', ['-qp', '--requires', rpmPath(dir)], { encoding: 'utf-8' });
         assert.match(requires, /^gjs >= 1\.86$/m);
         assert.doesNotMatch(requires, /nodejs/);
     });

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -1468,7 +1468,9 @@ On **Linux** it is depended on, not shipped: `gjs (>= 1.86)`, or `nodejs (>= 24)
 
 On **macOS and Windows** there is no system interpreter to depend on, so the artifact carries its own from `@gjsify/node-runtime-<target>`, with the GTK closure from `@gjsify/gtk-runtime-<target>` and the addon from `@gjsify/node-gi`. You declare all three yourself in the project you package. They are resolved **by name** out of your own `node_modules` at ship time, so they have to be installed there. `GJSIFY_NODE_RUNTIME` and `GJSIFY_GTK_RUNTIME` override the first two with a directory. All six names resolve on npm at `0.44.0`, and `scripts/check-shipped-runtime-packages.mjs` re-measures them on every pull request. [macOS app bundles](/gjsify/ship/macos/) and [Windows artifacts](/gjsify/ship/windows/) carry the copy-pasteable blocks.
 
-That is also why the four macOS and Windows formats accept `gjsify.app: "node"` only. There is no relocatable GJS to put inside a downloadable bundle, and there is no GJS host on Windows at all.
+That is also why the four macOS and Windows formats accept `node` only. There is no relocatable GJS to put inside a downloadable bundle, and there is no GJS host on Windows at all.
+
+Which runtime a target ships is `gjsify.ship.app.<os>` — keyed `linux`, `darwin`, `win32` — falling back to `gjsify.app`. It is per target because the answer is: a project can be GJS on Linux, where the distribution provides one, and Node where nothing does. One field for both questions meant that asking for a `.app` moved the Linux package's `Depends:` with it.
 
 ### `gjsify flatpak`
 

--- a/website/src/content/docs/ship/index.mdx
+++ b/website/src/content/docs/ship/index.mdx
@@ -41,11 +41,17 @@ one payload under `ship/stage/`, and wraps that payload once per format into
 assembles the layout of the host you are sitting at, so name the operating
 system whenever you want one you are not on.
 
-| Command | What lands in `ship/out/` | Your app declares |
+| Command | What lands in `ship/out/` | That target runs |
 |---|---|---|
-| `gjsify ship linux` | `my-app_1.2.3-1_all.deb`, `my-app-1.2.3-1.noarch.rpm` | `gjsify.app: "gjs"` or `"node"` |
-| `gjsify ship darwin` | `My App.app`, `my-app-1.2.3-1.arm64.zip` | `gjsify.app: "node"` |
-| `gjsify ship windows` | `My App/`, `my-app-1.2.3-1.x64.zip` | `gjsify.app: "node"` |
+| `gjsify ship linux` | `my-app_1.2.3-1_all.deb`, `my-app-1.2.3-1.noarch.rpm` | `gjs` or `node` |
+| `gjsify ship darwin` | `My App.app`, `my-app-1.2.3-1.arm64.zip` | `node` |
+| `gjsify ship windows` | `My App/`, `my-app-1.2.3-1.x64.zip` | `node` |
+
+Each target's runtime is its own: `gjsify.ship.app.<os>`, keyed `linux`,
+`darwin`, `win32`, falling back to `gjsify.app`. So one project can be GJS on
+Linux and Node where no GJS exists, and stating the second half does not restate
+the first — before that key, asking for a `.app` moved the Linux package's
+`Depends:` with it.
 
 Assembling is never host-bound, so one workstation produces all three artifact
 sets. Packing is a different question, and two formats out of nine answer it
@@ -54,9 +60,8 @@ differently. See [where each format can be packed](#where-each-format-can-be-pac
 A Linux package declares its interpreter and its GTK libraries as dependencies
 and takes them from the distribution. The macOS bundle and the Windows program
 directory carry a Node interpreter and a GTK closure inside themselves, because
-neither operating system ships one. That is why those two accept
-`gjsify.app: "node"` only, and why they need extra packages in your
-`package.json`.
+neither operating system ships one. That is why those two accept `node` only,
+and why they need extra packages in your `package.json`.
 
 - [Linux packages](/gjsify/ship/linux-packages/) covers `.deb`, `.rpm` and the
   Flatpak bundle.
@@ -78,7 +83,7 @@ run.
 | `license` (an SPDX id such as `"MIT"`) | a required field in `.deb` and `.rpm` | `gjsify.ship.license.project` |
 | `author` as `"Name <you@example.org>"` | `Maintainer:`, `Packager:` and the MSI's `Publisher` | `gjsify.ship.maintainer` |
 | `gjsify.main` (or `main`) | the built bundle the launcher runs | `gjsify.ship.bundle` |
-| `gjsify.app` | the interpreter the launcher execs, `gjs -m` or `node`. Ship refuses a package whose launcher and declared dependency disagree | none |
+| `gjsify.app` | the interpreter the launcher execs, `gjs -m` or `node`. Ship refuses a package whose launcher and declared dependency disagree | `gjsify.ship.app.<os>`, per target |
 | `scripts.build` | the build step ship runs first | pass `--skip-build` instead |
 
 Two more you have to set yourself, because nothing can derive them:

--- a/website/src/content/docs/ship/linux-packages.md
+++ b/website/src/content/docs/ship/linux-packages.md
@@ -356,10 +356,14 @@ Depends: nodejs (>= 24)          # deb
 Requires: nodejs(engine) >= 24   # rpm
 ```
 
-`gjsify ship` picks the interpreter from `gjsify.app`, the same field your build
-already uses, and the launcher it writes execs that one and no other. A package
-therefore declares exactly one interpreter, and ship refuses to build one whose
-launcher and dependency disagree.
+`gjsify ship` picks the interpreter from `gjsify.ship.app.linux`, falling back to
+`gjsify.app` — the same field your build already uses — and the launcher it writes
+execs that one and no other. A package therefore declares exactly one interpreter,
+and ship refuses to build one whose launcher and dependency disagree.
+
+The per-target key is what keeps this section INDEPENDENT of the other two OSes.
+A macOS or Windows artifact has to run Node, and before that key existed saying so
+moved this dependency too: a working GJS `.deb` became one apt refuses everywhere.
 
 The `>= 24` default excludes every current Debian stable and Ubuntu LTS:
 

--- a/website/src/content/docs/ship/macos.md
+++ b/website/src/content/docs/ship/macos.md
@@ -25,10 +25,10 @@ run it on. It labels the artifact and picks which runtime packages are staged.
 It does not cross-compile your payload, so pass the architecture your bundle was
 built for.
 
-## Your project has to be a Node project
+## The darwin target has to be a Node target
 
-Set `gjsify.app` to `"node"`. A `--app gjs` project can stage the darwin layout
-and cannot pack it:
+A target whose runtime resolves to `gjs` can stage the darwin layout and cannot
+pack it:
 
 ```text
 gjsify ship: macos-app and macos-app-zip wrap the darwin layout, and neither can
@@ -38,6 +38,23 @@ run this project …
 macOS does ship GJS through Homebrew, and that is a fact about a developer's
 machine rather than about a `.app` a stranger downloads. There is no relocatable
 GJS to put inside a bundle, so a downloadable macOS artifact runs on Node.
+
+Say so for **this target alone**, which leaves a Linux package of the same
+project on GJS:
+
+```jsonc
+{
+  "gjsify": {
+    "app": "gjs",                        // the project default — Linux keeps it
+    "ship": { "app": { "darwin": "node" } }  // and macOS does not
+  }
+}
+```
+
+Setting `gjsify.app` to `"node"` works too and means something bigger: it moves
+every target, including the Linux `.deb`, from `Depends: gjs` to
+`Depends: nodejs`. Use the per-target key unless the whole application is a Node
+application.
 
 ## What your package.json declares
 
@@ -206,7 +223,7 @@ bundle will start on a Mac with neither Node nor Homebrew GTK installed.
 
 | Message says | Fix |
 |---|---|
-| `macos-app and macos-app-zip … neither can run this project` | set `gjsify.app` to `"node"` and rebuild the bundle for Node |
+| `macos-app and macos-app-zip … neither can run this project` | set `gjsify.ship.app.darwin` to `"node"` (or `gjsify.app`, for every target) and rebuild the bundle for Node |
 | `a macos-app-dmg artifact is packed on darwin and this host is …` | `--stage` here, `--from-stage` on a Mac |
 | `packing a macos-app on … needs glib-compile-schemas` | Fedora `sudo dnf install glib2`, Debian or Ubuntu `sudo apt install libglib2.0-bin` |
 | `this stage was assembled for …, and --target names …` | re-run the `--stage` command with every format named |

--- a/website/src/content/docs/ship/windows.md
+++ b/website/src/content/docs/ship/windows.md
@@ -26,11 +26,30 @@ Windows, publishes no arm64 binaries, so there is no GTK for a Windows on ARM
 artifact to load. `--arch arm64` is refused by name rather than producing a
 directory that cannot start.
 
-## Your project has to be a Node project
+## The windows target has to be a Node target
 
-Set `gjsify.app` to `"node"`. There is no GJS host on Windows at all, so nothing
-on that operating system can run a `--app gjs` payload. Ship says so before it
-packs anything.
+There is no GJS host on Windows at all, so nothing on that operating system can
+run a `gjs` payload. Ship says so before it packs anything.
+
+Set it for **this target alone**, and a Linux package of the same project stays
+on GJS:
+
+```jsonc
+{
+  "gjsify": {
+    "app": "gjs",                       // the project default — Linux keeps it
+    "ship": { "app": { "win32": "node" } }  // and Windows does not
+  }
+}
+```
+
+The key is `win32`, the `process.platform` spelling — not `windows`, the
+spelling the command positional takes. A key nothing reads would leave the
+target on the project default with nothing to say so, so `gjsify ship` and the
+manifest audit both refuse it by name.
+
+Setting `gjsify.app` to `"node"` works too and moves every target with it,
+including the Linux `.deb`'s `Depends:`.
 
 ## What your package.json declares
 
@@ -217,7 +236,7 @@ process computes about itself. The positional accepts both `windows` and
 
 | Message says | Fix |
 |---|---|
-| the windows layout cannot run a `gjs` app | set `gjsify.app` to `"node"` and rebuild the bundle for Node |
+| the windows layout cannot run a `gjs` app | set `gjsify.ship.app.win32` to `"node"` (or `gjsify.app`, for every target) and rebuild the bundle for Node |
 | `the windows layout is not assemblable for --arch arm64` | use `--arch x64`; there is no Windows on ARM GTK to load |
 | `packing a msi on … needs … wixl` | install `msitools`, or WiX Toolset v3.14 on Windows |
 | `is not a version an .msi can carry` | set `gjsify.ship.version` to a plain `x.y.z` |


### PR DESCRIPTION
Implements the fix #1486 filed, in the shape that entry records as binding.

## The defect

`gjsify.app` answered **two questions on one field**: which runtime the application needs, and which package formats a target can build. Same answer for a single-OS project, different answers for the cross-OS split ADR 0024 § 4 argues for — so § 4's own table was not statable.

Measured, on a GTK4 app that wants GJS on Linux and Node where no relocatable GJS exists:

| | |
|---|---|
| `gjsify ship darwin --stage` | `formats (none — macos-app and macos-app-zip need gjsify.app: "node")` |
| set `gjsify.app: "node"` to get them | the Linux `.deb` moves too: `Depends: gjs (>= 1.86)` → `Depends: nodejs (>= 24)` |

That floor is unsatisfiable on Debian trixie, Ubuntu 24.04 and Ubuntu 26.04 — so asking for a `.app` made the `.deb` uninstallable. The deb generator read the **project** field rather than the resolved runtime of **its own** target.

## The resolution

`gjsify.app` becomes the DEFAULT; each ship target may override it.

```jsonc
{
  "gjsify": {
    "app": "gjs",
    "ship": { "app": { "darwin": "node", "win32": "node" } }
  }
}
```

- **Keyed `linux` / `darwin` / `win32`** — the `process.platform` spelling, because the value that resolves is chosen by the LAYOUT being assembled and never by the host assembling it. Same rule `gjsify.ship.sign` already follows (ADR 0024 § A12).
- **One resolver.** `resolveShipApp` (`utils/ship/settings.ts`) turns the pair into a runtime and is the only thing that does. `commands/ship.ts`'s free `assertShippableTarget` folds into it, so the `browser`/`nativescript` refusal names the **key** that carried the value — with two keys, "this project declares" no longer locates it.
- **Every generator reads its own target's answer**: the launcher, `deriveDepends`, `resolveCarriedRuntime`, the format-availability filter. `resolveShipSettings` takes the already-resolved value typed `'gjs' | 'node'`, so handing it the project field is a compile error rather than a silent regression.
- **`--from-stage` is untouched and needs to be.** The stage manifest has always recorded the RESOLVED value, so the packing host reads an answer rather than re-deriving a default it has no project for.
- **No per-LAYOUT default.** An absent override means `gjsify.app`, never `Layout.shippedRuntime` — defaulting darwin to `node` is the measured defect that field's own doc records (a project with no `gjsify.app` key staged `exec node …/gjs.js` in front of a bundle opening with `import Gtk from 'gi://Gtk?version=4.0'`, at exit 0).
- The alternative #1486 rejects — just offering `macos-app`/`windows-dir` under `app: "gjs"` — stays rejected: it stages a bundle whose runtime assumption nobody stated.

### The mechanism, not only the fix

A mis-keyed override is the silent failure. `gjsify.ship.app.windows` — the `gjsify ship <os>` positional's spelling — would resolve to nothing, leave the target on the project-wide answer, and read to the author as gjsify not supporting the split, with every gate green. That is `gjsify.ship.sign`'s documented silent-key class one table over, so `manifest-conformance`'s `ship` rule refuses a key outside `{linux,darwin,win32}` and a value outside `{gjs,node}` by name. The override is also PRINTED at stage time.

## The class test

`tests/e2e/ship` guards the class — *a generator reading a project-wide field where a per-target one was meant* — and needs two directions to do it:

- **(a), the one #1486 prescribes:** `app: "gjs"` + `ship.app.win32: "node"` → the Linux `.deb`/`.rpm` carries **no** Node dependency, and `windows-dir` is offered anyway.
- **(b), the mirror, which is the discriminating one:** `app: "node"` + `ship.app.linux: "gjs"` → the Linux package depends on `gjs`. In (a) the project field and the Linux answer agree, so a generator that regressed to reading the project field would still emit `Depends: gjs` and (a) would distinguish nothing.

**Both were red before the fix**, verified by reverting the source and rebuilding: (a) on `windows-dir must be offered, got: (none)`, (b) on a staged launcher reading `exec node "$prefix"/lib/ship-demo/gjs.js`.

Plus four unit cases on `resolveShipApp` itself (default, override, which key answered, and the refusal naming the key).

## The ADR amendment

**§ A22 — `gjsify.app` is the DEFAULT; each ship target resolves its own runtime**, in the style of § A1-§ A21: the measurement, the decision, why there is no per-layout default, the rejected alternative, the conformance rule, and the two-direction test with what each was red on. § 4's table gains an inline `**Amended 2026-09-02 (§ A22)**` note — its heading's *"not chosen per app"* keeps its meaning and narrows its scope: nothing is derived from the layout, an author states it per OS.

The amendment also states **what this does not do**: the runtime is per target, the **bundle** is still one path (`gjsify.ship.bundle`). A cross-OS project builds two bundles and `discoverPayload` stages both, but every layout's launcher names the same one. `status/open-todos.md` drops the entry this PR closes and carries that next axis instead, with why it is not a five-line follow-up.

Docs updated with the contract: `docs/ship-formats.md`, the three website `ship/` pages, `cli-reference.md`, and the release-notes preamble.

## Verified locally

`@gjsify/cli` build + `check` + 3517 unit tests; `tests/e2e/{ship,ship-layout,ship-from-stage,ship-windows,ship-macos,ship-signing,ship-declaration}` all green (`ship-msi` needs `wixl`, which this workstation has no package for — it is baked into the CI image); `audit-runtimes --check`, `check-ship-format-vocabulary`, `lint`, `format --check`, `check-lint-visibility`, `check-source-visibility`, `check-doc-fences`, `check-changelog-references`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7cvsEJVF84chQMyj5A9x
