### PR TITLE
docs: guide for shipping your own fonts

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -201,6 +201,7 @@ export default defineConfig({
                         { slug: 'ship/macos', label: 'macOS' },
                         { slug: 'ship/windows', label: 'Windows' },
                         { slug: 'ship/signing', label: 'Signing' },
+                        { slug: 'guides/bundled-fonts', label: 'Bundled Fonts' },
                         { slug: 'guides/flatpak-app', label: 'Flatpak: GUI App' },
                         { slug: 'guides/flatpak-cli-tool', label: 'Flatpak: CLI Tool' },
                         { slug: 'guides/distributing-gjs-apps', label: 'One-Line Installer' },

--- a/website/src/content/docs/guides/bundled-fonts.md
+++ b/website/src/content/docs/guides/bundled-fonts.md
@@ -1,0 +1,290 @@
+---
+title: Ship your own fonts
+description: Put a brand typeface inside your app. gjsify.ship.fonts stages the faces, the launcher hands over GJSIFY_FONT_DIR, and one initFonts() call at startup makes the family real on every operating system.
+---
+
+Your app wants to render in a face nobody's machine has. Put the `.ttf` in the payload with
+`gjsify.ship.fonts`, then call `initFonts()` once before you build any UI.
+
+Two steps, because staging a file and having the toolkit *know about* it are different
+things — and the gap between them is the quietest failure in GTK. Pango does not report a
+missing family. `set_family('Brand')` against a font map that has never heard of `Brand`
+resolves to the default sans, the window draws, the process exits 0 and nothing anywhere
+says a word. Your app is just wearing the wrong typeface.
+
+## 1. Stage the faces
+
+```jsonc
+{
+  "gjsify": {
+    "ship": {
+      "fonts": "data/fonts"   // a directory, or a single face
+    }
+  }
+}
+```
+
+`data/fonts` is also the default: leave the key out and a directory by that name is picked
+up if it exists. Every face lands at `share/fonts/<appId>/<basename>` in the payload, on all
+three layouts — the app id is in the path because `/usr/share/fonts` is shared with every
+other package on the machine, and a `Regular.ttf` at the top of it belongs to whoever
+installed last.
+
+Ship the desktop formats: `.ttf`, `.otf`, `.ttc`, `.otc`. A `.woff`, `.woff2` or `.eot` is
+**refused by name**, not quietly skipped — whether FreeType can open one is a build option
+of the FreeType inside the *shipped* runtime, not the one on your packaging machine, so a
+web wrapper that works here is exactly the kind of thing that substitutes silently there.
+
+Two other refusals, same reasoning: a configured path that holds no face at all, and two
+faces whose basenames collide (one of them would not ship, and a face that did not ship is
+a substituted typeface rather than an error).
+
+## 2. Register them at startup
+
+`gjsify ship`'s launcher exports **`GJSIFY_FONT_DIR`** at the staged directory — on every
+layout, because only the launcher knows whether your payload became `/usr`, a `--prefix`
+tree, `/app`, a bundle's `Contents/Resources` or `C:\Program Files\My App`. Reading it is
+your app's side of the handover, and `@gjsify/gtk-host` does it for you:
+
+```bash
+gjsify install @gjsify/gtk-host
+```
+
+```ts
+import { initFonts } from '@gjsify/gtk-host/fonts';
+
+const fonts = initFonts();
+```
+
+That is the whole API. It reads `GJSIFY_FONT_DIR` itself, walks the directory, hands every
+face to `PangoCairo.FontMap.get_default().add_font_file()`, and returns what happened:
+
+```ts
+interface InitFontsResult {
+    /** The directory that was read, or `undefined` when nothing named one. */
+    dir: string | undefined;
+    /** Faces now on the default font map. */
+    registered: readonly string[];
+    /** Faces a font map that does no runtime registration refused — see below. */
+    declined: readonly string[];
+    /** Faces that failed for any other reason. Each one was also warned about on stderr. */
+    failed: readonly { path: string; message: string }[];
+}
+```
+
+It never throws. A face that will not open costs you one stderr line and one entry in
+`failed`; taking the app down over a decorative typeface would be worse than drawing it in
+a fallback. What it will not do is fail *silently*, which is the entire point:
+
+```text
+initFonts: /tmp/gjsify-badface-MHB3U3/NotAFont.ttf could not be read as an application font
+(Adding font /tmp/gjsify-badface-MHB3U3/NotAFont.ttf to fontconfig configuration failed).
+Text asking for a family this application ships will render in a substituted one.
+```
+
+It is also safe in an app that ships no fonts. The launcher exports `GJSIFY_FONT_DIR` only
+when it actually staged a face, so an unset variable gives you `dir: undefined` and three
+empty arrays.
+
+### Running from your source tree
+
+Before there is a payload there is no `GJSIFY_FONT_DIR`. Pass the directory instead — the
+option wins over the environment, so one line covers both:
+
+```ts
+import GLib from 'gi://GLib?version=2.0';
+import { initFonts } from '@gjsify/gtk-host/fonts';
+
+const fonts = initFonts({ fontDir: GLib.getenv('GJSIFY_FONT_DIR') ?? 'data/fonts' });
+print(`dir=${fonts.dir} registered=${fonts.registered.length} failed=${fonts.failed.length}`);
+```
+
+Run from a project whose `data/fonts` holds one face:
+
+```text
+dir=data/fonts registered=1 failed=0
+```
+
+A relative path resolves against the working directory, which is what you want in a source
+tree and never what you want in a shipped app — where `GJSIFY_FONT_DIR` is absolute and
+takes over.
+
+## 3. Call it before you build any UI
+
+This is a contract, not a style preference.
+
+**Registration is not retroactive.** The fontconfig-backed font map caches the *fontset* it
+resolved for a font description, and `add_font_file` does not invalidate that cache. So a
+`Pango.Layout` that measured your family before the call keeps measuring the fallback for
+the life of the process — even though `list_families()` now lists the family, and even
+though a context created afterwards loads the real face.
+
+Measured, on Linux, with one layout before the call and one after:
+
+```text
+before initFonts: listed=false measured=87x63
+initFonts: registered=1 declined=0 failed=0
+after  initFonts: listed=true measured=87x63
+control (invented family): 87x63
+```
+
+Read the last three lines together. `registered=1` succeeded. `listed=true` says the family
+is on the font map. And the text still measures `87x63` — byte for byte what a family that
+does not exist measures. The symptom is not "no font"; it is a **stale measurement**, which
+from inside your app reads like "the font is installed and Pango is ignoring me".
+
+On Windows a late call recovers, because that backend clears the map's cache when you add a
+file. So registering early is free on the backend that recovers and unrecoverable on the
+one that does not — which is why the rule is stated flatly for both.
+
+In an `Adw.Application`, the place that satisfies the rule is `startup`, before the first
+window exists:
+
+```ts
+import Adw from 'gi://Adw?version=1';
+import GObject from 'gi://GObject?version=2.0';
+import { initFonts } from '@gjsify/gtk-host/fonts';
+
+class MyApplication extends Adw.Application {
+    static { GObject.registerClass(MyApplication); }
+
+    vfunc_startup(): void {
+        initFonts();          // before anything measures text
+        super.vfunc_startup();
+        // …now build your windows, load your CSS, create your widgets
+    }
+}
+```
+
+If you use [`runAdwaitaApp`](/gjsify/guides/native-adwaita-app/), the line above it is early
+enough: `createWindow` does not run until the first `activate`.
+
+## What each operating system actually does
+
+One payload directory, three different readers. You write the same call everywhere; each
+operating system answers it differently, and all three answers are correct:
+
+| Where it runs | What reaches the font map | What `initFonts()` reports |
+|---|---|---|
+| **Linux** (`.deb`, `.rpm`, Flatpak, a `--prefix` tree) | fontconfig finds the staged directory on its own, through the stock `fonts.conf` | the faces in `registered` |
+| **macOS** (`.app`) | `ATSApplicationFontsPath` in `Info.plist`: macOS activates the directory for your app before your code runs | the faces in `declined` — **expected, not a failure** |
+| **Windows** (program directory, `.msi`) | **nothing.** This call is the mechanism | the faces in `registered` |
+
+Windows is the row that matters. GTK4 there is pangowin32, and that font map is populated
+from DirectWrite and from nothing else — no filesystem search path, no fontconfig. A
+fontconfig directory beside your app is inert: measured on Windows 11, a config naming your
+staged directory moves the default font map by zero families *even when it is the only
+configuration loaded*. `add_font_file` on that same map — the one a `Gtk.Label` renders
+through — is what puts the family there.
+
+macOS goes the other way. Pango's CoreText font map implements no runtime registration at
+all, so the call answers `G_IO_ERROR_NOT_SUPPORTED` and `initFonts()` files the face under
+`declined` rather than `failed`. **Nothing is lost**: the bundle's `Info.plist` already had
+the OS activate the same directory at launch, earlier than any code of yours could have
+run. So `declined` on macOS is the correct outcome and needs no branch in your app — which
+is why there is no `process.platform` check anywhere in this API. The decision is made from
+the error the font map returns, so it stays right whichever backend a host actually
+compiled in.
+
+## Check that it worked
+
+Do not take `registered.length` as proof. It says the call did not fail; it does not say
+the family is renderable, and a substituted family looks identical to a resolved one from
+the outside. Measure instead — an invented family is your control:
+
+```ts
+import Pango from 'gi://Pango?version=1.0';
+import PangoCairo from 'gi://PangoCairo?version=1.0';
+import { initFonts } from '@gjsify/gtk-host/fonts';
+
+const FAMILY = 'Round9x13';            // the family name your face carries
+const CONTROL = 'ZzzNoSuchFamily';     // a family that cannot exist
+
+const fonts = initFonts();
+print(`dir=${fonts.dir}`);
+print(`registered=${fonts.registered.length} declined=${fonts.declined.length} failed=${fonts.failed.length}`);
+
+const map = PangoCairo.FontMap.get_default();
+const listed = (family: string) => map.list_families().some((f) => f.get_name() === family);
+
+const measure = (family: string) => {
+    const description = new Pango.FontDescription();
+    description.set_family(family);
+    description.set_size(40 * Pango.SCALE);
+    const layout = Pango.Layout.new(map.create_context());
+    layout.set_font_description(description);
+    layout.set_text('Wg', -1);
+    return layout.get_pixel_size().join('x');
+};
+
+print(`listed=${listed(FAMILY)}`);
+print(`${FAMILY}=${measure(FAMILY)} vs ${CONTROL}=${measure(CONTROL)}`);
+```
+
+Two things have to be true, and the second is the one that discriminates:
+
+- the family appears in `list_families()`, **and**
+- it measures *differently* from the control.
+
+With the face staged and `GJSIFY_FONT_DIR` pointing at it:
+
+```text
+dir=/tmp/fontcheck
+registered=1 declined=0 failed=0
+listed=true
+Round9x13=66x50 vs ZzzNoSuchFamily=87x63
+```
+
+The same program with nothing staged — which is what a broken payload looks like from the
+inside:
+
+```text
+dir=undefined
+registered=0 declined=0 failed=0
+listed=false
+Round9x13=87x63 vs ZzzNoSuchFamily=87x63
+```
+
+`87x63` twice. Your family and a family that cannot exist are rendering as the same face,
+and nothing about the run says so. That is why the control is in the check.
+
+On macOS the honest expectation is different again: `declined=1`, and the family absent
+from `list_families()` *at this point in the process* — with the text still correct on
+screen, because the OS activated the directory before your code ran. The check to run in a
+shipped `.app` is `PangoCairo.FontMap.get_default().list_families()` inside the running
+bundle, and `PANGOCAIRO_BACKEND=bogus ./YourApp` makes Pango print which backends it was
+actually built with.
+
+## Who does what
+
+| Piece | Job |
+|---|---|
+| `gjsify.ship.fonts` | names the faces; `gjsify ship` copies them to `share/fonts/<appId>/` |
+| the generated launcher | exports `GJSIFY_FONT_DIR` at that directory, on every layout |
+| `initFonts()` from `@gjsify/gtk-host/fonts` | reads the variable and registers what it finds |
+
+`gjsify ship` deliberately does not make the call for you. A packaging command that injected
+a startup step would be deciding your app's initialisation order, invisibly — and the
+ordering above is exactly the thing that has to stay yours.
+
+## When it does not work
+
+| What you see | What it means |
+|---|---|
+| `dir` is `undefined` in a shipped app | the payload staged no face — check `gjsify.ship.fonts` and re-run `gjsify ship` |
+| `declined` holds your faces, on macOS | correct. `ATSApplicationFontsPath` already did the work |
+| `declined` holds your faces, anywhere else | this process resolved a font map that does no runtime registration; check `PANGOCAIRO_BACKEND` |
+| `initFonts: … could not be read as an application font` | FreeType would not open that file — truncated, corrupt, or something wearing a face extension |
+| the family is listed but text is unchanged | something laid out text before `initFonts()`. Move the call earlier |
+| `gjsify ship: … is a web-font wrapper` | replace the `.woff2` with the desktop face it was made from |
+| `gjsify ship: … holds no font face` | the configured directory has no `.ttf`/`.otf`/`.ttc`/`.otc` in it |
+
+## Where to next
+
+- [Windows artifacts](/gjsify/ship/windows/) — the layout where this call is the only
+  mechanism there is.
+- [macOS app bundles](/gjsify/ship/macos/) — where the `Info.plist` key does the work
+  instead.
+- [Linux packages](/gjsify/ship/linux-packages/) — where fontconfig gets there on its own.
+- [CLI Reference → `gjsify ship`](/gjsify/cli-reference/#gjsify-ship) lists every
+  configuration key.

--- a/website/src/content/docs/ship/linux-packages.md
+++ b/website/src/content/docs/ship/linux-packages.md
@@ -183,6 +183,25 @@ them first with [`gjsify gettext`](/gjsify/cli-reference/#gjsify-gettext). The
 catalogues are staged into `share/locale/` and the launcher exports
 `GJSIFY_LOCALE_DIR`.
 
+## Ship a brand typeface
+
+`gjsify.ship.fonts` — a directory of faces, or one face, defaulting to `data/fonts`
+when that exists — stages them at `share/fonts/<appId>/`.
+
+```jsonc
+"gjsify": { "ship": { "fonts": "data/fonts" } }
+```
+
+On Linux the toolkit gets there without you: the stock `fonts.conf` names
+`/usr/share/fonts` unconditionally, which covers the `.deb` and the `.rpm`, and it
+expands `<dir prefix="xdg">fonts</dir>` over `XDG_DATA_DIRS` — which the launcher
+already sets at the staged `share/` on every prefix, including Flatpak's `/app`.
+There is no `fc-cache` step; the cache is built lazily on first use.
+
+Neither macOS nor Windows gets there that way, so if your project also ships those,
+read [Ship your own fonts](/gjsify/guides/bundled-fonts/) — the one call it adds to
+your startup is redundant here and the only mechanism there is on Windows.
+
 ## The Flatpak bundle
 
 The same payload also becomes a single-file Flatpak.
@@ -456,6 +475,8 @@ to set. The ones you are most likely to meet:
   self-executing bundles and dlx.
 - [macOS app bundles](/gjsify/ship/macos/) and [Windows artifacts](/gjsify/ship/windows/)
   cover the other two operating systems.
+- [Ship your own fonts](/gjsify/guides/bundled-fonts/) if your app carries a brand
+  typeface and you want it to render on all three.
 - [CLI Reference → `gjsify ship`](/gjsify/cli-reference/#gjsify-ship) is the
   condensed flag and configuration reference.
 - [Flatpak: GUI app](/gjsify/guides/flatpak-app/) if you also want a Flathub

--- a/website/src/content/docs/ship/macos.md
+++ b/website/src/content/docs/ship/macos.md
@@ -159,6 +159,14 @@ CI leg here starts an `.app`** — so that macOS then resolves the family is not
 something this project has measured, unlike the Linux and Windows halves. And a
 `.app` is the only macOS layout that carries fonts; there is no `.pkg` path.
 
+The `initFonts()` call the [Windows](/gjsify/ship/windows/) row needs is still safe
+to leave in a shared codebase. Pango's CoreText font map implements no runtime
+registration, so the call answers `G_IO_ERROR_NOT_SUPPORTED`, the faces come back
+under `declined` rather than `failed`, and nothing is lost — the `Info.plist` key
+already activated the same directory before your code ran. So you need no
+`process.platform` branch. [Ship your own fonts](/gjsify/guides/bundled-fonts/) has
+the detail, including what to check inside a running bundle.
+
 ## Make a .dmg
 
 A `.dmg` is a UDIF image over a real HFS+ volume, and the only program that
@@ -249,5 +257,7 @@ bundle will start on a Mac with neither Node nor Homebrew GTK installed.
 - [Sign your artifacts](/gjsify/ship/signing/) covers `--sign` and `--notarize`.
 - [Windows artifacts](/gjsify/ship/windows/) is the same shape one operating
   system over.
+- [Ship your own fonts](/gjsify/guides/bundled-fonts/) covers the payload key and
+  what your app does with it on the other two.
 - [CLI Reference → `gjsify ship`](/gjsify/cli-reference/#gjsify-ship) lists
   every flag and configuration key.

--- a/website/src/content/docs/ship/windows.md
+++ b/website/src/content/docs/ship/windows.md
@@ -186,27 +186,29 @@ targets for prerelease builds.
 `gjsify.ship.fonts` stages your faces into `share/fonts/<appId>/` and the launcher
 exports `GJSIFY_FONT_DIR` pointing at it. On Windows that is where the command's job
 ends: `pangocairo` selects the win32 backend, which populates from DirectWrite alone,
-so a fontconfig directory is inert here. Measured — the default font map stays at its
-82 system families even when your config is the only one loaded.
+so a fontconfig directory is inert here. Measured — a config naming your staged
+directory moves the default font map by zero families even when it is the only one
+loaded.
 
-So register them yourself, once, before the first styled widget:
+So register them, once, before you build any UI. One call from the GTK host layer
+does it:
 
-```js
-import GLib from 'gi://GLib?version=2.0';
-import PangoCairo from 'gi://PangoCairo?version=1.0';
+```ts
+import { initFonts } from '@gjsify/gtk-host/fonts';
 
-const dir = GLib.getenv('GJSIFY_FONT_DIR');
-if (dir) {
-  for (const file of listFontFiles(dir)) {
-    PangoCairo.FontMap.get_default().add_font_file(file);
-  }
-}
+initFonts();
 ```
 
-`add_font_file()` arrived in Pango 1.56 and works on Linux too, so the same call
-covers both and you do not need an OS branch. Skip it and Pango falls back to a
-system face — silently. The app merely looks wrong, with no error and no exit code,
+It reads `GJSIFY_FONT_DIR` itself, hands every face it finds to
+`PangoCairo.FontMap.get_default().add_font_file()`, never throws, and does nothing
+when the payload carries no font — so the same line goes in your Linux and macOS
+builds with no OS branch around it. Skip it on Windows and Pango falls back to a
+system face, silently: the app merely looks wrong, with no error and no exit code,
 which is why this section exists rather than a warning at build time.
+
+[Ship your own fonts](/gjsify/guides/bundled-fonts/) has the staging key, where in
+`startup` the call belongs, and a check that tells a registered family apart from a
+substituted one.
 
 ## One thing to know before you hand it to a user
 
@@ -277,5 +279,7 @@ process computes about itself. The positional accepts both `windows` and
 - [Sign your artifacts](/gjsify/ship/signing/) covers `--sign` and `--notarize`.
 - [macOS app bundles](/gjsify/ship/macos/) is the same shape one operating
   system over.
+- [Ship your own fonts](/gjsify/guides/bundled-fonts/) is the whole story behind
+  the `initFonts()` call above.
 - [CLI Reference → `gjsify ship`](/gjsify/cli-reference/#gjsify-ship) lists
   every flag and configuration key.


### PR DESCRIPTION
## What this replaces

`ship/windows.md` told the reader that `gjsify.ship.fonts` stages faces and the launcher
exports `GJSIFY_FONT_DIR`, and then handed them a hand-written loop calling
`PangoCairo.FontMap.get_default().add_font_file(file)` over an undefined `listFontFiles()`.
That loop is now `initFonts()` in `@gjsify/gtk-host/fonts`, and a hand-rolled one gets the
hard parts wrong — it does not know that CoreText declines the call, and it says nothing
about *when* the call has to happen.

## The new page

`website/src/content/docs/guides/bundled-fonts.md` — "Ship your own fonts", in the
**Ship your app** sidebar group:

- why staging a face is not the same as the toolkit knowing about it, with the Windows
  reason stated plainly (pangowin32 is populated from DirectWrite alone);
- the import and the call, and what `InitFontsResult` tells you;
- **when** to call it, as a contract rather than advice — registration is not retroactive
  on the fontconfig backend, so a layout that measured the family first keeps measuring
  the fallback for the life of the process;
- what each OS actually does, including that macOS *declines* the call and that this is
  the correct outcome rather than a failure;
- a check the reader can run, with an invented family as the control.

## Every snippet was executed

Built with `gjsify build --app gjs` against this branch's `@gjsify/gtk-host` and run on
gjs 1.88.1 / Pango 1.57.1 / Fedora 44. The pasted outputs are the real ones, including
the negative control:

```text
# GJSIFY_FONT_DIR set
dir=/tmp/fontcheck
registered=1 declined=0 failed=0
listed=true
Round9x13=66x50 vs ZzzNoSuchFamily=87x63

# nothing staged — the shipped family and an invented one measure the same
dir=undefined
registered=0 declined=0 failed=0
listed=false
Round9x13=87x63 vs ZzzNoSuchFamily=87x63
```

The ordering contract was measured the same way, and it is the interesting one:

```text
before initFonts: listed=false measured=87x63
initFonts: registered=1 declined=0 failed=0
after  initFonts: listed=true measured=87x63
control (invented family): 87x63
```

`registered=1`, `listed=true`, and the text still measures exactly what a non-existent
family measures.

## Also here

- `ship/macos.md` — says the same `initFonts()` call is safe to leave in a shared
  codebase, and why `declined` is the right answer there.
- `ship/linux-packages.md` — gains the fonts section it never had (`gjsify.ship.fonts`,
  the two `fonts.conf` routes, no `fc-cache` step).
- `ship/windows.md` — drops the live "82 system families" count for the delta that was
  actually measured, which is what does not drift.

## Checks

| | |
|---|---|
| `node scripts/check-doc-fences.mjs` | exit 0 |
| `node scripts/check-website-package-names.mjs` | exit 0 |
| `gjsify run docs:build` | exit 0, 67 pages, `/guides/bundled-fonts/` among them |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGTu3xiJDXtxVdB7vkzcyC
