### PR TITLE
docs: add a guide for embedding web views

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -155,6 +155,7 @@ export default defineConfig({
                         { slug: 'guides/native-adwaita-app' },
                         { slug: 'patterns/gobject-classes' },
                         { slug: 'patterns/bridges', label: 'Bridge Widgets' },
+                        { slug: 'guides/web-views' },
                         { slug: 'guides/storybook' },
                         { slug: 'guides/devtools' },
                         { slug: 'guides/vite-plugin' },

--- a/website/src/content/docs/guides/web-views.md
+++ b/website/src/content/docs/guides/web-views.md
@@ -1,0 +1,302 @@
+---
+title: Web Views
+description: Embed real web content in a native app with @gjsify/iframe — the same code on Linux, macOS and Windows, plus the Windows caveats you will hit.
+---
+
+`@gjsify/iframe` puts a real browser engine inside your app. You write against
+`HTMLIFrameElement` the way you would on a web page — `src`, `srcdoc`,
+`contentWindow.postMessage()`, `addEventListener('message')` — and what renders is a full
+web view with cookies, JavaScript, CSS and developer tools behind it. An HTML report, a
+help page, an OAuth flow, a third-party widget, a Markdown preview: this is the package for
+all of them.
+
+It works on Linux, macOS and Windows, and **your source does not branch for any of them**.
+
+## Install
+
+```bash
+gjsify install @gjsify/iframe
+```
+
+On Linux you also need WebKitGTK 6.0 from your distribution — `gjsify system-check` tells
+you whether it is there. On macOS and Windows the engine comes with the package, with one
+proviso on Windows: your users need the WebView2 runtime, which
+[has its own section](#the-webview2-runtime-has-to-be-on-the-users-machine) below.
+[One API, three engines](#one-api-three-engines) explains where each engine comes from.
+
+## A window with a web view
+
+`IFrameBridge` is a `Gtk.Widget` — it extends `WebKit.WebView` — so it goes wherever a
+widget goes. This is a complete program:
+
+```ts
+import Adw from 'gi://Adw?version=1';
+import { IFrameBridge } from '@gjsify/iframe';
+
+const app = new Adw.Application({ applicationId: 'org.example.WebViewDemo' });
+
+app.connect('activate', () => {
+    const view = new IFrameBridge();
+
+    view.onReady(async () => {
+        console.log('url:', view.currentUri);
+        console.log('h1:', await view.evaluateJavaScript('document.querySelector("h1").textContent'));
+        console.log('links:', (await view.getLinks()).map((link) => link.href).join(' '));
+        console.log('snapshot:', (await view.takeScreenshot('visible')).length, 'bytes of PNG');
+    });
+
+    view.loadHtml(`<!doctype html>
+        <title>Web view demo</title>
+        <h1>Hello from the web view</h1>
+        <p><a href="https://gjsify.github.io/gjsify/">Documentation</a></p>`);
+
+    const win = new Adw.ApplicationWindow({
+        application: app,
+        title: 'Web view demo',
+        defaultWidth: 800,
+        defaultHeight: 600,
+    });
+    win.set_content(view);
+    win.present();
+});
+
+app.run([]);
+```
+
+Build it for whichever runtime you have and run it:
+
+```bash
+gjsify build src/main.ts --app gjs  --outfile dist/app.gjs.mjs   # Linux, on gjs
+gjsify build src/main.ts --app node --outfile dist/app.node.mjs  # Linux, macOS, Windows
+
+gjsify run dist/app.gjs.mjs
+gjsify run --runtime node dist/app.node.mjs   # or --runtime bun / --runtime deno
+```
+
+A window opens with the page in it, and the terminal shows:
+
+```
+url: about:srcdoc
+h1: Hello from the web view
+links: https://gjsify.github.io/gjsify/
+snapshot: 11819 bytes of PNG
+```
+
+The snapshot size depends on your window, so expect a different number.
+
+There is no GJS on macOS or Windows, so off Linux the `--app node` bundle is the one to
+build. [Platform Support](/gjsify/platform-support/) has the whole picture.
+
+## Two APIs, and you can use either
+
+**The standard DOM one**, on `view.iframeElement`: `src`, `srcdoc`, `contentWindow`,
+`postMessage`, `addEventListener('message')`. Reach for it when the same code should also
+run in a browser.
+
+**The bridge one**, on the widget itself: `loadUri()`, `loadHtml()`, `postMessage()`,
+`goBack()`, `goForward()`, `reload()`, guarded by `canGoBack` / `canGoForward`, with
+`currentUri`, `pageTitle` and `lastLoadError` reporting state. Reach for it when you want
+the engine's own back/forward list instead of one you track yourself.
+
+Prefer `loadUri(url)` and `loadHtml(html, baseUri?)` over setting `src` and `srcdoc`
+directly: they keep the engine and the iframe element's attributes in step.
+
+Two things to watch. `contentWindow` is `null` until the first navigation finishes, and
+`onReady()` is drained per load — so re-attach your message listener from `onReady()` after
+each load. (A browser `<iframe>` keeps `contentWindow` across navigations, so a browser
+build does not need this.) And `pageTitle` is still empty inside `onReady()`: the engine
+reports the document title a moment after the load finishes. If you mirror the title into a
+header bar, watch for it instead of reading it once:
+
+```ts
+view.connect('notify::title', () => {
+    win.title = view.pageTitle;
+});
+```
+
+If your code calls `document.createElement('iframe')` or names `HTMLIFrameElement`
+directly, `gjsify build` sees the reference and wires up the DOM surface for you — that is
+what `--globals auto` (the default) does. `new IFrameBridge()` needs none of it and works
+under `--globals none`; when you want the global installed unconditionally, the bridge has
+`installGlobals()`.
+
+## Driving the page
+
+Beyond loading, the bridge is a small automation surface — the same calls whether the app
+is on screen or running headless in a test:
+
+| Call | What it does |
+|---|---|
+| `evaluateJavaScript(expr)` | Evaluate an *expression* in the page and get its value back. Wrap multi-statement logic in an IIFE that returns something. |
+| `queryDom(selector, limit?)` | Metadata for every element matching a CSS selector. |
+| `getLinks()` | Every `<a href>` on the page: resolved href, trimmed text, title. |
+| `clickElement(selectorOrText)` | Click the first match — a CSS selector, or an `<a>` matched by its exact text. |
+| `waitForNavigation(timeoutMs?)` | Resolve on the next finished load. Register it *before* the click that triggers one. |
+| `takeScreenshot('full' \| 'visible')` | The rendered page as PNG bytes. |
+| `getConsoleLogs()` / `onConsole(cb)` | The page's own `console.*` output, with `new IFrameBridge({ captureConsole: true })`. |
+| `getViewportSize()` / `setViewportSize(w, h)` | Read the realised content size; request a different one. |
+
+Values from `evaluateJavaScript` round-trip through JSON, so anything that is not
+JSON-serialisable — a DOM node, a function, a circular object — comes back as `undefined`,
+and a thrown page error rejects the promise.
+
+## One API, three engines
+
+`@gjsify/iframe` imports `gi://WebKit?version=6.0` and never asks what operating system it
+is on. Which engine answers to that name is decided by packaging:
+
+| OS | Where the engine comes from | Engine |
+|---|---|---|
+| Linux | your distribution's WebKitGTK | WebKit |
+| macOS | `@gjsify/webkit-native`, shipped by gjsify | Apple's WebKit |
+| Windows | `@gjsify/webview2-native`, shipped by gjsify | Chromium, via Microsoft's WebView2 |
+
+The Windows row is the interesting one. WebView2 is Chromium, and it is deliberately
+presented under the `WebKit-6.0` namespace anyway: the namespace names the API *shape*, not
+the engine. What that buys you is the whole point — **no backend seam, and no `if (os ===
+…)` anywhere in your code.** The same `new IFrameBridge()`, the same `loadUri()`, the same
+`evaluateJavaScript()`, on all three.
+
+Both shims are ordinary dependencies of `@gjsify/iframe` and contain no JavaScript. Each
+one's binaries arrive through per-platform optional dependencies, which your package manager
+installs only on the matching platform and skips silently everywhere else — so a Linux
+install pulls in two empty packages and no binaries at all.
+
+Where the engines genuinely differ, the differences are below, and each one announces
+itself at the call site rather than failing quietly.
+
+## Windows: the view is an overlay
+
+On Windows the web content is a child window the OS composites on top of your app. It is
+not a node in GTK's scene graph, which buys you input, focus and accessibility straight
+from the OS — and costs you clipping. An ancestor cannot cut the page to shape, nothing can
+be drawn over it, and opacity and transforms do not reach it.
+
+So these arrangements will not do what you expect:
+
+- **inside a `Gtk.ScrolledWindow` or `Gtk.Viewport`** — the scrolled window scrolls the
+  widget, not the page, and the content is not clipped to the viewport;
+- **as the main child of a `Gtk.Overlay`** — anything you overlay is drawn *under* the web
+  content instead of over it;
+- **inside a `Gtk.Popover`** — the popover's rounded, clipped surface is not followed;
+- **with an opacity below 1**, on the view or on any ancestor — it is not applied to the
+  web content.
+
+gjsify warns once per finding, naming the ancestor, rather than letting it look like a bug
+in your layout. The view also keeps the list:
+
+```js
+view.get_hosting_mode();        // WebKit.HostingMode.OVERLAY
+view.get_overlay_constraints(); // the arrangements it cannot honour, as readable strings
+```
+
+Those two names exist on the Windows backend only — they describe a condition Linux and
+macOS do not have — so guard the call or keep it to Windows-specific diagnostics.
+
+What the detector cannot see is a CSS `border-radius` that reaches the widget — that is not
+readable from GTK's public API — so treat the list as the arrangements that have been
+reported, not as proof there are no others.
+
+Design around it the same way you would around a video overlay: give the web view its own
+rectangle in the window. A full-page document under a header bar is the shape that works.
+
+### Windows behaviour differences
+
+Each of these is deliberate, and each says so at the call rather than silently doing
+something else:
+
+- **A user script carrying an allow-list or block-list of URL patterns is refused.**
+  WebView2's injection point has no URL filter, and injecting anyway is exactly the failure
+  a block list exists to prevent, so it narrows in the safe direction.
+- **Named script worlds are ignored.** There is no public isolated-world API to map them
+  onto. `user_script_new_for_world()` still exists so your call site stays portable, and it
+  tells you what it did — worth knowing because macOS *does* honour the same argument, so
+  the identical call is isolated there and not here.
+- **A full-document snapshot returns the viewport.** `takeScreenshot('full')` captures what
+  is laid out, not the whole scrollable document. Snapshot options other than the default
+  are ignored too.
+- **`WebKit.WebView.evaluate_javascript()`, called directly, returns JSON text** where the
+  other two platforms return a live value. Strings, numbers and booleans read the same; an
+  object comes back as its JSON text, and `null` and `undefined` are not distinguishable
+  (`is_null()` is true for both, `is_undefined()` never is). The bridge's own
+  `evaluateJavaScript()` is unaffected: it already serialises inside the page.
+- **End-of-document script injection is approximated** by a document-start script that
+  defers itself to `DOMContentLoaded`.
+- **Console forwarding to stdout is not honoured** — use the bridge's own
+  `captureConsole` option, which works on every platform.
+- **`allow-file-access-from-file-urls` is not offered as a setting**, because the
+  equivalent is a process-wide switch rather than a per-view one. An absent property warns
+  at the call; a present one that quietly did nothing would not.
+- **x64 only.** There is no arm64 GTK for Windows to build against.
+
+### What else has to be on the machine
+
+The Windows backend links GTK, GLib and GObject, and Windows has no system copy of any of
+them, so install `@gjsify/gtk-runtime-win32-x64` alongside it — the same bundle every
+Windows gjsify app already uses to reach `gi://` at all. It is deliberately not pulled in
+for you: a second copy of those DLLs on the process's search path is a worse failure than
+the one it would solve.
+
+### The WebView2 runtime has to be on the user's machine
+
+The Evergreen WebView2 runtime ships with Windows 11 and with Edge on Windows 10, but it is
+a dependency and not an assumption. On a machine without it, creating the view fails with a
+message naming the runtime and the Fixed Version redistributable, rather than a bare error
+code.
+
+If you ship an `.msi` with [`gjsify ship windows`](/gjsify/ship/windows/), that is yours to
+handle: declare the runtime, detect it at install time, and offer the Fixed Version
+redistributable for an application that must not depend on what the machine happens to
+have. The generated installer does not do this for you yet.
+
+**And read both registry views if you write that detection.** On 64-bit Windows the
+Evergreen runtime's client key lives only under
+`HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\…`; the 64-bit view of the same path
+does not have it. A detector that checks only the 64-bit path reports "not installed" on a
+machine that has the runtime — a check that looks green everywhere it is tested and is
+wrong at the user. Read both views, or call
+`GetAvailableCoreWebView2BrowserVersionString`, which is view-independent.
+
+### What is proven on Windows, and what is not
+
+The Windows view has been exercised without an application window on screen: `gi://WebKit`
+6.0 resolves, the view is a real `Gtk.Widget`, a page loads to completion,
+`evaluate_javascript` reads a value back **out of the DOM**, a snapshot comes back as a
+texture, and the page's own `postMessage` arrives on the app side.
+
+What has not been verified is the same view re-parented under a real application window:
+tracking its bounds as the window moves and resizes, hiding when the widget is unmapped,
+and input and focus arriving from the OS. If you are deciding whether to depend on the
+Windows web view today, that is the line — the engine, the loading, the scripting and the
+snapshots are demonstrated; the widget-in-a-window behaviour is not yet.
+
+## macOS notes
+
+macOS gets Apple's WebKit through `@gjsify/webkit-native`, which gjsify ships as a
+prebuild. There is no WebKitGTK to install and no Homebrew formula to look for: upstream's
+GTK port is Linux-only by decision, not by omission.
+
+The widget is *built* rather than embedded. GTK 4 has no foreign-window embedding, so the
+page renders offscreen and is presented as a texture, refreshed on a tick while the widget
+is mapped. Measured at 1024×768 on a GPU-less Intel VM a snapshot averages 15.8 ms, so
+expect a ceiling around 63 fps before any GPU is involved. Mouse, scroll and keyboard input
+are forwarded from the GTK widget into the page, and a click focuses the element under it.
+
+What the macOS backend deliberately does not do:
+
+- **`document.hasFocus()` is always `false`**, so `window.onfocus` and `onblur` never fire
+  and no caret blinks. It comes from a responder chain a windowless view has no place in.
+- **The pointer cursor never changes** over links or text, for the same reason.
+- **App Sandbox is unanswered.** The hardened runtime works, so a notarised app has no
+  web-view-specific obstacle; a sandboxed one has not been shown to work.
+
+The minimum deployment target is macOS 11.
+
+## Related
+
+- [Bridge Widgets](/gjsify/patterns/bridges/#embed-a-web-page) — where `IFrameBridge` sits
+  next to the canvas, WebGL and video bridges, and when to reach for each
+- [Minimalist Browser](/gjsify/showcases/minimalist-browser/) — a URL bar, history and
+  `postMessage`, in one small app
+- [Platform Support](/gjsify/platform-support/) — what reaches your operating system
+- [Ship your app](/gjsify/ship/) — packaging for Linux, macOS and Windows

--- a/website/src/content/docs/platform-support.mdx
+++ b/website/src/content/docs/platform-support.mdx
@@ -18,6 +18,7 @@ Linux-only, because the native library underneath it is.
 | **Apps on GJS** (`--app gjs`) | supported | partial, see below | not available (no GJS host) |
 | **Apps on Node/Bun/Deno** (`--app node`, via `@gjsify/node-gi`) | supported | supported | supported |
 | **Browser builds** (`--app browser`) | supported | supported | supported |
+| **Web views** (`@gjsify/iframe`) | supported | supported | supported, with limits |
 | **The CLI on a `gjs` host** (no Node, Bun or Deno on the machine) | supported | engines ship, not exercised in CI | not available (no GJS host) |
 | **The CLI on Node, Bun or Deno** | supported, all three exercised in CI | supported, Node exercised in CI | supported, Node exercised in CI |
 
@@ -30,6 +31,11 @@ Deno. Off Linux, the CI leg that drives the toolchain end to end is the Node one
 Browser builds carry no native code at all, so they are portable by
 construction. The rows that name a `gjs` process are where the operating system
 matters.
+
+The web-view row is a capability rather than a build target, and it reaches all
+three because each operating system supplies a different engine under one
+namespace. What "with limits" means on Windows is spelled out below and in
+[Web Views](/gjsify/guides/web-views/).
 
 ## Windows
 
@@ -66,6 +72,15 @@ GTK 4 / Adwaita closure that `@gjsify/node-gi` loads `gi://` namespaces from, so
 there is no gvsbuild or system GTK to install. CI runs a real GTK window and the
 full Adwaita storybook against that bundle.
 
+Web views reach Windows too. `@gjsify/webview2-native` supplies a `WebKit-6.0`
+namespace backed by Microsoft's WebView2, so the code that embeds a page on Linux
+embeds one here unchanged. What decides whether you can build on it: the view is
+an overlay the OS composites on top of your window, so no ancestor can clip or
+scroll it; the WebView2 Evergreen runtime has to be present on the end user's
+machine, which is your installer's job to declare; and the view has been proven
+headlessly rather than re-parented under a real application window.
+[Web Views](/gjsify/guides/web-views/) has each of those in full.
+
 Two host settings are worth getting right before you start, because both fail in
 ways that do not name themselves:
 
@@ -90,6 +105,13 @@ ships the GTK 4 / Adwaita closure so you do not need a Homebrew GTK. Intel Macs
 get the same treatment against `@gjsify/gtk-runtime-darwin-x64`: the same builds,
 the same display-free conformance and the same windowed GUI proof, each one a
 matrix leg beside its Apple-silicon twin rather than a reduced substitute.
+
+Web views come with the package here. `@gjsify/webkit-native` puts Apple's WebKit
+behind the same `WebKit-6.0` namespace `@gjsify/iframe` uses on Linux, so there is
+no WebKitGTK to hunt for — upstream's GTK port is Linux-only by decision — and
+nothing in your code changes. The minimum deployment target is macOS 11, and a few
+page-level behaviours differ (document focus, the pointer cursor);
+[Web Views](/gjsify/guides/web-views/) names them.
 
 What is not proven is the CLI on a `gjs` host. `gjsify build` under GJS needs a
 bundler, `@gjsify/rolldown-native` is the one that runs there, and it does
@@ -181,5 +203,6 @@ is in [ADR 0013](https://github.com/gjsify/gjsify/blob/main/docs/adr/0013-sab-na
 ## Related
 
 - [Runtimes](/gjsify/runtimes/): GJS, Node.js, Bun, Deno and the browser
+- [Web Views](/gjsify/guides/web-views/): one web-view API, three engines, and the Windows caveats
 - [Install & Update](/gjsify/guides/install/): getting the CLI onto each platform
 - [How It Works](/gjsify/how-it-works/#what-the-platform-marks-prove): what the platform checks actually prove


### PR DESCRIPTION
## Why

`grep -ri webview website/src/content/docs` returned zero hits, and `platform-support.mdx`
named neither WebKit nor web views — while the capability now reaches Linux, macOS and
Windows. A user asking "can I embed a page, and will it work on Windows?" had nothing on
the site to read.

## What this adds

**A new guide, `guides/web-views.md`:**

- What `@gjsify/iframe` gives you, with a complete Adwaita program that loads a page, reads
  a value out of its DOM, lists its links and snapshots it. Built and run on Linux; its
  output is pasted verbatim into the page.
- The two API surfaces (the standard `HTMLIFrameElement` one, and the bridge's own
  navigation/automation one) and when to pick which.
- **One API, three engines** — the system WebKitGTK on Linux, Apple's WebKit on macOS,
  Microsoft's WebView2 on Windows, all under the same `WebKit-6.0` namespace, and why that
  matters to the reader: their code carries no OS branch.
- **The Windows caveats, plainly.** The view is an OS-composited overlay: a scrolling
  ancestor, use as an overlay's main child, a popover, or fractional opacity will not
  behave as expected, and gjsify warns rather than failing silently. User-script URL
  allow/block lists are refused; named script worlds are ignored; a full-document snapshot
  returns the viewport. The WebView2 runtime must be on the end user's machine — what that
  means for an `.msi`, plus the detection trap where the Evergreen registry key lives only
  under `WOW6432Node`.
- **What is not proven yet**, once and without drama: the Windows view is demonstrated
  headlessly (loads, scripts the DOM, snapshots); re-parented under a real application
  window it is not verified.
- macOS notes worth flagging: offscreen rendering and its measured snapshot cost,
  `document.hasFocus()` always false, no cursor changes, macOS 11 minimum.

**`platform-support.mdx`:** a web-view row in the short-answer table, plus a paragraph each
in the Windows and macOS sections and a Related link.

**`astro.config.mjs`:** the sidebar entry under Guides.

## Verification

| what | result |
|---|---|
| the guide's program, `gjsify build --app gjs` + `gjsify run` | runs; output pasted into the page |
| `node scripts/check-doc-fences.mjs` | exit 0 |
| `node scripts/check-website-package-names.mjs` | exit 0 |
| `gjsify workspace @gjsify/website build` | exit 0, 67 pages, every in-page anchor resolves |
| `check-generated-website-data`, `check-website-adwaita-gallery`, `check-website-attr-samples`, `check-website-preview-not-content`, `check-doc-revert` | exit 0 |

Two facts in the guide were measured rather than assumed while writing it: `pageTitle` is
still empty inside `onReady()` and arrives on `notify::title` shortly after, and the
snapshot byte count varies with the window size (the page says so next to the output).

Nothing on the Windows path could be executed here — those statements come from the
packages' own documentation, and no snippet is on the site that could not at least be
type-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGTu3xiJDXtxVdB7vkzcyC
