### PR TITLE
feat(node-gi): marshal GError OUT/INOUT/IN args

### DIFF
--- a/docs/node-gi-gjs-surface.md
+++ b/docs/node-gi-gjs-surface.md
@@ -25,7 +25,17 @@ containers, struct OUT params and **caller-allocates OUT structs** — boxed
 (incl. the GValue auto-unbox) AND plain non-boxed C structs (the engine
 g_malloc0's the struct, the callee fills it in place, JS gets a field-readable
 handle that owns the storage — e.g. the `PangoRectangle`s of
-`PangoLayout.get_pixel_extents()`, the canvas2d `measureText` path). A JS
+`PangoLayout.get_pixel_extents()`, the canvas2d `measureText` path).
+A **`GError` parameter** (`GI_TYPE_TAG_ERROR`) marshals in every direction — the
+explicit one an API declares, as distinct from the implicit `throws=1` GError the
+invoker turns into a thrown `GLib.Error`. An OUT/INOUT slot reads back as a
+field-readable `GLib.Error` boxed (`Gst.Message.parse_error()`, `GLib.set_error_literal`),
+a slot the callee left alone reads back as `null` rather than an empty error, and an
+IN arg takes such a boxed and honours its transfer — borrowed for `(transfer none)`
+(`Gst.Message.new_error`), an independent `g_error_copy` for `(transfer full)`
+(`g_propagate_error` adopts and frees its `src`). Until #1495 the OUT direction was
+refused before the invoke, which put every GStreamer bus-error accessor out of
+reach: an application could see that playback stopped and not why. A JS
 `Uint8Array` (or `Buffer`/`DataView`/`ArrayBuffer`) passed where a **`GLib.Bytes`
 IN-arg** is expected is copied into a fresh GBytes and released per transfer
 after the call, exactly as GJS (`GdkPixbuf.Pixbuf.new_from_bytes(pixels, …)`);

--- a/docs/node-gi-gjs-surface.md
+++ b/docs/node-gi-gjs-surface.md
@@ -33,7 +33,13 @@ field-readable `GLib.Error` boxed (`Gst.Message.parse_error()`, `GLib.set_error_
 a slot the callee left alone reads back as `null` rather than an empty error, and an
 IN arg takes such a boxed and honours its transfer — borrowed for `(transfer none)`
 (`Gst.Message.new_error`), an independent `g_error_copy` for `(transfer full)`
-(`g_propagate_error` adopts and frees its `src`). Until #1495 the OUT direction was
+(`g_propagate_error` adopts and frees its `src`). An IN arg ALSO takes the OTHER
+`GLib.Error` shape node-gi hands out — the L1 JS class a `catch` or
+`new GLib.Error(…)` produces, which has no `GError*` behind it — by rebuilding a
+real GError from its domain/code/message and releasing it per the same transfer
+rule GBytes and GValue IN-args follow; an error whose domain resolves to quark 0
+is refused by name rather than marshalled into one `matches()` could never answer
+for. Until #1495 the OUT direction was
 refused before the invoke, which put every GStreamer bus-error accessor out of
 reach: an application could see that playback stopped and not why. A JS
 `Uint8Array` (or `Buffer`/`DataView`/`ArrayBuffer`) passed where a **`GLib.Bytes`

--- a/docs/node-gi-verification.md
+++ b/docs/node-gi-verification.md
@@ -54,6 +54,45 @@ parsed once at first use, zero cost when unset — never set them in production)
   env-cleanup drain race (`test/gc-cross-thread.test.mjs`, "teardown drain
   during env cleanup never aborts").
 
+### Ownership: assert the POINTER, don't wait for the crash
+
+An IN-transfer rule is a statement about pointer identity — *a transfer-full
+boxed IN arg gets an independent copy, never the block the JS handle still owns*
+— and the natural-looking test for it does not hold it. "Run the call 200 times,
+`gc()`, and see whether a double free aborts" only fails when the allocator has
+NOT recycled the block between the two frees. **Measured while reviewing #1496**:
+with `TransferBoxedIn` cut down to a bare borrow — a genuine double free on every
+one of those 200 rounds — `test/gerror-out.test.mjs` passed 5 runs out of 5, and
+the same program under `valgrind` reported 0 errors.
+
+So assert the addresses. `__boxedAddress(unwrap(value))` (index.js + gi.js,
+test-only) reports what a boxed handle wraps, and the rule becomes one
+deterministic line — `assert.notEqual(boxedAddress(dest), boxedAddress(src))` —
+that fails on the first round. It works wherever the callee stores the very
+pointer it was handed, which is the usual shape (`g_propagate_error`,
+`g_prefix_error_literal`). Keep the rounds + `drainFinalizers()` beside it: the
+identity check proves the copy is made, the rounds prove the copies are released.
+
+What this still does NOT catch is the pure LEAK half — a read-back that copies
+where it should adopt, or a synthesised IN object never released. Both keep every
+assertion green, because a leak has no observable effect in-process. Two
+instruments do catch it, neither in CI:
+
+```bash
+# 1. valgrind, twice at different volumes. `definitely lost` must be CONSTANT —
+#    a per-call leak scales with the loop, un-run finalizers at exit do not.
+NODE_GI_NATIVE=build ROUNDS=300  valgrind --leak-check=full --show-leak-kinds=definite \
+    --smc-check=all-non-file node --jitless --expose-gc <probe>.mjs
+NODE_GI_NATIVE=build ROUNDS=1500 valgrind … # same command, same totals expected
+# 2. a temporary counter: increment in MakeBoxedHandle and in
+#    FreeBoxedHandleRecord's g_boxed_free branch, print both at exit. After a
+#    gc + finalizer drain they must be EQUAL. Removed again before committing.
+```
+
+RSS is not one of them. A flat RSS over 200 000 allocate-and-drop cycles is
+consistent with a small per-call leak the allocator keeps reusing, so it can
+refute a large leak and never establish the absence of one.
+
 ## Conformance (golden-diff)
 
 The exactness oracle for GJS parity: small self-contained `gi://` programs

--- a/packages/node-gi/node-gi/conformance/golden/gerror-out-params.txt
+++ b/packages/node-gi/node-gi/conformance/golden/gerror-out-params.txt
@@ -1,0 +1,13 @@
+OUT is null: false
+message: boom
+code: 7
+matches(domain, 7): true
+matches(domain, 8): false
+matches(other, 7): false
+propagated message: boom
+propagated code: 7
+propagated matches(domain, 7): true
+source still readable: boom
+prefixed message: context: boom
+prefixed code: 7
+inout source untouched: boom

--- a/packages/node-gi/node-gi/conformance/golden/gerror-out-params.txt
+++ b/packages/node-gi/node-gi/conformance/golden/gerror-out-params.txt
@@ -11,3 +11,7 @@ source still readable: boom
 prefixed message: context: boom
 prefixed code: 7
 inout source untouched: boom
+constructed message: constructed
+constructed code: 9
+constructed matches(domain, 9): true
+constructed matches(other, 9): false

--- a/packages/node-gi/node-gi/conformance/programs/gerror-out-params.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/gerror-out-params.conf.mjs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// GError-typed OUT / INOUT / IN parameters (`GI_TYPE_TAG_ERROR`, #1495) — the
+// direction half of the GError contract; error-matches.conf.mjs covers the
+// implicit `throws=1` one. GLib only, so it runs on every runtime.
+//
+// The numeric GQuark is deliberately NOT printed: it depends on how many quarks
+// the process interned first, so it is a value, not a fact. matches() carries the
+// domain instead — and carries it as a DISCRIMINATOR (a wrong code and a wrong
+// domain must both be false), because a stub answering true would satisfy the
+// positive case alone.
+import GLib from 'gi://GLib?version=2.0';
+
+const DOMAIN = GLib.quark_from_string('node-gi-conf-gerror');
+const OTHER = GLib.quark_from_string('node-gi-conf-gerror-other');
+
+// void return + one (transfer full) GError OUT → the error, bare.
+const err = GLib.set_error_literal(DOMAIN, 7, 'boom');
+print('OUT is null:', err === null);
+print('message:', err.message);
+print('code:', err.code);
+print('matches(domain, 7):', err.matches(DOMAIN, 7));
+print('matches(domain, 8):', err.matches(DOMAIN, 8));
+print('matches(other, 7):', err.matches(OTHER, 7));
+
+// (transfer full) GError IN — g_propagate_error adopts `src`, so the binding owes
+// the callee an independent copy and the source stays readable here.
+const propagated = GLib.propagate_error(err);
+print('propagated message:', propagated.message);
+print('propagated code:', propagated.code);
+print('propagated matches(domain, 7):', propagated.matches(DOMAIN, 7));
+print('source still readable:', err.message);
+
+// INOUT — the callee reads the slot it was handed and writes the rewritten error back.
+const prefixed = GLib.prefix_error_literal(propagated, 'context: ');
+print('prefixed message:', prefixed.message);
+print('prefixed code:', prefixed.code);
+print('inout source untouched:', propagated.message);

--- a/packages/node-gi/node-gi/conformance/programs/gerror-out-params.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/gerror-out-params.conf.mjs
@@ -35,3 +35,16 @@ const prefixed = GLib.prefix_error_literal(propagated, 'context: ');
 print('prefixed message:', prefixed.message);
 print('prefixed code:', prefixed.code);
 print('inout source untouched:', propagated.message);
+
+// A GError an application BUILT, handed back into an IN arg. On gjs there is one
+// GLib.Error object and this is the same path as above; node-gi has two shapes
+// (the L1 JS class here, a boxed handle above) and this is the one an application
+// actually holds after a `catch`. `instanceof` is deliberately not printed — that
+// IS the divergence still open (status/open-todos.md), and a golden asserting it
+// would freeze the wrong side.
+const built = new GLib.Error(DOMAIN, 9, 'constructed');
+const rebuilt = GLib.propagate_error(built);
+print('constructed message:', rebuilt.message);
+print('constructed code:', rebuilt.code);
+print('constructed matches(domain, 9):', rebuilt.matches(DOMAIN, 9));
+print('constructed matches(other, 9):', rebuilt.matches(OTHER, 9));

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -166,7 +166,12 @@ function buildGError(domainName, domainQuark, code, message) {
     error.domainQuark = domainQuark;
     return error;
 }
-native.setErrorBuilder(buildGError);
+// The CLASS is registered with the builder, because the engine needs it the other
+// way round too: a `GError`-typed IN argument recognises a caught (or `new`-ed)
+// GLib.Error by `instanceof` and rebuilds a real GError from its fields, so an
+// application can hand back the error it is holding (`GLib.propagate_error`,
+// `Gst.Message.new_error`). One call, so builder and class cannot drift apart.
+native.setErrorBuilder(buildGError, GLibError);
 
 // Stamps a makeClass prototype with its { namespace, typeName } so Gio._promisify can
 // record WHICH introspected class a registration belongs to — matched against the

--- a/packages/node-gi/node-gi/index.d.ts
+++ b/packages/node-gi/node-gi/index.d.ts
@@ -57,10 +57,15 @@ export function getErrorDomain(namespace: string, name: string): { name: string;
 
 /**
  * Register the L1 GLib.Error factory the engine calls when a GI invoke fails, so
- * a failed sync call throws a real `GLib.Error` (instanceof, with `.matches()`).
+ * a failed sync call throws a real `GLib.Error` (instanceof, with `.matches()`),
+ * together with the CLASS it builds — which a `GError`-typed IN argument uses to
+ * recognise such an error coming back and rebuild a real `GError` from its
+ * fields. Without the class that direction accepts only a marshalled (boxed)
+ * error, so a caught one cannot be handed on.
  */
 export function setErrorBuilder(
     builder: (domainName: string, domainQuark: number, code: number, message: string) => Error,
+    errorClass?: new (domain: unknown, code: number, message: string) => Error,
 ): void;
 
 /** Prepend a directory to the GIRepository typelib search path. */
@@ -387,6 +392,14 @@ export function setBoxedField(handle: BoxedHandle, name: string, value: unknown)
  * registered GType. Lets L1 attach type-specific conveniences (GLib.Bytes.toArray).
  */
 export function boxedTypeName(value: unknown): string | null;
+/**
+ * TEST-ONLY: the address a boxed handle wraps, as a hex string (`null` for anything
+ * else). Lets a test assert an IN-transfer ownership rule — "a transfer-full boxed
+ * IN arg is handed a COPY" — directly, instead of running the call many times and
+ * waiting for a double free that only aborts when the allocator has not recycled
+ * the block. Nothing on the runtime path may branch on it.
+ */
+export function __boxedAddress(value: unknown): string | null;
 
 /**
  * Opaque handle to a GObject.ParamSpec (a GObject fundamental, ref-counted via
@@ -604,6 +617,7 @@ declare const native: {
     getBoxedField: typeof getBoxedField;
     setBoxedField: typeof setBoxedField;
     boxedTypeName: typeof boxedTypeName;
+    __boxedAddress: typeof __boxedAddress;
     isParamSpecHandle: typeof isParamSpecHandle;
     paramSpecProp: typeof paramSpecProp;
     variantNew: typeof variantNew;

--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -244,6 +244,9 @@ export const boxedMemberKind = native.boxedMemberKind;
 export const getBoxedField = native.getBoxedField;
 export const setBoxedField = native.setBoxedField;
 export const boxedTypeName = native.boxedTypeName;
+/** TEST-ONLY: the address a boxed handle wraps, so an ownership rule about pointer
+ * IDENTITY can be asserted instead of waited on (see marshal.cc BoxedAddress). */
+export const __boxedAddress = native.__boxedAddress;
 export const isParamSpecHandle = native.isParamSpecHandle;
 
 // True for a non-GObject GObject-fundamental handle (a GskRenderNode from

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -110,6 +110,7 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("getBoxedField", Napi::Function::New(env, GetBoxedField));
   exports.Set("setBoxedField", Napi::Function::New(env, SetBoxedField));
   exports.Set("boxedTypeName", Napi::Function::New(env, BoxedTypeName));
+  exports.Set("__boxedAddress", Napi::Function::New(env, BoxedAddress));
   exports.Set("isParamSpecHandle", Napi::Function::New(env, IsParamSpecHandle));
   exports.Set("isFundamentalHandle", Napi::Function::New(env, IsFundamentalHandle));
   exports.Set("paramSpecProp", Napi::Function::New(env, ParamSpecProp));

--- a/packages/node-gi/node-gi/src/calls.cc
+++ b/packages/node-gi/node-gi/src/calls.cc
@@ -331,9 +331,8 @@ static NodeGiCallback* CreateCallback(Napi::Env env, Napi::Function fn, GICallab
 
 // Whether `type` is a supported OUT/INOUT marshalling type for this milestone:
 // fundamentals (numbers/bool), strings (utf8/filename), GObject/interface +
-// enums/flags, struct/boxed/union (wrapped as boxed handles on return), and the
-// containers (arrays, GList/GSList/GHashTable). GError (its own roadmap PR) is
-// deferred: a clear error rather than silent mis-handling. *why receives a short
+// enums/flags, struct/boxed/union (wrapped as boxed handles on return), GError,
+// and the containers (arrays, GList/GSList/GHashTable). *why receives a short
 // type label on refusal. Declared in common.h — shared with the vfunc chain-up
 // path (class.cc CallParentVfunc), which routes each OUT/INOUT vfunc arg the same
 // way this function-invoke path does.
@@ -365,6 +364,20 @@ bool IsSupportedOutType(GITypeInfo* type, std::string* why) {
       if (iface != nullptr) gi_base_info_unref(iface);
       return ok;
     }
+    case GI_TYPE_TAG_ERROR:
+      // A `GError**` OUT slot — `Gst.Message.parse_error()` and the nine other bus
+      // accessors of the GStreamer message APIs, `GLib.set_error_literal`,
+      // `GLib.propagate_error`. Every one of the 18 in a 264-typelib sweep is
+      // caller_allocates=false + transfer=EVERYTHING, i.e. the ordinary pointer
+      // slot: the callee writes a GError the caller then owns. ReadOutOrReturn
+      // falls through to GIArgumentToJs's GI_TYPE_TAG_ERROR arm (marshal.cc), which
+      // wraps it through GLib.Error's struct info — G_TYPE_ERROR is a boxed type,
+      // so the JS handle adopts the transfer-full pointer and its finalizer
+      // g_boxed_free's it (= g_error_free) exactly like any other EVERYTHING boxed
+      // OUT. A callee that leaves the slot untouched (`parse_info()` on an ERROR
+      // message) reads back the zero-initialised slot as `null`, matching gjs,
+      // because `slots` is value-initialised and that arm null-guards the pointer.
+      return true;
     case GI_TYPE_TAG_ARRAY:
     case GI_TYPE_TAG_GLIST:
     case GI_TYPE_TAG_GSLIST:

--- a/packages/node-gi/node-gi/src/calls.cc
+++ b/packages/node-gi/node-gi/src/calls.cc
@@ -365,18 +365,22 @@ bool IsSupportedOutType(GITypeInfo* type, std::string* why) {
       return ok;
     }
     case GI_TYPE_TAG_ERROR:
-      // A `GError**` OUT slot — `Gst.Message.parse_error()` and the nine other bus
+      // A plain `GError**` OUT slot — `Gst.Message.parse_error()` and the other bus
       // accessors of the GStreamer message APIs, `GLib.set_error_literal`,
-      // `GLib.propagate_error`. Every one of the 18 in a 264-typelib sweep is
-      // caller_allocates=false + transfer=EVERYTHING, i.e. the ordinary pointer
-      // slot: the callee writes a GError the caller then owns. ReadOutOrReturn
-      // falls through to GIArgumentToJs's GI_TYPE_TAG_ERROR arm (marshal.cc), which
-      // wraps it through GLib.Error's struct info — G_TYPE_ERROR is a boxed type,
-      // so the JS handle adopts the transfer-full pointer and its finalizer
-      // g_boxed_free's it (= g_error_free) exactly like any other EVERYTHING boxed
-      // OUT. A callee that leaves the slot untouched (`parse_info()` on an ERROR
-      // message) reads back the zero-initialised slot as `null`, matching gjs,
-      // because `slots` is value-initialised and that arm null-guards the pointer.
+      // `GLib.propagate_error`. Swept over the installed typelibs, EVERY GError
+      // OUT/INOUT parameter is caller_allocates=false + transfer=EVERYTHING, so
+      // this tag never reaches the caller-allocates branch above and the callee
+      // always writes a GError the caller then owns.
+      //
+      // Ownership needs nothing new: ReadOutOrReturn falls through to
+      // GIArgumentToJs's GI_TYPE_TAG_ERROR arm (marshal.cc), and G_TYPE_ERROR is a
+      // BOXED type — glib gobject/gboxed.c,
+      // `G_DEFINE_BOXED_TYPE(GError, g_error, g_error_copy, g_error_free)` — so the
+      // handle adopts a transfer-full pointer and its finalizer g_boxed_free's it
+      // (= g_error_free) exactly like any other EVERYTHING boxed OUT. A callee that
+      // leaves the slot untouched (`parse_info()` on an ERROR message) reads back as
+      // `null` and not an empty error, because `slots` is value-initialised and that
+      // arm null-guards the pointer — matching gjs.
       return true;
     case GI_TYPE_TAG_ARRAY:
     case GI_TYPE_TAG_GLIST:
@@ -594,6 +598,7 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
   // belong to the callee (dropped only when the callee never ran).
   CreatedBytes createdBytes;
   CreatedValues createdValues;
+  CreatedErrors createdErrors;
   bool ok = true;
   size_t jsCursor = 0;
   std::vector<LengthWrite> lengthWrites;
@@ -772,7 +777,8 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
           jsCursor++;
           GITransfer tr = gi_arg_info_get_ownership_transfer(ai);
           if (JsToGIArgument(env, v, ti, &slots[i], &held[i], tr, &ownedInStrings, nullptr,
-                             nullptr, nullptr, gi_base_info_get_name(reinterpret_cast<GIBaseInfo*>(ai)))) {
+                             nullptr, nullptr, &createdErrors,
+                             gi_base_info_get_name(reinterpret_cast<GIBaseInfo*>(ai)))) {
             in_args[inPos[i]].v_pointer = &slots[i];
             out_args[outPos[i]].v_pointer = &slots[i];
           } else {
@@ -878,7 +884,7 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
       } else {
         GITransfer tr = gi_arg_info_get_ownership_transfer(ai);
         ok = JsToGIArgument(env, v, ti, &in_args[inPos[i]], &held[i], tr, &ownedInStrings,
-                            &createdClosures, &createdBytes, &createdValues,
+                            &createdClosures, &createdBytes, &createdValues, &createdErrors,
                             gi_base_info_get_name(reinterpret_cast<GIBaseInfo*>(ai)));
       }
     }
@@ -900,6 +906,9 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
     // Likewise every GValue boxed from a plain JS value — never adopted.
     for (GValue* gv : createdValues.transferNone) NodeGiFreeBoxedGValue(gv);
     for (GValue* gv : createdValues.transferFull) NodeGiFreeBoxedGValue(gv);
+    // Likewise every GError built from an L1 GLib.Error — never adopted.
+    for (GError* e : createdErrors.transferNone) g_error_free(e);
+    for (GError* e : createdErrors.transferFull) g_error_free(e);
     // Likewise the transfer-full-instance ref: the callee never consumed it.
     if (instanceRefTaken) g_object_unref(static_cast<GObject*>(instance));
     for (gpointer s : ownedInStrings) g_free(s);  // never reached the callee (#658)
@@ -944,6 +953,11 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
   // box is ours to free — success AND error paths, mirroring the GBytes rule.
   // Transfer-full GValues were adopted by the callee — no release.
   for (GValue* gv : createdValues.transferNone) NodeGiFreeBoxedGValue(gv);
+  // Transfer-none GError IN-args built from an L1 GLib.Error: the callee copied
+  // what it kept (gst_message_new_error copies the GError into the message), so
+  // the build is ours to free — success AND error paths, mirroring the two rules
+  // above. Transfer-full GErrors were adopted by the callee — no release.
+  for (GError* e : createdErrors.transferNone) g_error_free(e);
   if (!success) {
     for (const InContainer& c : inContainers) FreeInContainer(c);
     // A failed invoke did not adopt the transfer-full IN/INOUT strings we g_strdup'd

--- a/packages/node-gi/node-gi/src/class.cc
+++ b/packages/node-gi/node-gi/src/class.cc
@@ -837,7 +837,8 @@ static Napi::Value InvokeVFuncPointer(Napi::Env env, GObject* obj, GICallableInf
         jsCursor++;
         GITransfer tr = gi_arg_info_get_ownership_transfer(ai);
         if (JsToGIArgument(env, v, ti, &slots[i], &holds[i], tr, &ownedInStrings, nullptr,
-                           nullptr, nullptr, gi_base_info_get_name(reinterpret_cast<GIBaseInfo*>(ai))))
+                           nullptr, nullptr, nullptr,
+                           gi_base_info_get_name(reinterpret_cast<GIBaseInfo*>(ai))))
           giArgs[1 + i].v_pointer = &slots[i];
         else
           ok = false;  // JsToGIArgument already threw
@@ -892,7 +893,8 @@ static Napi::Value InvokeVFuncPointer(Napi::Env env, GObject* obj, GICallableInf
       jsCursor++;
       GITransfer tr = gi_arg_info_get_ownership_transfer(ai);
       ok = JsToGIArgument(env, v, ti, &giArgs[1 + i], &holds[i], tr, &ownedInStrings, nullptr,
-                          nullptr, nullptr, gi_base_info_get_name(reinterpret_cast<GIBaseInfo*>(ai)));
+                          nullptr, nullptr, nullptr,
+                          gi_base_info_get_name(reinterpret_cast<GIBaseInfo*>(ai)));
     }
 
     avalue.push_back(&giArgs[1 + i]);

--- a/packages/node-gi/node-gi/src/common.h
+++ b/packages/node-gi/node-gi/src/common.h
@@ -66,6 +66,11 @@ GIRepository* DupDefaultRepository();
 // Init, freed by the instance-data finalizer at env teardown.
 struct NodeGiEnvData {
   napi_ref errorBuilder = nullptr;
+  // The CLASS the builder above constructs — L1's `GLib.Error`. Registered with
+  // the builder (one call, so the two cannot drift apart) and read the other way
+  // round: a GError-typed IN arg uses it to recognise an L1 error and rebuild a
+  // real GError from its fields. Per-env for the same reason as errorBuilder.
+  napi_ref errorClass = nullptr;
   // L1-registered resolver for Gtk.Template `<signal handler="…">` callbacks: given
   // (instanceHandle, handlerName) it returns the instance's bound JS method (or
   // undefined). Stored per-env for the same reason as errorBuilder (a napi_ref is
@@ -279,22 +284,32 @@ struct CreatedClosures {
   std::vector<GClosure*> transferFull;  // callee adopts; unref only when the callee never ran
 };
 
-// ---- JS bytes -> GBytes IN-args ----------------------------------------------
+// ---- C objects this layer SYNTHESISES for one IN argument --------------------
 //
+// Three IN arms build a throw-away C object out of a plain JS value, because the
+// JS side has no handle to hand over: a Uint8Array for a `GLib.Bytes` arg, a
+// number/string for a `GObject.Value` arg, an L1 `GLib.Error` for a `GError` arg.
+// All three carry the SAME lifetime rule, which is why they share one type
+// instead of a third near-identical struct: transfer-none → the callee borrowed
+// (or copied) it, so we release it after the invoke; transfer-full → the callee
+// adopted it, so it is released only when the invoke never ran.
+template <typename T>
+struct CreatedIn {
+  std::vector<T*> transferNone;  // release after the invoke (callee borrowed/copied)
+  std::vector<T*> transferFull;  // callee adopts; release only when the callee never ran
+  void Record(T* p, GITransfer transfer) {
+    (transfer == GI_TRANSFER_NOTHING ? transferNone : transferFull).push_back(p);
+  }
+};
+
 // A JS Uint8Array (or any TypedArray/DataView/ArrayBuffer) passed for a
 // `GLib.Bytes`-typed IN parameter (e.g. GdkPixbuf.Pixbuf.new_from_bytes,
 // g_compute_checksum_for_bytes) is COPIED into a fresh GBytes — exactly what GJS
 // does (refs/gjs/gi/arg-cache.cpp GBytesIn::in → gjs_byte_array_get_bytes →
-// g_bytes_new). Lifetime follows gjs: a transfer-none arg drops the fresh ref
-// after the invoke (GBytesInTransferNone::release → g_boxed_free; a callee that
-// kept the bytes holds its own ref), a transfer-full arg leaves the ref with the
-// callee (GBytesIn::release skips via the ignore_release mark). GBytes created
-// during an invoke are recorded here so calls.cc can release them on the right
-// path (mirrors CreatedClosures).
-struct CreatedBytes {
-  std::vector<GBytes*> transferNone;  // unref after the invoke (callee borrowed/ref'd)
-  std::vector<GBytes*> transferFull;  // callee adopts; unref only when the callee never ran
-};
+// g_bytes_new), and released per the rule above (gjs
+// GBytesInTransferNone::release → g_boxed_free; GBytesIn::release skips for
+// transfer-full via the ignore_release mark).
+using CreatedBytes = CreatedIn<GBytes>;
 
 // A plain JS value handed to a `GObject.Value` IN-arg is BOXED into a fresh
 // GValue whose GType is guessed from the JS value — exactly what GJS does
@@ -305,14 +320,18 @@ struct CreatedBytes {
 // with "Unsupported interface IN argument", because a JS number is not a boxed
 // handle. An existing GObject.Value boxed handle still routes through the
 // boxed-handle path and is passed through untouched.
-//
-// Lifetime mirrors CreatedBytes: the box is freed after the invoke for
-// transfer-none (the callee copied whatever it needed — g_object_set_property
-// copies into the property), and left with the callee for transfer-full.
-struct CreatedValues {
-  std::vector<GValue*> transferNone;  // free after the invoke (callee borrowed)
-  std::vector<GValue*> transferFull;  // callee adopts; free only when it never ran
-};
+using CreatedValues = CreatedIn<GValue>;
+
+// An L1 `GLib.Error` (what a `catch` hands you, and what `new GLib.Error(…)`
+// builds) has no `GError*` behind it — it is a JS class, not a boxed handle — so
+// a `GError`-typed IN arg gets a fresh `g_error_new_literal` built from its
+// domain/code/message. Without this, the hand-back direction the OUT direction
+// exists for is only open to errors that came OUT of GI in the first place:
+// `GLib.propagate_error(caught)` and `Gst.Message.new_error(src, caught, dbg)`
+// both refused where gjs accepts, which is the shape an application actually
+// writes. A marshalled GError (a boxed handle) still routes through
+// TransferBoxedIn and is not copied here.
+using CreatedErrors = CreatedIn<GError>;
 
 // Release a GValue this layer boxed: unset the held value (dropping the ref an
 // object/boxed/string GValue took) and free the struct. A plain `g_free` would
@@ -340,6 +359,9 @@ GClosure* NodeGiMakeGenericJsClosure(Napi::Env env, Napi::Value fn);
 // `values` (optional): enables the JS-value→GValue IN-arg boxing above; nullptr
 // (the default) keeps the previous behaviour (plain value → TypeError) on paths
 // that cannot release a created GValue.
+// `errors` (optional): enables the L1-GLib.Error→GError IN-arg build above;
+// nullptr (the default) keeps a marshalled boxed handle working and refuses the
+// L1 class, on paths that cannot release a created GError.
 // `argName` (optional): the introspected argument name, used ONLY in error
 // messages so a refusal reads like gjs's ("Expected type string for argument
 // 'name' but got type number"); nullptr degrades to a message without the name.
@@ -350,6 +372,7 @@ bool JsToGIArgument(Napi::Env env, Napi::Value v, GITypeInfo* type, GIArgument* 
                     CreatedClosures* closures = nullptr,
                     CreatedBytes* bytes = nullptr,
                     CreatedValues* values = nullptr,
+                    CreatedErrors* errors = nullptr,
                     const char* argName = nullptr);
 
 // ---- IN container building -----------------------------------------
@@ -607,6 +630,8 @@ Napi::Value BoxedMemberKind(const Napi::CallbackInfo& info);
 Napi::Value GetBoxedField(const Napi::CallbackInfo& info);
 Napi::Value SetBoxedField(const Napi::CallbackInfo& info);
 Napi::Value BoxedTypeName(const Napi::CallbackInfo& info);
+// TEST-ONLY (see marshal.cc): the address a boxed handle wraps, as hex.
+Napi::Value BoxedAddress(const Napi::CallbackInfo& info);
 // GParamSpec wrapping (object.cc): a tagged GObject-fundamental handle plus its
 // name/nick/blurb/flags/value_type/owner_type/default_value accessors.
 Napi::Value MakeParamSpecHandle(Napi::Env env, GParamSpec* pspec, GITransfer transfer);

--- a/packages/node-gi/node-gi/src/marshal.cc
+++ b/packages/node-gi/node-gi/src/marshal.cc
@@ -296,6 +296,28 @@ bool TryGetBoxedPtr(Napi::Value v, gpointer* out) {
   return true;
 }
 
+// __boxedAddress(value) -> the address a boxed handle wraps, as a hex string, or
+// null when `value` is not one. TEST-ONLY (the `__` prefix marks it, as on the
+// __stressRefUnref* pair) — nothing on the runtime path may branch on it.
+//
+// It exists because the IN-transfer ownership rules are statements about POINTER
+// IDENTITY ("a transfer-full boxed IN arg gets an independent copy, never the
+// block this handle still owns"), and nothing else could observe one. The tests
+// guarding them ran the call many times and waited for a double free to abort —
+// which only happens if the allocator has NOT recycled the block between the two
+// frees. Measured while reviewing #1496: with `TransferBoxedIn` replaced by a bare
+// borrow — a real double free on every round — `gerror-out.test.mjs` passed 5 runs
+// out of 5, and the same program under valgrind reported 0 errors. An identity
+// assertion fails on the first round instead.
+Napi::Value BoxedAddress(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  gpointer ptr = nullptr;
+  if (info.Length() < 1 || !TryGetBoxedPtr(info[0], &ptr)) return env.Null();
+  char buf[2 + sizeof(gpointer) * 2 + 1];
+  g_snprintf(buf, sizeof(buf), "%p", ptr);
+  return Napi::String::New(env, buf);
+}
+
 // boxedTypeName(value) -> the boxed handle's GType name (e.g. "GBytes"), or null
 // when the handle carries no registered GType. Lets the L1 layer attach a
 // type-specific convenience (GLib.Bytes.toArray) without a per-type wrapper.
@@ -441,6 +463,55 @@ static const char* InformalValueTypeName(const Napi::Value& v) {
   return "Object";
 }
 
+// The refusal a GError-typed IN arg raises, named after the argument the way gjs
+// names its marshalling errors.
+static void ThrowExpectedGLibError(Napi::Env env, const char* argName, const std::string& got) {
+  std::string where = argName != nullptr ? std::string("argument '") + argName + "'" : "argument";
+  Napi::TypeError::New(env, "expected a GLib.Error for " + where + ", got " + got)
+      .ThrowAsJavaScriptException();
+}
+
+// Whether `v` is an instance of the L1 `GLib.Error` class — the shape a `catch`
+// around a failed GI invoke hands you, and what `new GLib.Error(domain, code,
+// message)` builds. Recognition is `instanceof` against the class L1 registered
+// alongside its error builder, never duck-typing: a plain object carrying a
+// `code` must still be refused.
+static bool IsL1GLibError(Napi::Env env, Napi::Value v) {
+  if (!v.IsObject()) return false;
+  NodeGiEnvData* d = EnvData(env);
+  if (d == nullptr || d->errorClass == nullptr) return false;
+  napi_value cls = nullptr;
+  if (napi_get_reference_value(env, d->errorClass, &cls) != napi_ok || cls == nullptr) return false;
+  Napi::Value clsValue(env, cls);
+  return clsValue.IsFunction() && v.As<Napi::Object>().InstanceOf(clsValue.As<Napi::Function>());
+}
+
+// Build a real GError out of an L1 `GLib.Error`, which carries no `GError*` of
+// its own. Throws + returns nullptr when its domain is unusable.
+//
+// `.domainQuark` is the numeric GQuark the engine read off the original GError;
+// `.domain` is its NAME (the node-gi divergence documented in
+// docs/node-gi-gjs-surface.md), which is what an error constructed in JS from a
+// quark name carries. Either resolves to the same quark; a value with neither is
+// not a usable GError — quark 0 would produce an error no `matches()` can ever
+// answer for, so it is refused rather than marshalled into a silent mismatch.
+static GError* ErrorFromL1GLibError(Napi::Env env, Napi::Value v, const char* argName) {
+  Napi::Object err = v.As<Napi::Object>();
+  Napi::Value quark = err.Get("domainQuark");
+  Napi::Value domain = err.Get("domain");
+  GQuark gq = 0;
+  if (quark.IsNumber()) gq = static_cast<GQuark>(NodeGiToUint32(quark));
+  else if (domain.IsString())
+    gq = g_quark_from_string(domain.As<Napi::String>().Utf8Value().c_str());
+  if (gq == 0) {
+    ThrowExpectedGLibError(env, argName, "a GLib.Error with no domain");
+    return nullptr;
+  }
+  Napi::Value message = err.Get("message");
+  std::string text = message.IsString() ? message.As<Napi::String>().Utf8Value() : std::string();
+  return g_error_new_literal(gq, NodeGiToInt32(err.Get("code")), text.c_str());
+}
+
 // "Gtk.Box" for an introspected GType, g_type_name() otherwise (a registerClass
 // subtype has no GI info of its own; its C name is still exact). The gjs twin is
 // GIWrapperBase::format_name() (refs/gjs/gi/wrapperutils.h).
@@ -469,6 +540,7 @@ bool JsToGIArgument(Napi::Env env, Napi::Value v, GITypeInfo* type, GIArgument* 
                     CreatedClosures* closures,
                     CreatedBytes* bytes,
                     CreatedValues* values,
+                    CreatedErrors* errors,
                     const char* argName) {
   if (v.IsEmpty()) {
     // Residue of a swallowed napi failure (a fallible Get()/coercion upstream
@@ -716,36 +788,49 @@ bool JsToGIArgument(Napi::Env env, Napi::Value v, GITypeInfo* type, GIArgument* 
       // A GError IN/INOUT argument: `Gst.Message.new_error(src, error, debug)` —
       // how an application POSTS the failure the bus accessors read back —
       // `GLib.propagate_error`, and the INOUT `err` of `GLib.prefix_error_literal`.
-      // The JS value is the boxed handle a GError-typed return/OUT produced, so
-      // ownership is the ordinary boxed one and TransferBoxedIn supplies it:
-      // transfer-none is a borrow, transfer-full hands the callee an independent
-      // g_error_copy (g_propagate_error ADOPTS and frees its `src`) so the JS
-      // handle's finalizer cannot double-free it. Measured against gjs: after
-      // `GLib.propagate_error(e)` the original `e` is still readable there too.
       // null/undefined → a NULL GError, the same leniency the object/boxed arms
       // keep (gjs refuses both for a non-nullable arg — status/open-todos.md).
       if (v.IsNull() || v.IsUndefined()) {
         out->v_pointer = nullptr;
         return true;
       }
+      // Shape 1: the boxed handle a GError-typed return/OUT produced. Ownership is
+      // the ordinary boxed one and TransferBoxedIn supplies it: transfer-none is a
+      // borrow, transfer-full hands the callee an independent g_error_copy
+      // (g_propagate_error ADOPTS and frees its `src`) so the JS handle's finalizer
+      // cannot double-free it. Measured against gjs: after `GLib.propagate_error(e)`
+      // the original `e` is still readable there too.
+      //
       // Type-safety is UNCONDITIONAL here, unlike the struct/boxed arm's "compare
       // only when both sides carry a registered GType": the expected type is known
       // (G_TYPE_ERROR, always), so a handle without it is a wrong pointer — and a
       // wrong pointer in a GError slot is a wild dereference inside GLib.
       BoxedHandle* h = TryGetBoxedHandle(v);
-      if (h == nullptr || h->gtype == G_TYPE_INVALID || !g_type_is_a(h->gtype, G_TYPE_ERROR)) {
-        std::string got = h != nullptr && h->gtype != G_TYPE_INVALID ? g_type_name(h->gtype)
-                                                                    : InformalValueTypeName(v);
-        Napi::TypeError::New(env, std::string("expected a GLib.Error for ") +
-                                      (argName != nullptr
-                                           ? std::string("argument '") + argName + "'"
-                                           : std::string("argument")) +
-                                      ", got " + got)
-            .ThrowAsJavaScriptException();
-        return false;
+      if (h != nullptr) {
+        if (h->gtype == G_TYPE_INVALID || !g_type_is_a(h->gtype, G_TYPE_ERROR)) {
+          ThrowExpectedGLibError(env, argName,
+                                 h->gtype != G_TYPE_INVALID ? g_type_name(h->gtype)
+                                                            : InformalValueTypeName(v));
+          return false;
+        }
+        out->v_pointer = TransferBoxedIn(h, transfer);
+        return true;
       }
-      out->v_pointer = TransferBoxedIn(h, transfer);
-      return true;
+      // Shape 2: the L1 `GLib.Error` JS class — a caught error, or one built with
+      // `new GLib.Error(…)`. It carries no GError*, so build one and release it per
+      // transfer (CreatedErrors, the rule GBytes and GValue already follow). gjs has
+      // ONE object for both shapes and accepts either; refusing this one left the
+      // hand-back the OUT direction exists for closed to exactly the errors an
+      // application has in hand.
+      if (errors != nullptr && IsL1GLibError(env, v)) {
+        GError* built = ErrorFromL1GLibError(env, v, argName);
+        if (built == nullptr) return false;  // ErrorFromL1GLibError already threw
+        out->v_pointer = built;
+        errors->Record(built, transfer);
+        return true;
+      }
+      ThrowExpectedGLibError(env, argName, InformalValueTypeName(v));
+      return false;
     }
     default:
       Napi::TypeError::New(

--- a/packages/node-gi/node-gi/src/marshal.cc
+++ b/packages/node-gi/node-gi/src/marshal.cc
@@ -712,6 +712,41 @@ bool JsToGIArgument(Napi::Env env, Napi::Value v, GITypeInfo* type, GIArgument* 
       out->v_size = static_cast<gsize>(gt);
       return true;
     }
+    case GI_TYPE_TAG_ERROR: {
+      // A GError IN/INOUT argument: `Gst.Message.new_error(src, error, debug)` —
+      // how an application POSTS the failure the bus accessors read back —
+      // `GLib.propagate_error`, and the INOUT `err` of `GLib.prefix_error_literal`.
+      // The JS value is the boxed handle a GError-typed return/OUT produced, so
+      // ownership is the ordinary boxed one and TransferBoxedIn supplies it:
+      // transfer-none is a borrow, transfer-full hands the callee an independent
+      // g_error_copy (g_propagate_error ADOPTS and frees its `src`) so the JS
+      // handle's finalizer cannot double-free it. Measured against gjs: after
+      // `GLib.propagate_error(e)` the original `e` is still readable there too.
+      // null/undefined → a NULL GError, the same leniency the object/boxed arms
+      // keep (gjs refuses both for a non-nullable arg — status/open-todos.md).
+      if (v.IsNull() || v.IsUndefined()) {
+        out->v_pointer = nullptr;
+        return true;
+      }
+      // Type-safety is UNCONDITIONAL here, unlike the struct/boxed arm's "compare
+      // only when both sides carry a registered GType": the expected type is known
+      // (G_TYPE_ERROR, always), so a handle without it is a wrong pointer — and a
+      // wrong pointer in a GError slot is a wild dereference inside GLib.
+      BoxedHandle* h = TryGetBoxedHandle(v);
+      if (h == nullptr || h->gtype == G_TYPE_INVALID || !g_type_is_a(h->gtype, G_TYPE_ERROR)) {
+        std::string got = h != nullptr && h->gtype != G_TYPE_INVALID ? g_type_name(h->gtype)
+                                                                    : InformalValueTypeName(v);
+        Napi::TypeError::New(env, std::string("expected a GLib.Error for ") +
+                                      (argName != nullptr
+                                           ? std::string("argument '") + argName + "'"
+                                           : std::string("argument")) +
+                                      ", got " + got)
+            .ThrowAsJavaScriptException();
+        return false;
+      }
+      out->v_pointer = TransferBoxedIn(h, transfer);
+      return true;
+    }
     default:
       Napi::TypeError::New(
           env, "Unsupported IN argument type tag " + std::to_string(static_cast<int>(tag)) +

--- a/packages/node-gi/node-gi/src/repo.cc
+++ b/packages/node-gi/node-gi/src/repo.cc
@@ -13,6 +13,7 @@ void NodeGiEnvDataFinalize(napi_env env, void* data, void* /*hint*/) {
   NodeGiEnvData* d = static_cast<NodeGiEnvData*>(data);
   if (d == nullptr) return;
   if (d->errorBuilder != nullptr) napi_delete_reference(env, d->errorBuilder);
+  if (d->errorClass != nullptr) napi_delete_reference(env, d->errorClass);
   if (d->templateCallbackResolver != nullptr)
     napi_delete_reference(env, d->templateCallbackResolver);
   if (d->cairoWrappers != nullptr) napi_delete_reference(env, d->cairoWrappers);
@@ -258,14 +259,18 @@ Napi::Value GetErrorDomain(const Napi::CallbackInfo& info) {
   return result;
 }
 
-// setErrorBuilder(builder: (domainName, domainQuark, code, message) => Error) -> void
+// setErrorBuilder(builder: (domainName, domainQuark, code, message) => Error,
+//                 errorClass?: typeof GLib.Error) -> void
 // Register the L1 GLib.Error factory the engine calls when a GI invoke fails, so a
-// failed sync call throws a real GLib.Error. Stored per-env (a napi_ref is env-
-// specific; the throw path is gated on the same env).
+// failed sync call throws a real GLib.Error, together with the class it builds —
+// which the GError IN-arg path needs to recognise one coming back. Both stored
+// per-env (a napi_ref is env-specific; both paths are gated on the same env), in
+// ONE call so a registration cannot supply the builder and forget the class.
 Napi::Value SetErrorBuilder(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   if (info.Length() < 1 || !info[0].IsFunction()) {
-    Napi::TypeError::New(env, "setErrorBuilder(builder: function)").ThrowAsJavaScriptException();
+    Napi::TypeError::New(env, "setErrorBuilder(builder: function, errorClass?: function)")
+        .ThrowAsJavaScriptException();
     return env.Undefined();
   }
   NodeGiEnvData* d = EnvData(env);
@@ -275,6 +280,12 @@ Napi::Value SetErrorBuilder(const Napi::CallbackInfo& info) {
     d->errorBuilder = nullptr;
   }
   napi_create_reference(env, info[0], 1, &d->errorBuilder);
+  if (d->errorClass != nullptr) {
+    napi_delete_reference(env, d->errorClass);
+    d->errorClass = nullptr;
+  }
+  if (info.Length() >= 2 && info[1].IsFunction())
+    napi_create_reference(env, info[1], 1, &d->errorClass);
   return env.Undefined();
 }
 

--- a/packages/node-gi/node-gi/test/boxed-in-transfer.test.mjs
+++ b/packages/node-gi/node-gi/test/boxed-in-transfer.test.mjs
@@ -27,18 +27,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { requireGi } from '../gi.js';
-
-/**
- * Drain the napi finalizer queue: boxed finalizers run off the GC's callback
- * queue on a later loop turn, so a double free only aborts after both a
- * collection AND a turn of the loop.
- */
-async function collect() {
-    for (let i = 0; i < 2; i++) {
-        globalThis.gc?.();
-        await new Promise((resolve) => setTimeout(resolve, 50));
-    }
-}
+import { drainFinalizers } from './gc-drain.mjs';
 
 test('a (transfer full) boxed IN arg is copied, not surrendered: Pango.AttrList.insert', async () => {
     const Pango = requireGi('Pango', '1.0');
@@ -53,7 +42,7 @@ test('a (transfer full) boxed IN arg is copied, not surrendered: Pango.AttrList.
         list.insert(attr);
     }
 
-    await collect();
+    await drainFinalizers();
 
     // Still usable afterwards — the copy is a real, independent attribute.
     const list = Pango.AttrList.new();
@@ -69,7 +58,7 @@ test('a (transfer none) boxed IN arg is still a plain borrow: GLib.DateTime.diff
     const b = a.add_hours(1);
     for (let i = 0; i < 200; i++) assert.equal(b.difference(a), 3600000000);
 
-    await collect();
+    await drainFinalizers();
 
     assert.equal(a.get_year(), 2006);
     assert.equal(b.difference(a), 3600000000);
@@ -96,7 +85,7 @@ test('a (transfer full) IN container hands over COPIES of its boxed elements: Pa
     }
 
     // …and the handles survive collection, which is where the double free aborts.
-    await collect();
+    await drainFinalizers();
 
     const c = Pango.FontDescription.from_string('Monospace 9');
     Pango.Font.descriptions_free([c]);
@@ -128,7 +117,7 @@ test('a (transfer none) IN container still borrows its boxed elements: GLib.Vari
         assert.equal(child.get_int32(), 42);
     }
 
-    await collect();
+    await drainFinalizers();
 
     const child = GLib.Variant.new_string('kept');
     assert.equal(GLib.Variant.new_tuple([child]).get_type_string(), '(s)');

--- a/packages/node-gi/node-gi/test/gc-drain.mjs
+++ b/packages/node-gi/node-gi/test/gc-drain.mjs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+// "Have the native finalizers actually run?" — one answer, shared by every
+// ownership test.
+//
+// A boxed handle's release is a napi finalizer, and napi finalizers do NOT run
+// inside the collection: V8 resets the weak persistent during GC and Node defers
+// the finalize callback to a later loop turn (#1475). So a double free raised by
+// a wrong transfer only aborts after BOTH a collection and a turn of the loop,
+// and a `gc()` alone proves nothing — a suite that skips the loop turn reports
+// green while the abort is still queued.
+//
+// Two rounds because the first collection is what makes the wrappers unreachable
+// and the second turn is what lets their finalizers run; `globalThis.gc` is
+// optional so the same test file still runs without `--expose-gc` (it then only
+// stops proving the ownership half, rather than failing).
+
+/** Collect, then give the loop the turn the napi finalizer queue needs. */
+export async function drainFinalizers() {
+    for (let i = 0; i < 2; i++) {
+        globalThis.gc?.();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+}

--- a/packages/node-gi/node-gi/test/gerror-out.test.mjs
+++ b/packages/node-gi/node-gi/test/gerror-out.test.mjs
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+// GError-typed OUT / INOUT / IN parameters (`GI_TYPE_TAG_ERROR`) — the direction
+// half of the GError contract; `gerror-return.test.mjs` is the RETURN half.
+//
+// Regression for #1495: `IsSupportedOutType` (calls.cc) allow-listed every tag but
+// this one, so `Gst.Message.parse_error()` threw
+// `TypeError: GstMessage.parse_error: OUT type tag 20 parameters are not yet
+// supported` BEFORE the invoke — and with it every other way to learn why a
+// GStreamer pipeline stopped. Ten of the eighteen GError OUT parameters in a
+// 264-typelib sweep are the bus-error accessors of Gst / GstPlay / GstTranscoder,
+// and `parse_error_details` hands back a GstStructure, not the error, so there was
+// no route around it. The read-back it needed already existed (marshal.cc's
+// `GI_TYPE_TAG_ERROR` arm, written for `Gtk.GLArea.get_error()`); only the gate
+// stood in front of it. ADR 0024 stages 4+5 put the shipped `.app` and the Windows
+// program directory on Node, so on two of three target OSes this path is the
+// ONLY path.
+//
+// GLib carries the whole shape and is present on every runtime leg (the arm64 CI
+// container has no GStreamer), so the mechanism is proven with GLib and the
+// issue's own call is proven where GStreamer exists:
+//   * OUT, transfer-full  — `GLib.set_error_literal` writes a fresh GError the JS
+//     handle then owns (finalizer → g_boxed_free = g_error_free).
+//   * IN, transfer-full   — `GLib.propagate_error` ADOPTS its `src`, so the handle
+//     must hand over an independent g_error_copy or both sides free it.
+//   * IN, transfer-none   — `Gst.Message.new_error` borrows.
+//   * INOUT               — `GLib.prefix_error_literal` reads and rewrites the slot.
+//   * NULL is a VALUE     — a callee that leaves the slot alone must read back as
+//     `null`, never as an empty GLib.Error.
+//
+// gjs is the reference and every expectation below was measured against
+// gjs 1.88.1 first (`GLib.propagate_error(e)` returns a copy there too, and
+// `msg.parse_info()` on an ERROR message yields `[null, null]`).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { requireGi } from '../gi.js';
+
+const GLib = requireGi('GLib', '2.0');
+
+// A private error domain, so no other test's quark can make an assertion pass.
+const DOMAIN = GLib.quark_from_string('node-gi-gerror-out-test');
+const OTHER_DOMAIN = GLib.quark_from_string('node-gi-gerror-out-test-other');
+
+/**
+ * Drain the napi finalizer queue: boxed finalizers run off the GC's callback
+ * queue on a later loop turn, so a double free only aborts after both a
+ * collection AND a turn of the loop. Same helper as boxed-in-transfer.test.mjs.
+ */
+async function collect() {
+    for (let i = 0; i < 2; i++) {
+        globalThis.gc?.();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+}
+
+test('a (transfer full) GError OUT reads back as a field-readable GLib.Error', () => {
+    // void return + one GError OUT → the error, bare (the GJS return-tuple convention).
+    const err = GLib.set_error_literal(DOMAIN, 7, 'boom');
+
+    assert.notEqual(err, null, 'the OUT slot must not read back as null — the callee filled it');
+    assert.equal(err.message, 'boom', 'the message FIELD must read back');
+    assert.equal(err.code, 7, 'the code FIELD must read back');
+    assert.equal(err.domain, DOMAIN, 'the domain FIELD is the numeric GQuark, as on gjs');
+
+    // matches() has to DISCRIMINATE, not just answer: a stub returning true would
+    // pass the positive assertion alone.
+    assert.equal(err.matches(DOMAIN, 7), true);
+    assert.equal(err.matches(DOMAIN, 8), false, 'a wrong code must not match');
+    assert.equal(err.matches(OTHER_DOMAIN, 7), false, 'a wrong domain must not match');
+});
+
+test('a (transfer full) GError IN arg is copied, not surrendered: GLib.propagate_error', async () => {
+    // g_propagate_error ADOPTS `src` (transfer full) and stores it in `dest`, which
+    // the returned handle then owns too. Handing over the borrowed pointer makes
+    // both handles own one GError — `free(): invalid pointer` from the finalizer
+    // queue, long after the call. Many rounds so at least one pair is collected
+    // while the test still runs.
+    for (let i = 0; i < 200; i++) {
+        const src = GLib.set_error_literal(DOMAIN, i, `round ${i}`);
+        const dest = GLib.propagate_error(src);
+        assert.equal(dest.code, i);
+        assert.equal(dest.message, `round ${i}`);
+    }
+
+    await collect();
+
+    // Both instances are independent and still readable afterwards.
+    const original = GLib.set_error_literal(DOMAIN, 42, 'original');
+    const propagated = GLib.propagate_error(original);
+    assert.equal(original.message, 'original', 'the source handle survives the hand-over');
+    assert.equal(propagated.message, 'original');
+    assert.equal(propagated.code, 42);
+    assert.equal(propagated.domain, DOMAIN);
+});
+
+test('a GError INOUT slot is read and rewritten: GLib.prefix_error_literal', () => {
+    const err = GLib.set_error_literal(DOMAIN, 3, 'boom');
+    const prefixed = GLib.prefix_error_literal(err, 'context: ');
+
+    assert.equal(prefixed.message, 'context: boom', 'the callee rewrote the slot it was handed');
+    assert.equal(prefixed.code, 3, 'domain and code survive the rewrite');
+    assert.equal(prefixed.domain, DOMAIN);
+    // The arg is (transfer full) too, so the callee got a copy and the original
+    // is untouched — the same ownership rule as propagate_error above.
+    assert.equal(err.message, 'boom');
+});
+
+test('an untouched GError OUT slot reads back as null, not an empty GLib.Error', () => {
+    // g_prefix_error_literal is a no-op when `*err` is NULL (no precondition
+    // warning, unlike g_propagate_error), so this is the plain "the callee wrote
+    // nothing" case: the zero-initialised slot must marshal to `null`.
+    const nothing = GLib.prefix_error_literal(null, 'context: ');
+
+    assert.strictEqual(nothing, null, 'a NULL GError is `null`, not an object');
+    // The guard against passing for the wrong reason: `null` here must be the
+    // MARSHALLED slot, not a refusal that returned nothing. The same call with a
+    // real error returns a real error.
+    const something = GLib.prefix_error_literal(GLib.set_error_literal(DOMAIN, 1, 'x'), 'context: ');
+    assert.equal(something.message, 'context: x');
+});
+
+test('a non-GError value at a GError IN arg is refused, not forwarded', () => {
+    // The refusal is load-bearing: forwarding a wrong pointer into a GError slot
+    // is a wild dereference inside GLib, not a catchable JS error.
+    assert.throws(() => GLib.propagate_error({}), /expected a GLib.Error/);
+    assert.throws(() => GLib.propagate_error('not an error'), /expected a GLib.Error/);
+    assert.throws(() => GLib.propagate_error(GLib.TimeZone.new_utc()), /expected a GLib.Error/);
+});
+
+// ---- the issue's own call, where GStreamer exists ---------------------------
+//
+// Gated on the typelib rather than on the platform: the aarch64 CI leg runs the
+// suite on a plain fedora:44 with no GStreamer, and every other leg has it. The
+// GLib tests above prove the same marshalling; these prove the reported call.
+let Gst = null;
+let gstError = null;
+try {
+    Gst = requireGi('Gst', '1.0');
+    Gst.init(null);
+} catch (err) {
+    gstError = err;
+}
+const gstSkip = gstError ? `Gst 1.0 unavailable: ${gstError.message}` : false;
+
+test('Gst.Message.parse_error returns the bus error and its debug string', { skip: gstSkip }, () => {
+    const src = Gst.ElementFactory.make('fakesrc', 'gerror-out-test-src');
+    assert.notEqual(src, null, 'fakesrc must resolve — an empty registry would fake a pass');
+
+    const err = GLib.set_error_literal(DOMAIN, 11, 'no such file');
+    // (transfer none) GError IN — the callee copies what it keeps.
+    const message = Gst.Message.new_error(src, err, 'debug-detail');
+
+    const [parsed, debug] = message.parse_error();
+    assert.notEqual(parsed, null, 'the GError OUT — the parameter #1495 refused');
+    assert.equal(parsed.message, 'no such file');
+    assert.equal(parsed.code, 11);
+    assert.equal(parsed.domain, DOMAIN);
+    assert.equal(parsed.matches(DOMAIN, 11), true);
+    assert.equal(debug, 'debug-detail', 'the second OUT still marshals beside the GError');
+    assert.equal(err.message, 'no such file', 'the borrowed IN error is untouched');
+});
+
+test('a real pipeline failure is READABLE off the bus', { skip: gstSkip }, () => {
+    // The effect the fix exists for, end to end: not "parse_error returns an
+    // object" but "an application learns why playback stopped". A synthesised
+    // Gst.Message cannot show that — the error has to come from GStreamer itself.
+    // filesrc on a missing path fails its READY transition and posts the error
+    // synchronously, so no main loop and no network are involved.
+    const pipeline = Gst.parse_launch('filesrc location=/nonexistent-node-gi-gerror ! fakesink');
+    pipeline.set_state(Gst.State.PLAYING);
+    const message = pipeline.get_bus().timed_pop_filtered(5 * Gst.SECOND, Gst.MessageType.ERROR);
+    pipeline.set_state(Gst.State.NULL);
+
+    assert.notEqual(message, null, 'the pipeline must post an ERROR message');
+    const [err, debug] = message.parse_error();
+    assert.notEqual(err, null);
+    assert.equal(err.matches(Gst.resource_error_quark(), Gst.ResourceError.NOT_FOUND), true);
+    assert.equal(typeof err.message, 'string');
+    assert.ok(err.message.length > 0, 'the reason must be a readable string');
+    assert.match(String(debug), /nonexistent-node-gi-gerror/, 'the debug string names the file');
+});
+
+test('parse_info on an ERROR message yields [null, null], as on gjs', { skip: gstSkip }, () => {
+    const src = Gst.ElementFactory.make('fakesrc', 'gerror-out-test-src2');
+    const message = Gst.Message.new_error(src, GLib.set_error_literal(DOMAIN, 5, 'boom'), 'dbg');
+
+    // gst_message_parse_info's g_return_if_fail rejects the wrong message type and
+    // returns WITHOUT touching either OUT slot — the GStreamer-CRITICAL on stderr
+    // is expected and is the point. gjs 1.88.1 prints the same critical and returns
+    // [null, null]; an empty GLib.Error here would be the defect.
+    assert.deepEqual(message.parse_info(), [null, null]);
+});

--- a/packages/node-gi/node-gi/test/gerror-out.test.mjs
+++ b/packages/node-gi/node-gi/test/gerror-out.test.mjs
@@ -6,8 +6,8 @@
 // this one, so `Gst.Message.parse_error()` threw
 // `TypeError: GstMessage.parse_error: OUT type tag 20 parameters are not yet
 // supported` BEFORE the invoke — and with it every other way to learn why a
-// GStreamer pipeline stopped. Ten of the eighteen GError OUT parameters in a
-// 264-typelib sweep are the bus-error accessors of Gst / GstPlay / GstTranscoder,
+// GStreamer pipeline stopped. A sweep of the installed typelibs found most GError
+// OUT parameters to BE the bus-error accessors of Gst / GstPlay / GstTranscoder,
 // and `parse_error_details` hands back a GstStructure, not the error, so there was
 // no route around it. The read-back it needed already existed (marshal.cc's
 // `GI_TYPE_TAG_ERROR` arm, written for `Gtk.GLArea.get_error()`); only the gate
@@ -26,6 +26,8 @@
 //   * INOUT               — `GLib.prefix_error_literal` reads and rewrites the slot.
 //   * NULL is a VALUE     — a callee that leaves the slot alone must read back as
 //     `null`, never as an empty GLib.Error.
+//   * BOTH JS shapes      — node-gi hands out two `GLib.Error`s (the L1 JS class for
+//     a thrown one, a boxed handle for a marshalled one) and an IN arg takes either.
 //
 // gjs is the reference and every expectation below was measured against
 // gjs 1.88.1 first (`GLib.propagate_error(e)` returns a copy there too, and
@@ -33,25 +35,20 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { requireGi } from '../gi.js';
+import { __boxedAddress } from '../index.js';
+import { requireGi, unwrap } from '../gi.js';
+import { drainFinalizers } from './gc-drain.mjs';
+import { Gst, gstSkip } from './gst-gate.mjs';
 
 const GLib = requireGi('GLib', '2.0');
+const Gio = requireGi('Gio', '2.0');
+
+/** The address the GError behind a wrapped GLib.Error occupies (`null` for anything else). */
+const boxedAddress = (value) => __boxedAddress(unwrap(value));
 
 // A private error domain, so no other test's quark can make an assertion pass.
 const DOMAIN = GLib.quark_from_string('node-gi-gerror-out-test');
 const OTHER_DOMAIN = GLib.quark_from_string('node-gi-gerror-out-test-other');
-
-/**
- * Drain the napi finalizer queue: boxed finalizers run off the GC's callback
- * queue on a later loop turn, so a double free only aborts after both a
- * collection AND a turn of the loop. Same helper as boxed-in-transfer.test.mjs.
- */
-async function collect() {
-    for (let i = 0; i < 2; i++) {
-        globalThis.gc?.();
-        await new Promise((resolve) => setTimeout(resolve, 50));
-    }
-}
 
 test('a (transfer full) GError OUT reads back as a field-readable GLib.Error', () => {
     // void return + one GError OUT → the error, bare (the GJS return-tuple convention).
@@ -73,8 +70,25 @@ test('a (transfer full) GError IN arg is copied, not surrendered: GLib.propagate
     // g_propagate_error ADOPTS `src` (transfer full) and stores it in `dest`, which
     // the returned handle then owns too. Handing over the borrowed pointer makes
     // both handles own one GError — `free(): invalid pointer` from the finalizer
-    // queue, long after the call. Many rounds so at least one pair is collected
-    // while the test still runs.
+    // queue, long after the call.
+    //
+    // ASSERTED ON THE POINTERS, not on a crash. g_propagate_error stores the very
+    // pointer it was handed, so `dest` wraps whatever went in: two equal addresses
+    // mean two owners of one GError. The rounds-and-wait-for-SIGABRT form this
+    // replaces does NOT discriminate — with TransferBoxedIn reduced to a bare
+    // borrow, a double free on every round, it passed 5 runs out of 5 (and under
+    // valgrind), because the allocator recycles the block between the two frees.
+    const src = GLib.set_error_literal(DOMAIN, 1, 'identity');
+    const dest = GLib.propagate_error(src);
+    assert.notEqual(
+        boxedAddress(dest),
+        boxedAddress(src),
+        'a (transfer full) IN arg must hand the callee an independent g_error_copy',
+    );
+    assert.equal(typeof boxedAddress(src), 'string', 'both sides must BE boxed handles');
+
+    // Rounds + a drain on top: the identity check proves the copy, this proves the
+    // copies are then released rather than piling up.
     for (let i = 0; i < 200; i++) {
         const src = GLib.set_error_literal(DOMAIN, i, `round ${i}`);
         const dest = GLib.propagate_error(src);
@@ -82,7 +96,7 @@ test('a (transfer full) GError IN arg is copied, not surrendered: GLib.propagate
         assert.equal(dest.message, `round ${i}`);
     }
 
-    await collect();
+    await drainFinalizers();
 
     // Both instances are independent and still readable afterwards.
     const original = GLib.set_error_literal(DOMAIN, 42, 'original');
@@ -100,8 +114,11 @@ test('a GError INOUT slot is read and rewritten: GLib.prefix_error_literal', () 
     assert.equal(prefixed.message, 'context: boom', 'the callee rewrote the slot it was handed');
     assert.equal(prefixed.code, 3, 'domain and code survive the rewrite');
     assert.equal(prefixed.domain, DOMAIN);
-    // The arg is (transfer full) too, so the callee got a copy and the original
-    // is untouched — the same ownership rule as propagate_error above.
+    // The arg is (transfer full) too, so the callee got a COPY and rewrote that —
+    // and g_prefix_error_literal edits in place, so the slot reads back the very
+    // pointer it was handed. Two distinct addresses is the whole ownership claim:
+    // one owner each, no double free when both handles finalize.
+    assert.notEqual(boxedAddress(prefixed), boxedAddress(err), 'INOUT must not surrender the slot');
     assert.equal(err.message, 'boom');
 });
 
@@ -121,26 +138,97 @@ test('an untouched GError OUT slot reads back as null, not an empty GLib.Error',
 
 test('a non-GError value at a GError IN arg is refused, not forwarded', () => {
     // The refusal is load-bearing: forwarding a wrong pointer into a GError slot
-    // is a wild dereference inside GLib, not a catchable JS error.
+    // is a wild dereference inside GLib, not a catchable JS error. gjs 1.88.1
+    // refuses the same four (`… is not a subclass of GLib_Error`, and
+    // `Expected type error for Argument 'src'` for the string) — the wording
+    // diverges, which of them is refused does not.
     assert.throws(() => GLib.propagate_error({}), /expected a GLib.Error/);
     assert.throws(() => GLib.propagate_error('not an error'), /expected a GLib.Error/);
     assert.throws(() => GLib.propagate_error(GLib.TimeZone.new_utc()), /expected a GLib.Error/);
+    // The refusal must DISCRIMINATE by more than "not a boxed handle": an object
+    // that merely LOOKS like an error is not one, and duck-typing would take it.
+    assert.throws(
+        () => GLib.propagate_error({ domainQuark: DOMAIN, code: 1, message: 'lookalike' }),
+        /expected a GLib.Error/,
+    );
+});
+
+// ---- the SECOND JS shape: the L1 GLib.Error class ---------------------------
+//
+// A GError reaches JS as one of two objects, and only one of them used to be
+// accepted back: a MARSHALLED error (a GError-typed OUT/RETURN) is a boxed handle
+// over the real GError*, while a THROWN one — the implicit `throws=1` GError of a
+// failed invoke, and anything `new GLib.Error(…)` builds — is L1's JS class with
+// no GError* behind it at all. gjs has ONE object for both and takes either.
+//
+// Refusing the JS class closed the hand-back direction for exactly the errors an
+// application is holding: you catch a failure and cannot post it. Measured on
+// gjs 1.88.1 first — `GLib.propagate_error(caught)` and
+// `GLib.propagate_error(new GLib.Error(q, c, m))` both succeed there.
+
+test('a CAUGHT GLib.Error can be handed back into a GError IN arg', () => {
+    let caught = null;
+    try {
+        Gio.File.new_for_path('/nonexistent-node-gi-gerror-in').load_contents(null);
+    } catch (err) {
+        caught = err;
+    }
+    assert.notEqual(caught, null, 'the failing call must throw — otherwise this proves nothing');
+    assert.ok(caught instanceof GLib.Error, 'a thrown GError is the L1 class, not a boxed handle');
+
+    // (transfer full) IN: the binding builds a GError from the JS class and the
+    // callee adopts it, so `dest` carries the same domain/code/message.
+    const propagated = GLib.propagate_error(caught);
+    assert.equal(propagated.message, caught.message);
+    assert.equal(propagated.code, caught.code);
+    assert.equal(
+        propagated.matches(Gio.io_error_quark(), Gio.IOErrorEnum.NOT_FOUND),
+        true,
+        'the DOMAIN survives the rebuild — a wrong quark would still carry the message',
+    );
+    assert.equal(propagated.matches(OTHER_DOMAIN, caught.code), false, 'a wrong domain must not match');
+});
+
+test('a CONSTRUCTED GLib.Error can be handed back into a GError IN arg', async () => {
+    // `new GLib.Error(...)` is the other producer of the JS class, and the only one
+    // an application controls. Many rounds + a drain: the built GError is released
+    // per transfer, so a wrong rule surfaces here as a double free rather than at
+    // process exit, where nothing is watching.
+    for (let i = 0; i < 200; i++) {
+        const made = new GLib.Error(DOMAIN, i, `built ${i}`);
+        const propagated = GLib.propagate_error(made);
+        assert.equal(propagated.code, i);
+        assert.equal(propagated.message, `built ${i}`);
+        assert.equal(propagated.matches(DOMAIN, i), true);
+    }
+
+    await drainFinalizers();
+
+    // The INOUT arm takes the JS class too, and does not rewrite the JS object.
+    const made = new GLib.Error(DOMAIN, 4, 'built');
+    const prefixed = GLib.prefix_error_literal(made, 'context: ');
+    assert.equal(prefixed.message, 'context: built');
+    assert.equal(made.message, 'built', 'the JS error the caller still holds is not rewritten');
+});
+
+test('a GLib.Error with no domain is refused BY NAME, not marshalled as quark 0', () => {
+    // Quark 0 would build an error `matches()` can never answer for — a silent
+    // mismatch far from here. `new GLib.Error(undefined, …)` sets neither `.domain`
+    // nor `.domainQuark`, and the refusal has to say which of the two problems it is.
+    // gjs refuses this too, one step earlier — at construction, with
+    // `Error.new_literal: undefined is not a valid domain`, because there the JS
+    // class IS the introspected boxed. Here the class is L1's, so the refusal can
+    // only land at the marshalling boundary; refused either way, never marshalled.
+    assert.throws(
+        () => GLib.propagate_error(new GLib.Error(undefined, 1, 'no domain')),
+        /expected a GLib\.Error for argument 'src', got a GLib\.Error with no domain/,
+    );
 });
 
 // ---- the issue's own call, where GStreamer exists ---------------------------
 //
-// Gated on the typelib rather than on the platform: the aarch64 CI leg runs the
-// suite on a plain fedora:44 with no GStreamer, and every other leg has it. The
-// GLib tests above prove the same marshalling; these prove the reported call.
-let Gst = null;
-let gstError = null;
-try {
-    Gst = requireGi('Gst', '1.0');
-    Gst.init(null);
-} catch (err) {
-    gstError = err;
-}
-const gstSkip = gstError ? `Gst 1.0 unavailable: ${gstError.message}` : false;
+// The GLib tests above prove the same marshalling; these prove the reported call.
+// `gst-gate.mjs` answers whether this host has GStreamer at all.
 
 test('Gst.Message.parse_error returns the bus error and its debug string', { skip: gstSkip }, () => {
     const src = Gst.ElementFactory.make('fakesrc', 'gerror-out-test-src');
@@ -158,6 +246,32 @@ test('Gst.Message.parse_error returns the bus error and its debug string', { ski
     assert.equal(parsed.matches(DOMAIN, 11), true);
     assert.equal(debug, 'debug-detail', 'the second OUT still marshals beside the GError');
     assert.equal(err.message, 'no such file', 'the borrowed IN error is untouched');
+});
+
+test('a caught error POSTS to a Gst bus: the (transfer none) IN arm', { skip: gstSkip }, async () => {
+    // The round trip the IN direction exists for, with the error shape an
+    // application actually has: catch a failure, post it, read it back off the bus.
+    // `error` is (transfer none) here, so the GError built from the JS class is
+    // OURS to free after the invoke — the arm gst_message_new_error copies from.
+    // Many rounds, so a missing release shows as a growing heap and a premature one
+    // as a use-after-free inside GStreamer, rather than as nothing at all.
+    let caught = null;
+    try {
+        Gio.File.new_for_path('/nonexistent-node-gi-gerror-post').load_contents(null);
+    } catch (err) {
+        caught = err;
+    }
+    const src = Gst.ElementFactory.make('fakesrc', 'gerror-post-test-src');
+    assert.notEqual(src, null, 'fakesrc must resolve — an empty registry would fake a pass');
+
+    for (let i = 0; i < 200; i++) {
+        const [parsed] = Gst.Message.new_error(src, caught, `dbg ${i}`).parse_error();
+        assert.equal(parsed.message, caught.message);
+        assert.equal(parsed.matches(Gio.io_error_quark(), Gio.IOErrorEnum.NOT_FOUND), true);
+    }
+
+    await drainFinalizers();
+    assert.equal(caught.message.length > 0, true, 'the JS error survives every hand-over');
 });
 
 test('a real pipeline failure is READABLE off the bus', { skip: gstSkip }, () => {

--- a/packages/node-gi/node-gi/test/gst-elements.test.mjs
+++ b/packages/node-gi/node-gi/test/gst-elements.test.mjs
@@ -20,18 +20,8 @@
 // any host with the bundle staged — unlike the windowing proofs beside it.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { requireGi } from '../gi.js';
 
-let Gst = null;
-let loadError = null;
-try {
-    Gst = requireGi('Gst', '1.0');
-    Gst.init(null);
-} catch (err) {
-    loadError = err;
-}
-
-const skip = loadError ? `Gst 1.0 unavailable: ${loadError.message}` : false;
+import { Gst, gstSkip as skip } from './gst-gate.mjs';
 
 // The pipeline @gjsify/webaudio is built from, element by element. Named
 // individually rather than asserted as a count, because "20 plugins loaded" is the

--- a/packages/node-gi/node-gi/test/gst-gate.mjs
+++ b/packages/node-gi/node-gi/test/gst-gate.mjs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// "Is GStreamer usable on this host?" — one answer, shared by every Gst test.
+//
+// Gated on the TYPELIB, never on the platform: the aarch64 CI leg runs the suite
+// on a plain `fedora:44` with no GStreamer at all, while every other leg has it,
+// and `Gst.init()` is part of the question — a namespace that loads against an
+// empty registry still fails at the first `ElementFactory.make`.
+//
+// The gate initialises Gst on import, so a test file that skips gets its reason
+// from the load error rather than repeating the try/catch.
+import { requireGi } from '../gi.js';
+
+let gst = null;
+let loadError = null;
+try {
+    gst = requireGi('Gst', '1.0');
+    gst.init(null);
+} catch (err) {
+    // The one throw path that matters: no typelib, no shared library, or an
+    // init that refuses. Recorded as the skip reason, never swallowed.
+    loadError = err;
+}
+
+/** The initialised `Gst` namespace, or `null` where GStreamer is unavailable. */
+export const Gst = gst;
+
+/** A node:test `skip` reason string when GStreamer is unavailable, else `false`. */
+export const gstSkip = loadError ? `Gst 1.0 unavailable: ${loadError.message}` : false;

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -342,6 +342,31 @@ either), and the day a consumer needs the throw, the place to add it is the
 `vfunc_` branch of `makeClassPrototype`'s `materialize` (gi.js), gated on the
 engine addressing the slot.
 
+### node-gi: two `GLib.Error` shapes, and only one of them can be passed back IN
+
+A GError node-gi hands to JS takes one of two shapes, and they are not the same
+object. A **thrown** one — a failed sync invoke, via `ThrowGError` → the L1
+builder — is the `GLibError` JS class: `instanceof GLib.Error`, `.domain` the
+quark NAME string with the number on `.domainQuark` (a divergence gjs does not
+have, already documented in `docs/node-gi-gjs-surface.md`). A **marshalled** one
+— a GError-typed return or OUT parameter — is a boxed handle over the real
+`GError*`: `.domain` the numeric GQuark, as on gjs, but `instanceof GLib.Error`
+false, because L1 shadows the introspected `GLib.Error` with the JS class.
+
+Consequence, measured while landing #1495's IN direction: only the boxed one can
+go back into a GError IN argument. `GLib.propagate_error(caughtError)` and
+`GLib.propagate_error(new GLib.Error(domain, code, msg))` both refuse with
+`expected a GLib.Error for argument 'src', got Object`, while gjs accepts both —
+there, the two shapes are one object. The marshalling arm is not what is missing:
+the JS class has no `GError*` behind it at all, and `GLib.Error.new_literal` (the
+introspected constructor that would make one) is exactly what the shadow hides.
+
+Not fixed here because it is an L1 identity decision, not a type-tag arm: either
+the class gains a lazily-built backing GError, or the shadow goes and `instanceof`
++ `.matches()` move onto the boxed handle. Both change what every existing
+`catch` sees, so it wants its own conformance program pinning the two shapes'
+surfaces before either is picked.
+
 ### The Vue plugin's virtual suffix is coupled to deepkit's filter, and nothing checks it
 
 `@gjsify/rolldown-plugin-vue` mints module ids ending in `VIRTUAL_SUFFIX =

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -342,7 +342,7 @@ either), and the day a consumer needs the throw, the place to add it is the
 `vfunc_` branch of `makeClassPrototype`'s `materialize` (gi.js), gated on the
 engine addressing the slot.
 
-### node-gi: two `GLib.Error` shapes, and only one of them can be passed back IN
+### node-gi: two `GLib.Error` shapes, and they answer `instanceof` differently
 
 A GError node-gi hands to JS takes one of two shapes, and they are not the same
 object. A **thrown** one — a failed sync invoke, via `ThrowGError` → the L1
@@ -353,19 +353,21 @@ have, already documented in `docs/node-gi-gjs-surface.md`). A **marshalled** one
 `GError*`: `.domain` the numeric GQuark, as on gjs, but `instanceof GLib.Error`
 false, because L1 shadows the introspected `GLib.Error` with the JS class.
 
-Consequence, measured while landing #1495's IN direction: only the boxed one can
-go back into a GError IN argument. `GLib.propagate_error(caughtError)` and
-`GLib.propagate_error(new GLib.Error(domain, code, msg))` both refuse with
-`expected a GLib.Error for argument 'src', got Object`, while gjs accepts both —
-there, the two shapes are one object. The marshalling arm is not what is missing:
-the JS class has no `GError*` behind it at all, and `GLib.Error.new_literal` (the
-introspected constructor that would make one) is exactly what the shadow hides.
+What is left open is the IDENTITY, not the marshalling. The hand-back half —
+measured while landing #1495 and fixed with it — was a separable defect and had
+to be: `GLib.propagate_error(caughtError)` refused with `expected a GLib.Error
+for argument 'src', got Object` where gjs accepts, so the direction the OUT half
+exists for was closed to exactly the errors an application holds. A GError IN arg
+now takes either shape (`CreatedErrors`, marshal.cc), which changes nothing about
+what a `catch` sees.
 
-Not fixed here because it is an L1 identity decision, not a type-tag arm: either
-the class gains a lazily-built backing GError, or the shadow goes and `instanceof`
-+ `.matches()` move onto the boxed handle. Both change what every existing
-`catch` sees, so it wants its own conformance program pinning the two shapes'
-surfaces before either is picked.
+Still divergent: `marshalled instanceof GLib.Error` is false, `.domain` is a
+number on one shape and a name string on the other, and `GLib.Error.new_literal`
+— the introspected constructor — is hidden by the shadow. Fixing THAT is an L1
+identity decision (either the class gains a lazily-built backing GError, or the
+shadow goes and `instanceof` + `.matches()` move onto the boxed handle), and both
+options change what every existing `catch` sees, so it wants its own conformance
+program pinning the two shapes' surfaces before either is picked.
 
 ### The Vue plugin's virtual suffix is coupled to deepkit's filter, and nothing checks it
 


### PR DESCRIPTION
`GstMessage.parse_error: OUT type tag 20 parameters are not yet supported` — thrown before the
invoke, so a media application on Node could see that playback stopped and never learn why.

Reproduced first, on this Fedora 44 host, exactly as reported (the issue measured it on Windows;
the gate has no OS branch in it):

```
GLib.set_error_literal:   THREW -> TypeError: GLib.set_error_literal: OUT type tag 20 parameters are not yet supported
Gst.Message.parse_error:  THREW -> TypeError: GstMessage.parse_error: OUT type tag 20 parameters are not yet supported
```

## What was wrong

`IsSupportedOutType` (`calls.cc`) is an allow-list `switch`; `GI_TYPE_TAG_ERROR` fell into its
`default:` arm and threw at `calls.cc:674` / `class.cc:783`, ahead of the invoke. The read-back it
needed **already existed** — `GIArgumentToJs`'s `GI_TYPE_TAG_ERROR` arm (`marshal.cc`, written
for `Gtk.GLArea.get_error()`), which `ReadOutOrReturn` falls through to. The conversion was written
and unreachable.

## Ownership

**Ownership follows the path every other transfer-full boxed OUT already takes**, no second way
invented. Every GError OUT/INOUT parameter in the sweep is `caller_allocates=false` +
`transfer=EVERYTHING`, i.e. the plain `GError**` slot. `WrapBoxed` sees `G_TYPE_ERROR`, which
`G_TYPE_IS_BOXED` — glib `gobject/gboxed.c`,
`G_DEFINE_BOXED_TYPE (GError, g_error, g_error_copy, g_error_free)` — so the handle adopts the
pointer with `owns=true` and `FreeBoxedHandleRecord`'s napi finalizer calls
`g_boxed_free(G_TYPE_ERROR, ptr)`, which *is* `g_error_free`.

The two sides never both adopt one pointer, in either transfer mode: `WrapBoxed` COPIES a
transfer-none read-back and adopts a transfer-full one, while `TransferBoxedIn` borrows on
transfer-none and copies on transfer-full. **INOUT** (`GLib.prefix_error_literal`, transfer
EVERYTHING both ways) is the interesting case — `g_prefix_error_literal` rewrites in place, so the
slot reads back the very pointer it was handed — and it is exactly one owner each: the caller's
handle keeps its own GError, the read-back adopts the copy.

Measured three ways, none of them RSS:

| instrument | result |
|---|---|
| alloc/free counters (temporary, in `MakeBoxedHandle` + `FreeBoxedHandleRecord`) | `made == freed`, `live == 0` at 20 000 rounds × 4 shapes (OUT, IN, INOUT, INOUT-chained) |
| valgrind at 300 and at 1500 rounds | no `Invalid free`/`Invalid read`/`Invalid write`; `definitely lost` **constant** across the 5× volume change (= un-run finalizers at exit, not a per-call leak) |
| mutation | `TransferBoxedIn` → bare borrow is caught on the first round by the address assertions below |

RSS was dropped as evidence: a flat RSS over 200 000 allocate-and-drop cycles is consistent with a
small per-call leak the allocator keeps reusing, so it can refute a large leak and never establish
the absence of one.

**`NULL` is a value.** `std::vector<GIArgument> slots(n_args)` is value-initialised and the ERROR
arm null-guards the pointer, so a callee that leaves the slot alone reads back as `null`, never as
an empty `GLib.Error`. Pinned twice: `GLib.prefix_error_literal(null, …)` (a no-op with no
precondition warning) and `msg.parse_info()` on an ERROR message → `[null, null]`, byte-identical
to gjs 1.88.1, which prints the same GStreamer-CRITICAL and returns the same pair.

## Reach — measured, and reconciled with the issue

Re-scanned the same 264 typelibs (91 444 callables), splitting by WHICH callable kinds are walked,
so the issue's numbers and this PR's reconcile rather than compete:

| walked | IN | OUT/INOUT | RETURN |
|---|---:|---:|---:|
| functions + methods only (the issue's scan) | 135 | **18** | 32 |
| + vfuncs + signals | 222 | **18** | 51 |
| + callback-typed struct fields | 293 | **18** | 58 |

OUT/INOUT is **18 in every configuration** — the headline claim does not depend on the scan's
shape. All 18 are `transfer=EVERYTHING` + `caller_allocates=false`; one is INOUT
(`GLib.prefix_error_literal`), contradicting the issue's assumption that INOUT was not in play.
`caller_allocates` is genuinely absent (0 of 18) and is not touched.

**IN is in** rather than deferred, because without it the direction just opened cannot be handed
back — `Gst.Message.new_error(src, error, debug)` is how an application *posts* the failure the bus
accessors read — and because it costs no new lifetime machinery on the boxed path:
`TransferBoxedIn` already carries the rule. Type-safety is unconditional in this arm, unlike the
struct/boxed one — the expected GType is always `G_TYPE_ERROR`, and a wrong pointer in a GError
slot is a wild dereference inside GLib.

## Both `GLib.Error` shapes go back IN

node-gi hands out two `GLib.Error` objects: the L1 JS class for a **thrown** error (what a `catch`
gives you, and what `new GLib.Error(…)` builds) and a boxed handle for a **marshalled** one.
Accepting only the boxed one closed the hand-back to exactly the errors an application is holding:

```
propagate(caught)  : THREW -> TypeError: expected a GLib.Error for argument 'src', got Object
propagate(new)     : THREW -> TypeError: expected a GLib.Error for argument 'src', got Object
```

while gjs accepts both. That is separable from the identity divergence it was first ledgered with,
and had to be separated: accepting the class changes nothing about what an existing `catch` sees,
whereas fixing identity changes it for every one. The arm builds a `g_error_new_literal` from
domain/code/message and releases it per transfer — the rule GBytes and GValue IN-args already
follow, so their two near-identical lifetime structs are lifted into one `CreatedIn<T>` instead of
gaining a third copy. Recognition is `instanceof` against the class L1 now registers with its error
builder, never duck-typing; an error whose domain resolves to quark 0 is refused BY NAME rather
than marshalled into one `matches()` could never answer for.

Still open and ledgered in `status/open-todos.md`, now narrowed to what it is: the IDENTITY —
`marshalled instanceof GLib.Error` is false and `.domain` is a number on one shape, a name string
on the other. That is an L1 decision (a backing GError on the class, or dropping the shadow over
the introspected `GLib.Error`), and both options change what every existing `catch` sees.

## The effect, not the state

The point is that an application can READ a bus error. `playbin3` on two unreachable URIs, on Node:

```
file:///does-not-exist.mp4
  source : filesrc0
  domain : 2336 (gst-resource-error / NOT_FOUND)
  code   : 3
  message: Resource not found.
  debug  : ../plugins/elements/gstfilesrc.c(585): gst_file_src_start (): /GstPlayBin3:playbin3-0/…/GstFileSrc:filesrc0:
https://invalid.invalid/clip.mp4
  source : souphttpsrc0
  domain : 2679 (other)
  code   : 1
  message: Internal data stream error.
  debug  : ../libs/gst/base/gstbasesrc.c(3187): gst_base_src_loop (): /GstPlayBin3:playbin3-1/…/GstSoupHTTPSrc:souphttpsrc0:
```

Every one of those lines was unreachable before this PR.

## Tests — measured PER ARM, not as a block

`test/gerror-out.test.mjs`, 12 cases. Each arm was broken on its own and the suite re-run, because
a suite that only goes red as a whole does not say what broke:

| mutation | red |
|---|---|
| drop the `GI_TYPE_TAG_ERROR` arm of `IsSupportedOutType` | 12 of 12 (the entry gate) |
| drop the boxed IN arm | 5 — the OUT-only and pipeline cases stay green, so IN and OUT are separated |
| drop the L1-class IN arm | exactly the 4 L1 cases |
| drop the quark-0 guard | exactly 1 |
| `TransferBoxedIn` → bare borrow | exactly the 2 ownership cases, deterministically |
| free a transfer-full built GError as if borrowed | exactly the 2 L1 round-trip cases |
| NULL slot → an empty `GLib.Error` | exactly the 2 NULL cases |
| accept any boxed handle at a GError IN arg | exactly 1 |
| **read-back copies instead of adopting (a pure leak)** | **0 — not caught** |
| **a transfer-none built GError never released (a pure leak)** | **0 — not caught** |

The ownership rules are now asserted **on the address**, not on a crash. The
rounds-and-wait-for-SIGABRT form they had does not discriminate: with `TransferBoxedIn` cut to a
bare borrow — a genuine double free on every one of 200 rounds — the file passed 5 runs out of 5,
and under valgrind too, because the allocator recycles the block between the two frees.
`__boxedAddress` (test-only) makes the rule one deterministic line, since `g_propagate_error` and
`g_prefix_error_literal` store the very pointer they were handed. The rounds + drain stay beside
it: the identity check proves the copy is made, the rounds prove it is released.

The two leak mutants that stay green are recorded in `docs/node-gi-verification.md` with the two
instruments that DO catch them (valgrind at two volumes; a temporary alloc/free counter) rather
than papered over. Leaks have no observable in-process effect, so no in-suite assertion can hold
them.

Other guards against a green-for-the-wrong-reason pass: `matches()` must answer *false* for a wrong
code and for a wrong domain; the private quark means no other test's domain can satisfy an
assertion; `fakesrc` must resolve, so an empty registry cannot fake it; the NULL case is paired with
the same call on a real error; and a look-alike object (`{domainQuark, code, message}`) sits among
the refusals, so recognition cannot degrade to duck-typing.

The mechanism is proven with **GLib only**, because the aarch64 CI leg runs the suite on a plain
`fedora:44` with no GStreamer. The issue's own call is proven where GStreamer exists (gated on the
typelib), including a **real pipeline failure read off the bus** — `filesrc` on a missing path, no
main loop, no network — and a caught error POSTED to a bus through the transfer-none arm.

Conformance program `gerror-out-params` (golden = gjs output) — green on **gjs, node, bun and
deno**, byte-identical, and extended with the constructed-error round trip. Two duplicated test
helpers, each in its second copy, moved to `test/gc-drain.mjs` and `test/gst-gate.mjs` beside the
existing `display-gate.mjs`.

Full local runs: `npm test` 629 / 0 fail, `npm run test:gc` 629 / 0 fail,
`npm run test:conformance` all 33 programs × 4 runtimes green, `npm run test:gimarshalling`
444 / 0 fail. `oxfmt --check` and `oxlint` clean on the touched files (`packages/node-gi/**` is a
classifier-ignore path, so only `tree-checks` formats it).

Closes #1495

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fg7cvsEJVF84chQMyj5A9x
