### PR TITLE
feat(adwaita-react-native)!: drop the flat classes

### DIFF
--- a/docs/adr/0034-widget-vocabulary-convergence.md
+++ b/docs/adr/0034-widget-vocabulary-convergence.md
@@ -2,16 +2,19 @@
 
 - Status: **Proposed** — amended twice on 2026-08-30: § Amendment (the premise under the
   stage order moved; stages 2 and 3 landed first) and § Amendment 2 (stages 6 and 4 landed;
-  the property numbers were re-measured and moved); and four times on 2026-09-01.
-  § Amendments 3 and 4 carry clause 2 onto React Native and the web. § Amendment 5 holds
-  clause 1 on `@gjsify/adwaita-web`: nine elements took their GIR names, `<adw-radio>`
-  became a declared `webOnly`, and the printed distance was widened to the surface it had
-  been leaving out. § Amendment 6 REVERSES part of § 3 for `@gjsify/adwaita-web`: the
-  namespace is no longer additive there, the flat `Adw…`/`Gtk…` widget-class exports are
-  gone from the package root, and the namespace became a MODULE (`export * as Adw`) so it
-  can be annotated with as well as constructed from. § Amendment 7 carries both clauses
-  onto `@gjsify/adwaita-nativescript`, the last surface: four widgets took their GIR names,
-  eleven property names converged, and clause 2 now holds on all three.
+  the property numbers were re-measured and moved); four times on 2026-09-01; and once on
+  2026-09-03. § Amendments 3 and 4 carry clause 2 onto React Native and the web.
+  § Amendment 5 holds clause 1 on `@gjsify/adwaita-web`: nine elements took their GIR
+  names, `<adw-radio>` became a declared `webOnly`, and the printed distance was widened to
+  the surface it had been leaving out. § Amendment 6 REVERSES part of § 3 for
+  `@gjsify/adwaita-web`: the namespace is no longer additive there, the flat
+  `Adw…`/`Gtk…` widget-class exports are gone from the package root, and the namespace
+  became a MODULE (`export * as Adw`) so it can be annotated with as well as constructed
+  from. § Amendment 7 carries both clauses onto `@gjsify/adwaita-nativescript`, the last
+  surface: four widgets took their GIR names, eleven property names converged, and clause 2
+  now holds on all three. § Amendment 8 carries § Amendment 6's REVERSAL onto
+  `@gjsify/adwaita-react-native`: 28 flat widget-class exports gone from each of its three
+  barrels, `Adw.<Name>` the only spelling the package root has.
 - Date: 2026-08-29
 - Deciders: Pascal Garber
 - Related: [ADR 0027 § 9 (the goal)](0027-gtk-host-layer.md), [ADR 0028 § 6 (the alignment mechanism)](0028-widget-table-provenance.md), [ADR 0029 (the vocabulary in `@girs/*`)](0029-girs-widget-vocabulary.md), [ADR 0019 (ts-for-gir as a library; where the `.gir` travels)](0019-ts-for-gir-as-library.md), [ADR 0004 (headless core)](0004-headless-adwaita-core.md), [ADR 0032 (React Native on the host)](0032-react-native-on-the-gtk-host.md), [ADR 0033 (templates preferred)](0033-declarative-templates-preferred.md)
@@ -607,10 +610,11 @@ three clauses is nearly free, and it is the row whose cost rises at the next rel
 
 ### 3. The namespace is a RE-EXPORT layer, never a rename
 
-> **Superseded in part by § Amendment 6 (2026-09-01)** for `@gjsify/adwaita-web`: the
-> "all of it is additive" sentence below described the adoption step, and on that surface
-> the flat widget classes have since been removed. The re-export mechanism, and the
-> refusal to rename the CLASSES, are unchanged everywhere.
+> **Superseded in part by § Amendment 6 (2026-09-01)** for `@gjsify/adwaita-web` and by
+> § Amendment 8 (2026-09-03) for `@gjsify/adwaita-react-native`: the "all of it is
+> additive" sentence below described the adoption step, and on both surfaces the flat
+> widget classes have since been removed. The re-export mechanism, and the refusal to
+> rename the CLASSES, are unchanged everywhere.
 
 Clause 2 is satisfied by an export, not by moving anything. Each surface gains
 
@@ -1203,6 +1207,10 @@ it also listed are done.
 
 ## Amendment 3, 2026-09-01 — clause 2 holds on React Native, and what it cost to make it not a second list
 
+> **Superseded in part by § Amendment 8 (2026-09-03).** "Additive" below described the
+> adoption step; the flat widget classes are now gone from all three barrels, and the
+> "two mentions of each module" argument became a one-mention one with vectors under it.
+
 Stage 1's remaining content was the `Adw` namespace export. It is done for
 `@gjsify/adwaita-react-native`: all three barrels — base, `.gtk`, `.native` — export
 `Adw`, additive, with `AdwBin` and `AdwClamp` unchanged.
@@ -1790,3 +1798,148 @@ and on this surface neither question had an oracle. Four A/B pairs, each after t
 formatter ran (a wrapped guard is a defused guard): an unprefixed element, a barrel export
 dropped, a story write renamed back, a fence write renamed back — exit 1 each, exit 0
 restored each.
+## Amendment 8, 2026-09-03 — the flat classes are gone from React Native too, and one line now carries what two did
+
+`@gjsify/adwaita-react-native` exports `Adw` with 28 members on each of its three
+barrels, and nothing else names a widget. The run of `export { AdwActionRow } from
+'./widgets/action-row.js'` lines — 28 per barrel, 84 in the package — is removed from
+`src/index.ts`, `src/index.gtk.ts` and `src/index.native.ts`. `Adw.ActionRow` is the only
+spelling the package root has.
+
+This is § Amendment 6 applied to the second surface, for the reason given there: § 3's
+"**all of it is additive**" bought the ADOPTION and decided nothing about afterwards, and
+a second spelling that is never removed is a permanent second vocabulary — the thing
+clause 1 exists to remove, one level in. § Amendment 3's "Additive: `AdwBin` keeps
+working and nothing published moves" is the sentence being amended here; it was true of
+the export and is not true any more.
+
+**It cost nothing to migrate, and that is a measurement rather than luck.** Outside the
+package, `@gjsify/adwaita-react-native` is named in 20 files and IMPORTED in none
+(`git grep -l`, minus the package's own four): `gtk-host`'s `descriptors/adw.ts`,
+`adwaita-core`'s `wrap-box.ts`, the NativeScript `wrap-box-layout.ts`, a showcase's
+refusals table and the website's React Native page all mention it in prose or provenance;
+the rest are the readers, the workflows, the changelog and this document. Inside the package, no module imports the barrel
+either — the specs import widget modules directly, which `parity.spec.ts` explains is
+forced (`platform-resolve` rewrites `./index.js` to `./index.gtk.js` before the bundler
+sees it, so the obvious version of that suite asserted a refusal against the GTK
+component). So the two things § Amendment 6 had to pay for on the web — six showcase
+files and a browser driver whose element set came out of the barrel — have no counterpart
+here.
+
+### The split, and the one place a flat `AdwClamp` still lives on purpose
+
+|  | count per barrel | what happens |
+|---|---|---|
+| widget components with a namespace member | 28 | flat export **removed**; reachable as `Adw.X` |
+| prop interfaces, handles and shared unions | 34 | flat export **kept** (`export type`) |
+
+There is no third column, because this package root has nothing else in it: no helper, no
+factory, no widget without a GIR name. The 12 `webOnly` element classes that made
+§ Amendment 6's table interesting have no counterpart — every widget here already shares
+a spelling with a GTK tag, which is what `check-vocabulary-alignment.mjs` has printed
+since § Amendment 3 (*"28 share a spelling, 0 should converge, 0 declared own, 0
+undecided"*).
+
+The types stay flat for the reason § Amendment 6 gave: `AdwClampProps` is not a second
+name for a widget, and `Adw.ClampProps` would name something libadwaita does not have.
+
+**What is NOT removed is the components' own `AdwClamp` identifier**, and it is worth
+saying why, because unlike the web surface this package publishes a per-widget entry
+point. `exports['./widgets/clamp']` is how a consumer takes one widget without the barrel,
+and there `AdwClamp` is the widget's ONLY name — § Amendment 6's rule, at a different
+door. Renaming it to a bare `Clamp` would put an unqualified noun in a consumer's import
+list, and it would break the coupling three readers derive through `widgetClass`:
+`adwaitaReactNativeWidgets` holds the class name against the module name,
+`check-adwaita-rn-platform-split.mjs` rule 8 holds the namespace member against the
+module it is bound from, and `refuseBaseModule` prints the component in the message a
+mis-resolved base module throws. Rule 10 (below) says this in its failure text, so the
+distinction does not have to be re-derived from this document.
+
+The residual is therefore real and named: a consumer CAN still write `AdwClamp`, from the
+subpath. What it cannot do any more is write it and mean the barrel.
+
+### An object literal here, a module on the web, and the difference is types
+
+§ Amendment 6 had to make `Adw` a MODULE (`export * as Adw from './namespace/adw.js'`)
+because the web's classes are annotated — `document.createElement(...) as Adw.HeaderBar`
+— and `export const Adw = {…}` gives value position only. This surface keeps the object
+literal, on both halves of the fork, and needs nothing more: the members are function
+components, and the TYPE authority is the `Adw…Props` interfaces that stay exported flat
+beside them. `React.ComponentProps<typeof Adw.Clamp>` works off the literal.
+
+The second reason is the platform split. Each barrel must build `Adw` from its OWN
+platform modules (§ Amendment 3), and rules 3 and 5 of
+`check-adwaita-rn-platform-split.mjs` read module specifiers out of the barrel file
+itself. A namespace module per barrel would put the fork one hop away from the file those
+rules read, and buy nothing this surface uses.
+
+### The reader lost its second mention, and that is the interesting part
+
+§ Amendment 3 explained why the namespace members were IMPORTED a second time instead of
+being built from the re-exports above them: those `export … from` lines were load-bearing
+for `adwaitaReactNativeWidgets`, which derives this package's widget set from them and
+refuses a line whose exported name and module name disagree. "Two mentions of each module,
+held equal by a rule, beats one mention that no longer says which widget it is."
+
+Removing the export leaves ONE mention, so the coupling moves onto the line that stayed —
+which carries one half more than the old one did. `adwaitaReactNativeWidgets` now reads
+`import { AdwClamp as Clamp } from './widgets/clamp.js'` and holds BOTH halves against the
+module name: the binding must be `widgetClass('clamp')`, and the member must be
+`Clamp`, because since this amendment the member IS the name the package publishes.
+
+**And a one-mention reader needs vectors, which the two-mention one did not.** Its
+under-read is the QUIET kind: fewer widgets read means a shorter widget set, and
+`RN_WIDGET_ALIGNMENT` — empty — agrees with a shorter set exactly as well as with the
+right one. That is § Amendment 6's "scan that is merely narrower than it reads", arriving
+where no floor and no assertion count would notice. So `reactNativeBarrelWidgets` is split
+out as a pure function over source, and `check-vocabulary-alignment.mjs` gained eight
+vectors beside the namespace-barrel ones (19 reader vectors → 27).
+
+**The first of them went red on the first run, and the bug was a comma.** The regex
+required `}` directly after the alias, and oxfmt writes a trailing comma as soon as an
+import wraps — so the day the longest-named widget in the barrel wrapped
+(`AdwNavigationSplitView as NavigationSplitView` is 94 characters with its specifier), it
+would have dropped out of every set derived from the barrel with every gate green. The
+vector is what found it; nothing in the real tree does, because the real tree has not
+wrapped yet.
+
+### Rule 10: what stops the flat spelling from growing back
+
+Rule 8 holds what `Adw` CONTAINS. Nothing held what sits beside it, and the removed run
+was one `export … from` line per widget — the cheapest thing in this repository to put
+back, and invisible in a review that is looking at the namespace. Rule 10 of
+`check-adwaita-rn-platform-split.mjs` refuses a widget class in any `export { … }` clause
+of any of the three barrels.
+
+It is derived from the widgets on disk rather than from a `/^Adw[A-Z]/` shape, because
+the barrels legitimately export `AdwClampProps` and `AdwToastOverlayHandle`, and a rule
+that refuses a SHAPE is one prop type away from a false alarm — which is how a gate gets
+loosened. And it reads BOTH halves of a specifier: `export { AdwClamp as Clamp }`
+publishes no `AdwClamp` and is still the barrel re-exporting a widget class, one that
+would put a bare `Clamp` at the root as a THIRD spelling.
+
+A/B with real exit codes, each shape separately, restored between: `export { AdwClamp }`
+→ exit 1; `export { AdwClamp as Clamp }` → exit 1; removed → exit 0. Rule 3 was
+re-falsified in the same way after the comment stripper it shares was factored out, so a
+refactor made for rule 10 could not have quietly stopped rule 3 from reading anything.
+
+### The numbers, and what did not move
+
+Both halves, each rebuilt and run separately, exit codes read without a pipe: **478
+assertions on the Node leg and 350 on the GJS leg, on the commit before this change and
+after it**. Nothing was traded for anything — the specs import widget modules directly, so
+no suite's subject was the barrel's export list. `check-adwaita-rn-platform-split` reports
+28 widgets on all three barrels before and after; `check-vocabulary-alignment` still
+prints `28 @gjsify/adwaita-react-native widgets — 28 share a spelling, 0 should converge,
+0 declared own, 0 undecided` and `@gjsify/adwaita-react-native exports Adw with 28`, with
+its reader-vector count up from 19 to 27.
+
+### What is still not held, and it is not this surface's to hold
+
+Nothing checks how a CONSUMER spells the vocabulary. On this surface that gap is
+currently closed by arithmetic rather than by a gate: the root exports NO flat widget
+class at all, so `import { AdwClamp } from '@gjsify/adwaita-react-native'` is a
+resolution error in every tool that reads the barrel. The web surface is where the gap is
+real — 12 `webOnly` classes keep their flat export there, so a flat import still resolves
+and a consumer can go on spelling the vocabulary the old way with nothing failing. A
+gate over consumer import sites belongs beside that, not here.

--- a/packages/framework/adwaita-react-native/README.md
+++ b/packages/framework/adwaita-react-native/README.md
@@ -4,9 +4,9 @@ Adwaita widgets with **one API surface and two implementations**: the real `Adw.
 widget on GTK4, React Native primitives on a phone.
 
 ```tsx
-import { AdwClamp } from '@gjsify/adwaita-react-native';
+import { Adw } from '@gjsify/adwaita-react-native';
 
-<AdwClamp maximumSize={400}>{content}</AdwClamp>;
+<Adw.Clamp maximumSize={400}>{content}</Adw.Clamp>;
 ```
 
 On GTK that is `Adw.Clamp` through [`@gjsify/gtk-host`](../gtk-host). On Android and
@@ -15,11 +15,19 @@ iOS it is a `View` whose width and offset come from
 `adw_clamp_layout_allocate` — libadwaita's own easing curve, not a `maxWidth`
 approximation.
 
+**`Adw.<Name>` is the only spelling the package root has**, and the sameness above is the
+point: the member is libadwaita's own type name with its namespace prefix read back off
+it (ADR 0034 clause 1 + § Amendment 8). There are no `AdwClamp` class exports at the root
+any more. One widget on its own comes from its subpath —
+`import { AdwClamp } from '@gjsify/adwaita-react-native/widgets/clamp'` — where that
+identifier is the widget's only name and not a second one; the prop TYPES keep their flat
+spelling for the same reason, since `Adw.ClampProps` names nothing libadwaita has.
+
 ## What this is, honestly
 
 **Not a widget set yet.** The table below is the whole of it, and every row carries the
 whole vertical — both platform halves, the resolution mechanism, the `exports` entry, a
-gate, and a suite on each side that reads the REAL tree. `AdwBin` and `AdwClamp` came
+gate, and a suite on each side that reads the REAL tree. `Adw.Bin` and `Adw.Clamp` came
 first and proved that shape; the groups since are where it starts earning its keep, and
 the content-and-feedback widgets are the clearest case — each has a DERIVATION as its
 shared half (an initials hash, a palette index, a queue policy, a ring geometry), so the
@@ -58,34 +66,34 @@ a GTK-only consumer does not need it installed.
 
 | widget | props | notes |
 |---|---|---|
-| `AdwActionRow` | `title`, `subtitle`, `activatable` (false), `onActivated`, `children` | The fundamental boxed-list row. `children` are the SUFFIX |
-| `AdwAvatar` | `size` (**required**), `text`, `showInitials`, `iconName` | Initials and palette entry from one port of `extract_initials_from_text` + `set_class_color`. `size` is required because libadwaita's default is the `-1` "ask the stylesheet" sentinel and neither renderer here has one |
-| `AdwBanner` | `title`, `buttonLabel`, `revealed`, `useMarkup`, `buttonStyle`, `onButtonClicked` | An omitted `useMarkup` is FALSE on both halves — the value the widget reads back, not the TRUE its `GParamSpec` declares |
-| `AdwBin` | `children` | One child, no layout of its own |
-| `AdwButtonContent` | `iconName`, `label`, `useUnderline`, `canShrink` | Four derivations from the core, including the 6px gap that is `border-spacing` and not `GtkBox:spacing` |
-| `AdwButtonRow` | `title`, `onActivated` | A row that behaves like a button — always activatable, and holds no children at all |
-| `AdwClamp` | `children`, `maximumSize` (600), `tighteningThreshold` (400) | Constrain a child's width and centre it, on libadwaita's easing curve |
-| `AdwComboRow` | `title`, `subtitle`, `model`, `selected`, `useSubtitle`, `onNotifySelected` | Pick one item of a list. `model` keeps libadwaita's NAME and takes `@gjsify/adwaita-core`'s option vocabulary instead of a `Gio.ListModel` — the GTK half builds the real `Gtk.StringList`. One item or none is not a choice: no chevron, and the row is not activatable. `useSubtitle` MOVES the value into the subtitle rather than adding a second copy of it |
-| `AdwEntryRow` | `title`, `text`, `maxLength` (0), `editable` (true), `showApplyButton` (false), `onNotifyText`, `onApply`, `onEntryActivated` | The row IS the entry. `max-length` counts CHARACTERS |
-| `AdwExpanderRow` | `title`, `subtitle`, `expanded` (false), `onNotifyExpanded`, `children` | `children` are the DISCLOSED rows. The header toggles, the disclosure does not |
-| `AdwHeaderBar` | `start`, `titleWidget`, `title`, `subtitle`, `end` | The three slots as PROPS, in draw order. No window controls: a phone has none |
-| `AdwNavigationPage` | `children`, `title`, `tag`, `canPop` (true) | One page of a navigation view, or one pane of a navigation split view. A widget on GTK because `adw_navigation_view_add` takes one; three properties and no drawing of its own |
-| `AdwNavigationSplitView` | `children` (the content), `sidebar`, `sidebarTag`, `contentTag`, `sidebarTitle`, `contentTitle`, `collapsed`, `showContent`, `sidebarPosition`, plus the four sizing props | Sidebar beside content; a navigation stack when collapsed. Both panes are wrapped in an `Adw.NavigationPage` on GTK, because the two slots take nothing else |
-| `AdwNavigationView` | `children` (the pages, first is the root), `animateTransitions` (true), `popOnEscape` (true), `ref` (`push`, `pop`, `popToTag`, `replaceWithTags`, `visiblePageTag`, `canGoBack`, `backButtonTooltip`) | A page stack. Pushed BY TAG through the ref, never by prop — `Adw.NavigationView:visible-page` is read-only |
-| `AdwOverlaySplitView` | `children` (the content), `sidebar`, `collapsed`, `showSidebar` (true), `pinSidebar`, `sidebarPosition`, `enableShowGesture` (true), `enableHideGesture` (true), `onNotifyShowSidebar`, plus the four sizing props | Sidebar that slides OVER the content when collapsed. Collapsing hides an unpinned sidebar itself, which is what `onNotifyShowSidebar` reports |
-| `AdwPasswordEntryRow` | `title`, `text`, `maxLength`, `editable`, `showApplyButton`, `onNotifyText`, `onApply`, `onEntryActivated` | `Adw.EntryRow`'s surface exactly — the subclass declares no property of its own. `maxLength` counts CHARACTERS through the core, never `TextInput.maxLength`'s UTF-16 units |
-| `AdwPreferencesGroup` | `children` (the rows), `title`, `description` | A titled card. Five visibility answers from one `derivePreferencesGroupHeader` call; the card hides itself at zero rows while its header stays |
-| `AdwPreferencesPage` | `children` (the groups), `title`, `iconName`, `name`, `description`, `descriptionCentered`, `useUnderline` | Four of the five properties are identity a view switcher reads, drawn by neither half — as in libadwaita. Only `description` is painted |
-| `AdwSpinRow` | `title`, `subtitle`, `value`, `lower`, `upper`, `stepIncrement`, `digits`, `onNotifyValue` | The range is `Gtk.Adjustment`'s three own property names rather than a fourth private spelling. Every mutation clamps, including a bound that moves under the value |
-| `AdwSpinner` | `widthRequest`, `heightRequest` | The BOX and the RING are two numbers: an unbounded box around a ring capped at 64 |
-| `AdwStatusPage` | `children`, `iconName`, `title`, `description` | A centred empty state. The icon draws on GTK only |
-| `AdwSwitchRow` | `title`, `subtitle`, `active` (false), `onNotifyActive` | Controlled. The whole row toggles, not only the handle |
-| `AdwToastOverlay` | `children`, `ref` (`addToast`, `dismissAll`) | One toast at a time. A toast is PUSHED through the ref, never declared as a prop — `add_toast` is a call |
-| `AdwToolbarView` | `children` (the content), `topBar`, `bottomBar`, `topBarStyle` (`flat`), `bottomBarStyle` (`flat`), `extendContentToTopEdge` (false), `extendContentToBottomEdge` (false) | Content framed by bars. The two styles reach the real widget on GTK and draw nothing on a phone |
-| `AdwViewStack` | `pages` (`name`, `title`, `iconName`, `visible`, `badgeNumber`, `needsAttention`, `useUnderline`, `child`), `visibleChildName`, `onNotifyVisibleChild` | Named pages, one visible. A page is a PROP OBJECT because `Adw.ViewStackPage` is a GObject and not a widget |
-| `AdwViewSwitcher` | `AdwViewStack`'s props plus `policy` (`narrow`) | A button row over the stack. It BUNDLES the stack libadwaita keeps separate, as both other renderers do — on GTK it still builds a real `Adw.ViewStack` and binds it to `Adw.ViewSwitcher:stack` |
-| `AdwWindowTitle` | `title`, `subtitle` | Two labels; an EMPTY one takes no space, a blank one does |
-| `AdwWrapBox` | `children` plus libadwaita's fourteen: `childSpacing`/`childSpacingUnit`, `lineSpacing`/`lineSpacingUnit`, `align`, `justify`, `justifyLastLine`, `lineHomogeneous`, `naturalLineLength`/`naturalLineLengthUnit`, `packDirection`, `wrapReverse`, `wrapPolicy`, `orientation` | Children flow onto new lines. The line DECISION is `@gjsify/adwaita-core`'s, the line BREAKING is Yoga's |
+| `Adw.ActionRow` | `title`, `subtitle`, `activatable` (false), `onActivated`, `children` | The fundamental boxed-list row. `children` are the SUFFIX |
+| `Adw.Avatar` | `size` (**required**), `text`, `showInitials`, `iconName` | Initials and palette entry from one port of `extract_initials_from_text` + `set_class_color`. `size` is required because libadwaita's default is the `-1` "ask the stylesheet" sentinel and neither renderer here has one |
+| `Adw.Banner` | `title`, `buttonLabel`, `revealed`, `useMarkup`, `buttonStyle`, `onButtonClicked` | An omitted `useMarkup` is FALSE on both halves — the value the widget reads back, not the TRUE its `GParamSpec` declares |
+| `Adw.Bin` | `children` | One child, no layout of its own |
+| `Adw.ButtonContent` | `iconName`, `label`, `useUnderline`, `canShrink` | Four derivations from the core, including the 6px gap that is `border-spacing` and not `GtkBox:spacing` |
+| `Adw.ButtonRow` | `title`, `onActivated` | A row that behaves like a button — always activatable, and holds no children at all |
+| `Adw.Clamp` | `children`, `maximumSize` (600), `tighteningThreshold` (400) | Constrain a child's width and centre it, on libadwaita's easing curve |
+| `Adw.ComboRow` | `title`, `subtitle`, `model`, `selected`, `useSubtitle`, `onNotifySelected` | Pick one item of a list. `model` keeps libadwaita's NAME and takes `@gjsify/adwaita-core`'s option vocabulary instead of a `Gio.ListModel` — the GTK half builds the real `Gtk.StringList`. One item or none is not a choice: no chevron, and the row is not activatable. `useSubtitle` MOVES the value into the subtitle rather than adding a second copy of it |
+| `Adw.EntryRow` | `title`, `text`, `maxLength` (0), `editable` (true), `showApplyButton` (false), `onNotifyText`, `onApply`, `onEntryActivated` | The row IS the entry. `max-length` counts CHARACTERS |
+| `Adw.ExpanderRow` | `title`, `subtitle`, `expanded` (false), `onNotifyExpanded`, `children` | `children` are the DISCLOSED rows. The header toggles, the disclosure does not |
+| `Adw.HeaderBar` | `start`, `titleWidget`, `title`, `subtitle`, `end` | The three slots as PROPS, in draw order. No window controls: a phone has none |
+| `Adw.NavigationPage` | `children`, `title`, `tag`, `canPop` (true) | One page of a navigation view, or one pane of a navigation split view. A widget on GTK because `adw_navigation_view_add` takes one; three properties and no drawing of its own |
+| `Adw.NavigationSplitView` | `children` (the content), `sidebar`, `sidebarTag`, `contentTag`, `sidebarTitle`, `contentTitle`, `collapsed`, `showContent`, `sidebarPosition`, plus the four sizing props | Sidebar beside content; a navigation stack when collapsed. Both panes are wrapped in an `Adw.NavigationPage` on GTK, because the two slots take nothing else |
+| `Adw.NavigationView` | `children` (the pages, first is the root), `animateTransitions` (true), `popOnEscape` (true), `ref` (`push`, `pop`, `popToTag`, `replaceWithTags`, `visiblePageTag`, `canGoBack`, `backButtonTooltip`) | A page stack. Pushed BY TAG through the ref, never by prop — `Adw.NavigationView:visible-page` is read-only |
+| `Adw.OverlaySplitView` | `children` (the content), `sidebar`, `collapsed`, `showSidebar` (true), `pinSidebar`, `sidebarPosition`, `enableShowGesture` (true), `enableHideGesture` (true), `onNotifyShowSidebar`, plus the four sizing props | Sidebar that slides OVER the content when collapsed. Collapsing hides an unpinned sidebar itself, which is what `onNotifyShowSidebar` reports |
+| `Adw.PasswordEntryRow` | `title`, `text`, `maxLength`, `editable`, `showApplyButton`, `onNotifyText`, `onApply`, `onEntryActivated` | `Adw.EntryRow`'s surface exactly — the subclass declares no property of its own. `maxLength` counts CHARACTERS through the core, never `TextInput.maxLength`'s UTF-16 units |
+| `Adw.PreferencesGroup` | `children` (the rows), `title`, `description` | A titled card. Five visibility answers from one `derivePreferencesGroupHeader` call; the card hides itself at zero rows while its header stays |
+| `Adw.PreferencesPage` | `children` (the groups), `title`, `iconName`, `name`, `description`, `descriptionCentered`, `useUnderline` | Four of the five properties are identity a view switcher reads, drawn by neither half — as in libadwaita. Only `description` is painted |
+| `Adw.SpinRow` | `title`, `subtitle`, `value`, `lower`, `upper`, `stepIncrement`, `digits`, `onNotifyValue` | The range is `Gtk.Adjustment`'s three own property names rather than a fourth private spelling. Every mutation clamps, including a bound that moves under the value |
+| `Adw.Spinner` | `widthRequest`, `heightRequest` | The BOX and the RING are two numbers: an unbounded box around a ring capped at 64 |
+| `Adw.StatusPage` | `children`, `iconName`, `title`, `description` | A centred empty state. The icon draws on GTK only |
+| `Adw.SwitchRow` | `title`, `subtitle`, `active` (false), `onNotifyActive` | Controlled. The whole row toggles, not only the handle |
+| `Adw.ToastOverlay` | `children`, `ref` (`addToast`, `dismissAll`) | One toast at a time. A toast is PUSHED through the ref, never declared as a prop — `add_toast` is a call |
+| `Adw.ToolbarView` | `children` (the content), `topBar`, `bottomBar`, `topBarStyle` (`flat`), `bottomBarStyle` (`flat`), `extendContentToTopEdge` (false), `extendContentToBottomEdge` (false) | Content framed by bars. The two styles reach the real widget on GTK and draw nothing on a phone |
+| `Adw.ViewStack` | `pages` (`name`, `title`, `iconName`, `visible`, `badgeNumber`, `needsAttention`, `useUnderline`, `child`), `visibleChildName`, `onNotifyVisibleChild` | Named pages, one visible. A page is a PROP OBJECT because `Adw.ViewStackPage` is a GObject and not a widget |
+| `Adw.ViewSwitcher` | `Adw.ViewStack`'s props plus `policy` (`narrow`) | A button row over the stack. It BUNDLES the stack libadwaita keeps separate, as both other renderers do — on GTK it still builds a real `Adw.ViewStack` and binds it to `Adw.ViewSwitcher:stack` |
+| `Adw.WindowTitle` | `title`, `subtitle` | Two labels; an EMPTY one takes no space, a blank one does |
+| `Adw.WrapBox` | `children` plus libadwaita's fourteen: `childSpacing`/`childSpacingUnit`, `lineSpacing`/`lineSpacingUnit`, `align`, `justify`, `justifyLastLine`, `lineHomogeneous`, `naturalLineLength`/`naturalLineLengthUnit`, `packDirection`, `wrapReverse`, `wrapPolicy`, `orientation` | Children flow onto new lines. The line DECISION is `@gjsify/adwaita-core`'s, the line BREAKING is Yoga's |
 
 Props are libadwaita's own names, camelCased — `maximumSize` is `AdwClamp:maximum-size`,
 not a React Native `maxWidth` — so the property you look up in libadwaita's documentation
@@ -96,8 +104,8 @@ A signal is named the way [`@gjsify/gtk-host`](../gtk-host)'s generated surface 
 half hands the prop straight to the host and a second spelling here would be a translation
 table nothing checks.
 
-**A slot is a prop, never a `slot`-carrying child.** `AdwHeaderBar`'s three ends and
-`AdwToolbarView`'s two bars are props because gtk-host routes a child by a `slot` prop on
+**A slot is a prop, never a `slot`-carrying child.** `Adw.HeaderBar`'s three ends and
+`Adw.ToolbarView`'s two bars are props because gtk-host routes a child by a `slot` prop on
 the CHILD, and a prop of a React component is an arbitrary `ReactNode` with nothing to
 write it on — `cloneElement` sets a prop on a COMPOSITE component, which forwards
 nothing, so the slot would be silently dropped for exactly the children this package
@@ -120,7 +128,7 @@ side.
 `@gjsify/adwaita-core`'s tokens through, so what the React Native half carries is layout
 and visibility. Inventing a styling seam is a decision this slice does not make.
 
-### `AdwExpanderRow` needs a curated placement, and this package added it
+### `Adw.ExpanderRow` needs a curated placement, and this package added it
 
 `Adw.ExpanderRow` was in `@gjsify/gtk-host`'s GENERATED table, which knows the tag and no
 placement rule, so every child of an `<adw-expander-row>` was an `uncurated-placement`
@@ -190,8 +198,8 @@ nothing:
 | the millisecond&rarr;second conversion cannot turn a brief toast into a permanent one | `Adw.Toast:timeout` counts whole seconds and reads back 5 on a default toast; `DEFAULT_TOAST_TIMEOUT` counts 5000 ms. The conversion is `ceil`, asserted against libadwaita's own default rather than against itself — `Math.round(400 / 1000)` is 0, which is "until dismissed" |
 | the spinner's box and its ring are held on the half where each is a node | GTK measures the BOX (`[16, 16]` unrequested, 200 requested, no upper bound); React Native asserts the RING, which on GTK is an `AdwSpinnerPaintable` and not a widget at all — 64 points with an 8-point stroke inside a 200-point box |
 | the rows share libadwaita's derivations rather than re-deriving them | the React Native half runs `@gjsify/adwaita-core` and the GTK half reads the answer back off the real widget: `activatable` false on `Adw.ActionRow` and `BUTTON_ROW_ACTIVATABLE` true on `Adw.ButtonRow`, the `notify` gate that stays SILENT for a set to the value already held on both the switch row and the expander, and `max-length` keeping `'🔒é'` — 2 characters, 3 UTF-16 units — where `TextInput.maxLength` would cut the pair in half |
-| `AdwExpanderRow`: the disclosure is an ALLOCATION, not a flag | the live GTK tree, with animations off: the disclosed row is unmapped at 0×0 and still PARENTED while collapsed, and 596 wide below the header once revealed, with the expander's height equal to its header list plus its revealer to the point (109 = 55 + 54 on libadwaita 1.9.3) |
-| `AdwExpanderRow`: an unechoed toggle survives the next render, on both halves | a second render with the prop unchanged, asserted on each side — the GTK one against the real widget through `@gjsify/gtk-host`'s patch-on-change, the React Native one through `ExpanderState` |
+| `Adw.ExpanderRow`: the disclosure is an ALLOCATION, not a flag | the live GTK tree, with animations off: the disclosed row is unmapped at 0×0 and still PARENTED while collapsed, and 596 wide below the header once revealed, with the expander's height equal to its header list plus its revealer to the point (109 = 55 + 54 on libadwaita 1.9.3) |
+| `Adw.ExpanderRow`: an unechoed toggle survives the next render, on both halves | a second render with the prop unchanged, asserted on each side — the GTK one against the real widget through `@gjsify/gtk-host`'s patch-on-change, the React Native one through `ExpanderState` |
 
 **Not proven: the row THEME.** What the rows lay out is structure — `flexDirection: 'row'`
 is what makes a row a row — and what they do not carry is padding, the type scale, the
@@ -210,7 +218,7 @@ and until then it is a gap, not a formality.
 These are places where the two halves cannot be made identical, written down rather
 than smoothed over.
 
-- **`AdwPreferencesPage` is not a scroller on React Native.** `Adw.PreferencesPage` wraps
+- **`Adw.PreferencesPage` is not a scroller on React Native.** `Adw.PreferencesPage` wraps
   its groups in a `GtkScrolledWindow`; this half emits the column and a consumer wraps it.
   Not a shortcut: `testing/react-native.ts` may only double a React Native component that
   IS a host element with its props forwarded, and `ScrollView` is a COMPOSITE that renders
@@ -218,17 +226,17 @@ than smoothed over.
   A double of it would be a nesting real React Native never emits, and every assertion
   written against it would be about the double — the measured reason `spinner.native.tsx`
   refuses `ActivityIndicator`. The same wrapper carries the page's CLAMP:
-  `adw-preferences-page.ui` puts an `AdwClamp` inside the scrolled window, so a wide window
-  centres the groups at the clamp width while this half stretches them. `AdwClamp` is in
+  `adw-preferences-page.ui` puts an `Adw.Clamp` inside the scrolled window, so a wide window
+  centres the groups at the clamp width while this half stretches them. `Adw.Clamp` is in
   this package, so a consumer that wants both wraps with both.
-- **`AdwPreferencesGroup` has no `header-suffix` and no `separate-rows`.** The first is a
+- **`Adw.PreferencesGroup` has no `header-suffix` and no `separate-rows`.** The first is a
   placement question, not a naming one: `header-suffix` holds a WIDGET, so a React surface
   has to spell it as a slot, and the group's curated descriptor in `@gjsify/gtk-host` is
   `ordered` — `add`/`remove`, `remove-all` to reorder, because `Adw.PreferencesGroup.insert`
   does not exist on libadwaita 1.x — which has no slots at all. Adding one changes a
   placement policy other conformance vectors already assert, with its own measurement. The
   second is pure card styling, and this package's React Native half draws no theme.
-- **`AdwPreferencesGroup`'s `single-line` header state is derived and not drawn.** It is a
+- **`Adw.PreferencesGroup`'s `single-line` header state is derived and not drawn.** It is a
   stylesheet number — `min-height: 34px` against `margin-bottom: 6px` — and there is no
   theme layer here to spend it in. It is computed because it comes out of the same core call
   as the four states that ARE drawn.
@@ -238,12 +246,12 @@ than smoothed over.
   paints the string verbatim and passes `useMarkup: false`, which is the case
   `derivePreferencesGroupHeader` documents that value for, and which both sibling renderers
   pass as well.
-- **`AdwComboRow` has no popover on React Native.** `Adw.ComboRow` opens a `GtkPopover` over
+- **`Adw.ComboRow` has no popover on React Native.** `Adw.ComboRow` opens a `GtkPopover` over
   a `GtkListView`; a row with no overlay layer cannot. The press advances to the next option
   and wraps, which still runs the real `ComboState.select` guard — bounds and
   no-op-on-same — so the arithmetic underneath is the shipped one and only the gesture is
   this half's own.
-- **`AdwComboRow`'s `useSubtitle` publishes the value at once on React Native and on the
+- **`Adw.ComboRow`'s `useSubtitle` publishes the value at once on React Native and on the
   next selection change on GTK.** What both halves DO agree on is that the value is drawn in
   one place: `adw-combo-row.ui` binds the inline value view's `visible` to `use-subtitle`
   with `sync-create|invert-boolean`, and this half hides its trailing label the same way.
@@ -254,14 +262,14 @@ than smoothed over.
   `use-subtitle` on and is replaced by the next selection change. Measured on libadwaita
   1.9.3 and asserted on both halves. Reproducing the lag here would mean carrying a
   libadwaita ordering artefact into a renderer that has no reason for it.
-- **`AdwSpinRow`'s range is spelled `lower`/`upper`/`stepIncrement`, where the two sibling
+- **`Adw.SpinRow`'s range is spelled `lower`/`upper`/`stepIncrement`, where the two sibling
   Adwaita renderers spell it `min`/`max`/`step`.** Those are
   `adw_spin_row_new_with_range`'s PARAMETER names; these are `Gtk.Adjustment`'s own GObject
   property names for the same three values, and this package's rule is that a caller writes
   the property they would look up in libadwaita's documentation. The arithmetic is still
   shared — both halves map onto `@gjsify/adwaita-core`'s `SpinState`, which uses the short
   names internally.
-- **`AdwSpinRow`'s decimal separator is the process locale's on GTK and always `.` on React
+- **`Adw.SpinRow`'s decimal separator is the process locale's on GTK and always `.` on React
   Native.** `gtk_spin_button_update` formats the displayed value through the C library's
   locale — measured on gjs 1.88.1 under a de_DE locale, a `digits={2}` row of 3.14159 reads
   `3,14` — while `Number.prototype.toFixed` is specified never to localise and gives `3.14`
@@ -276,18 +284,18 @@ than smoothed over.
   still 100, and `SpinState`'s clamp answers the maximum. `onNotifyValue` therefore reports
   `100, 200, 250` where GTK reports the end state. The settled value is the same on both,
   React batches the renders, and the stream is asserted so that changing it is a decision.
-- **`AdwSpinRow` carries no `climb-rate`, `snap-to-ticks`, `numeric`, `update-policy` or
+- **`Adw.SpinRow` carries no `climb-rate`, `snap-to-ticks`, `numeric`, `update-policy` or
   `wrap`.** Each needs an editable text entry or a key-repeat timer the React Native half
   does not have, so carrying them would mean a property GTK honours and the phone ignores.
   Neither sibling renderer has them either.
-- **`AdwPasswordEntryRow`'s caps-lock indicator is present and can never show.**
+- **`Adw.PasswordEntryRow`'s caps-lock indicator is present and can never show.**
   `indicatorVisible` is `editing && show_indicator`, and `show_indicator` is pushed from
   `!revealed && capsLockOn` — but React Native exposes no keyboard modifier state, and this
   surface carries no prop libadwaita does not have, so nothing can set it. The node stays in
   the tree, hidden, and a test asserts that: "no caps-lock warning" and "no caps-lock
   support" must not be the same picture. `@gjsify/adwaita-nativescript` hit the same wall
   and answered it with a host seam, which is a surface this package does not have.
-- **`AdwPasswordEntryRow` publishes no `revealed`, where both sibling renderers do.**
+- **`Adw.PasswordEntryRow` publishes no `revealed`, where both sibling renderers do.**
   `Adw.PasswordEntryRow` declares no property of its own — its generated prop interface is
   empty over `AdwEntryRowProps` — and the peek state is private to the widget. A `revealed`
   prop would be the one place this surface invents a name; the button owns it on both halves.
@@ -300,13 +308,13 @@ than smoothed over.
   shared fallback. The accessible NAMES beside them do come from the core, so
   "Show Password"/"Hide Password"/"Apply"/"Caps Lock is on" are one string in one place
   across three renderers.
-- **`AdwClamp` ignores the child's intrinsic minimum on React Native.** libadwaita's
+- **`Adw.Clamp` ignores the child's intrinsic minimum on React Native.** libadwaita's
   clamp is a two-pass measure-then-allocate, and a child minimum wider than the clamp
   RAISES all three thresholds — which is how such a child still gets its minimum
   instead of being cut off. React Native has no such pass: `onLayout` reports a size
   after layout and never the child's intrinsic minimum. So `childMin`/`childNat` are
   passed as 0, and a child wider than the clamp is compressed here and is not on GTK.
-- **`AdwClamp`'s `small`/`medium`/`large` size class is not carried.** libadwaita stamps
+- **`Adw.Clamp`'s `small`/`medium`/`large` size class is not carried.** libadwaita stamps
   it on the child as a style class; React Native has no class system to stamp it into,
   and inventing a styling seam is a decision this slice does not make.
 - **One unclamped frame.** Before the first `onLayout` there is no available width, so
@@ -318,30 +326,30 @@ than smoothed over.
   such limit and renders both. Both behaviours are pinned by a test on each side, so
   neither can move alone. Refusing more than one child on both halves would close it and
   is a surface decision this slice does not make.
-- **`AdwHeaderBar` resolves an unauthored title on GTK and leaves it blank on a phone.**
+- **`Adw.HeaderBar` resolves an unauthored title on GTK and leaves it blank on a phone.**
   Authoring neither `title` nor `subtitle` installs no title widget at all, so
   libadwaita's `update_title` (adw-header-bar.c:475) walks navigation page → dialog →
   window → application name and puts what it finds in the centre; a phone has none of
   those to walk. Both sides are asserted — the GTK suite reads the window's own title
   back out of the bar, the React Native suite reads two collapsed labels.
-- **`AdwHeaderBar` has a `title`/`subtitle` that `Adw.HeaderBar` does not.** The real
+- **`Adw.HeaderBar` has a `title`/`subtitle` that `Adw.HeaderBar` does not.** The real
   widget has no `title` property; its derived centre is a plain `gtk_label_new (NULL)`
-  with no subtitle at all, and an app that wants one sets an `AdwWindowTitle` as its
+  with no subtitle at all, and an app that wants one sets an `Adw.WindowTitle` as its
   title widget. A declarative surface wants the attribute, so authoring either installs
-  an `AdwWindowTitle` centre. This is the same divergence `@gjsify/adwaita-web` and
+  an `Adw.WindowTitle` centre. This is the same divergence `@gjsify/adwaita-web` and
   `@gjsify/adwaita-nativescript` carry, recorded as `HeaderBarRenderState.derivedSubtitle`
   in `@gjsify/adwaita-core`.
 - **Neither renderer here resolves an icon theme, so `iconName` is accepted and not
   drawn.** `icon-name` names an entry in an ICON THEME and React Native has none — no
   `Image` source a GNOME symbolic name resolves to, and no renderer for the SVG
   `@gjsify/adwaita-nativescript` substituted instead. Drawing the name as text would put
-  the literal `folder-symbolic` on screen. So `AdwStatusPage` shows no icon, `AdwAvatar`'s
+  the literal `folder-symbolic` on screen. So `Adw.StatusPage` shows no icon, `Adw.Avatar`'s
   icon mode is a coloured circle with the initials hidden where GTK draws
-  `adw-avatar-default-symbolic`, and `AdwButtonContent`'s icon slot sits in the row with
+  `adw-avatar-default-symbolic`, and `Adw.ButtonContent`'s icon slot sits in the row with
   libadwaita's own `hexpand` and holds no glyph. The props are carried so a GTK consumer's
   props stay portable, and the ABSENCE of an icon node is asserted in each case, so the
   day one appears it is a decision and not a drift.
-- **`AdwToolbarView` does not run libadwaita's allocation on React Native, and cannot.**
+- **`Adw.ToolbarView` does not run libadwaita's allocation on React Native, and cannot.**
   `adw_toolbar_view_size_allocate` is two chained CLAMPs over the bars' MINIMUM and
   NATURAL heights — ported as `toolbarViewAllocate` and held to vectors — and React
   Native hands a component an already-laid-out size and never a child's intrinsic
@@ -349,40 +357,40 @@ than smoothed over.
   the identity and dress a pass-through up as libadwaita's arithmetic. The consequence is
   one-directional: a STRETCHY bar keeps its natural height where libadwaita would shrink
   it toward its minimum to protect the content.
-- **`AdwToolbarView`'s four style classes have nowhere to land on a phone.** `raised`,
+- **`Adw.ToolbarView`'s four style classes have nowhere to land on a phone.** `raised`,
   `border`, `undershoot-top` and `undershoot-bottom` are what `topBarStyle` and
   `bottomBarStyle` derive; React Native has no class system to stamp them into. Both
   props are carried and reach no style, which is asserted on the React Native side and
   measured against libadwaita's own `update_undershoots` on the GTK side.
-- **`AdwWrapBox`'s `naturalLineLength` is a MAX SIZE on React Native.** libadwaita caps
+- **`Adw.WrapBox`'s `naturalLineLength` is a MAX SIZE on React Native.** libadwaita caps
   the box's NATURAL size REQUEST and leaves a larger allocation free to happen; neither
   CSS nor Yoga has a property that caps only the intrinsic contribution, so this half
   writes `maxWidth`/`maxHeight`. `@gjsify/adwaita-web` records the same deliberate
   deviation. Limiting line length inside a popover — the intended use — behaves the same
   either way.
-- **`AdwWrapBox` wraps every child in a `View` of its own.** `flex-grow` and `flex-shrink`
+- **`Adw.WrapBox` wraps every child in a `View` of its own.** `flex-grow` and `flex-shrink`
   belong to the CHILD, and this component does not own its children's styles:
   NativeScript sets them as attached properties and the browser publishes a custom
   property its stylesheet reads, and neither seam exists here. The wrapper is therefore
   visible in the tree and is asserted rather than left as an implementation detail.
-- **`AdwWrapBox`'s `align` is snapped to three positions on both non-GTK renderers.** C
+- **`Adw.WrapBox`'s `align` is snapped to three positions on both non-GTK renderers.** C
   offsets the whole line block by `roundf (length_delta * align)` — a continuum — and
   flexbox has `flex-start`, `center` and `flex-end`. The snap is the renderers'
   approximation and not libadwaita's rule, which is why it lives in
   `@gjsify/adwaita-core`'s `wrapBoxFlexStyle` rather than in a conformance vector. The
   GTK half runs none of it: `Adw.WrapBox` is `adw-wrap-layout.c` itself, and the suite
   reads the continuum back off the live tree.
-- **`AdwAvatar`'s font size is the CAP, not a measurement.** `update_font_size` scales
+- **`Adw.Avatar`'s font size is the CAP, not a measurement.** `update_font_size` scales
   the label's measured aspect ratio against `avatarMaxFontSize(size)`; React Native
   reports a text box only through `onLayout`, i.e. after layout — the same missing
-  measure pass that makes `AdwClamp` pass `childMin: 0`. Using the cap alone stays inside
+  measure pass that makes `Adw.Clamp` pass `childMin: 0`. Using the cap alone stays inside
   libadwaita's bound. The NativeScript port's `size * 0.4` heuristic is deliberately not
   copied: it is not monotonic in `size` and exceeds the cap above ~54 points.
-- **`AdwButtonContent` cannot stamp `image-text-button`.** `adw_button_content_root` puts
+- **`Adw.ButtonContent` cannot stamp `image-text-button`.** `adw_button_content_root` puts
   the class on the nearest `GtkButton` ancestor, and this package ships no button for it
   to find. `buttonContentStyleTargetIndex` holds the retarget rule for a renderer that has
   a tree to walk; when a button lands here, that is the call to make.
-- **`AdwSpinner` draws the track and not the arc.** `AdwSpinnerPaintable`'s segment
+- **`Adw.Spinner` draws the track and not the arc.** `AdwSpinnerPaintable`'s segment
   extends, overlaps, contracts and idles on an ease-in-out-sine while the whole figure
   turns, and drawing it needs a path renderer that is not a dependency of this package.
   What is drawn is the circle underneath — `ADW_SPINNER_TRACK_OPACITY` of the current
@@ -400,7 +408,7 @@ than smoothed over.
   `adw_toast_overlay_dismiss_all` animates the strip out over real time, and pumping the
   main context for ~1.6s leaves the `AdwToastWidget` in place — measured. GTK asserts that
   the call lands and costs no diagnostic; the removal is asserted where the queue is ours.
-- **`AdwBanner` reduces markup to its plain text.** React Native has no inline-markup
+- **`Adw.Banner` reduces markup to its plain text.** React Native has no inline-markup
   layer, and painting `<b>Metered</b>` literally is further from what GTK draws than
   painting `Metered` is. Unparseable markup keeps the raw string, which is Pango's own
   fallback.
@@ -425,7 +433,7 @@ than smoothed over.
   Native has no slot mechanism, and giving the surface a `prefix` PROP taking a node would
   be a second child channel that only one half implements, so the surface offers `children`
   only — the suffix on the action row, the disclosure on the expander.
-- **`AdwExpanderRow` carries no `enable-expansion` and no `show-enable-switch`.** The
+- **`Adw.ExpanderRow` carries no `enable-expansion` and no `show-enable-switch`.** The
   enable switch is a SECOND control inside the row with its own veto over the disclosure,
   and the rule tying the two flags together lives in no shared place:
   `@gjsify/adwaita-core`'s `ExpanderState` — what all three renderers compose — models the
@@ -438,11 +446,11 @@ than smoothed over.
   libadwaita 1.9.3, a `Gtk.Label` disclosed child leaks on unmount behind a single
   `Gtk-WARNING`, an `Adw.ActionRow` round-trips cleanly. The curated descriptor carries the
   measurement. A React Native `View` has no such rule.
-- **`AdwEntryRow`'s empty↔filled cross-fade is a hard swap.** libadwaita animates between
+- **`Adw.EntryRow`'s empty↔filled cross-fade is a hard swap.** libadwaita animates between
   the placeholder and the floating title over its own duration; the React Native half
   switches at the two endpoints, the same compromise `@gjsify/adwaita-nativescript` makes,
   because a cross-fade needs an animation seam this slice does not add.
-- **`AdwSwitchRow` is strictly controlled and `Adw.SwitchRow` is not.** React Native's own
+- **`Adw.SwitchRow` is strictly controlled and `Adw.SwitchRow` is not.** React Native's own
   contract for `Switch` is that the component renders the `value` prop whatever the user
   does, so a toggle the consumer declines to echo back is not kept here — where GTK keeps
   it. The other two stateful rows go the GTK way (see [Widgets](#widgets)); this one goes
@@ -472,7 +480,7 @@ than smoothed over.
   the sidebar can take its full share of a view too narrow for both panes, and the view
   cannot refuse to be narrower than its contents the way GTK does (the GTK suite asserts
   that refusal at 380 against `measureSplitViewHorizontal`; the React Native suite cannot
-  ask). Same class as `AdwClamp`'s `childMin`.
+  ask). Same class as `Adw.Clamp`'s `childMin`.
 - **The two sidebar-width rules can only be told apart one at a time on GTK.**
   `resolveNavigationSidebarWidth` caps the sidebar's MAX BOUND by `width - content_min`
   and `resolveOverlaySidebarWidth` caps the RESULT, which the core's own vectors separate
@@ -504,7 +512,7 @@ than smoothed over.
   differs is the push/pop DIRECTION, which a renderer spends on a slide and this one has
   none of. The position IS asserted where it is observable: the docked draw order.
 - **`sidebarTitle` and `contentTitle` reach a real page on GTK and nothing on a phone.**
-  They are `Adw.NavigationPage:title` of the wrap `AdwNavigationSplitView` puts around each
+  They are `Adw.NavigationPage:title` of the wrap `Adw.NavigationSplitView` puts around each
   pane, which libadwaita uses for the header of a collapsed view. The React Native half has
   no header bar to put a title in, so it carries them and draws neither — the same shape as
   `iconName`.
@@ -527,7 +535,7 @@ than smoothed over.
   would be read off (measured — the GTK half used to report `''` there, a name no page
   carries), and on the other half the core's auto-pick lands before the subscription
   exists. Both halves are asserted at the two ends of that.
-- **`AdwViewSwitcher` bundles the stack libadwaita keeps separate.** `Adw.ViewSwitcher:stack`
+- **`Adw.ViewSwitcher` bundles the stack libadwaita keeps separate.** `Adw.ViewSwitcher:stack`
   points at an `Adw.ViewStack` elsewhere in the tree, and a React prop cannot hold a widget
   that does not exist yet on the half where widgets exist at all. Both other renderers made
   the same call. On GTK nothing is simulated: the component builds a real `Adw.ViewStack`

--- a/packages/framework/adwaita-react-native/src/index.gtk.ts
+++ b/packages/framework/adwaita-react-native/src/index.gtk.ts
@@ -44,45 +44,31 @@ export type {
     AdwWrapBoxProps,
 } from './props.js';
 
-export { AdwActionRow } from './widgets/action-row.gtk.js';
-export { AdwAvatar } from './widgets/avatar.gtk.js';
-export { AdwBanner } from './widgets/banner.gtk.js';
-export { AdwBin } from './widgets/bin.gtk.js';
-export { AdwButtonContent } from './widgets/button-content.gtk.js';
-export { AdwButtonRow } from './widgets/button-row.gtk.js';
-export { AdwClamp } from './widgets/clamp.gtk.js';
-export { AdwComboRow } from './widgets/combo-row.gtk.js';
-export { AdwEntryRow } from './widgets/entry-row.gtk.js';
-export { AdwExpanderRow } from './widgets/expander-row.gtk.js';
-export { AdwHeaderBar } from './widgets/header-bar.gtk.js';
-export { AdwNavigationPage } from './widgets/navigation-page.gtk.js';
-export { AdwNavigationSplitView } from './widgets/navigation-split-view.gtk.js';
-export { AdwNavigationView } from './widgets/navigation-view.gtk.js';
-export { AdwOverlaySplitView } from './widgets/overlay-split-view.gtk.js';
-export { AdwPasswordEntryRow } from './widgets/password-entry-row.gtk.js';
-export { AdwPreferencesGroup } from './widgets/preferences-group.gtk.js';
-export { AdwPreferencesPage } from './widgets/preferences-page.gtk.js';
-export { AdwSpinRow } from './widgets/spin-row.gtk.js';
-export { AdwSpinner } from './widgets/spinner.gtk.js';
-export { AdwStatusPage } from './widgets/status-page.gtk.js';
-export { AdwSwitchRow } from './widgets/switch-row.gtk.js';
-export { AdwToastOverlay } from './widgets/toast-overlay.gtk.js';
-export { AdwToolbarView } from './widgets/toolbar-view.gtk.js';
-export { AdwViewStack } from './widgets/view-stack.gtk.js';
-export { AdwViewSwitcher } from './widgets/view-switcher.gtk.js';
-export { AdwWindowTitle } from './widgets/window-title.gtk.js';
-export { AdwWrapBox } from './widgets/wrap-box.gtk.js';
-
-// ADR 0034 clause 2 — the vocabulary is also reachable as a NAMESPACE, not only as
-// prefixed classes. Additive: `AdwBin` keeps working and nothing published moves.
+// THE WIDGETS ARE REACHABLE ONLY AS `Adw.<Name>` (ADR 0034 clause 2 + § Amendment 8).
+// A run of `export { AdwBin } from './widgets/bin.gtk.js'` lines used to sit above this
+// and duplicate every member below one for one. They are gone, and with them the second
+// spelling: `Adw.Bin` is the name this package root has for the widget.
 //
-// The members are imported a second time rather than built from the re-exports above,
-// because those `export … from` lines are load-bearing for two readers:
-// `adwaitaReactNativeWidgets` derives this package's widget set from them, and it
-// refuses a line whose exported name and module name disagree. Collapsing them into
-// `import` + `export {}` would take that coupling away. What keeps the second mention
-// from drifting is rule 8 of `check-adwaita-rn-platform-split.mjs`, which holds the
-// members of `Adw` against the widgets on disk in both directions.
+// THE COMPONENTS KEEP THEIR `AdwBin` IDENTIFIER, and that is not the spelling that was
+// removed. `widgets/bin.ts` declares it, `exports['./widgets/bin']` publishes it, and
+// `refuseBaseModule` prints it — at that entry point it is the widget's ONLY name, the
+// same reason `@gjsify/adwaita-web` kept `class GtkEntry` while dropping the flat export
+// (§ Amendment 6). What a bare `Bin` would gain in a consumer's file is nothing; what it
+// would cost is the module-name coupling three readers derive through `widgetClass`.
+//
+// THE IMPORT LINES BELOW ARE NOW THE SINGLE MENTION of each widget, so they carry the
+// coupling the removed exports used to: `adwaitaReactNativeWidgets` derives this
+// package's widget set from them and refuses a line whose binding, alias and module name
+// disagree, and rule 8 of `check-adwaita-rn-platform-split.mjs` holds the members of
+// `Adw` against the widgets on disk in both directions. Rule 10 is what stops the flat
+// spelling from growing back beside them.
+//
+// AN OBJECT LITERAL, not `export * as Adw from './namespace/adw.js'` — the shape
+// `@gjsify/adwaita-web` had to take. A module namespace buys the TYPE meaning of its
+// members, which that surface needs because its classes are annotated (`as Adw.Window`).
+// These are function components, annotated through the `Adw…Props` types above, so value
+// position is the whole requirement here. And a namespace module per barrel would move
+// the platform fork one hop away from the file that rules 3 and 5 read.
 
 import { AdwActionRow as ActionRow } from './widgets/action-row.gtk.js';
 import { AdwAvatar as Avatar } from './widgets/avatar.gtk.js';

--- a/packages/framework/adwaita-react-native/src/index.native.ts
+++ b/packages/framework/adwaita-react-native/src/index.native.ts
@@ -42,45 +42,31 @@ export type {
     AdwWrapBoxProps,
 } from './props.js';
 
-export { AdwActionRow } from './widgets/action-row.native.js';
-export { AdwAvatar } from './widgets/avatar.native.js';
-export { AdwBanner } from './widgets/banner.native.js';
-export { AdwBin } from './widgets/bin.native.js';
-export { AdwButtonContent } from './widgets/button-content.native.js';
-export { AdwButtonRow } from './widgets/button-row.native.js';
-export { AdwClamp } from './widgets/clamp.native.js';
-export { AdwComboRow } from './widgets/combo-row.native.js';
-export { AdwEntryRow } from './widgets/entry-row.native.js';
-export { AdwExpanderRow } from './widgets/expander-row.native.js';
-export { AdwHeaderBar } from './widgets/header-bar.native.js';
-export { AdwNavigationPage } from './widgets/navigation-page.native.js';
-export { AdwNavigationSplitView } from './widgets/navigation-split-view.native.js';
-export { AdwNavigationView } from './widgets/navigation-view.native.js';
-export { AdwOverlaySplitView } from './widgets/overlay-split-view.native.js';
-export { AdwPasswordEntryRow } from './widgets/password-entry-row.native.js';
-export { AdwPreferencesGroup } from './widgets/preferences-group.native.js';
-export { AdwPreferencesPage } from './widgets/preferences-page.native.js';
-export { AdwSpinRow } from './widgets/spin-row.native.js';
-export { AdwSpinner } from './widgets/spinner.native.js';
-export { AdwStatusPage } from './widgets/status-page.native.js';
-export { AdwSwitchRow } from './widgets/switch-row.native.js';
-export { AdwToastOverlay } from './widgets/toast-overlay.native.js';
-export { AdwToolbarView } from './widgets/toolbar-view.native.js';
-export { AdwViewStack } from './widgets/view-stack.native.js';
-export { AdwViewSwitcher } from './widgets/view-switcher.native.js';
-export { AdwWindowTitle } from './widgets/window-title.native.js';
-export { AdwWrapBox } from './widgets/wrap-box.native.js';
-
-// ADR 0034 clause 2 — the vocabulary is also reachable as a NAMESPACE, not only as
-// prefixed classes. Additive: `AdwBin` keeps working and nothing published moves.
+// THE WIDGETS ARE REACHABLE ONLY AS `Adw.<Name>` (ADR 0034 clause 2 + § Amendment 8).
+// A run of `export { AdwBin } from './widgets/bin.native.js'` lines used to sit above this
+// and duplicate every member below one for one. They are gone, and with them the second
+// spelling: `Adw.Bin` is the name this package root has for the widget.
 //
-// The members are imported a second time rather than built from the re-exports above,
-// because those `export … from` lines are load-bearing for two readers:
-// `adwaitaReactNativeWidgets` derives this package's widget set from them, and it
-// refuses a line whose exported name and module name disagree. Collapsing them into
-// `import` + `export {}` would take that coupling away. What keeps the second mention
-// from drifting is rule 8 of `check-adwaita-rn-platform-split.mjs`, which holds the
-// members of `Adw` against the widgets on disk in both directions.
+// THE COMPONENTS KEEP THEIR `AdwBin` IDENTIFIER, and that is not the spelling that was
+// removed. `widgets/bin.ts` declares it, `exports['./widgets/bin']` publishes it, and
+// `refuseBaseModule` prints it — at that entry point it is the widget's ONLY name, the
+// same reason `@gjsify/adwaita-web` kept `class GtkEntry` while dropping the flat export
+// (§ Amendment 6). What a bare `Bin` would gain in a consumer's file is nothing; what it
+// would cost is the module-name coupling three readers derive through `widgetClass`.
+//
+// THE IMPORT LINES BELOW ARE NOW THE SINGLE MENTION of each widget, so they carry the
+// coupling the removed exports used to: `adwaitaReactNativeWidgets` derives this
+// package's widget set from them and refuses a line whose binding, alias and module name
+// disagree, and rule 8 of `check-adwaita-rn-platform-split.mjs` holds the members of
+// `Adw` against the widgets on disk in both directions. Rule 10 is what stops the flat
+// spelling from growing back beside them.
+//
+// AN OBJECT LITERAL, not `export * as Adw from './namespace/adw.js'` — the shape
+// `@gjsify/adwaita-web` had to take. A module namespace buys the TYPE meaning of its
+// members, which that surface needs because its classes are annotated (`as Adw.Window`).
+// These are function components, annotated through the `Adw…Props` types above, so value
+// position is the whole requirement here. And a namespace module per barrel would move
+// the platform fork one hop away from the file that rules 3 and 5 read.
 
 import { AdwActionRow as ActionRow } from './widgets/action-row.native.js';
 import { AdwAvatar as Avatar } from './widgets/avatar.native.js';

--- a/packages/framework/adwaita-react-native/src/index.ts
+++ b/packages/framework/adwaita-react-native/src/index.ts
@@ -1,7 +1,7 @@
 // The BASE barrel — what a tool that ignores `exports` loads through `module`/`main`.
 // Everything it names refuses at first render; who reaches it is in `refuse.ts`.
 //
-// IT RE-EXPORTS THE BASE MODULES, NEVER A PLATFORM SIBLING: a sibling named here would
+// IT NAMES THE BASE MODULES, NEVER A PLATFORM SIBLING: a sibling named here would
 // RUN on the wrong half as a working worse copy of the widget, which is why
 // `scripts/check-adwaita-rn-platform-split.mjs` rule 3 refuses one.
 //
@@ -46,45 +46,31 @@ export type {
     AdwWrapBoxProps,
 } from './props.js';
 
-export { AdwActionRow } from './widgets/action-row.js';
-export { AdwAvatar } from './widgets/avatar.js';
-export { AdwBanner } from './widgets/banner.js';
-export { AdwBin } from './widgets/bin.js';
-export { AdwButtonContent } from './widgets/button-content.js';
-export { AdwButtonRow } from './widgets/button-row.js';
-export { AdwClamp } from './widgets/clamp.js';
-export { AdwComboRow } from './widgets/combo-row.js';
-export { AdwEntryRow } from './widgets/entry-row.js';
-export { AdwExpanderRow } from './widgets/expander-row.js';
-export { AdwHeaderBar } from './widgets/header-bar.js';
-export { AdwNavigationPage } from './widgets/navigation-page.js';
-export { AdwNavigationSplitView } from './widgets/navigation-split-view.js';
-export { AdwNavigationView } from './widgets/navigation-view.js';
-export { AdwOverlaySplitView } from './widgets/overlay-split-view.js';
-export { AdwPasswordEntryRow } from './widgets/password-entry-row.js';
-export { AdwPreferencesGroup } from './widgets/preferences-group.js';
-export { AdwPreferencesPage } from './widgets/preferences-page.js';
-export { AdwSpinRow } from './widgets/spin-row.js';
-export { AdwSpinner } from './widgets/spinner.js';
-export { AdwStatusPage } from './widgets/status-page.js';
-export { AdwSwitchRow } from './widgets/switch-row.js';
-export { AdwToastOverlay } from './widgets/toast-overlay.js';
-export { AdwToolbarView } from './widgets/toolbar-view.js';
-export { AdwViewStack } from './widgets/view-stack.js';
-export { AdwViewSwitcher } from './widgets/view-switcher.js';
-export { AdwWindowTitle } from './widgets/window-title.js';
-export { AdwWrapBox } from './widgets/wrap-box.js';
-
-// ADR 0034 clause 2 — the vocabulary is also reachable as a NAMESPACE, not only as
-// prefixed classes. Additive: `AdwBin` keeps working and nothing published moves.
+// THE WIDGETS ARE REACHABLE ONLY AS `Adw.<Name>` (ADR 0034 clause 2 + § Amendment 8).
+// A run of `export { AdwBin } from './widgets/bin.js'` lines used to sit above this
+// and duplicate every member below one for one. They are gone, and with them the second
+// spelling: `Adw.Bin` is the name this package root has for the widget.
 //
-// The members are imported a second time rather than built from the re-exports above,
-// because those `export … from` lines are load-bearing for two readers:
-// `adwaitaReactNativeWidgets` derives this package's widget set from them, and it
-// refuses a line whose exported name and module name disagree. Collapsing them into
-// `import` + `export {}` would take that coupling away. What keeps the second mention
-// from drifting is rule 8 of `check-adwaita-rn-platform-split.mjs`, which holds the
-// members of `Adw` against the widgets on disk in both directions.
+// THE COMPONENTS KEEP THEIR `AdwBin` IDENTIFIER, and that is not the spelling that was
+// removed. `widgets/bin.ts` declares it, `exports['./widgets/bin']` publishes it, and
+// `refuseBaseModule` prints it — at that entry point it is the widget's ONLY name, the
+// same reason `@gjsify/adwaita-web` kept `class GtkEntry` while dropping the flat export
+// (§ Amendment 6). What a bare `Bin` would gain in a consumer's file is nothing; what it
+// would cost is the module-name coupling three readers derive through `widgetClass`.
+//
+// THE IMPORT LINES BELOW ARE NOW THE SINGLE MENTION of each widget, so they carry the
+// coupling the removed exports used to: `adwaitaReactNativeWidgets` derives this
+// package's widget set from them and refuses a line whose binding, alias and module name
+// disagree, and rule 8 of `check-adwaita-rn-platform-split.mjs` holds the members of
+// `Adw` against the widgets on disk in both directions. Rule 10 is what stops the flat
+// spelling from growing back beside them.
+//
+// AN OBJECT LITERAL, not `export * as Adw from './namespace/adw.js'` — the shape
+// `@gjsify/adwaita-web` had to take. A module namespace buys the TYPE meaning of its
+// members, which that surface needs because its classes are annotated (`as Adw.Window`).
+// These are function components, annotated through the `Adw…Props` types above, so value
+// position is the whole requirement here. And a namespace module per barrel would move
+// the platform fork one hop away from the file that rules 3 and 5 read.
 
 import { AdwActionRow as ActionRow } from './widgets/action-row.js';
 import { AdwAvatar as Avatar } from './widgets/avatar.js';

--- a/packages/framework/adwaita-react-native/src/parity.spec.ts
+++ b/packages/framework/adwaita-react-native/src/parity.spec.ts
@@ -473,7 +473,7 @@ export default async () => {
     await describe('the base modules refuse', async () => {
         // THIS TESTS THE REFUSAL, NOT THE REACHING OF IT, and the reason is a
         // measurement that also narrowed the design's claim about who reaches it
-        // (`refuse.ts`). `import { AdwClamp } from './index.js'` inside this package
+        // (`refuse.ts`). `import { Adw } from './index.js'` inside this package
         // does NOT load the base barrel in any gjsify build: `platform-resolve`
         // rewrites the specifier to `./index.gtk.js` before the bundler sees it, for a
         // relative import exactly as for one from `node_modules`. Written the obvious

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -789,8 +789,22 @@ export function adwaitaNativeScriptWidgets(root) {
 /** The React Native surface: one barrel, and the base module each widget lives in. */
 export const ADWAITA_RN_SRC = 'packages/framework/adwaita-react-native/src';
 
-/** `export { AdwClamp } from './widgets/clamp.js';` — the only shape the barrel uses. */
-const RN_BARREL_EXPORT = /export\s*\{\s*(Adw[A-Za-z0-9]*)\s*\}\s*from\s*'\.\/widgets\/([a-z0-9-]+)\.js'/g;
+/**
+ * `import { AdwClamp as Clamp } from './widgets/clamp.js';` — the only shape the barrel
+ * uses, and since ADR 0034 § Amendment 8 the ONLY mention each widget gets there.
+ *
+ * It USED to be `export { AdwClamp } from './widgets/clamp.js'`, read beside an import
+ * line that duplicated it. The flat re-exports are gone with the second spelling, so the
+ * coupling this reader needs moved onto the line that stayed — which carries one more
+ * half than the old one did, the namespace member, and is held on all three.
+ *
+ * THE TRAILING COMMA IS OPTIONAL AND THAT IS NOT COSMETIC. oxfmt writes one as soon as an
+ * import wraps, so a regex without it drops the longest-named widget of the set on the day
+ * the file is reformatted — silently, because a shorter widget set is a set nothing counts.
+ * Found by a vector, not by the tree: nothing in the barrel has wrapped yet.
+ */
+const RN_NAMESPACE_IMPORT =
+    /import\s*\{\s*(Adw[A-Za-z0-9]*)\s+as\s+([A-Za-z0-9]*)\s*,?\s*\}\s*from\s*'\.\/widgets\/([a-z0-9-]+)\.js'/g;
 
 /**
  * Every widget `@gjsify/adwaita-react-native` ships → its repo-relative base module.
@@ -798,51 +812,89 @@ const RN_BARREL_EXPORT = /export\s*\{\s*(Adw[A-Za-z0-9]*)\s*\}\s*from\s*'\.\/wid
  * A THIRD naming convention, because the package has neither of the other two: no
  * `customElements.define`, and its modules are `clamp.ts` rather than `adw-clamp.ts`
  * (the `Adw` lives in the exported component, and the platform split puts
- * `clamp.gtk.tsx` beside it). So the widget set is the BASE BARREL's export list,
- * which is also what `exports['.']` resolves for a condition-blind tool and what
- * `check-adwaita-rn-platform-split.mjs` rule 5 already holds for completeness.
+ * `clamp.gtk.tsx` beside it). So the widget set is the BASE BARREL's namespace import
+ * list, which is what `exports['.']` resolves for a condition-blind tool and what
+ * `check-adwaita-rn-platform-split.mjs` rules 5 and 8 already hold for completeness.
  *
- * The class name is held against the module name the same way the other two readers
- * hold theirs: `export { AdwClamp } from './widgets/bin.js'` is refused rather than
- * recorded, because a widget under a name its module does not promise drops out of
- * every set derived from here with nothing failing.
+ * BOTH HALVES OF THE LINE ARE HELD against the module name, the same way the other two
+ * readers hold theirs: `import { AdwClamp as Clamp } from './widgets/bin.js'` is refused
+ * rather than recorded, and so is `import { AdwBin as Clamp } from './widgets/bin.js'`.
+ * A widget under a name its module does not promise drops out of every set derived from
+ * here with nothing failing, and the alias is now the name the package publishes.
  *
  * @param {string} root repository root
  * @returns {Map<string, string>} bare widget name → repo-relative base module
  */
 export function adwaitaReactNativeWidgets(root) {
     const barrel = join(root, ADWAITA_RN_SRC, 'index.ts');
-    const text = stripComments(readFileSync(barrel, 'utf8'));
+    const modules = reactNativeBarrelWidgets(stripComments(readFileSync(barrel, 'utf8')), `${ADWAITA_RN_SRC}/index.ts`);
     /** @type {Map<string, string>} */
     const widgets = new Map();
-    for (const [, exported, module] of text.matchAll(RN_BARREL_EXPORT)) {
-        const expected = widgetClass(module);
-        if (exported !== expected) {
-            throw new Error(
-                `${ADWAITA_RN_SRC}/index.ts exports ${exported} from ./widgets/${module}.js, not ${expected}. ` +
-                    'A widget and its module are renamed together or not at all: rename one alone and the ' +
-                    'widget leaves the set this reader feeds with no gate failing.',
-            );
-        }
+    for (const module of modules) {
         const source = resolveLocalSource(barrel, `./widgets/${module}.js`);
         if (source === null) {
             throw new Error(
-                `${ADWAITA_RN_SRC}/index.ts exports ${exported} from ./widgets/${module}.js, which resolves ` +
-                    'to no source file. The barrel names the type authority for both platform halves, so a ' +
-                    'specifier with nothing behind it is a widget nothing can read.',
+                `${ADWAITA_RN_SRC}/index.ts binds ${widgetClass(module)} from ./widgets/${module}.js, which ` +
+                    'resolves to no source file. The barrel names the type authority for both platform halves, ' +
+                    'so a specifier with nothing behind it is a widget nothing can read.',
             );
         }
         widgets.set(module, toPosixPath(relative(root, source)));
     }
+    return new Map([...widgets].sort(([a], [b]) => a.localeCompare(b)));
+}
 
-    if (widgets.size === 0) {
+/**
+ * The widget MODULES a React Native barrel names, from source and nothing else.
+ *
+ * Split out of {@link adwaitaReactNativeWidgets} so the parse can be held by vectors
+ * without a tree on disk, which it needs more than it did before ADR 0034 § Amendment 8:
+ * the reader used to have a second mention of every widget to disagree with, and now it
+ * has one. An under-reading regex here does not go loud — it hands every consumer a
+ * SHORTER widget set, and a table compared against a shorter set agrees with it. That is
+ * the "scan that is merely narrower than it reads" § Amendment 6 found in two browser
+ * drivers, arriving where nothing counts what was skipped.
+ *
+ * A FLAT `export { AdwClamp } from './widgets/clamp.js'` IS NOT A MEMBER, deliberately.
+ * It is the spelling § Amendment 8 removed, and a reader that still accepted it would let
+ * the second vocabulary back in without anything going red — which is why the vector for
+ * it wants a throw rather than a widget.
+ *
+ * @param {string} code already-comment-stripped barrel source
+ * @param {string} where the barrel's repo-relative path, for the throws
+ * @returns {string[]} bare widget module names, sorted
+ */
+export function reactNativeBarrelWidgets(code, where) {
+    /** @type {Set<string>} */
+    const modules = new Set();
+    for (const [, bound, member, module] of code.matchAll(RN_NAMESPACE_IMPORT)) {
+        const expected = widgetClass(module);
+        if (bound !== expected) {
+            throw new Error(
+                `${where} binds ${bound} from ./widgets/${module}.js, not ${expected}. ` +
+                    'A widget and its module are renamed together or not at all: rename one alone and the ' +
+                    'widget leaves the set this reader feeds with no gate failing.',
+            );
+        }
+        const expectedMember = pascalCase(module);
+        if (member !== expectedMember) {
+            throw new Error(
+                `${where} names ${expected} \`Adw.${member}\`, not \`Adw.${expectedMember}\`. ` +
+                    'Since the flat exports went, the member IS the name this package publishes the widget ' +
+                    'under, so a member its module name does not promise is a widget nothing here can find.',
+            );
+        }
+        modules.add(module);
+    }
+
+    if (modules.size === 0) {
         throw new Error(
-            `no \`export { Adw… } from './widgets/…'\` line in ${ADWAITA_RN_SRC}/index.ts. ` +
-                'Either the barrel moved or its export shape changed — a scan that finds nothing ' +
+            `no \`import { Adw… as … } from './widgets/…'\` line in ${where}. ` +
+                'Either the barrel moved or its import shape changed — a scan that finds nothing ' +
                 'passes vacuously, so this is a failure, not a pass.',
         );
     }
-    return new Map([...widgets].sort(([a], [b]) => a.localeCompare(b)));
+    return [...modules].sort((a, b) => a.localeCompare(b));
 }
 
 /** The two GIR namespaces clause 2 is satisfied by. Nothing else is a namespace here. */

--- a/scripts/check-adwaita-rn-platform-split.mjs
+++ b/scripts/check-adwaita-rn-platform-split.mjs
@@ -44,7 +44,7 @@
 // real one. No import error, no type error, no failing test; a window that is subtly
 // wrong. Hence rule 3 below: a base module refuses, and may not re-export a sibling.
 //
-// WHAT IT CHECKS — nine rules, each falsified in both directions before landing:
+// WHAT IT CHECKS — ten rules, each falsified in both directions before landing:
 //
 //   1. Every widget has all three modules (base, `.gtk.tsx`, `.native.tsx`), and no
 //      platform module exists without the other two. Both directions, because a
@@ -103,6 +103,15 @@
 //      the specifier `react-native` is ALIASED onto `@gjsify/react-native` there, so a
 //      `.gtk` module importing it runs — as the working worse copy this whole file is
 //      about. The pragma proves the JSX runtime; only this proves the module graph.
+//  10. No barrel exports a widget CLASS flat. ADR 0034 § Amendment 8 removed the run of
+//      `export { AdwClamp } from './widgets/clamp.js'` lines from all three barrels, so
+//      `Adw.Clamp` is the only name the package root has for the widget. Rule 8 holds
+//      the namespace and would not notice a flat export returning BESIDE it — that is
+//      the shape the removal was reversing, and it is one line to write and invisible in
+//      review. The widget's own `AdwClamp` identifier is untouched: `widgets/clamp.ts`
+//      declares it, `exports['./widgets/clamp']` publishes it, `refuseBaseModule` prints
+//      it, and at that entry point it is the widget's ONLY name. This rule is about the
+//      three barrels and nothing else.
 //
 // A SCOPE THAT FINDS NOTHING IS A FAILURE. Zero widgets means a renamed directory or a
 // reader that stopped matching, and printing OK over a tree nothing looked at is the
@@ -181,6 +190,27 @@ const read = (path) => readFileSync(path, 'utf8');
  * under-detects, which is the same failure pointing the other way.
  */
 function moduleSpecifiers(source) {
+    const code = withoutComments(source);
+    const specifiers = new Set();
+    // The backtick is in the class because `import(`./clamp.native.js`)` is a legal
+    // specifier and was NOT read by the first version — measured: a base module reaching
+    // its sibling that way passed rule 3 at exit 0. A reader that under-detects is worse
+    // than no reader, because the rule it fronts for reads as enforced.
+    for (const match of code.matchAll(/(?:\bfrom|\bimport)\s*\(?\s*(['"`])([^'"`]+)\1/g)) {
+        specifiers.add(match[2]);
+    }
+    return specifiers;
+}
+
+/**
+ * `source` with comments removed and string literals kept, string-aware.
+ *
+ * Its own function because rule 10 needs the same view of a barrel that
+ * {@link moduleSpecifiers} does, and the two must not disagree about what code is: a
+ * second stripper is a second answer to "is this line real", and the rule that got the
+ * looser one stops gating without saying so.
+ */
+function withoutComments(source) {
     let code = '';
     let index = 0;
     while (index < source.length) {
@@ -216,15 +246,7 @@ function moduleSpecifiers(source) {
         code += char;
         index += 1;
     }
-    const specifiers = new Set();
-    // The backtick is in the class because `import(`./clamp.native.js`)` is a legal
-    // specifier and was NOT read by the first version — measured: a base module reaching
-    // its sibling that way passed rule 3 at exit 0. A reader that under-detects is worse
-    // than no reader, because the rule it fronts for reads as enforced.
-    for (const match of code.matchAll(/(?:\bfrom|\bimport)\s*\(?\s*(['"`])([^'"`]+)\1/g)) {
-        specifiers.add(match[2]);
-    }
-    return specifiers;
+    return code;
 }
 
 if (!existsSync(WIDGETS_DIR)) {
@@ -605,6 +627,51 @@ const namespaceCheck = (barrel, suffixOf) => {
 namespaceCheck('index.ts', '.js');
 for (const platform of PLATFORMS) namespaceCheck(platform.barrel, platform.buildSuffix);
 
+// ─── Rule 10 — no barrel exports a widget class flat ────────────────────────
+// ADR 0034 § Amendment 8. Rule 8 above holds what the namespace CONTAINS; nothing held
+// what sits beside it, and the flat run this replaced was one `export … from` line per
+// widget — the cheapest possible thing to put back, and the whole of what was removed.
+//
+// It is derived from the widgets on disk rather than matching `/^Adw[A-Z]/`, because the
+// barrels legitimately export `AdwClampProps` and `AdwToastOverlayHandle` beside the
+// namespace, and a rule that refused a shape instead of a NAME would be one prop type
+// away from a false alarm. A false alarm is how a gate gets loosened.
+/** `clamp` → `AdwClamp`: the identifier a widget module exports, and rule 10's subject. */
+const widgetClassName = (widget) => `Adw${namespaceMember(widget)}`;
+/** `export { A, B as C }` and `export type { … }` — a clause, and both halves of a name. */
+const EXPORT_CLAUSE = /export\s*(?:type\s*)?\{([^}]*)\}/g;
+const flatWidgetCheck = (barrel) => {
+    const path = join(PACKAGE_DIR, 'src', barrel);
+    if (!existsSync(path)) return; // rule 6 already failed for this barrel
+    const classes = new Map([...widgets].map((widget) => [widgetClassName(widget), widget]));
+    for (const [, names] of withoutComments(read(path)).matchAll(EXPORT_CLAUSE)) {
+        for (const entry of names.split(',')) {
+            const name = entry.trim().replace(/^type\s+/, '');
+            if (name === '') continue;
+            // BOTH halves, not only the exported one: `export { AdwClamp as Clamp }`
+            // publishes no `AdwClamp` and is still the barrel re-exporting a widget class
+            // beside the namespace — a bare `Clamp` at the root would be a THIRD spelling
+            // rather than the removed one, which is not an improvement on two.
+            const halves = name.split(/\s+as\s+/).map((half) => half.trim());
+            const exported = halves.find((half) => classes.has(half)) ?? halves[halves.length - 1];
+            const widget = classes.get(exported);
+            if (widget !== undefined) {
+                fail(
+                    'flat',
+                    `\`src/${barrel}\` exports \`${exported}\` flat, beside \`Adw.${namespaceMember(widget)}\`. ` +
+                        'ADR 0034 § Amendment 8 removed that spelling from the package root: two names for one ' +
+                        'widget is the second vocabulary clause 1 exists to remove, and the namespace is where ' +
+                        `this one lives. The component keeps the identifier \`${exported}\` in ` +
+                        `\`src/widgets/${widget}.ts\` and on the \`./widgets/${widget}\` subpath, which is a ` +
+                        "different question — there it is the widget's only name.",
+                );
+            }
+        }
+    }
+};
+flatWidgetCheck('index.ts');
+for (const platform of PLATFORMS) flatWidgetCheck(platform.barrel);
+
 // ─── Vacuity ────────────────────────────────────────────────────────────────
 if (widgets.size === 0) {
     console.error(
@@ -632,5 +699,5 @@ console.log(
         `${PLATFORMS.map((p) => p.name).join(' and a ')} module, an \`exports\` entry naming both ` +
         'in an order that resolves to them, the JSX source its platform needs, no import ' +
         `from the other platform, and a member of \`Adw\` on each of the ${PLATFORMS.length + 1} barrels bound ` +
-        "from that barrel's own module.",
+        "from that barrel's own module — and no flat widget class beside it on any of them.",
 );

--- a/scripts/check-vocabulary-alignment.mjs
+++ b/scripts/check-vocabulary-alignment.mjs
@@ -166,6 +166,7 @@ import { fileURLToPath } from 'node:url';
 import {
     adwaitaNativeScriptWidgets,
     namespaceBarrelMembers,
+    reactNativeBarrelWidgets,
     settablePropertiesOfClass,
     tagClass,
 } from './adwaita-elements.mjs';
@@ -2164,6 +2165,62 @@ const NAMESPACE_BARREL_VECTORS = [
     ['export const Clamp = 1;', []],
 ];
 
+/**
+ * The React Native barrel reader gets vectors too, and it needs them MORE than the two
+ * above.
+ *
+ * `adwaitaReactNativeWidgets` used to read a flat `export { AdwClamp } from
+ * './widgets/clamp.js'` line that sat beside an import of the same widget; ADR 0034
+ * § Amendment 8 removed the export, so one line now carries the whole coupling. An
+ * under-reading regex here is the QUIET failure, not the loud one: it hands every
+ * consumer a shorter widget set, and `RN_WIDGET_ALIGNMENT` compared against a shorter set
+ * agrees with it. Nothing counts what was skipped, which is § Amendment 6's "scan that is
+ * merely narrower than it reads" arriving on this surface.
+ *
+ * Each vector is a barrel fragment plus the widget modules the reader must find; `[]`
+ * wants the throw, which is what an empty read and a refused line both do.
+ */
+const RN_BARREL_VECTORS = [
+    ["import { AdwClamp as Clamp } from './widgets/clamp.js';", ['clamp']],
+    // The multi-word case, where the class, the member and the module all differ in shape.
+    ["import { AdwSpinRow as SpinRow } from './widgets/spin-row.js';", ['spin-row']],
+    // Wrapped — oxfmt writes this shape once a line passes the width.
+    [
+        "import {\n    AdwNavigationSplitView as NavigationSplitView,\n} from './widgets/navigation-split-view.js';",
+        ['navigation-split-view'],
+    ],
+    // THE FLAT SPELLING IS NOT A MEMBER. This is the vector that pins the removal: a
+    // reader loosened back to the export form would let the second vocabulary return with
+    // nothing going red.
+    ["export { AdwClamp } from './widgets/clamp.js';", []],
+    // A type-only import ships no widget, and `import type {` is not `import {`.
+    ["import type { AdwClamp as Clamp } from './widgets/clamp.js';", []],
+    // The base barrel names BASE modules; a platform specifier is a different file and
+    // rule 3 of `check-adwaita-rn-platform-split.mjs` is what refuses it there.
+    ["import { AdwClamp as Clamp } from './widgets/clamp.gtk.js';", []],
+    // Both halves of the line are held against the module name, each on its own.
+    ["import { AdwClamp as Clamp } from './widgets/bin.js';", []],
+    ["import { AdwBin as Clamp } from './widgets/bin.js';", []],
+];
+
+function reactNativeBarrelSelfTest() {
+    const failures = [];
+    for (const [source, want] of RN_BARREL_VECTORS) {
+        let got;
+        try {
+            got = reactNativeBarrelWidgets(source, 'vector');
+        } catch {
+            // An empty read and a refused line both THROW; a vector that wants nothing
+            // wants that throw, so a silent [] would be a different answer.
+            got = [];
+        }
+        if (got.join(',') !== [...want].join(',')) {
+            failures.push(`reactNativeBarrelWidgets(${JSON.stringify(source)}) found [${got}], wanted [${want}]`);
+        }
+    }
+    return failures;
+}
+
 function namespaceBarrelSelfTest() {
     const failures = [];
     for (const [source, want] of NAMESPACE_BARREL_VECTORS) {
@@ -2182,7 +2239,7 @@ function namespaceBarrelSelfTest() {
 }
 
 function readerSelfTest() {
-    const failures = [...namespaceBarrelSelfTest()];
+    const failures = [...namespaceBarrelSelfTest(), ...reactNativeBarrelSelfTest()];
     for (const [source, wantImports, wantLiterals] of READER_VECTORS) {
         const { imported, literals } = readDialect(source);
         const got = [...imported].sort().join(',');
@@ -2354,7 +2411,7 @@ const census = propertyCensus(world);
 const propConverge = kindCount(NS_PROPERTY_ALIGNMENT, 'gir');
 console.log(
     `check-vocabulary-alignment: self-test green — ${VECTORS.length - 1} failing vector(s), ` +
-        `${READER_VECTORS.length + NAMESPACE_BARREL_VECTORS.length} reader vector(s). ` +
+        `${READER_VECTORS.length + NAMESPACE_BARREL_VECTORS.length + RN_BARREL_VECTORS.length} reader vector(s). ` +
         `${world.surfaces.declared.length} declared widget surface(s), every one of them read. ` +
         `${world.runtime.size} GTK tags across ${DIALECTS.length} dialect surfaces + the runtime table + the ` +
         `surface data; ${world.webElements.length} ${WEB_SURFACE} elements — ${shared} share a spelling, ` +

--- a/scripts/widget-surfaces.mjs
+++ b/scripts/widget-surfaces.mjs
@@ -65,8 +65,9 @@ export const SURFACE_ROLES = ['reference', 'renderer'];
  * generated table `check-vocabulary-alignment.mjs` reads directly, and a second reader of
  * the same file would be a copy that can drift.
  *
- * `namespace(root)` answers ADR 0034 clause 2 — the same vocabulary reachable as
- * `Adw.Bin`, not only as `AdwBin` — mapping each member to the identifier it is bound to,
+ * `namespace(root)` answers ADR 0034 clause 2 — the vocabulary reachable as `Adw.Bin`,
+ * which on two of these surfaces is now the ONLY spelling (§ Amendments 6 and 8) —
+ * mapping each member to the identifier it is bound to,
  * and returning `null` for a surface that exports none. It REPORTS adoption rather than
  * demanding it: a renderer that has not adopted the clause is work that is left, and a
  * gate failing on that would only be turned off. What a surface HAS adopted is then held
@@ -99,7 +100,7 @@ export const WIDGET_SURFACE_READERS = {
     '@gjsify/adwaita-react-native': {
         role: 'renderer',
         namespace: (root) => namespaceExport(root, 'packages/framework/adwaita-react-native/src'),
-        reads: "the base barrel's `export { Adw… } from './widgets/…'` lines",
+        reads: "the base barrel's `import { Adw… as … } from './widgets/…'` lines",
         widgets: (root) => [...adwaitaReactNativeWidgets(root).keys()].map((name) => `adw-${name}`),
     },
 };

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -488,8 +488,9 @@ sites outside the package.
 risk ADR 0034 § Risks named ("the cheap stage is skipped because it is the least
 urgent-looking"), so it is written down here with its price rather than left to be
 re-derived. Stage 4 took the other two thirds: React Native declares itself a surface, its
-widget set is read from the base barrel's `export { Adw… } from './widgets/…'` lines, and
-its (empty) `RN_WIDGET_ALIGNMENT` is held against the GIR tag table. What is left is clause
+widget set is read from the base barrel's `import { Adw… as … } from './widgets/…'` lines
+(they were `export … from` lines until § Amendment 8 removed the flat spelling), and its
+(empty) `RN_WIDGET_ALIGNMENT` is held against the GIR tag table. What is left is clause
 2, the `Adw` namespace export. What stage 1 no longer buys: the guarantee that the rule
 costs that package nothing it can ever undo. Both its names are already correct, so no
 rename is in it at any price.

--- a/website/src/content/docs/frameworks/react-native.mdx
+++ b/website/src/content/docs/frameworks/react-native.mdx
@@ -284,17 +284,20 @@ on React Native's primitives — has been **started**, as
 and it is a walking skeleton rather than a way to run an Adwaita app on a phone.
 
 Every widget it ships carries the whole vertical — both platform halves, the resolution
-mechanism, the manifest declaration, a gate and suites on each side. `AdwBin` and `AdwClamp`
+mechanism, the manifest declaration, a gate and suites on each side. `Adw.Bin` and `Adw.Clamp`
 came first and proved that shape; the package's own README table is the live set, and
 `check-vocabulary-alignment.mjs` prints the count on every run. The halves fork at the
-package's `exports` map on the `react-native` condition, never by file name.
+package's `exports` map on the `react-native` condition, never by file name. You write
+`import { Adw } from '@gjsify/adwaita-react-native'` and then `<Adw.Clamp>`: the member is
+libadwaita's own type name with its namespace prefix read back off it, and it is the only
+spelling the package root has.
 
 What it is honest about is more useful than what it claims. The phone half is not a `maxWidth`
 approximation — it runs `@gjsify/adwaita-core`'s port of `adw_clamp_layout_allocate`, libadwaita's
 own easing curve — but it **has never run on a device**: its numbers are asserted as instructions,
 not measured as pixels, because there is no Yoga and no phone in the loop. And its divergences
 are named in its README rather than smoothed over, the first of them on the very widget above:
-React Native has no measure pass, so `AdwClamp` passes the child's intrinsic minimum as `0`, and a
+React Native has no measure pass, so `Adw.Clamp` passes the child's intrinsic minimum as `0`, and a
 child wider than the clamp is compressed there where GTK would widen the clamp instead.
 
 It is on npm (since `0.44.0`), but no gallery tab renders it — so nothing you see on this site


### PR DESCRIPTION
ADR 0034 clause 2 landed `Adw` on `@gjsify/adwaita-react-native` as an **additive**
re-export layer, beside 28 flat `AdwActionRow`-style class exports on each of its three
barrels. A second spelling that never goes away is a permanent second vocabulary — the
thing clause 1 exists to remove — so this does for React Native what #1467 did for
`@gjsify/adwaita-web`: the flat widget classes are gone from `src/index.ts`,
`src/index.gtk.ts` and `src/index.native.ts`, and `Adw.ActionRow` is the only name the
package root has.

Recorded as **§ Amendment 8** of `docs/adr/0034-widget-vocabulary-convergence.md`, with
§ 3's "all of it is additive" and § Amendment 3's "Additive: `AdwBin` keeps working" both
carrying a supersession note.

## Nothing had to be migrated, and that is measured

Outside the package `@gjsify/adwaita-react-native` is named in **20 files and imported in
none** — `gtk-host`'s `descriptors/adw.ts`, `adwaita-core`'s `wrap-box.ts`, the
NativeScript `wrap-box-layout.ts`, one showcase's refusals table and the website's React
Native page all mention it in prose or provenance. Inside the package no module imports
the barrel either: `platform-resolve` rewrites `./index.js` to `./index.gtk.js` before the
bundler sees it, which `parity.spec.ts` already documents, so every spec names its widget
module directly. So the two things #1467 had to pay for — six showcase files and a browser
driver whose element set came out of the barrel — have no counterpart here.

## The split

| | count per barrel | what happens |
|---|---|---|
| widget components with a namespace member | 28 | flat export **removed**; reachable as `Adw.X` |
| prop interfaces, handles and shared unions | 34 | flat export **kept** (`export type`) |

There is no third column: this root has no helper, no factory and no widget without a GIR
name, so #1467's twelve `webOnly` classes have no counterpart.

**The components keep their `AdwClamp` identifier**, and that is not the spelling being
removed. `widgets/clamp.ts` declares it, `exports['./widgets/clamp']` publishes it,
`refuseBaseModule` prints it, and at that entry point it is the widget's ONLY name — the
same rule that kept `class GtkEntry` on the web. A bare `Clamp` would put an unqualified
noun in a consumer's import list and break the module-name coupling three readers derive
through `widgetClass`. Rule 10's failure text says this, so it need not be re-derived.

**An object literal, not the module namespace #1467 needed.** A module namespace buys the
TYPE meaning of its members, which the web needs because its classes are annotated
(`as Adw.Window`). These are function components annotated through the `Adw…Props` types,
so value position is the whole requirement — and a namespace module per barrel would move
the platform fork one hop from the file rules 3 and 5 read.

## What keeps it from drifting back

`adwaitaReactNativeWidgets` derived this package's widget set from the removed export
lines, so the coupling moves onto the import that stayed — which now holds **both** halves,
binding and member, against the module name. A one-mention reader under-reads QUIETLY: a
shorter widget set, and an empty `RN_WIDGET_ALIGNMENT` agrees with a shorter set exactly as
well as with the right one. So the parse is split out as `reactNativeBarrelWidgets` and
gets **8 vectors** (reader vectors 19 → 27).

**The first vector went red on the first run.** The regex wanted `}` directly after the
alias, and oxfmt writes a trailing comma as soon as an import wraps — so the day
`AdwNavigationSplitView as NavigationSplitView` wrapped, that widget would have dropped out
of every derived set with every gate green. Nothing in the real tree reproduces it.

**Rule 10** of `check-adwaita-rn-platform-split.mjs` refuses a widget class in any
`export { … }` clause of any barrel. Rule 8 holds what `Adw` *contains* and would not see
one line returning beside it — the cheapest possible reversal. It is derived from the
widgets on disk rather than from a `/^Adw[A-Z]/` shape (the barrels legitimately export
`AdwClampProps`), and it reads both halves of a specifier, so `export { AdwClamp as Clamp }`
— a bare `Clamp` at the root, a *third* spelling — fails too.

A/B, real exit codes, restored between: `export { AdwClamp }` → 1, `export { AdwClamp as
Clamp }` → 1, removed → 0. `check-vocabulary-alignment` stays **green** with the flat
export back, which is what makes rule 10 load-bearing rather than decorative. Rule 3 was
re-falsified the same way after the comment stripper it shares was factored out.

## Verification — both halves, real output

```
gjsify workspace @gjsify/adwaita-react-native test
✔ [Node.js 24.19.0] 478 completed  (663ms)
✔ [Gjs 1.88.1] 350 completed  (3.02s)
exit 0
```

478 / 350 on the commit **before** this change and after it, each half rebuilt and run
separately — nothing traded for anything.

| gate | exit |
|---|---|
| `check-vocabulary-alignment` | 0 — `28 @gjsify/adwaita-react-native widgets — 28 share a spelling`, `exports Adw with 28`, 27 reader vectors |
| `check-rn-surface` | 0 |
| `check-adwaita-rn-platform-split` | 0 — 28 widgets, "and no flat widget class beside it on any of them" |
| `audit-runtimes --check` | 0 |
| `oxfmt --check` | 0 |
| `oxlint` (errors only) | 0 |
| `gjsify workspace @gjsify/adwaita-react-native check` (tsc) | 0 |
| `gjsify run docs:build` | 0 — 69 pages |
| `gjsify run build:examples` | 0 — all 23 showcases, the gap #1467 fell into |
| `check-doc-fences`, `check-adr-index`, `check-comment-budget`, `check-agent-context-size`, `check-source-visibility` | 0 |

## What is deliberately left

Nothing checks how a **consumer** spells the vocabulary. On this surface that gap is closed
by arithmetic rather than by a gate: the root exports no flat widget class at all, so
`import { AdwClamp } from '@gjsify/adwaita-react-native'` is a resolution error in every
tool that reads the barrel. The gap is real on `@gjsify/adwaita-web`, where twelve
`webOnly` classes keep their flat export and a flat import still resolves. A consumer-side
gate belongs beside that, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGTu3xiJDXtxVdB7vkzcyC
