### PR TITLE
feat(iframe): depend on the win32 WebKit backend

### DIFF
--- a/packages/framework/iframe/README.md
+++ b/packages/framework/iframe/README.md
@@ -14,6 +14,33 @@ npm install @gjsify/iframe
 yarn add @gjsify/iframe
 ```
 
+## Where `gi://WebKit` 6.0 comes from
+
+This package imports `gi://WebKit?version=6.0` and never branches on the
+operating system. Which typelib answers to that name is decided by packaging —
+one backend per OS:
+
+| OS | provider | engine |
+|---|---|---|
+| Linux | the system WebKitGTK | WebKit |
+| macOS | [`@gjsify/webkit-native`](../webkit-native/README.md) ([ADR 0022](https://github.com/gjsify/gjsify/blob/main/docs/adr/0022-webkit-on-darwin.md)) | Apple's WebKit |
+| Windows | [`@gjsify/webview2-native`](../webview2-native/README.md) ([ADR 0035](https://github.com/gjsify/gjsify/blob/main/docs/adr/0035-web-view-on-win32.md)) | Chromium, via WebView2 |
+
+Both shims are ordinary dependencies of this package and contain no JavaScript.
+Each one's prebuilt library and typelib arrive through its *own* per-target
+`optionalDependencies`, which a package manager installs only on the matching
+`os`/`cpu` and silently skips everywhere else
+([ADR 0017](https://github.com/gjsify/gjsify/blob/main/docs/adr/0017-native-package-distribution.md)).
+So a Linux install pulls in two empty packages and no binaries at all.
+
+> **Windows is stage 1, and stage 1 is not a widget.** `@gjsify/webview2-native`
+> hosts an OS-composited child window that sits *outside* GSK's scene graph, and
+> the hosted path itself — re-parenting under a real GTK toplevel, bounds
+> tracking, hiding on unmap — is **not yet verified**; everything green so far
+> ran against a hidden parking window. Read that package's README before
+> relying on it: a full-page document in a window works, a web view used as an
+> ordinary widget does not.
+
 ## Usage
 
 ```typescript

--- a/packages/framework/iframe/package.json
+++ b/packages/framework/iframe/package.json
@@ -51,7 +51,8 @@
         "@gjsify/dom-elements": "workspace:^",
         "@gjsify/dom-events": "workspace:^",
         "@gjsify/message-channel": "workspace:^",
-        "@gjsify/webkit-native": "workspace:^"
+        "@gjsify/webkit-native": "workspace:^",
+        "@gjsify/webview2-native": "workspace:^"
     },
     "devDependencies": {
         "@gjsify/cli": "workspace:^",

--- a/packages/framework/webkit-native/package.json
+++ b/packages/framework/webkit-native/package.json
@@ -22,7 +22,7 @@
         },
         "osNotes": {
             "linux": "Binds Apple's WebKit.framework, which exists only on macOS. Linux has the real thing: @gjsify/iframe imports gi://WebKit 6.0 there and never reaches this package.",
-            "win32": "Binds Apple's WebKit.framework, which exists only on macOS. Windows has no GJS host either (see @gjsify/os win32 notes)."
+            "win32": "Binds Apple's WebKit.framework, which exists only on macOS. Windows is served by @gjsify/webview2-native, which claims the same namespace with Microsoft's WebView2 behind it (ADR 0035). Neither OS has a GJS host for this pillar; Node is the host on both (see @gjsify/os win32 notes)."
         },
         "tier": 1
     },


### PR DESCRIPTION
Stacked on #1499. The diff is three files: one dependency line, one `osNotes`
string, one README section.

## The gap

[ADR 0035](../blob/main/docs/adr/0035-web-view-on-win32.md) landed
`@gjsify/webview2-native` in #1494 so that **`@gjsify/iframe` needs no new code**
on Windows — the package deliberately squats the `WebKit-6.0` GI namespace with
Chromium behind it, exactly as `@gjsify/webkit-native` does on darwin with
Apple's WebKit. Decision 1 is explicit that the namespace *is* the integration
contract, and the ADR's own Consequences section says "`@gjsify/iframe` gains no
code. As on darwin, that is the measure of whether the namespace decision was
right."

That measure holds — and it is precisely why the gap was invisible. #1494 touched
23 files and **none of them was `@gjsify/iframe`**. "Needs no new *code*" is true;
it still needs a graph *edge*, and nobody drew it.

Measured on `fix/false-npm-claims` before this change:

| | fact |
|---|---|
| `iframe` `dependencies` | `@girs/webkit-6.0` + `@gjsify/webkit-native` (HARD), no mention of `@gjsify/webview2-native` |
| `webkit-native` `optionalDependencies` | `{darwin-arm64, darwin-x64}` — darwin only |
| `iframe` source references to either backend | **zero** (`grep` over `src/`) — a pure namespace consumer |

So `WebKit-6.0` reached a win32 consumer of `@gjsify/iframe` from **no graph edge
at all**: Linux gets the system WebKitGTK, darwin gets `webkit-native`, Windows
got nothing.

## The sequencing constraint — checked, and met

Landing this edge before the win32 prebuild was committed would have pointed the
dependency at an empty `prebuilds/`, which is worse than no edge. It is committed:

- `@gjsify/webview2-native-win32-x64` carries **no `gjsify.platformsUncommitted`**
  (the only two exemptions in the tree are `@gjsify/napi`'s, both reported by the
  audit as `napi-darwin-arm64` / `napi-linux-x64`).
- `prebuilds/win32-x64/` holds `gjsifywebview2.dll` (122 368 B),
  `WebKit-6.0.typelib` (7 360 B) and `WebKit-6.0.gir` (52 030 B), all three
  **tracked in git** and clean, landed by `46ba2cee5c chore: update native
  prebuilds [skip ci]`.
- `prebuilds.yml` run **33721635589** on `main`: job
  `Build prebuilds (win32-x64) [webview2-native via MSVC]` = **success**, job
  `Commit prebuilds to repo` = **success**.
- Both npm names are live at **0.45.0** (`@gjsify/webview2-native` and
  `@gjsify/webview2-native-win32-x64`), verified against the registry.

## Hard dependency, not optional — and why

Mirrors `webkit-native` exactly, and the precedent is right rather than merely
established. Both bridges are `files: []` packages with **no top-level `os`/`cpu`
field** and `tier: 1`, so:

- A hard edge costs a Linux or macOS consumer nothing — it installs an empty
  package and no binaries. The platform gate lives one level down, at
  `@gjsify/webview2-native-win32-x64`, which declares `os: ["win32"]` +
  `cpu: ["x64"]` and is referenced as an `optionalDependency`, so a package
  manager silently skips it everywhere else. That is ADR 0017's model, and the
  bridge is not where the OS question gets asked.
- Making the **bridge** optional would gate nothing (there is no platform
  mismatch at that level to absorb) while converting a genuine registry or
  network failure into silence. That is the failure mode ADR 0035 decision 5
  names — "a namespace that resolves, advertises its classes and dies in the
  constructor" — bought for no benefit.

Two backends for one namespace declared two different ways would also be an
asymmetry with no reason behind it.

## What the change deliberately does NOT do

**`iframe` gains no `gjsify.os` / `osNotes`.** It does not branch on the operating
system — zero source references to either backend, still `import ... from
'gi://WebKit?version=6.0'` verbatim. The `os-axis` rule governs "a package that
branches on the operating system", and ADR 0035 decision 1 names the absence of an
`gjsify.os` declaration as part of what the namespace decision buys. Adding one
would assert a branch that does not exist.

## ⚠️ This is a packaging edge, not a working reader

Do not read this merge as "the reader works on Windows". Per #1494's own status
line and `webview2-native`'s README, the **HOSTED path is unverified**:
re-parenting the child `HWND` under a real GTK toplevel, bounds tracking in device
pixels, and hide-on-unmap are all untested, because the probe never presents a
toplevel — an SSH session on Windows lands in session 0, where `present()` dies
with `0xC0000005`. Everything green ran against a **hidden parking window**. Stage
2 (content in GSK's scene graph) does not exist. What this PR makes true is that
the typelib now *arrives*; the README section added here says so in those terms.

## ADR

**ADR 0035 already covers this** and no new ADR is needed. `docs/governance.md`
requires an ADR for decisions that "change a published contract", which this edge
does — but ADR 0035 *is* that decision, written for exactly this: decision 1 fixes
the namespace and the package name, the Consequences section states that
`@gjsify/iframe` gains no code, and ADR 0017 already fixes the per-target
distribution shape this follows. This PR implements a decision already accepted;
it does not make a new one. Tier direction also holds (1 → 1).

## Checks

Run in this worktree, after the change:

| command | exit |
|---|---|
| `node scripts/audit-runtimes.mjs --check` | **0** |
| `node scripts/audit-runtimes.mjs --check --strict` (what CI runs) | **0** |
| `node scripts/verify-published-closure.mjs` | **0** |
| `node scripts/check-shipped-runtime-packages.mjs` | **0** |
| `node scripts/check-adr-index.mjs` | **0** |

`verify-published-closure` is the interesting one — a new sibling edge is exactly
what it walks. It went from **374 → 375** release-pinned edges (308 → 309
`dependencies`) across 209 packages, and all 375 resolve at 0.45.0.

No lockfile change: `gjsify-lock.json` records only registry deps (0 `@gjsify/*`
entries, 0 `workspace:` entries), so a workspace-internal edge does not touch it.
No committed bundle is affected — the diff is manifests and a README.

## Not changed, by instruction

I did not touch `status/open-todos.md` or `status/agent-context-budget.json`
(another agent owns them this round). What should land there:

- **`status/open-todos.md`** — the ADR 0035 follow-up entry should record that the
  packaging edge is now drawn, and narrow the remaining win32 work to the two
  things still open: the **hosted path** (re-parent under a real toplevel, bounds
  tracking, hide-on-unmap — currently unexercised because the probe parks in a
  hidden window) and **stage 2** (visual hosting + `Windows.Graphics.Capture` into
  a `Gdk.Texture`). Decision 5's `.msi` Evergreen declaration is also still
  undone. Worth naming the class, not just the instance: #1494 shipped a backend
  and its per-target package without the consumer edge, and every check in the
  tree stayed green — nothing asserts that a declared OS backend is *reachable*
  from the package it exists to serve.
- **`status/agent-context-budget.json`** — no change needed; this PR adds no
  agent-context file and no AGENTS.md bytes. `packages/framework/AGENTS.md`
  already documents the `webkit-native · webview2-native` pair correctly and
  needed no edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGTu3xiJDXtxVdB7vkzcyC
