### PR TITLE
test: gate every test entry on reaching run()

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -84,6 +84,18 @@ jobs:
       - name: Check test scripts run their declared runtime legs
         run: node scripts/audit-test-scripts.mjs
 
+      # And the leg that IS run must be able to fail. `run()` is the only place
+      # `@gjsify/unit` turns a verdict into an exit code, so an entry that awaits its
+      # spec defaults itself executes every test, prints every red mark and exits 0 —
+      # the suite reports green and the summary line the node-gi harness parses is
+      # never printed. `@gjsify/webaudio` shipped that shape (#872), `@gjsify/gamepad`
+      # was found identical in the same sweep, and `@gjsify/webrtc` — 17 red tests
+      # under it — was missed by that sweep and then fixed on a branch that never
+      # merged. Two hand corrections and one that did not stick; this is the check
+      # that replaces the comments those fixes left behind.
+      - name: Check every test entry reaches the runner
+        run: node scripts/check-test-entry-run.mjs
+
       # Containerised jobs vs the image they run on. Two derived questions: a
       # job ON the baked image must not `dnf install` something the Dockerfile
       # lacks (the "MUST stay in lockstep" comment, made real), and a job still

--- a/packages/web/gamepad/src/test.mts
+++ b/packages/web/gamepad/src/test.mts
@@ -1,8 +1,3 @@
-// Test entry — routed through `@gjsify/unit`'s `run()` so the suite REPORTS.
-// Awaiting the spec directly prints per-test results but nothing else: `run()`
-// is what emits the summary line AND sets the process exit code, so without it
-// a failing assertion still exited 0 (the defect fixed for `@gjsify/webaudio`
-// in #872 — this entry had the identical shape).
 import { run } from '@gjsify/unit';
 
 import testSuiteGamepad from './gamepad.spec.js';

--- a/packages/web/webaudio/src/test.mts
+++ b/packages/web/webaudio/src/test.mts
@@ -1,14 +1,3 @@
-// Test entry — routed through `@gjsify/unit`'s `run()` so the suite REPORTS.
-//
-// Awaiting the spec directly (the previous shape) prints per-test results but
-// nothing else: `run()` is what emits the summary line AND sets the process exit
-// code. Without it a failing assertion printed a red ❌ and the runner still
-// exited 0 — verified by breaking an assertion on purpose — so `gjsify workspace
-// @gjsify/webaudio test` reported success on a red suite, and the node-gi
-// consumer harness (`node scripts/node-gi-consumer-harness.mjs webaudio`), which
-// parses that summary, could only say "ran-no-summary" for node/bun/deno. This
-// package's whole claim is that REAL decode + playback work, so a suite that
-// cannot fail is the one thing it must not have.
 import { run } from '@gjsify/unit';
 
 import testSuiteWebaudio from './webaudio.spec.js';

--- a/scripts/check-node-test-registration.mjs
+++ b/scripts/check-node-test-registration.mjs
@@ -33,10 +33,13 @@
 // `scripts/suite-registration.mjs`, which is also where the driver gate now gets its
 // answer from. It reports TWO facts about a spec, and this file asks for the weaker
 // one: `reachable`, "some entry imports it". The stronger one, `live` ("an entry hands
-// its suite to `run({…})`"), is deliberately not gated here — `packages/web/webrtc`
-// awaits its four spec defaults instead of registering them, and a package with several
-// entries registers a leg-appropriate subset in each. Gating reachability repo-wide and
-// liveness where a caller can justify it is the split that holds.
+// its suite to `run({…})`"), is deliberately not gated here: a package with several
+// entries registers a leg-appropriate subset in each, so a spec missing from one of them
+// is not evidence of anything. Gating reachability repo-wide and liveness where a caller
+// can justify it is the split that holds.
+//
+// Whether the ENTRY in turn reaches `run()` — without which the suite runs and cannot
+// fail — is a third question, held repo-wide by `check-test-entry-run.mjs`.
 //
 // Usage: node scripts/check-node-test-registration.mjs [--root <dir>]
 

--- a/scripts/check-test-entry-run.mjs
+++ b/scripts/check-test-entry-run.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+// Every test entry reaches `@gjsify/unit`'s `run()`, or its suite cannot fail.
+//
+// THE INCIDENT
+//
+// `run()` is where a verdict becomes an exit code: `exitCodeFor(countTestsFailed,
+// suiteBodyThrew)` and the `process.exit`/`imports.system.exit` that consume it live inside
+// it and nowhere else (`packages/gjs/unit/src/index.ts`). An entry that awaits its spec
+// defaults itself — `const _results = { a: await aSpec(), … }` — executes every test, prints
+// every red mark, then falls off the end of the module. Node and GJS both exit 0 and the
+// package reports green. `scripts/node-gi-consumer-harness.mjs` parses the summary line
+// `run()` prints, so such a package can additionally only ever score `ran-no-summary` on
+// node/bun/deno.
+//
+// `@gjsify/webaudio` shipped that shape and #872 fixed it — verified by breaking an assertion
+// on purpose, which still exited 0. `@gjsify/gamepad` was found identical and fixed by hand in
+// the same sweep. Both entries were then given a comment telling the next author not to do it,
+// and a comment is the mechanism this file replaces. `@gjsify/webrtc` had the same shape with
+// 17 red tests under it; the sweep missed it, a later branch fixed it, and that branch never
+// merged — so the defect outlived two separate corrections. A hand sweep that fixed two of
+// three, and a fix that did not stay fixed, are the argument for a check rather than a fourth
+// pair of eyes.
+//
+// WHY A `run(` GREP IS THE WRONG TEST, IN BOTH DIRECTIONS
+//
+// Too permissive: `loop.run()` and `mainloop.run()` are how this repo starts a GLib main loop,
+// and a bare `run(` accepts an entry that only does that. So the name is bound at its IMPORT —
+// the local name a `@gjsify/unit` clause introduces for the `run` export — and only a call of
+// THAT name, not reached through a member access, counts.
+//
+// Too strict: a browser entry may own no `run({…})` and delegate wholesale to the sibling that
+// does (`export * from './test.mjs'`), which runs the suite and sets the exit code exactly
+// once. Every `test.browser.mts` in `packages/node/*` that re-exports its shared entry has this
+// shape; a gate reporting them would be accusing correct code, and a gate that fires on correct
+// code is one people learn to route around. So a relative import landing on another entry of
+// the same package is followed and the question asked there. Whether that re-export shape is
+// DESIRABLE for a browser entry is a different question, owned by `tests/AGENTS.md` § Browser
+// tests; this file only asks whether the exit code gets set.
+//
+// Resolution is path arithmetic plus `existsSync` (`resolveToSource`), never the module graph:
+// `audit-runtimes.yml` does no install and no build, so anything needing `node_modules` could
+// not run there at all.
+//
+// WHICH FILES ARE ENTRIES — the package's own scripts, not a filename walk
+//
+// The subject is the set CI BUILDS AND RUNS, so it is read from where that is decided: a
+// `gjsify build … --app <target>` in one of the package's own scripts, narrowed to the
+// test-entry naming convention so the app builds (`src/index.ts --app gjs`) drop out. Walking
+// `src/` for the same names instead finds one extra file — `packages/infra/cli`'s own
+// `src/commands/test.ts`, the CLI command, which is not a test entry and would be a permanent
+// false accusation. Measured the other way round, the script-derived set misses nothing the
+// walk finds: it covers all five entries kept in `src/ts/`, which a flat read of `src/` does
+// not. An entry no script builds is deliberately out of scope — nothing runs it, so it cannot
+// report a false green.
+//
+// WHAT THIS DOES NOT ASK
+//
+// Only whether an entry reaches the runner. Whether every SPEC reaches an entry is
+// `check-node-test-registration.mjs`; whether a browser-only package registers all of them is
+// `check-browser-test-registration.mjs`. The three compose: specs reach entries, entries reach
+// `run()`, and `run()` reaches the exit code.
+//
+// Usage: node scripts/check-test-entry-run.mjs [--root <dir>]
+
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { isTestEntry, packageDirs, relativeImports, stripComments } from './suite-registration.mjs';
+
+const args = process.argv.slice(2);
+const rootFlag = args.indexOf('--root');
+if (rootFlag !== -1 && args[rootFlag + 1] === undefined) {
+    console.error('check-test-entry-run: --root needs a directory.');
+    process.exit(2);
+}
+const ROOT =
+    rootFlag === -1
+        ? resolve(dirname(fileURLToPath(import.meta.url)), '..')
+        : resolve(process.cwd(), args[rootFlag + 1]);
+
+/**
+ * Trees whose packages ship suites CI builds. `showcases/` holds none today and is listed so
+ * that the first one to grow an entry is covered on the day it lands, not the day someone
+ * remembers this list.
+ */
+const TREES = ['packages', 'tests', 'examples', 'showcases'];
+
+const RUNNER = '@gjsify/unit';
+
+/** One `gjsify build …` clause per match, cut at the shell operator that ends the command. */
+const BUILD_CLAUSE = /\bbuild\b([^&|;]*)/g;
+/** A TypeScript source named inside such a clause, quoted or bare. */
+const CLAUSE_SOURCE = /(?:^|\s)['"]?([^\s'"]+\.(?:mts|ts|tsx))['"]?/g;
+
+/**
+ * The entry files a package's scripts hand to `gjsify build … --app <target>`.
+ *
+ * `--app` is what separates a runnable bundle from `build:gjsify`'s `--library` pass over the
+ * whole of `src/`, which emits modules and runs nothing.
+ */
+function scriptedEntries(pkgDir) {
+    const manifest = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'));
+    const found = new Set();
+    for (const command of Object.values(manifest.scripts ?? {})) {
+        if (typeof command !== 'string') continue;
+        for (const [, clause] of command.matchAll(BUILD_CLAUSE)) {
+            if (!/--app\s+\S/.test(clause)) continue;
+            for (const [, file] of clause.matchAll(CLAUSE_SOURCE)) {
+                if (isTestEntry(basename(file))) found.add(join(pkgDir, file));
+            }
+        }
+    }
+    return [...found].filter((file) => existsSync(file));
+}
+
+/**
+ * The local name(s) `source` binds to the runner's `run` export.
+ *
+ * The clause is read rather than the string `run` searched for, because `import { run as
+ * runSuite }` is legal and would otherwise read as an entry that never calls the runner.
+ */
+function runnerBindings(source) {
+    const names = [];
+    const pattern = new RegExp(String.raw`import\s*\{([^}]*)\}\s*from\s*['"]${RUNNER}['"]`, 'g');
+    for (const [, clause] of source.matchAll(pattern)) {
+        for (const member of clause.split(',')) {
+            const alias = /^\s*run\s+as\s+([A-Za-z_$][\w$]*)\s*$/.exec(member);
+            if (alias) names.push(alias[1]);
+            else if (member.trim() === 'run') names.push('run');
+        }
+    }
+    return names;
+}
+
+/** Whether `source` calls one of `names` as a free identifier — `x.run()` does not count. */
+const callsAny = (source, names) => names.some((name) => new RegExp(String.raw`(^|[^.\w$])${name}\s*\(`).test(source));
+
+const violations = [];
+let entriesChecked = 0;
+let packagesChecked = 0;
+
+for (const tree of TREES) {
+    const treeDir = join(ROOT, tree);
+    if (!existsSync(treeDir)) continue;
+
+    for (const pkg of packageDirs(treeDir)) {
+        const entries = scriptedEntries(pkg);
+        if (entries.length === 0) continue;
+        packagesChecked++;
+        entriesChecked += entries.length;
+
+        const isEntry = new Set(entries);
+        const sources = new Map(entries.map((entry) => [entry, stripComments(readFileSync(entry, 'utf8'))]));
+        const callsRun = new Map(
+            entries.map((entry) => [entry, callsAny(sources.get(entry), runnerBindings(sources.get(entry)))]),
+        );
+        // A re-export entry names its target twice (`export * from './test.mjs'` beside
+        // `import './test.mjs'`), so the set is what keeps a violation report from listing
+        // the same sibling twice.
+        const delegates = new Map(
+            entries.map((entry) => [
+                entry,
+                [
+                    ...new Set(
+                        relativeImports(entry, sources.get(entry))
+                            .map(({ target }) => target)
+                            .filter((target) => isEntry.has(target) && target !== entry),
+                    ),
+                ],
+            ]),
+        );
+
+        /** Whether `entry` calls the runner, or delegates to a sibling entry that does. */
+        const reachesRunner = (entry, seen = new Set()) => {
+            if (callsRun.get(entry)) return true;
+            if (seen.has(entry)) return false;
+            seen.add(entry);
+            return delegates.get(entry).some((target) => reachesRunner(target, seen));
+        };
+
+        for (const entry of entries.sort()) {
+            if (reachesRunner(entry)) continue;
+            violations.push({
+                entry: relative(ROOT, entry),
+                delegates: delegates.get(entry).map((target) => relative(pkg, target)),
+            });
+        }
+    }
+}
+
+if (violations.length > 0) {
+    console.error('check-test-entry-run: test entries that never reach the runner.\n');
+    for (const { entry, delegates } of violations) {
+        console.error(`  ${entry}`);
+        console.error(
+            delegates.length === 0
+                ? `      calls no \`run(…)\` from '${RUNNER}', and delegates to no sibling entry`
+                : `      calls no \`run(…)\` from '${RUNNER}', and neither does: ${delegates.join(', ')}`,
+        );
+    }
+    console.error(
+        '\nA suite that does not reach `run()` executes its tests, prints their results and then\n' +
+            'exits 0 — a red assertion reports green, and the per-runtime summary line the node-gi\n' +
+            `harness reads is never printed. Import \`run\` from '${RUNNER}' and hand it the suites:\n` +
+            '`run({ mySuite, … })`.\n',
+    );
+    process.exit(1);
+}
+
+console.log(
+    `check-test-entry-run: ${entriesChecked} test entr(ies) across ${packagesChecked} package(s) ` +
+        'all reach the runner.',
+);

--- a/scripts/suite-registration.mjs
+++ b/scripts/suite-registration.mjs
@@ -237,9 +237,10 @@ function separatorIndex(part) {
 /**
  * The identifiers `source` registers as suites: the values of a `run({…})` property at
  * any depth (`runTests` recurses into a nested object, so a suite grouped inside one is
- * registered just as much as a top-level entry), plus anything the entry CALLS —
- * `packages/web/webrtc/src/test.mts` awaits its four spec defaults directly instead of
- * handing them to `run`, and that runs them.
+ * registered just as much as a top-level entry), plus anything the entry CALLS, because
+ * a suite the entry awaits by hand does run. Note that hand-calling it is all it does:
+ * the failures land outside the counter `run()` turns into an exit code, which is why
+ * `check-test-entry-run.mjs` requires every entry to reach `run()` as well.
  *
  * VALUE position, not key: `run({ Promise: promiseSuite })` registers `promiseSuite`,
  * and it is the local binding a caller compares against. An inline `key: async () => {…}`


### PR DESCRIPTION
> Base note: this was written to stack on `fix/false-npm-claims`, but #1499 was squash-merged
> while it was in progress and its branch deleted. Rebased onto `main` (v0.46.0); git skipped
> the already-applied commit, so this PR is the one commit below.

## Blocker — read before merging

Fixing `packages/web/webrtc/src/test.mts` does exactly what it was asked to do: the suite
stops lying and now reports **17 of 590 tests failing**, exit 1. Those 17 are pre-existing
defects the silent entry has been hiding, not a regression from this PR. `main.yml`'s test
shard runs `gjsify foreach test` over `@gjsify/webrtc`, so **that leg will go red until they
are resolved** — which is the required check doing its job, and the reason this PR should not
be merged on its own. See _What the webrtc fix uncovered_ below for where the fixes already
are.

## What this adds

`run()` is the only place `@gjsify/unit` turns a verdict into an exit code —
`exitCodeFor(countTestsFailed, suiteBodyThrew)` and the `process.exit`/`imports.system.exit`
that consume it live inside it and nowhere else. An entry that awaits its spec defaults
itself executes every test, prints every red mark, falls off the end of the module and exits
**0**. `scripts/check-node-test-registration.mjs` said this narrowing out loud
("deliberately not gated here"); `scripts/check-test-entry-run.mjs` closes it.

### The incident, and why a gate rather than a fourth pair of eyes

- `@gjsify/webaudio` shipped that shape and #872 fixed it — verified by breaking an
  assertion on purpose, which still exited 0.
- `@gjsify/gamepad` was found identical and fixed by hand in the same sweep.
- `@gjsify/webrtc` had the same shape, the sweep **missed** it, and the later fix landed only
  on the local branch `fix/webrtc-suite-reports`, which was **never pushed**. So the defect
  survived two separate corrections.

Both fixed entries were left carrying a comment telling the next author not to do it. That
comment is the manual mechanism this check replaces, so both are deleted here and their
incident moves one hop into the check's header — where the mechanism is.

## What I measured

| | |
|---|---|
| test entries the gate now holds | 197, across 145 packages |
| entries with no `run(` call at all | 11 |
| of those, correct re-export entries (`export * from './test.js'`) | 10 |
| real violators | 1 — `packages/web/webrtc/src/test.mts` |

The 10 are `packages/node/{assert,async_hooks,constants,diagnostics_channel,events,path,querystring,string_decoder,sys,util}/src/test.browser.mts`.
They delegate to a sibling that owns the `run({…})`, so a gate reporting them would be
accusing correct code. Whether that re-export shape is *desirable* for a browser entry is a
separate, already-recorded defect; this gate deliberately does not touch it.

### How the two shapes are told apart

A relative import that lands on **another entry of the same package** is followed and the
question asked there, transitively. Resolution is `resolveToSource` — path arithmetic plus
`existsSync`, no module graph — because `audit-runtimes.yml` does no install and no build, so
anything needing `node_modules` could not run there at all.

Two other decisions, both measured rather than assumed:

- **`run` is bound at its import**, not grepped. `loop.run()` / `mainloop.run()` appear 20+
  times in this tree; a bare `run(` search would accept an entry that only starts a GLib main
  loop.
- **The entry set comes from each package's own scripts** — the files handed to
  `gjsify build … --app <target>`, i.e. what CI actually builds and runs. A filename walk of
  `src/` finds one extra file, `packages/infra/cli/src/commands/test.ts` (the CLI command),
  which would be a permanent false accusation. Measured the other way, the script-derived set
  misses nothing the walk finds — including the five entries kept in `src/ts/`, which the flat
  `readdirSync(src)` the sibling gates use never reaches.

## Proving the gate can go RED

Executed on this branch against `packages/web/eventsource`, whose entry was mutated and then
restored byte-for-byte (`git status` clean at the end).

**A0 — baseline, tree as committed**

```
$ node scripts/check-test-entry-run.mjs
check-test-entry-run: 197 test entr(ies) across 145 package(s) all reach the runner.
exit=0
```

**A1 — synthetic violator: the specs awaited directly instead of handed to `run()`**

```ts
import testSuiteEventSource from './eventsource.spec.js';

const _results = {
    eventsource: await testSuiteEventSource(),
};
```

```
$ node scripts/check-test-entry-run.mjs
check-test-entry-run: test entries that never reach the runner.

  packages/web/eventsource/src/test.mts
      calls no `run(…)` from '@gjsify/unit', and delegates to no sibling entry

A suite that does not reach `run()` executes its tests, prints their results and then
exits 0 — a red assertion reports green, and the per-runtime summary line the node-gi
harness reads is never printed. Import `run` from '@gjsify/unit' and hand it the suites:
`run({ mySuite, … })`.

exit=1
```

**A2 — the same file made a re-export of the sibling that owns `run()`: must PASS**

```ts
export * from './test.browser.mjs';
import './test.browser.mjs';
```

```
$ node scripts/check-test-entry-run.mjs
check-test-entry-run: 197 test entr(ies) across 145 package(s) all reach the runner.
exit=0
```

**A3 — delegation is not an escape hatch.** Keeping A2's re-export and removing `run()` from
the *target* must fail both files, which is the discriminator working rather than a blanket
pass for anything that re-exports:

```
$ node scripts/check-test-entry-run.mjs
check-test-entry-run: test entries that never reach the runner.

  packages/web/eventsource/src/test.browser.mts
      calls no `run(…)` from '@gjsify/unit', and delegates to no sibling entry
  packages/web/eventsource/src/test.mts
      calls no `run(…)` from '@gjsify/unit', and neither does: src/test.browser.mts

exit=1
```

**A4 — both files reverted to the committed source**

```
$ git status --short   # (nothing for packages/web/eventsource)
$ node scripts/check-test-entry-run.mjs
check-test-entry-run: 197 test entr(ies) across 145 package(s) all reach the runner.
exit=0
```

And the red path against the **real** defect, before the fix in this PR:

```
$ node scripts/check-test-entry-run.mjs
check-test-entry-run: test entries that never reach the runner.

  packages/web/webrtc/src/test.mts
      calls no `run(…)` from '@gjsify/unit', and delegates to no sibling entry

exit=1
```

## What the webrtc fix uncovered

```
$ gjsify workspace @gjsify/webrtc run test
❌ [Gjs 1.88.1] 17 of 590 tests failed  (10.16s)
exit=1
```

The 17 map one-for-one onto the list in the commit message of `0815cc1e9f`
(`test(webrtc): route the suite through run()`) on the unpushed local branch
`fix/webrtc-suite-reports`, measured 2026-07-30 on the same Fedora / GJS 1.88.1 /
GStreamer 1.28.5 combination: 2 SCTP regressions, 1 tee multiplexer, 2 negotiationneeded,
4 setLocalDescription rollback, 2 stale assertions, 2 sender/receiver transport, 3
getParameters, and 1 upstream.

That branch (21 commits, 50 files, +1141/-312) already fixes **16 of the 17**. The 17th —
`WPT — RTCDataChannel-send › send/receive empty string` — is blocked in GStreamer 1.28.5
(`webrtcdatachannel.c` builds a zero-length buffer where RFC 8831 § 6.6 requires one zero
byte) and that branch deliberately leaves it red, which means **even that branch could not
land green**, and is very likely why it was never pushed.

**Suggested sequencing:** push `fix/webrtc-suite-reports`' nine webrtc commits as their own
PR, and convert the upstream-blocked test to `it.failing(name, fn, reason)` — the tool
`tests/AGENTS.md` rule 6 mandates for exactly this case, and better than "keep it red"
because it self-retires the day GStreamer fixes it. This PR then merges green on top.

## Checks run

| check | exit |
|---|---|
| `node scripts/check-test-entry-run.mjs` | **0** |
| `node scripts/check-workflow-run-syntax.mjs` | **0** |
| `node scripts/check-node-test-registration.mjs` | **0** |
| `node scripts/audit-runtimes.mjs --check` | **0** |
| `oxfmt --check` (the 6 touched `.mjs`/`.mts`) | **0** |
| `oxlint` (same 6) | **0** |
| `gjsify workspace @gjsify/webrtc run test` | **1** — the 17 above |

Also green, as neighbours of the shared reader I touched: `check-browser-test-registration`,
`audit-test-scripts`, `check-adwaita-conformance-drivers`, `check-source-visibility`,
`check-agent-context-size --check`. `check-comment-budget --warn` leaves the `scripts` tree
at 0.581 against its 0.592 ceiling, so the new header fits without re-baselining.

## Deliberately not done

- **Not cherry-picked the nine webrtc impl commits.** ~1000 lines of WebRTC protocol work I
  did not author, on an unpushed branch in a shared checkout, and it would still not reach
  green because of the upstream blocker. Duplicating it would collide with whoever owns that
  branch.
- **Not used `it.failing` on the 17.** 16 are our own defects; `tests/AGENTS.md` rule 6 scopes
  that tool to blockers that are genuinely not ours, so reaching for it here would be
  weakening tests.
- **Not tightened `isTestEntry` in `scripts/suite-registration.mjs`.** `test-helpers.ts`,
  `test-server.ts` and `test-utils.ts` are helper modules the `startsWith('test')` predicate
  misclassifies as entries. I wrote the fix, then measured it as a no-op — all three sit in
  `src/ts/` or an integration suite, which the flat `readdirSync(src)` every current caller
  uses never reaches, and this gate reads the script set instead. Reverted rather than change
  a shared reader for no effect; worth its own change if a walking caller ever appears.
- **Not deleted the `called` term from `registeredSymbols`.** With webrtc fixed, **zero** spec
  edges in the tree still depend on it for liveness (measured across `packages/`, `tests/` and
  `examples/`), so it is now redundant — but removing it also changes `opaque`, which
  `check-adwaita-conformance-drivers.mjs` gates on, and it still encodes a shape the runner
  supports. Flagged, not acted on.
- **Not touched `status/open-todos.md` or `status/agent-context-budget.json`** (owned by
  another agent this round). Nothing in this change needs an entry retired there; the webrtc
  work above may warrant a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGTu3xiJDXtxVdB7vkzcyC
