### PR TITLE
fix(xmlhttprequest): spec the XHR, fix two gaps

### DIFF
--- a/packages/web/xmlhttprequest/package.json
+++ b/packages/web/xmlhttprequest/package.json
@@ -25,12 +25,16 @@
         "./globals.mjs"
     ],
     "scripts": {
-        "clear": "gjsify clear lib tsconfig.tsbuildinfo tsconfig.types.tsbuildinfo",
+        "clear": "gjsify clear lib tsconfig.tsbuildinfo tsconfig.types.tsbuildinfo test.gjs.mjs",
         "check": "gjsify tsc --noEmit",
         "build": "gjsify run build:gjsify && gjsify run build:types",
         "build:gjsify": "gjsify build --library 'src/**/*.{ts,js}' --exclude 'src/**/*.spec.{mts,ts}' 'src/test.{mts,ts}'",
         "build:types": "gjsify tsc",
-        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs"
+        "build:test": "gjsify run build:test:gjs && gjsify run build:test:browser",
+        "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
+        "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:gjs",
+        "test:gjs": "gjsify run test.gjs.mjs"
     },
     "keywords": [
         "gjs",
@@ -46,6 +50,8 @@
     },
     "devDependencies": {
         "@gjsify/cli": "workspace:^",
+        "@gjsify/node-globals": "workspace:^",
+        "@gjsify/unit": "workspace:^",
         "@types/node": "^25.9.2",
         "typescript": "^6.0.3"
     },

--- a/packages/web/xmlhttprequest/src/index.spec.ts
+++ b/packages/web/xmlhttprequest/src/index.spec.ts
@@ -1,0 +1,599 @@
+// Coverage for the XMLHttpRequest this package actually ships — `src/index.ts`.
+//
+// WHY THE IMPORT IS RELATIVE, and why it has to stay that way.
+// Every non-relative spelling of this package's own name reaches a DIFFERENT
+// XMLHttpRequest. `@gjsify/resolve-npm` maps both `xmlhttprequest` and
+// `@gjsify/xmlhttprequest` to `@gjsify/fetch` on the gjs target, to
+// `@gjsify/empty` on node, and to this package's `globals.mjs` (the runtime's
+// native XHR) on browser. A bare specifier here would therefore measure
+// `packages/web/fetch/src/xhr.ts` — a second, fuller XHR — and report green
+// while the class in THIS package stayed unmeasured. That is not hypothetical:
+// the pre-existing `src/test.browser.mts` measures the browser's native global
+// and says so in its own header, so a tier-1 package went its whole life at
+// zero coverage with a test file sitting next to it.
+//
+// WHY THERE IS NO `test:node`. `src/index.ts` imports the default export AND
+// `resolveRootRelativeUrl` from `@gjsify/fetch`; on `--app node` that specifier
+// routes to `fetch/globals.mjs`, which exports neither, and the build stops at
+// MISSING_EXPORT before a test can run. That is exactly what this package's
+// `gjsify.runtimes.node: "none"` declares, and it is the same shape as the
+// sibling GJS-only web packages (websocket, webaudio, gamepad, webrtc).
+
+import { describe, expect, it } from '@gjsify/unit';
+import GLib from 'gi://GLib?version=2.0';
+
+import { FakeBlob, XMLHttpRequest, installObjectURLSupport } from './index.js';
+
+let tempCounter = 0;
+
+/** A fresh temp file plus the `file://` URL that addresses it. */
+function tempFile(name: string, body: string | Uint8Array): { path: string; url: string } {
+    const path = GLib.build_filenamev([GLib.get_tmp_dir(), `gjsify-xhr-spec-${tempCounter++}-${name}`]);
+    GLib.file_set_contents(path, typeof body === 'string' ? new TextEncoder().encode(body) : body);
+    return { path, url: `file://${path}` };
+}
+
+/** A path under the temp dir that is guaranteed NOT to exist. */
+function missingPath(): string {
+    return GLib.build_filenamev([GLib.get_tmp_dir(), `gjsify-xhr-spec-absent-${tempCounter++}`]);
+}
+
+interface DriveResult {
+    xhr: XMLHttpRequest;
+    /** Event types in dispatch order, recorded through `addEventListener`. */
+    events: string[];
+}
+
+/**
+ * Drive one request to its terminal `loadend` and hand back the request plus the
+ * event order. `_emit` calls the `on<type>` property BEFORE the listeners, so the
+ * settle hook is registered as the LAST `loadend` listener — a `xhr.onloadend`
+ * resolver would win the race against the recorder and report `loadend` missing.
+ *
+ * A GLib timeout is the guard rather than `setTimeout`: this file is GJS-only and
+ * GLib is already the transport's dependency, so the guard adds no import that the
+ * subject does not already carry. Without it a request that never settles hangs the
+ * whole run instead of failing one test.
+ */
+function drive(configure: (xhr: XMLHttpRequest) => void): Promise<DriveResult> {
+    return new Promise<DriveResult>((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        const events: string[] = [];
+        for (const type of ['loadstart', 'progress', 'load', 'error', 'abort', 'loadend']) {
+            xhr.addEventListener(type, (event: { type: string }) => events.push(event.type));
+        }
+
+        const guard = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 10_000, () => {
+            reject(new Error(`XMLHttpRequest never reached loadend; saw [${events.join(', ')}]`));
+            return GLib.SOURCE_REMOVE;
+        });
+
+        xhr.addEventListener('loadend', () => {
+            GLib.source_remove(guard);
+            resolve({ xhr, events });
+        });
+
+        configure(xhr);
+        xhr.send();
+    });
+}
+
+export default async () => {
+    await describe('XMLHttpRequest — interface constants', async () => {
+        await it('exposes the readyState constants on an instance', async () => {
+            const xhr = new XMLHttpRequest();
+            expect(xhr.UNSENT).toBe(0);
+            expect(xhr.OPENED).toBe(1);
+            expect(xhr.HEADERS_RECEIVED).toBe(2);
+            expect(xhr.LOADING).toBe(3);
+            expect(xhr.DONE).toBe(4);
+        });
+
+        await it('exposes the readyState constants on the interface object', async () => {
+            // WebIDL puts an interface's constants on the interface OBJECT as well as
+            // on the prototype, so `XMLHttpRequest.DONE` is how most code spells the
+            // comparison. This package shipped only the instance half — which is why
+            // its own `src/test.browser.mts` could assert `XMLHttpRequest.UNSENT` and
+            // pass: in a browser it was reading the native global, never this class.
+            expect(XMLHttpRequest.UNSENT).toBe(0);
+            expect(XMLHttpRequest.OPENED).toBe(1);
+            expect(XMLHttpRequest.HEADERS_RECEIVED).toBe(2);
+            expect(XMLHttpRequest.LOADING).toBe(3);
+            expect(XMLHttpRequest.DONE).toBe(4);
+        });
+    });
+
+    await describe('XMLHttpRequest — initial state', async () => {
+        await it('starts UNSENT with every response field empty', async () => {
+            const xhr = new XMLHttpRequest();
+            expect(xhr.readyState).toBe(xhr.UNSENT);
+            expect(xhr.status).toBe(0);
+            expect(xhr.statusText).toBe('');
+            expect(xhr.response).toBeNull();
+            expect(xhr.responseText).toBe('');
+            expect(xhr.responseType).toBe('');
+            expect(xhr.responseURL).toBe('');
+            expect(xhr.timeout).toBe(0);
+            expect(xhr.withCredentials).toBe(false);
+        });
+
+        await it('starts with every event-handler property null', async () => {
+            const xhr = new XMLHttpRequest();
+            expect(xhr.onloadstart).toBeNull();
+            expect(xhr.onprogress).toBeNull();
+            expect(xhr.onload).toBeNull();
+            expect(xhr.onloadend).toBeNull();
+            expect(xhr.onerror).toBeNull();
+            expect(xhr.onabort).toBeNull();
+            expect(xhr.ontimeout).toBeNull();
+            expect(xhr.onreadystatechange).toBeNull();
+        });
+    });
+
+    await describe('XMLHttpRequest#open', async () => {
+        await it('moves UNSENT → OPENED', async () => {
+            const xhr = new XMLHttpRequest();
+            xhr.open('GET', 'file:///dev/null');
+            expect(xhr.readyState).toBe(xhr.OPENED);
+        });
+
+        await it('stays OPENED when called twice', async () => {
+            const xhr = new XMLHttpRequest();
+            xhr.open('GET', 'file:///dev/null');
+            xhr.open('POST', 'file:///dev/null');
+            expect(xhr.readyState).toBe(xhr.OPENED);
+        });
+
+        await it('clears a previous abort so the instance is reusable', async () => {
+            // `abort()` latches a flag that makes the completion handlers return early.
+            // `open()` clears it — without that, a reused instance silently never
+            // reports again, which is the shape a pooled/retrying caller hits.
+            const file = tempFile('reuse.txt', 'second');
+            const xhr = new XMLHttpRequest();
+            xhr.open('GET', file.url);
+            xhr.abort();
+
+            const settled = new Promise<void>((resolve, reject) => {
+                const guard = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 10_000, () => {
+                    reject(new Error('reused XMLHttpRequest never loaded'));
+                    return GLib.SOURCE_REMOVE;
+                });
+                xhr.onload = () => {
+                    GLib.source_remove(guard);
+                    resolve();
+                };
+            });
+
+            xhr.open('GET', file.url);
+            xhr.responseType = 'text';
+            xhr.send();
+            await settled;
+            expect(xhr.responseText).toBe('second');
+            GLib.unlink(file.path);
+        });
+    });
+
+    await describe('XMLHttpRequest — event dispatch', async () => {
+        // `abort()` emits synchronously, so it is the cheapest probe for the dispatch
+        // rules that every other event shares.
+        await it('hands the event type to the handler property and to the listeners', async () => {
+            const xhr = new XMLHttpRequest();
+            const seen: string[] = [];
+            xhr.onabort = (event: { type: string }) => seen.push(`property:${event.type}`);
+            xhr.addEventListener('abort', (event: { type: string }) => seen.push(`listener:${event.type}`));
+            xhr.abort();
+            expect(seen).toStrictEqual(['property:abort', 'listener:abort']);
+        });
+
+        await it('calls listeners in registration order', async () => {
+            const xhr = new XMLHttpRequest();
+            const seen: string[] = [];
+            xhr.addEventListener('abort', () => seen.push('first'));
+            xhr.addEventListener('abort', () => seen.push('second'));
+            xhr.abort();
+            expect(seen).toStrictEqual(['first', 'second']);
+        });
+
+        await it('binds `this` to the request', async () => {
+            // Compared inside the callbacks rather than captured into a variable:
+            // `typescript/no-this-alias` is an oxlint error, and the comparison
+            // answers the same question.
+            const xhr = new XMLHttpRequest();
+            let handlerBound = false;
+            let listenerBound = false;
+            xhr.onabort = function (this: unknown) {
+                handlerBound = this === xhr;
+            };
+            xhr.addEventListener('abort', function (this: unknown) {
+                listenerBound = this === xhr;
+            });
+            xhr.abort();
+            expect(handlerBound).toBe(true);
+            expect(listenerBound).toBe(true);
+        });
+
+        await it('stops calling a removed listener', async () => {
+            const xhr = new XMLHttpRequest();
+            let calls = 0;
+            const listener = () => {
+                calls++;
+            };
+            xhr.addEventListener('abort', listener);
+            xhr.removeEventListener('abort', listener);
+            xhr.abort();
+            expect(calls).toBe(0);
+        });
+
+        await it('ignores removeEventListener for a type with no listeners', async () => {
+            const xhr = new XMLHttpRequest();
+            const neverRegistered = () => {};
+            xhr.removeEventListener('progress', neverRegistered);
+            expect(xhr.readyState).toBe(xhr.UNSENT);
+        });
+    });
+
+    await describe('XMLHttpRequest#abort', async () => {
+        await it('emits abort then loadend and lands on DONE', async () => {
+            const xhr = new XMLHttpRequest();
+            const events: string[] = [];
+            xhr.addEventListener('abort', () => events.push('abort'));
+            xhr.addEventListener('loadend', () => events.push('loadend'));
+            xhr.open('GET', 'file:///dev/null');
+            xhr.abort();
+            expect(events).toStrictEqual(['abort', 'loadend']);
+            expect(xhr.readyState).toBe(xhr.DONE);
+        });
+
+        await it('suppresses the completion of an in-flight request', async () => {
+            const file = tempFile('suppressed.txt', 'never delivered');
+            const xhr = new XMLHttpRequest();
+            let loads = 0;
+            let errors = 0;
+            xhr.addEventListener('load', () => loads++);
+            xhr.addEventListener('error', () => errors++);
+            xhr.open('GET', file.url);
+            xhr.responseType = 'text';
+            xhr.send();
+            xhr.abort();
+
+            // The transport settles on a microtask; drain a main-loop turn so the
+            // suppressed continuation has actually had its chance to run.
+            await new Promise<void>((resolve) =>
+                GLib.timeout_add(GLib.PRIORITY_DEFAULT, 200, () => {
+                    resolve();
+                    return GLib.SOURCE_REMOVE;
+                }),
+            );
+
+            expect(loads).toBe(0);
+            expect(errors).toBe(0);
+            expect(xhr.responseText).toBe('');
+            GLib.unlink(file.path);
+        });
+    });
+
+    await describe('XMLHttpRequest#send — file:// transport', async () => {
+        await it('reads a file:// URL as text and reports 200/OK', async () => {
+            const file = tempFile('text.txt', 'hello gjs');
+            const { xhr } = await drive((x) => {
+                x.open('GET', file.url);
+                x.responseType = 'text';
+            });
+            expect(xhr.readyState).toBe(xhr.DONE);
+            expect(xhr.status).toBe(200);
+            expect(xhr.statusText).toBe('OK');
+            expect(xhr.responseText).toBe('hello gjs');
+            expect(xhr.response).toBe('hello gjs');
+            GLib.unlink(file.path);
+        });
+
+        await it('emits loadstart, progress, load and loadend in that order', async () => {
+            const file = tempFile('order.txt', 'ordered');
+            const { events } = await drive((x) => {
+                x.open('GET', file.url);
+                x.responseType = 'text';
+            });
+            expect(events).toStrictEqual(['loadstart', 'progress', 'load', 'loadend']);
+            GLib.unlink(file.path);
+        });
+
+        await it("treats the default responseType '' as text", async () => {
+            // XHR §response: an empty `responseType` behaves as `"text"`. Getting this
+            // wrong is invisible at the call site — `xhr.responseText` just stays `''`
+            // for the most common spelling of the API there is.
+            const file = tempFile('default.txt', 'default is text');
+            const { xhr } = await drive((x) => {
+                x.open('GET', file.url);
+            });
+            expect(xhr.responseText).toBe('default is text');
+            expect(xhr.response).toBe('default is text');
+            GLib.unlink(file.path);
+        });
+
+        await it('reports progress totals that match the payload length', async () => {
+            const file = tempFile('progress.txt', 'abcdefghij');
+            const xhr = new XMLHttpRequest();
+            const progress: Array<{ loaded: number; total: number; lengthComputable: boolean }> = [];
+            xhr.addEventListener('progress', (event: { loaded: number; total: number; lengthComputable: boolean }) =>
+                progress.push(event),
+            );
+            await new Promise<void>((resolve) => {
+                xhr.addEventListener('loadend', () => resolve());
+                xhr.open('GET', file.url);
+                xhr.responseType = 'text';
+                xhr.send();
+            });
+            expect(progress.length).toBe(1);
+            expect(progress[0]?.loaded).toBe(10);
+            expect(progress[0]?.total).toBe(10);
+            expect(progress[0]?.lengthComputable).toBe(true);
+            GLib.unlink(file.path);
+        });
+
+        await it("yields an ArrayBuffer for responseType 'arraybuffer'", async () => {
+            const file = tempFile('bytes.bin', new Uint8Array([1, 2, 3, 4]));
+            const { xhr } = await drive((x) => {
+                x.open('GET', file.url);
+                x.responseType = 'arraybuffer';
+            });
+            expect(xhr.response instanceof ArrayBuffer).toBe(true);
+            expect((xhr.response as ArrayBuffer).byteLength).toBe(4);
+            expect([...new Uint8Array(xhr.response as ArrayBuffer)]).toStrictEqual([1, 2, 3, 4]);
+            GLib.unlink(file.path);
+        });
+
+        await it("parses the body for responseType 'json'", async () => {
+            const file = tempFile('data.json', '{"answer":42,"tags":["a","b"]}');
+            const { xhr } = await drive((x) => {
+                x.open('GET', file.url);
+                x.responseType = 'json';
+            });
+            expect((xhr.response as { answer: number }).answer).toBe(42);
+            expect((xhr.response as { tags: string[] }).tags).toStrictEqual(['a', 'b']);
+            GLib.unlink(file.path);
+        });
+
+        await it("yields a FakeBlob backed by a temp file for responseType 'blob'", async () => {
+            const file = tempFile('image.png', new Uint8Array([137, 80, 78, 71]));
+            const { xhr } = await drive((x) => {
+                x.open('GET', file.url);
+                x.responseType = 'blob';
+            });
+            const blob = xhr.response as FakeBlob;
+            expect(blob instanceof FakeBlob).toBe(true);
+            expect(blob.size).toBe(4);
+            // The MIME type is guessed from the URL extension, not from a header —
+            // there is no header to read on the `file://` path.
+            expect(blob.type).toBe('image/png');
+            expect(typeof blob._tmpPath).toBe('string');
+            expect([...new Uint8Array(await blob.arrayBuffer())]).toStrictEqual([137, 80, 78, 71]);
+            if (blob._tmpPath) GLib.unlink(blob._tmpPath);
+            GLib.unlink(file.path);
+        });
+
+        await it('emits error then loadend for a file:// URL that does not exist', async () => {
+            const { xhr, events } = await drive((x) => {
+                x.open('GET', `file://${missingPath()}`);
+                x.responseType = 'text';
+            });
+            expect(events).toStrictEqual(['loadstart', 'error', 'loadend']);
+            expect(xhr.readyState).toBe(xhr.DONE);
+            expect(xhr.responseText).toBe('');
+        });
+
+        await it('runs onreadystatechange when a request completes', async () => {
+            // Deliberately `>= 1` and not an exact count: this implementation calls the
+            // hook once, after DONE, rather than on each readyState transition. Pinning
+            // the count would freeze that deviation into the suite.
+            const file = tempFile('rsc.txt', 'ok');
+            const xhr = new XMLHttpRequest();
+            let calls = 0;
+            xhr.onreadystatechange = () => calls++;
+            await new Promise<void>((resolve) => {
+                xhr.addEventListener('loadend', () => resolve());
+                xhr.open('GET', file.url);
+                xhr.responseType = 'text';
+                xhr.send();
+            });
+            expect(calls).toBeGreaterThan(0);
+            expect(xhr.readyState).toBe(xhr.DONE);
+            GLib.unlink(file.path);
+        });
+    });
+
+    await describe('XMLHttpRequest#send — HTTP transport', async () => {
+        // The Soup-backed leg, driven against a local `node:http` server (which is
+        // `@gjsify/http` here) exactly as `@gjsify/eventsource`'s suite does. `file://`
+        // never touches `@gjsify/fetch`, so without this leg `status`, `statusText`,
+        // `responseURL` and the request method are all unmeasured.
+        const { createServer } = await import('node:http');
+
+        async function withServer<T>(
+            handler: (method: string | undefined, url: string | undefined) => { status: number; body: string },
+            use: (origin: string, seen: { method?: string }) => Promise<T>,
+        ): Promise<T> {
+            const seen: { method?: string } = {};
+            const server = createServer((req, res) => {
+                seen.method = req.method;
+                const { status, body } = handler(req.method, req.url);
+                res.writeHead(status, { 'Content-Type': 'text/plain' });
+                res.end(body);
+            });
+            const port = await new Promise<number>((resolve) => {
+                server.listen(0, () => {
+                    const address = server.address();
+                    if (!address || typeof address === 'string') throw new Error('expected an AddressInfo');
+                    resolve(address.port);
+                });
+            });
+            try {
+                return await use(`http://127.0.0.1:${port}`, seen);
+            } finally {
+                server.close();
+            }
+        }
+
+        await it('exposes status, statusText and responseURL from the response', async () => {
+            await withServer(
+                () => ({ status: 200, body: 'from the server' }),
+                async (origin) => {
+                    const { xhr } = await drive((x) => {
+                        x.open('GET', `${origin}/hello`);
+                        x.responseType = 'text';
+                    });
+                    expect(xhr.status).toBe(200);
+                    expect(xhr.responseText).toBe('from the server');
+                    expect(xhr.responseURL).toBe(`${origin}/hello`);
+                },
+            );
+        });
+
+        await it('uppercases the method handed to open()', async () => {
+            await withServer(
+                () => ({ status: 200, body: 'ok' }),
+                async (origin, seen) => {
+                    await drive((x) => {
+                        x.open('post', `${origin}/upper`);
+                        x.responseType = 'text';
+                    });
+                    expect(seen.method).toBe('POST');
+                },
+            );
+        });
+
+        await it('surfaces a 404 as a status rather than as an error', async () => {
+            await withServer(
+                () => ({ status: 404, body: 'nope' }),
+                async (origin) => {
+                    const { xhr, events } = await drive((x) => {
+                        x.open('GET', `${origin}/missing`);
+                        x.responseType = 'text';
+                    });
+                    expect(xhr.status).toBe(404);
+                    expect(events).toContain('load');
+                    expect(events).not.toContain('error');
+                },
+            );
+        });
+    });
+
+    await describe('XMLHttpRequest — the header surface is a deliberate stub', async () => {
+        // Pinned, not aspirational: this class answers the XHR→Blob→Image chain and
+        // says so in its source. The full header implementation lives in
+        // `@gjsify/fetch`'s XHR, which is what the alias layer hands every bundled
+        // consumer. Asserting the stub keeps the day someone implements it a
+        // DELIBERATE edit here rather than a silent behaviour change.
+        await it('accepts setRequestHeader and overrideMimeType without recording them', async () => {
+            const xhr = new XMLHttpRequest();
+            xhr.open('GET', 'file:///dev/null');
+            xhr.setRequestHeader('X-Custom', 'value');
+            xhr.overrideMimeType('text/plain');
+            expect(xhr.getAllResponseHeaders()).toBe('');
+        });
+
+        await it('returns null from getResponseHeader for any name', async () => {
+            const xhr = new XMLHttpRequest();
+            expect(xhr.getResponseHeader('content-type')).toBeNull();
+            expect(xhr.getResponseHeader('anything-at-all')).toBeNull();
+        });
+    });
+
+    await describe('FakeBlob', async () => {
+        await it('carries the type and size it was constructed with', async () => {
+            const blob = new FakeBlob('image/png', 42);
+            expect(blob.type).toBe('image/png');
+            expect(blob.size).toBe(42);
+        });
+
+        await it('reads its temp file as an ArrayBuffer', async () => {
+            const file = tempFile('blob.bin', new Uint8Array([9, 8, 7]));
+            const blob = new FakeBlob('application/octet-stream', 3);
+            blob._tmpPath = file.path;
+            expect([...new Uint8Array(await blob.arrayBuffer())]).toStrictEqual([9, 8, 7]);
+            GLib.unlink(file.path);
+        });
+
+        await it('decodes its temp file as text', async () => {
+            const file = tempFile('blob.txt', 'blob text');
+            const blob = new FakeBlob('text/plain', 9);
+            blob._tmpPath = file.path;
+            expect(await blob.text()).toBe('blob text');
+            GLib.unlink(file.path);
+        });
+
+        await it('streams its bytes through a ReadableStream', async () => {
+            const file = tempFile('stream.bin', new Uint8Array([1, 2]));
+            const blob = new FakeBlob('application/octet-stream', 2);
+            blob._tmpPath = file.path;
+            const reader = blob.stream().getReader();
+            const first = await reader.read();
+            expect(first.done).toBe(false);
+            expect([...(first.value as Uint8Array)]).toStrictEqual([1, 2]);
+            expect((await reader.read()).done).toBe(true);
+            GLib.unlink(file.path);
+        });
+
+        await it('yields an empty ArrayBuffer when it has no temp file', async () => {
+            const blob = new FakeBlob('text/plain', 0);
+            expect((await blob.arrayBuffer()).byteLength).toBe(0);
+            expect(await blob.text()).toBe('');
+        });
+    });
+
+    await describe('installObjectURLSupport', async () => {
+        interface ObjectURLPatch {
+            createObjectURL: (blob: FakeBlob) => string;
+            revokeObjectURL: (url: string) => void;
+            __gjsify_objecturl?: boolean;
+        }
+        const patched = () => URL as unknown as ObjectURLPatch;
+
+        await it('installs createObjectURL and revokeObjectURL on URL', async () => {
+            installObjectURLSupport();
+            expect(typeof patched().createObjectURL).toBe('function');
+            expect(typeof patched().revokeObjectURL).toBe('function');
+            expect(patched().__gjsify_objecturl).toBe(true);
+        });
+
+        await it("turns a FakeBlob's temp path into a file:// URL", async () => {
+            installObjectURLSupport();
+            const file = tempFile('object.png', new Uint8Array([1]));
+            const blob = new FakeBlob('image/png', 1);
+            blob._tmpPath = file.path;
+            const url = patched().createObjectURL(blob);
+            expect(url).toBe(`file://${file.path}`);
+            GLib.unlink(file.path);
+        });
+
+        await it('unlinks the temp file on revoke', async () => {
+            installObjectURLSupport();
+            const file = tempFile('revoke.png', new Uint8Array([1]));
+            const blob = new FakeBlob('image/png', 1);
+            blob._tmpPath = file.path;
+            const url = patched().createObjectURL(blob);
+            expect(GLib.file_test(file.path, GLib.FileTest.EXISTS)).toBe(true);
+            patched().revokeObjectURL(url);
+            expect(GLib.file_test(file.path, GLib.FileTest.EXISTS)).toBe(false);
+        });
+
+        await it('leaves an unknown URL alone on revoke', async () => {
+            installObjectURLSupport();
+            const file = tempFile('untracked.png', new Uint8Array([1]));
+            patched().revokeObjectURL(`file://${file.path}`);
+            expect(GLib.file_test(file.path, GLib.FileTest.EXISTS)).toBe(true);
+            GLib.unlink(file.path);
+        });
+
+        await it('falls back for a blob that carries no temp path', async () => {
+            installObjectURLSupport();
+            expect(patched().createObjectURL(new FakeBlob('text/plain', 0))).toBe('file:///dev/null');
+        });
+
+        await it('is idempotent — a second call keeps the installed functions', async () => {
+            installObjectURLSupport();
+            const first = patched().createObjectURL;
+            installObjectURLSupport();
+            expect(patched().createObjectURL).toBe(first);
+        });
+    });
+};

--- a/packages/web/xmlhttprequest/src/index.ts
+++ b/packages/web/xmlhttprequest/src/index.ts
@@ -113,6 +113,18 @@ function writeToTmp(bytes: Uint8Array, ext: string): string {
 type XHREventType = 'loadstart' | 'progress' | 'load' | 'loadend' | 'error' | 'abort' | 'timeout';
 
 export class XMLHttpRequest {
+    // WebIDL exposes an interface's constants on the interface OBJECT as well as on
+    // instances, and `XMLHttpRequest.DONE` is how most consumer code spells the
+    // comparison. Only the instance half shipped, so every such read was `undefined`
+    // — including in this package's own `src/test.browser.mts`, which asserts
+    // `XMLHttpRequest.UNSENT` and passed regardless because in a browser it reads the
+    // native global, never this class.
+    static readonly UNSENT = 0;
+    static readonly OPENED = 1;
+    static readonly HEADERS_RECEIVED = 2;
+    static readonly LOADING = 3;
+    static readonly DONE = 4;
+
     // State
     readonly UNSENT = 0;
     readonly OPENED = 1;
@@ -205,7 +217,7 @@ export class XMLHttpRequest {
 
                 this._emit('progress', { loaded: len, total: len, lengthComputable: true });
 
-                if (responseType === 'blob' || responseType === '') {
+                if (responseType === 'blob') {
                     // Write to temp file so HTMLImageElement.src can load it via file://
                     const ext = guessExt(url);
                     const tmpPath = writeToTmp(bytes, ext);
@@ -217,7 +229,10 @@ export class XMLHttpRequest {
                 } else if (responseType === 'json') {
                     this.response = JSON.parse(new TextDecoder().decode(bytes));
                 } else {
-                    // 'text' or ''
+                    // 'text' or '' — XHR §response makes an empty responseType behave
+                    // as "text". The blob branch above used to claim `''` as well, so
+                    // the DEFAULT spelling of the API returned a FakeBlob and left
+                    // `responseText` at '' with nothing anywhere to say so.
                     this.responseText = new TextDecoder().decode(bytes);
                     this.response = this.responseText;
                 }

--- a/packages/web/xmlhttprequest/src/register.spec.ts
+++ b/packages/web/xmlhttprequest/src/register.spec.ts
@@ -1,0 +1,61 @@
+// The `/register` wiring, kept out of `index.spec.ts` because importing it
+// mutates globals for the whole run (tests/AGENTS.md § rule 7).
+//
+// TWO THINGS HERE ARE DELIBERATE AND BOTH LOOK LIKE MISTAKES.
+//
+// 1. The module is reached RELATIVELY, not as `@gjsify/xmlhttprequest/register`
+//    the way every sibling register spec reaches its own. That subpath is
+//    aliased to `@gjsify/fetch/register/xhr` on the gjs target, so the sibling
+//    spelling would install `@gjsify/fetch`'s XHR and then measure it — a green
+//    suite that never touched this package.
+//
+// 2. The import is DYNAMIC. `package.json#sideEffects` lists the BUILT
+//    `./lib/esm/register.js`, which is the right declaration for the published
+//    tarball but does not match the source path, so rolldown reads
+//    `src/register.ts` as side-effect-free and drops a static bare
+//    `import './register.js'` entirely. Measured: with the static form the
+//    bundle contained no assignment at all and `globalThis.XMLHttpRequest` was
+//    `undefined`. The siblings never meet this because the package subpath they
+//    import DOES match the `sideEffects` entry. Turn this back into a static
+//    import and the two tests below stop testing anything.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { XMLHttpRequest } from './index.js';
+
+interface RegisteredGlobals {
+    XMLHttpRequest?: typeof XMLHttpRequest;
+    URL: {
+        createObjectURL?: (blob: unknown) => string;
+        revokeObjectURL?: (url: string) => void;
+        __gjsify_objecturl?: boolean;
+    };
+}
+const registered = () => globalThis as unknown as RegisteredGlobals;
+
+export default async () => {
+    await import('./register.js');
+
+    await describe('@gjsify/xmlhttprequest/register', async () => {
+        await it("puts this package's XMLHttpRequest on globalThis", async () => {
+            // Identity, not `typeof === 'function'`: `register.ts` only assigns when the
+            // global is absent, and the weaker assertion would pass just as happily
+            // against a global something else had already installed — which is exactly
+            // the case worth knowing about.
+            expect(registered().XMLHttpRequest).toBe(XMLHttpRequest);
+        });
+
+        await it('constructs an UNSENT request through the global', async () => {
+            const Registered = registered().XMLHttpRequest as typeof XMLHttpRequest;
+            expect(typeof Registered).toBe('function');
+            const xhr = new Registered();
+            expect(xhr.readyState).toBe(xhr.UNSENT);
+        });
+
+        await it('patches URL.createObjectURL and URL.revokeObjectURL', async () => {
+            expect(typeof registered().URL.createObjectURL).toBe('function');
+            expect(typeof registered().URL.revokeObjectURL).toBe('function');
+            expect(registered().URL.__gjsify_objecturl).toBe(true);
+        });
+    });
+};

--- a/packages/web/xmlhttprequest/src/test.mts
+++ b/packages/web/xmlhttprequest/src/test.mts
@@ -1,0 +1,19 @@
+// GJS test entry for @gjsify/xmlhttprequest.
+//
+// GJS-ONLY on purpose — there is no `--app node` leg. `src/index.ts` imports the
+// default export and `resolveRootRelativeUrl` from `@gjsify/fetch`, and on node
+// that specifier routes to `fetch/globals.mjs`, which exports neither; the build
+// stops at MISSING_EXPORT. That is what `gjsify.runtimes.node: "none"` declares.
+// The browser leg is a separate entry (`src/test.browser.mts`) and measures the
+// runtime's native XHR, not this package.
+//
+// `@gjsify/node-globals/register/url` comes first because `installObjectURLSupport()`
+// patches the `URL` global in place and reads the bare identifier — with no `URL`
+// on `globalThis` the patch is a ReferenceError, not a no-op.
+import '@gjsify/node-globals/register/url';
+import { run } from '@gjsify/unit';
+
+import testSuite from './index.spec.js';
+import registerSuite from './register.spec.js';
+
+run({ testSuite, registerSuite });

--- a/status/status.json
+++ b/status/status.json
@@ -552,7 +552,7 @@
     },
     "@gjsify/xmlhttprequest": {
       "status": "full",
-      "note": "XMLHttpRequest (full `responseType`: arraybuffer / blob + temp-file / json / text / document), UTF-8 BOM stripped from responseText. FakeBlob with `_tmpPath`; owns the blob-file plumbing behind `URL.createObjectURL`. Backs Excalibur's asset loader and axios' XHR adapter. Known deno-under-node-gi stall at readyState 3 — see Open TODOs."
+      "note": "XMLHttpRequest (full `responseType`: arraybuffer / blob + temp-file / json / text / document), UTF-8 BOM stripped from responseText. FakeBlob with `_tmpPath`; owns the blob-file plumbing behind `URL.createObjectURL`. Backs Excalibur's asset loader and axios' XHR adapter. Known deno-under-node-gi stall at readyState 3 \u2014 see Open TODOs. Those behaviours are `@gjsify/fetch`'s XHR, which the alias layer substitutes for this package name on EVERY build target (gjs → `@gjsify/fetch`, node → `@gjsify/empty`, browser → the native global); this package's own `src/index.ts` \u2014 reached by a direct, unbundled `lib/esm` import \u2014 is narrower (no `document` responseType, no BOM strip, header accessors are stubs) and is covered by `src/index.spec.ts`."
     },
     "@gjsify/zlib": {
       "status": "full",


### PR DESCRIPTION
## Why

`@gjsify/xmlhttprequest` is **tier 1** — the tier that carries a stability promise (ADR 0003) —
and had **zero coverage of the class it ships**. Every premise was re-measured before writing
anything, and all three held:

| claim | measured |
|---|---|
| `src/` holds only `index.ts`, `register.ts`, `test.browser.mts` | ✅ no `*.spec.ts`, no `test.mts` |
| `test.browser.mts` never imports `./index.js` | ✅ it exercises the browser's **native** global, and its own header says so |
| no `test` / `test:gjs` / `test:node` script | ✅ only `clear, check, build, build:gjsify, build:types, build:test:browser` |

## What landed

- **`src/index.spec.ts`** — drives `./index.js` directly: the interface constants, initial
  state, `open`, event dispatch (handler property vs. listeners, ordering, `this` binding,
  removal), `abort` (including suppression of an in-flight completion), the `file://`
  transport across every `responseType`, an HTTP leg against a local `node:http` server (the
  `@gjsify/http` pattern `@gjsify/eventsource` already uses — no new server pattern invented),
  the header stubs, `FakeBlob`, and the `URL.createObjectURL`/`revokeObjectURL` cycle.
- **`src/register.spec.ts`** — the `/register` wiring in its own file, per `tests/AGENTS.md`
  rule 7.
- **`src/test.mts`** plus `test` / `test:gjs` / `build:test` / `build:test:gjs`, so CI runs it.
- Two implementation fixes (below).
- `@gjsify/unit` + `@gjsify/node-globals` as devDependencies — `@gjsify/unit` was already
  imported by `test.browser.mts` and was **undeclared**.
- A correction to this package's `status/status.json` note.

No `it.failing` was needed: the `file://` and local-HTTP legs cover everything without network
access.

## Test output — 102 assertions, green on GJS, exit 0

```
Running on Gjs 1.88.1
XMLHttpRequest — interface constants
  ✔ exposes the readyState constants on an instance  (0.2ms)
  ✔ exposes the readyState constants on the interface object  (0.1ms)
XMLHttpRequest — initial state
  ✔ starts UNSENT with every response field empty  (0.1ms)
  ✔ starts with every event-handler property null  (0.1ms)
XMLHttpRequest#open
  ✔ moves UNSENT → OPENED  (0.1ms)
  ✔ stays OPENED when called twice  (0.1ms)
  ✔ clears a previous abort so the instance is reusable  (0.4ms)
XMLHttpRequest — event dispatch
  ✔ hands the event type to the handler property and to the listeners  (0.1ms)
  ✔ calls listeners in registration order  (0.2ms)
  ✔ binds `this` to the request  (0.1ms)
  ✔ stops calling a removed listener  (0.1ms)
  ✔ ignores removeEventListener for a type with no listeners  (0.1ms)
XMLHttpRequest#abort
  ✔ emits abort then loadend and lands on DONE  (0.1ms)
  ✔ suppresses the completion of an in-flight request  (201ms)
XMLHttpRequest#send — file:// transport
  ✔ reads a file:// URL as text and reports 200/OK  (0.4ms)
  ✔ emits loadstart, progress, load and loadend in that order  (0.3ms)
  ✔ treats the default responseType '' as text  (0.2ms)
  ✔ reports progress totals that match the payload length  (0.3ms)
  ✔ yields an ArrayBuffer for responseType 'arraybuffer'  (0.3ms)
  ✔ parses the body for responseType 'json'  (0.3ms)
  ✔ yields a FakeBlob backed by a temp file for responseType 'blob'  (0.3ms)
  ✔ emits error then loadend for a file:// URL that does not exist  (0.4ms)
  ✔ runs onreadystatechange when a request completes  (0.3ms)
XMLHttpRequest#send — HTTP transport
  ✔ exposes status, statusText and responseURL from the response  (7.1ms)
  ✔ uppercases the method handed to open()  (3.8ms)
  ✔ surfaces a 404 as a status rather than as an error  (3.7ms)
XMLHttpRequest — the header surface is a deliberate stub
  ✔ accepts setRequestHeader and overrideMimeType without recording them  (0.1ms)
  ✔ returns null from getResponseHeader for any name  (0.1ms)
FakeBlob
  ✔ carries the type and size it was constructed with  (0.1ms)
  ✔ reads its temp file as an ArrayBuffer  (0.2ms)
  ✔ decodes its temp file as text  (0.2ms)
  ✔ streams its bytes through a ReadableStream  (0.3ms)
  ✔ yields an empty ArrayBuffer when it has no temp file  (0.1ms)
installObjectURLSupport
  ✔ installs createObjectURL and revokeObjectURL on URL  (0.1ms)
  ✔ turns a FakeBlob's temp path into a file:// URL  (0.1ms)
  ✔ unlinks the temp file on revoke  (0.1ms)
  ✔ leaves an unknown URL alone on revoke  (0.1ms)
  ✔ falls back for a blob that carries no temp path  (0.1ms)
  ✔ is idempotent — a second call keeps the installed functions  (0.1ms)
@gjsify/xmlhttprequest/register
  ✔ puts this package's XMLHttpRequest on globalThis  (0.1ms)
  ✔ constructs an UNSENT request through the global  (0.0ms)
  ✔ patches URL.createObjectURL and URL.revokeObjectURL  (0.1ms)

✔ [Gjs 1.88.1] 102 completed  (228ms)
```

## Two implementation bugs, found by the spec and fixed here

Each was **proven** by reverting the fix and confirming exactly one test turns red
(`❌ 2 of 97 tests failed`, naming precisely these two).

1. **`responseType === ''` did not behave as `"text"`.** The blob branch read
   `responseType === 'blob' || responseType === ''`, so the *default* spelling of the API
   returned a `FakeBlob` and left `responseText` at `''` — while the `else` branch's own
   comment still claimed `// 'text' or ''`. XHR §response makes an empty `responseType`
   behave as `"text"`; `@gjsify/fetch`'s XHR gets this right, this class never did. One
   token deleted.
2. **The WebIDL constants existed only on instances**, so `XMLHttpRequest.DONE` was
   `undefined`. This package's own `src/test.browser.mts` asserts `XMLHttpRequest.UNSENT` and
   passed anyway — in a browser it reads the native global, not this class. Five `static
   readonly` fields added.

## Findings reported, not fixed

### 1. This package's class is not what any bundled consumer gets (the big one)

`@gjsify/resolve-npm` routes the name away on **every** target:

| target | `@gjsify/xmlhttprequest` resolves to |
|---|---|
| gjs | `@gjsify/fetch` (`ALIASES_WEB_FOR_GJS`, comment: *"xmlhttprequest (implemented in @gjsify/fetch)"*) |
| node | `@gjsify/empty` |
| browser | this package's `globals.mjs` — the runtime's native XHR |

**Measured**, not inferred: a probe consumer built with `--app gjs` and
`import { XMLHttpRequest } from '@gjsify/xmlhttprequest'` gets an instance carrying `upload`
and a working `getAllResponseHeaders` — both exclusive to `packages/web/fetch/src/xhr.ts`.
So `packages/web/xmlhttprequest/src/index.ts` is reached only by a direct, unbundled
`lib/esm/index.js` import — which is exactly what the published tarball offers, hence it still
deserves the spec. `packages/web/fetch/src/utils/root-relative.ts` already records that these
two XHRs *"used to carry two spellings, and they drifted"* (#869).

The class was born in `63e7c25046` as *"Browser API stubs"* for the excalibur showcase and
never grew a test. Whether the right end state is deleting one of the two implementations, or
making this one the `/core` the other consumes, is a bigger call than this PR — flagging it.

### 2. `sideEffects` makes an in-package `/register` import vanish

`sideEffects` names the built `./lib/esm/register.js`, so rolldown reads `src/register.ts` as
side-effect-free and **drops a static bare `import './register.js'` entirely** — measured, the
bundle contained no assignment and `globalThis.XMLHttpRequest` stayed `undefined`. Every
sibling register spec sidesteps this by importing `@gjsify/<pkg>/register`, which *does* match
the `sideEffects` entry; that spelling is unavailable here because the name is aliased away.
`register.spec.ts` therefore uses `await import('./register.js')`, with the reason written
above it so it is not "cleaned up" back into a silent no-op.

### 3. Spec deviations characterized but left alone

Structural, and a wider change than this PR should carry:

- `readyState` never visits `HEADERS_RECEIVED`; `send()` sets `LOADING` *before* `loadstart`.
- `onreadystatechange` fires **once**, after `DONE`, with `{}` (no `type`), and never on
  `abort`/`error`. The spec test asserts `>= 1` call deliberately, so fixing this does not
  require rewriting the assertion.
- `abort()` sets `readyState = DONE` even from `UNSENT` (spec: stay `UNSENT`).
- `setRequestHeader` / `overrideMimeType` / `getResponseHeader` / `getAllResponseHeaders` are
  stubs. Pinned by tests **as stubs**, so implementing them becomes a deliberate edit here
  rather than a silent behaviour change.

## Why there is no `test:node`

Not a choice — measured. `src/index.ts` imports the default export **and**
`resolveRootRelativeUrl` from `@gjsify/fetch`; on `--app node` that specifier routes to
`fetch/globals.mjs`, which exports neither:

```
[MISSING_EXPORT] "default" is not exported by "../fetch/globals.mjs".
[MISSING_EXPORT] "resolveRootRelativeUrl" is not exported by "../fetch/globals.mjs".
```

That is exactly what `gjsify.runtimes.node: "none"` already declares, and it matches the
sibling GJS-only web packages (`websocket`, `webaudio`, `gamepad`, `webrtc`), none of which
declare `test:node` either.

## Exit codes

| command | exit |
|---|---|
| `gjsify workspace @gjsify/xmlhttprequest run test` (builds + `test:gjs`) | **0** — 102 completed |
| `gjsify workspace @gjsify/xmlhttprequest run test:gjs` | **0** |
| `test:node` | n/a — see above; the `--app node` build fails at `MISSING_EXPORT` |
| `node scripts/audit-runtimes.mjs --check` | **0** |
| `node scripts/check-node-test-registration.mjs` | **0** — 554 specs across 99 packages |
| `node scripts/check-browser-test-registration.mjs` | **0** — browser-only set 3 → 2, derived, no list to edit |
| `./node_modules/.bin/oxfmt --check` (touched files) | **0** |
| `./node_modules/.bin/oxlint packages/web/xmlhttprequest/src/` | **0** |
| `gjsify workspace @gjsify/xmlhttprequest run check` (tsc) | **0** |
| `node scripts/generate-status.mjs --check` | **0** |
| `gjsify install --immutable` (after the devDep additions) | **0** |
| `check-lint-visibility` / `check-source-visibility` / `check-gi-import-versions` / `check-agent-context-size` / `check-lockfile-current` | **0** |
| `check-comment-budget` (advisory) | `packages/web` 0.281 vs 0.292 budget — under |

## Not touched, by instruction

`status/open-todos.md` and `status/agent-context-budget.json` are owned by another agent this
round. Two things belong there or next to them:

- **`packages/web/AGENTS.md`** describes this package as *"XMLHttpRequest, full `responseType`.
  Backs Excalibur's asset loader"* — true of `@gjsify/fetch`'s XHR, not of this one. Editing
  any AGENTS.md changes its byte count and so requires `agent-context-budget.json`, hence left
  alone. The same drift in `status/status.json` **is** corrected here.
- Finding 1 above (two XHR implementations, one aliased over the other) is worth an
  `open-todos.md` entry.

## Rebase note

This was written against `fix/false-npm-claims` (PR #1499). That PR was squash-merged as
`8ced4a5a0f` and its branch deleted while this was in flight, so the branch is rebased onto
`main` (which now also carries `chore: release v0.46.0`) and the full install → `build:infra`
→ `build` → `test` gate was re-run on the rebased tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGTu3xiJDXtxVdB7vkzcyC
