### PR TITLE
docs(web): name both XHR implementations

### DIFF
--- a/packages/web/AGENTS.md
+++ b/packages/web/AGENTS.md
@@ -6,8 +6,8 @@
 
 | Pkg | Libs | Implements |
 |-----|------|------------|
-| fetch | Soup 3.0, Gio | fetch(), Request (raw body via `set_request_body_from_bytes`), Response, Headers. **No XHR** — that lives in `@gjsify/xmlhttprequest` |
-| xmlhttprequest | Soup 3.0, GLib | XMLHttpRequest, full `responseType`. Backs Excalibur's asset loader |
+| fetch | Soup 3.0, Gio | fetch(), Request (raw body via `set_request_body_from_bytes`), Response, Headers — **and an XHR**, `src/xhr.ts`, which is what a BUNDLED consumer of `@gjsify/xmlhttprequest` actually gets (`resolve-npm` routes that name here on gjs) |
+| xmlhttprequest | Soup 3.0, GLib | XMLHttpRequest, full `responseType`. Backs Excalibur's asset loader. Its own class is reached only by an UNBUNDLED `lib/esm` import — the second of two implementations, see open-todos |
 | dom-events | — | Event, CustomEvent, EventTarget, UI/Mouse/Pointer/Keyboard/Wheel/FocusEvent |
 | dom-exception | — | DOMException (WebIDL) |
 | abort-controller | — | AbortController, AbortSignal |

--- a/status/agent-context-budget.json
+++ b/status/agent-context-budget.json
@@ -11,6 +11,6 @@
     "packages/node-gi/AGENTS.md": 20239,
     "packages/node-runtime/AGENTS.md": 8770,
     "packages/node/AGENTS.md": 18085,
-    "packages/web/AGENTS.md": 9477,
+    "packages/web/AGENTS.md": 9694,
     "tests/AGENTS.md": 9638
 }

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -1,5 +1,31 @@
 <!-- Authored Open-TODO sections — THIS FILE is the tracked source of truth (the
-     rendered STATUS.md view is generated and gitignored). One `### <title>` per open item.
+     rendered STATUS.md view is generated and gitignored). One `### Two XMLHttpRequest implementations, and the docs name the wrong one as the only one
+
+`@gjsify/xmlhttprequest` ships a class in `src/index.ts`. `@gjsify/fetch` ships another in
+`src/xhr.ts` (11 269 bytes). `packages/infra/resolve-npm/lib/index.mjs` routes the SCOPED
+name to the second one on gjs (`:536`) and to `@gjsify/empty` on node (`:714`), with a
+comment at `:533` that says it outright — *"xmlhttprequest (implemented in @gjsify/fetch)"*.
+So a bundled consumer of `@gjsify/xmlhttprequest` never reaches that package's own class; it
+is reached only by an unbundled `lib/esm` import, which is what the published tarball offers.
+
+Measured with a probe consumer while #1505 was written: the instance carries `upload`, which
+exists only in `fetch/src/xhr.ts`.
+
+`packages/web/AGENTS.md` said the opposite in both directions until this entry was filed —
+*"**No XHR** — that lives in `@gjsify/xmlhttprequest`"* on the fetch row, while an 11 KB
+`xhr.ts` sat in that package and the routing table one directory over named it. Two files in
+one tree contradicting each other, and the reader following the AGENTS.md row lands in the
+implementation no bundle uses. The rows are corrected; the DUPLICATION is not.
+
+What is undecided, and why this is an entry rather than a fix: which class should survive.
+#1505 gave `src/index.ts` its first spec and fixed two defects in it (a `responseType === ''`
+that returned a FakeBlob instead of text, and WebIDL constants missing from the constructor),
+neither of which was ever checked against `fetch/src/xhr.ts` — which declares the same
+constants as module-level `export const`s and may or may not carry the same defect. Deleting
+either class is a published-contract change (`@gjsify/xmlhttprequest` is tier 1), and merging
+them is a decision about which package OWNS the API, not a refactor. Establish that first.
+
+### <title>` per open item.
      A RESOLVED item is DELETED (its record is the commit + CHANGELOG that closed
      it) — the status-data check rejects struck-through / ✓ / "Completed"
      headings, so the done-log cannot regrow. -->


### PR DESCRIPTION
`packages/web/AGENTS.md` says `@gjsify/fetch` has "**No XHR** — that lives in `@gjsify/xmlhttprequest`".

It ships one: `packages/web/fetch/src/xhr.ts`, 11 269 bytes. And `packages/infra/resolve-npm/lib/index.mjs` routes the scoped name **to it** on gjs (`:536`) and to `@gjsify/empty` on node (`:714`) — with a comment at `:533` saying so outright: *"xmlhttprequest (implemented in @gjsify/fetch)"*.

Two files in one tree contradicting each other, and the reader who follows the AGENTS.md row lands in the implementation that no bundle uses.

Found while #1505 gave `@gjsify/xmlhttprequest` its first spec: a probe consumer's instance carries `upload`, which exists only in `fetch/src/xhr.ts`.

## The rows are corrected. The duplication is filed, not fixed.

Which class should survive is a decision, not a refactor:

- `@gjsify/xmlhttprequest` is **tier 1**, so deleting either side is a change to a published contract.
- #1505's two fixes to `src/index.ts` — a `responseType === ''` that returned a `FakeBlob` instead of text, and WebIDL constants missing from the constructor — were **never checked against the other implementation**, which declares the same constants as module-level exports and may or may not carry the same defect.
- Merging them is a question about which package OWNS the API.

Establishing that first is the work; the `status/open-todos.md` entry says so and names what is undecided rather than proposing an answer.

## Checks

`check-agent-context-size --check` · `check-doc-fences` · `check-website-package-names` · `audit-runtimes --check` — all exit 0. The AGENTS.md byte ledger is re-baselined in the same commit, as its exact ratchet requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGTu3xiJDXtxVdB7vkzcyC