### PR TITLE
fix(vite-plugin-gettext): refuse to gut a catalog

### DIFF
--- a/docs/adr/0041-build-time-serializer-stays-with-the-application.md
+++ b/docs/adr/0041-build-time-serializer-stays-with-the-application.md
@@ -21,8 +21,12 @@ conditions under which the answer changes.
 
 ### What the Learn6502 serializer is — measured
 
-All numbers are from the checkout at `gjsify/easy6502` on 2026-09-03; the command that
-produced each is named so the number can be re-derived rather than trusted.
+All numbers are from the checkout at `gjsify/easy6502`; the command that produced each is
+named so the number can be re-derived rather than trusted. Re-derived on 2026-09-04 against
+`fix/translation-structural-validation`: the size, property and version numbers hold; the four
+that did not are corrected in place below, each with what the original command actually
+counted. That checkout is a SHALLOW clone with a graft horizon at 2026-06-05, which is why the
+churn figures below are marked unverifiable rather than restated.
 
 **Size and shape** (`wc -l` over `packages/learn/tsx/**`): 2 147 lines of TSX/TS.
 
@@ -39,13 +43,16 @@ of them imports `@learn6502/examples` and emits the app's own `SourceView` widge
 `line-number-start` …). They are Learn6502, not a general capability. What remains as a
 candidate for sharing is ~1 070 lines of label/box/list/heading mapping plus 232 shared.
 
-**Content** (`grep -c` over `tutorial.mdx`, 825 lines / 34.8 KB): 34 headings, 52 fenced
-code blocks, **0** images, **0** tables, **0** JSX components, **0** imports. The element
-map in `gtk.components.tsx` has 19 keys; the content exercises a subset. The serializer
-has never had to answer a question a plain markdown paragraph does not ask.
+**Content** (`grep -c` over `tutorial.mdx`, 825 lines / 34.8 KB): 34 headings, **26** fenced
+code blocks, **0** images, **0** tables, **0** JSX components, **0** imports. (`grep -c '^```'`
+returns 52; it counts fence DELIMITERS, opener and closer alike. 26 is confirmed independently by
+the 26 `SourceView` in the output, one per block.) The element map in `gtk.components.tsx` has
+**21** keys, 19 of them HTML element names; the content exercises a subset. The serializer has
+never had to answer a question a plain markdown paragraph does not ask.
 
-**Output** (`grep -o` over `dist/tutorial.ui`, 566 lines): 303 `GtkLabel`, 95 `GtkBox`,
-26 `SourceView`. Distinct `<property name>` values: **24**, of which **14** are GTK
+**Output** (`grep -o` over BOTH generated `.ui` files — `dist/tutorial.ui` is 566 lines and
+holds 155 `GtkLabel`, 14 `GtkBox`, 26 `SourceView`; with `dist/quick-help.ui` the totals are)
+303 `GtkLabel`, 95 `GtkBox`, 26 `SourceView`. Distinct `<property name>` values: **24**, of which **14** are GTK
 properties (`label`, `use-markup`, `wrap`, `halign`, `valign`, `xalign`, `hexpand`,
 `hexpand-set`, `vexpand`, `vexpand-set`, `margin-top`, `margin-bottom`, `margin-start`,
 `orientation`) and 10 are the `SourceView`'s own.
@@ -54,8 +61,11 @@ properties (`label`, `use-markup`, `wrap`, `halign`, `valign`, `xalign`, `hexpan
 --app gjs --globals node` and `gjsify run`. The package declares `@gjsify/cli ^0.10.0`;
 the installed CLI in that checkout is **0.16.3**, against gjsify `main` at 0.46.0.
 
-**Churn** (`git log --oneline -- packages/learn`): 12 commits in the package's life, 3
-touching `tsx/` since 2025. It is stable code.
+**Churn** (`git log --oneline -- packages/learn`): 12 commits visible, 3 of them touching
+`tsx/`, all three inside four weeks of 2026-06/07. **Not "the package's life":** the checkout is
+a shallow clone whose graft horizon is 2026-06-05, so it can see three months and the oldest
+`learn` commit it shows IS a graft root. The code may well be stable; this checkout cannot
+establish it, and a full clone is what would.
 
 **Consumers, and the test gap.** `app-gnome` imports `@learn6502/learn/dist/tutorial.ui`
 as a `GObject.registerClass` `Template` (`src/mdx/tutorial-view.ts`; `MdxView extends
@@ -78,23 +88,45 @@ that feeds Android is a `cp` in `package.json`.
 so one markdown paragraph, inline markup included, is **one gettext msgid**. `xgettext`
 scans the generated `.ui`; GtkBuilder does the lookup at load. There is no `_()` for
 tutorial content anywhere in the application. In the committed catalog
-(`eu.jumplink.Learn6502.pot`, 457 msgids) **165 are MDX-derived — 36 %** (`grep -c
-'translatable="yes"'` over both `.ui` files: 141 + 24).
+(`eu.jumplink.Learn6502.pot`, 457 `msgid` lines = 456 entries plus the header) **223 are
+MDX-derived — 49 %**, counted as POT entries carrying the `#. TRANSLATORS: MDX-derived` comment.
+(`grep -c 'translatable="yes"'` over the two `.ui` files returns 141 + 24 = 165, and that is a
+count of LINES: `quick-help.ui` packs 80 matches onto 23 lines. Per occurrence it is 146 + 80 =
+226 emitted, 223 distinct in the POT.)
 
 The measurement that shapes the decision: **the msgid is not a property of the `.ui`
 file.** It is `clearExtraSpaces(renderSSR(children))` — a function of the MDX paragraph
 and the inline element mapping (`em`→`<i>`, `strong`→`<b>`, `code`→`<tt>`,
 `sub`/`sup`→`<small>`), computed in `utils.ts` and identical in `GtkLabel.render()` and
-`NsHtmlView.render()`. Checked by sampling three msgids out of `tutorial.ui` and grepping
-`tutorial.ns.xml`: **3 of 3 byte-identical.** That is why one `.po` set serves GTK (via
-`msgfmt`) and Android (via `po2json` + runtime `localize(html)`) — Android never reads a
-`translatable` attribute; it looks the string up itself. The web target has no
+`NsHtmlView.render()` — *for a paragraph with no inline code.*
+
+An earlier draft of this ADR said "sampled three msgids out of `tutorial.ui`, grepped
+`tutorial.ns.xml`, 3 of 3 byte-identical" and drew the target-neutrality of the msgid from it.
+Run over the whole population on 2026-09-04 — all 146 `<property name="label" translatable="yes">`
+values in `dist/tutorial.ui`, substring-tested against `dist/tutorial.ns.xml`, both HTML-unescaped
+— **61 appear and 85 do not: 58 % diverge.** A three-sample was not a measurement of a
+population; it is corrected rather than deleted because the number it produced is what the
+argument below was built on.
+
+The divergence is structural, not escaping. Inline `code` becomes `<tt>…</tt>` inside the GTK
+label's msgid, and on the NativeScript target becomes a whole
+`<w:SourceView id="nsSourceView16" code="…">` element inside the same `html=` attribute; one
+paragraph measured 480 characters on GTK and 880 on NativeScript, identical up to its first
+inline code span. Since `build.js` extracts the POT from `../learn/dist/**/*.ui` only, those 85
+Android strings have no catalog entry to look up at all. That is a Learn6502 defect this ADR
+found and does not fix; it is in *What Learn6502 does* below.
+
+What survives, and is what the rest of this ADR needs: the msgid is derived **before any target
+is chosen**, by the inline-markup step, and one `.po` set serves GTK (via `msgfmt`) and Android
+(via `po2json` + runtime `localize(html)`) wherever the two agree — Android never reads a
+`translatable` attribute, it looks the string up itself. The web target has no
 internationalisation at all (`grep -rl gettext\|i18n packages/app-web/src`: nothing).
 
-So the serializer's valuable property is **"one msgid per paragraph, shared across
-targets"**, and it is produced by the MDX→inline-markup step. GtkBuilder's
-`translatable="yes"` is the cheapest *consumer* of that property on one target, not its
-source.
+So the serializer's valuable property is **"one msgid per paragraph, derived independently of the
+target"**. It is produced by the MDX→inline-markup step, and 58 % of the time the two targets do
+not currently agree on the result — which makes it a property the emitters would still have to be
+taught, not one that would arrive with them. GtkBuilder's `translatable="yes"` is the cheapest
+*consumer* of it on one target, not its source.
 
 ### What gjsify has — measured
 
@@ -141,12 +173,10 @@ Two things about that trap were asserted and both are wrong when measured:
    be produced by a Learn6502 build step, and `xgettext` would still read a sibling's build
    artifact. The ordering question is identical on either side of the boundary.
 
-The fix that does address it is at the core and in flight: the gjsify checkout is on
-`fix/xgettext-catalog-guards` with an untracked `xgettext.spec.ts` whose cases are *"fails
-on a pattern that matches no files"* and *"refuses to prune catalogs a collapsed POT would
-empty"*. At the time of writing the spec exists and `xgettext.ts` is unchanged, so this is
-work in progress, not a landed fact. Learn6502 PR #176 (the catalog validator) is open,
-not merged.
+The fix that does address it is at the core, and it is in the same PR as this ADR:
+`xgettextPlugin` refuses a `sources` pattern that matched no files, refuses a run that matched
+none at all, and refuses an `autoUpdatePo` merge that would obsolete more of the catalogs than
+`maxCatalogEntryLoss` allows. Learn6502 PR #176 (the catalog validator) is open, not merged.
 
 ### The four arguments, tested
 
@@ -174,7 +204,7 @@ gtk-host's `GtkLabelProps` — which needs Learn6502 on a gjsify that ships gtk-
 **2. "The i18n pipeline is split across repos."** Emitting is in Learn6502, extracting
 and compiling in gjsify, validating (PR #176) in Learn6502. Tested above: the split is
 not what created the trap and moving the emitter would not close it. What closes it is a
-plugin that refuses to run on an empty pattern (gjsify, in flight) and a build invocation
+plugin that refuses to run on an empty pattern (gjsify, in this PR) and a build invocation
 that pre-builds its declared dependency (`-t`, exists). The validator in PR #176 is about
 `.po` **content** (markup parses, `<tt>` survives) and reads only catalogs; it belongs
 with the catalogs.
@@ -182,11 +212,14 @@ with the catalogs.
 **3. "Rendering at runtime would lose one-msgid-per-paragraph."** False, by the
 measurement in § *The internationalisation property*: the msgid is derived before any
 target is chosen, and the Android target already performs a runtime lookup on exactly that
-string. A runtime renderer on gtk-host would keep the property if the build kept
+string for the 42 % of paragraphs where the two targets agree today. A runtime renderer on gtk-host would keep the property if the build kept
 **extracting** — a generated artifact `xgettext` can read (a `.ui`, or a generated `.ts`
 of `_("…")` per paragraph) — and called `Gettext.gettext(msgid)` once per block at render
 time. The msgid derivation would then have to live in one place both the extractor and
-the renderer import, which is a headless function of ~60 lines, not a serializer. What
+the renderer import. That piece is small: `utils.ts` is 59 lines, but only
+`clearExtraSpaces` (3 lines) is on the msgid path, joined by the 4-line inline-element map in
+`gtk.components.tsx` and nano-jsx's `renderSSR`, which is a dependency and not code here at all.
+Call it **under ten lines of first-party code plus an SSR renderer**, not a serializer. What
 gjsify does not have is that renderer: no package renders markdown onto gtk-host today.
 The design space for one was surveyed (label + Pango markup, `GtkTextBuffer` +
 `insert_markup`, or hybrid block-widgets/inline-Pango — the shapes gnome-software,
@@ -199,15 +232,17 @@ MDX UI content and for translatable templates:
 
 | consumer | `.blp` files | `_("…")` in `.blp` | markdown/MDX UI content |
 |---|---|---|---|
-| `pixel-rpg/map-editor` | 0 | 0 | none |
+| `pixel-rpg/map-editor` | not measured | not measured | not measured |
 | `buchhaltung/app` | 15 | 0 | none (the only `markdown` hit is LLM output handling) |
 | `bauplaner` | 0 | 0 | none |
 | `troedler/app` | 0 | 0 | none |
 | `postbote` (`projects/mail/app`) | 0 | 0 | none |
-| `templates/*` in gjsify | — | — | none |
+| `templates/*` in gjsify | 3 | 0 | none |
 
-Nobody else has long-form authored content in a GTK app, and nobody else marks a single
-string translatable in a template. The second consumer ADR 0003 requires for promotion
+`pixel-rpg/map-editor` is an uninitialised submodule in the workspace this was measured from, so
+its row is a gap, not a zero — initialising it is what would close it. Of the five that were
+measured, nobody has long-form authored content in a GTK app, and nobody marks a single string
+translatable in a template. The second consumer ADR 0003 requires for promotion
 out of Tier 3 does not exist, and a package written for one consumer is the shape ADR 0003
 § 3 puts at Tier 3 "no matter how promising" — with nothing to promote it.
 
@@ -247,17 +282,21 @@ Four reasons, each resting on a measurement above rather than on a preference:
 2. The ordering trap that raised the question is not a repository-boundary problem. The
    dependency is declared, the tool that honours it exists, and the guard that makes the
    failure loud is being built at the core, in the plugin that owns `xgettext`.
-3. The duplicated widget knowledge is 53 names of which 14 are used, in code that changed
-   three times since 2025. Its correct removal is a type import, not a package move.
+3. The duplicated widget knowledge is 53 names of which 14 are used, in code with three
+   commits in the three months this checkout can see. Its correct removal is a type import,
+   not a package move.
 4. There is one consumer, 39.5 % of the code is that consumer's `SourceView`, and no
    second consumer exists in the workspace or is in sight.
 
 **What gjsify owns instead**, all of it already the plugin's job:
 
 - `@gjsify/vite-plugin-gettext`'s `xgettextPlugin` **fails on a `sources` pattern that
-  matches no file** and **refuses an `autoUpdatePo` merge that would empty catalogs**. Both
-  are the cases in the in-flight spec; landing them is the whole of gjsify's answer to the
-  incident. A plugin that cannot see its input must say so, not report success.
+  matches no file**, fails when the run as a whole resolved to none, and **refuses an
+  `autoUpdatePo` merge that would obsolete more msgids than `maxCatalogEntryLoss` allows** —
+  measured as a set difference, because `msgmerge` matches by msgid and an equally long POT of
+  re-worded strings costs the same translations. It also stops reporting a failed `msgmerge` to
+  the console beside a zero exit code. Landing those is the whole of gjsify's answer to the
+  incident: a plugin that cannot see its input must say so, not report success.
 - The plugin's README documents that a `sources` entry pointing at a sibling package's
   build artifact is a **declared dependency to be built first**, and names
   `gjsify workspace -t` as the way to do that. That sentence is the one that was missing.
@@ -272,6 +311,10 @@ side of the boundary has obligations too — tracked in Learn6502, not in gjsify
   `dist/tutorial.ns.xml` and `dist/tutorial.html`, plus one assertion that the msgid set of
   the `.ui` equals the `html="…"` set of the `.ns.xml`. That test is what any future move
   of this code would need first, and it protects three consumers today.
+- Close the msgid divergence this ADR measured, or decide it is acceptable: 85 of the 146 GTK
+  label msgids do not appear in `tutorial.ns.xml`, because inline `code` serialises to `<tt>` on
+  one target and to a whole `SourceView` element on the other, and the POT is extracted from the
+  `.ui` files only. Those 85 Android strings have nothing to look up.
 - Optionally, trim the six read-only names out of the property lists or replace the lists
   with a `Pick<>` over gtk-host's generated props when Learn6502 next bumps gjsify. Not
   before: the bump is 0.16 → 0.4x and the serializer is not the reason to make it.
@@ -302,16 +345,18 @@ one user, and ADR 0003 already says where that lands and why it does not leave.
   No MDX, nano-jsx or SSR dependency enters the release train.
 - The Learn6502 serializer stays a private package with a private toolchain, and its
   property lists stay hand-typed. The cost of that is measured at 6 unused read-only
-  names and 3 commits since 2025; it is recorded so it is not rediscovered as "drift".
+  names and 3 commits in the visible history; it is recorded so it is not rediscovered as "drift".
 - The i18n pipeline stays split: emit in Learn6502, extract/compile in gjsify, validate
   `.po` content in Learn6502. The split is by ownership of the data each step reads, and
   after the plugin guard lands an empty input is loud on either side.
 - The three consumers of `dist/*` are untouched; nothing migrates and no migration risk is
   taken. The absence of a test over those outputs is a Learn6502 gap that this decision
   neither creates nor closes, and it is named above so it does not stay invisible.
-- A future markdown-on-gtk-host track inherits a finding it would otherwise have to
-  re-measure: the msgid derivation is target-neutral, and it is the one piece that must be
-  written once. Learn6502's `utils.ts` + the inline mapping is the reference.
+- A future markdown-on-gtk-host track inherits two findings it would otherwise have to
+  re-measure: the msgid derivation is target-neutral *by construction* and is the one piece that
+  must be written once, and the two emitters that exist do not currently agree on its output for
+  58 % of paragraphs. The second is the harder half, and it is a property of the inline mapping,
+  not of the XML emission. Learn6502's `utils.ts` + the inline mapping is the reference.
 - The rejected alternative is recorded: a `@gjsify/ui-serializer` at Tier 3 with
   Learn6502 as sole consumer, carrying nano-jsx and `@mdx-js/rollup`, whose GTK half
   would duplicate the vocabulary gtk-host already generates and whose `SourceView` half
@@ -322,11 +367,12 @@ one user, and ADR 0003 already says where that lands and why it does not leave.
 Since the decision is a refusal, the implementation is the set of things that make the
 refusal safe, in the order they should land.
 
-1. **gjsify — land the `xgettext` guards.** Finish `fix/xgettext-catalog-guards`:
-   `xgettextPlugin.buildStart` throws when any `sources` pattern matches zero files, and
-   `autoUpdatePo` refuses a merge that would drop entries a collapsed POT no longer
-   carries. The spec's own entry counting stays independent of the implementation's
-   counter, as its header requires. This is the only code change in gjsify.
+1. **gjsify — the `xgettext` guards**, in this PR. `xgettextPlugin` throws when a `sources`
+   pattern matches zero files or the run matches none, and `autoUpdatePo` refuses a merge that
+   would obsolete more of the catalogs than allowed. Extraction and merge failures stop being
+   `console.error` beside exit 0. The spec's entry counting is `gettext-parser`'s, so it is an
+   oracle independent of the implementation rather than a copy of it. This is the only code
+   change in gjsify.
 2. **gjsify — one paragraph in `packages/infra/vite-plugin-gettext/README.md`:** a
    `sources` entry into another package's `dist/` is a build-order dependency; declare it
    in `package.json` and run with `gjsify workspace -t`. Cite the 902-line incident in one
@@ -343,12 +389,15 @@ refusal safe, in the order they should land.
 ### What this ADR could not determine from the code
 
 - Whether the empty-glob incident is the only silent-failure path in the catalog
-  pipeline. `po2json` and `gettextPlugin` were not audited for the same class; the spec in
-  flight covers `xgettext` only.
+  pipeline. `po2json` and `gettextPlugin` were not audited for the same class; the spec
+  covers `xgettext` only. Two further paths of the same class WERE found while auditing
+  `xgettext.ts` and are fixed in this PR (a swallowed `POTFILES` write, a swallowed
+  `msgmerge`), which is evidence the class is not exhausted rather than that it is.
 - Whether a runtime markdown renderer on gtk-host is wanted at all. The survey of GTK
   markdown architectures exists as working notes, not as repository status, and no issue
   tracks it (`gh issue list --search markdown` on `gjsify/gjsify`: two unrelated hits).
-- The exact set of MDX elements the content uses. The map has 19 keys; the outputs show
+- The exact set of MDX elements the content uses. The map has 21 keys, 19 of them element
+  names; the outputs show
   headings, paragraphs, ordered/unordered lists, inline `em`/`strong`/`code`/`a`, and
   fenced code; tables and images are 0 (measured). Sub/sup are mapped but their use was
   not counted.

--- a/docs/adr/0041-build-time-serializer-stays-with-the-application.md
+++ b/docs/adr/0041-build-time-serializer-stays-with-the-application.md
@@ -1,0 +1,356 @@
+# 41. A build-time serializer of a component tree into declarative UI files stays with the application that owns the content
+
+- Status: **Proposed**
+- Date: 2026-09-04
+- Deciders: Pascal Garber
+- Related: [ADR 0033 (templates preferred)](0033-declarative-templates-preferred.md), [ADR 0027 (GTK host layer)](0027-gtk-host-layer.md), [ADR 0028 (widget table provenance)](0028-widget-table-provenance.md), [ADR 0034 (widget vocabulary convergence)](0034-widget-vocabulary-convergence.md), [ADR 0004 (headless Adwaita core)](0004-headless-adwaita-core.md), [ADR 0003 (package tiering)](0003-package-tiering.md), [ADR 0015 (headless package contract)](0015-headless-package-contract.md)
+
+## Context
+
+### The question
+
+Should gjsify offer build-time serialization of a component tree into declarative UI
+files — GtkBuilder XML, NativeScript XML, HTML — beside the runtime element layer it
+already has in `@gjsify/gtk-host`?
+
+The question comes from one place. `JumpLink/Learn6502` carries `packages/learn`, which
+turns two MDX files into three static artifacts, and a translation incident on 2026-09-03
+put that package's build wiring under a light. The proposal was that the emitter belongs
+in gjsify. This ADR tests that and answers **no**, with what happens instead and the two
+conditions under which the answer changes.
+
+### What the Learn6502 serializer is — measured
+
+All numbers are from the checkout at `gjsify/easy6502` on 2026-09-03; the command that
+produced each is named so the number can be re-derived rather than trusted.
+
+**Size and shape** (`wc -l` over `packages/learn/tsx/**`): 2 147 lines of TSX/TS.
+
+| part | lines | of which the `*-code` component |
+|---|---|---|
+| `components/gtk/` | 746 | 283 |
+| `components/html/` | 614 | 278 |
+| `components/nativescript/` | 555 | 287 |
+| `index.tsx` + `utils.ts` + `enums/gtk.enums.ts` | 232 | — |
+
+The three `*-code` components are **848 lines, 39.5 % of the package**, and every one
+of them imports `@learn6502/examples` and emits the app's own `SourceView` widget
+(`<object class="SourceView" id="sourceView0">`, with `code`, `language`, `readonly`,
+`line-number-start` …). They are Learn6502, not a general capability. What remains as a
+candidate for sharing is ~1 070 lines of label/box/list/heading mapping plus 232 shared.
+
+**Content** (`grep -c` over `tutorial.mdx`, 825 lines / 34.8 KB): 34 headings, 52 fenced
+code blocks, **0** images, **0** tables, **0** JSX components, **0** imports. The element
+map in `gtk.components.tsx` has 19 keys; the content exercises a subset. The serializer
+has never had to answer a question a plain markdown paragraph does not ask.
+
+**Output** (`grep -o` over `dist/tutorial.ui`, 566 lines): 303 `GtkLabel`, 95 `GtkBox`,
+26 `SourceView`. Distinct `<property name>` values: **24**, of which **14** are GTK
+properties (`label`, `use-markup`, `wrap`, `halign`, `valign`, `xalign`, `hexpand`,
+`hexpand-set`, `vexpand`, `vexpand-set`, `margin-top`, `margin-bottom`, `margin-start`,
+`orientation`) and 10 are the `SourceView`'s own.
+
+**Toolchain:** nano-jsx `renderSSR` under `@mdx-js/rollup`, run through `gjsify build
+--app gjs --globals node` and `gjsify run`. The package declares `@gjsify/cli ^0.10.0`;
+the installed CLI in that checkout is **0.16.3**, against gjsify `main` at 0.46.0.
+
+**Churn** (`git log --oneline -- packages/learn`): 12 commits in the package's life, 3
+touching `tsx/` since 2025. It is stable code.
+
+**Consumers, and the test gap.** `app-gnome` imports `@learn6502/learn/dist/tutorial.ui`
+as a `GObject.registerClass` `Template` (`src/mdx/tutorial-view.ts`; `MdxView extends
+Adw.Bin` finds `sourceView<N>` ids by regex over the XML). `app-android` loads a copied
+`app/mdx/tutorial.xml` through NativeScript's `Builder.load` and then localises each
+`HtmlView` at runtime (`localize(htmlView.html)`). `app-web` imports
+`dist/tutorial.html` as a fragment. **No test in the repository references any of the
+three outputs** (`grep -rl` over `*.test.*`/`*.spec.*`: nothing). The `build:copy` step
+that feeds Android is a `cp` in `package.json`.
+
+### The internationalisation property — where it actually lives
+
+`gtk-label.component.tsx` emits every prose block as
+
+```xml
+<property name="label" translatable="yes"
+          comments="TRANSLATORS: MDX-derived text from packages/learn/tutorial.mdx">
+```
+
+so one markdown paragraph, inline markup included, is **one gettext msgid**. `xgettext`
+scans the generated `.ui`; GtkBuilder does the lookup at load. There is no `_()` for
+tutorial content anywhere in the application. In the committed catalog
+(`eu.jumplink.Learn6502.pot`, 457 msgids) **165 are MDX-derived — 36 %** (`grep -c
+'translatable="yes"'` over both `.ui` files: 141 + 24).
+
+The measurement that shapes the decision: **the msgid is not a property of the `.ui`
+file.** It is `clearExtraSpaces(renderSSR(children))` — a function of the MDX paragraph
+and the inline element mapping (`em`→`<i>`, `strong`→`<b>`, `code`→`<tt>`,
+`sub`/`sup`→`<small>`), computed in `utils.ts` and identical in `GtkLabel.render()` and
+`NsHtmlView.render()`. Checked by sampling three msgids out of `tutorial.ui` and grepping
+`tutorial.ns.xml`: **3 of 3 byte-identical.** That is why one `.po` set serves GTK (via
+`msgfmt`) and Android (via `po2json` + runtime `localize(html)`) — Android never reads a
+`translatable` attribute; it looks the string up itself. The web target has no
+internationalisation at all (`grep -rl gettext\|i18n packages/app-web/src`: nothing).
+
+So the serializer's valuable property is **"one msgid per paragraph, shared across
+targets"**, and it is produced by the MDX→inline-markup step. GtkBuilder's
+`translatable="yes"` is the cheapest *consumer* of that property on one target, not its
+source.
+
+### What gjsify has — measured
+
+- `@gjsify/gtk-host` (`packages/framework/gtk-host`, 28 084 lines with specs, 20 320
+  without): `createElement` / `insert` / `materialize` over real widgets at runtime. It
+  contains **no** serializer to GtkBuilder XML (`grep -rl GtkBuilder\|serializ\|toXml
+  src`: only comments naming the XML key). Tier 3, published at 0.45.0.
+- gjsify does already emit text from a tree, twice, in `scripts/`:
+  `adwaita-gallery-trees.mjs` + `generate-adwaita-framework-snippets.mjs` write Solid, Vue
+  and React source snippets from one host-vocabulary tree, and
+  `adwaita-gallery-ns-templates.mjs` is a deliberately **second** source for the
+  NativeScript XML, because translating one toolkit's vocabulary into another's needs the
+  alias table ADR 0029 § 4 refuses. Both are documentation tooling, not packages; neither
+  emits a translatable artifact.
+- `@gjsify/vite-plugin-gettext` owns `xgettext`, `msgfmt` and `po2json`. Nothing in the
+  repository extracts strings from a component tree; the two places that reason about
+  user-visible text are lint rules (`no-literal-widget-label`,
+  `prefer-blueprint-template`), and their premise is the same one this ADR keeps: a string
+  is translatable only if `xgettext` can see it, either as `translatable` in a template or
+  as `_()` in code.
+- `@gjsify/stories` and the storybook renderers carry story metadata, not prose content.
+  There is no markdown or MDX pipeline in any published package (`grep -rn nano-jsx\|
+  @mdx-js\|renderSSR packages/framework packages/web`: nothing).
+
+### How the question arrived — the empty-glob incident
+
+`packages/translations/build.js` lists `../learn/dist/**/*.ui` among its `xgettext`
+sources. Built in the wrong order the pattern matched nothing, the `ui` group did not
+exist, and — as recorded in the header of the spec now sitting in gjsify — 902 lines left
+the POT and ~1 573 left each of 16 catalogs, at exit 0. It was caught by reading the diff.
+
+Two things about that trap were asserted and both are wrong when measured:
+
+1. *"Nothing declares the dependency."* `@learn6502/translations/package.json` declares
+   `"@learn6502/learn": "^0.7.0"` under `dependencies`. `gjsify workspace` has
+   `--with-dependencies` / `-t` (`packages/infra/cli/src/commands/workspace.ts`), which
+   pre-builds transitive workspace dependencies in topological order before the target
+   script; `gjsify foreach -t` does the same across the tree. The declaration exists and
+   the tool that honours it exists. The script that runs `xgettext` is invoked without
+   `-t`, and CI (`ci.yml`) runs only `translations check`, never `translations build`, so
+   nothing exercised the order.
+2. *"The split across repos is why the trap exists."* Moving the emitter into gjsify would
+   not move the **content**; `tutorial.mdx` and the `dist/*.ui` derived from it would still
+   be produced by a Learn6502 build step, and `xgettext` would still read a sibling's build
+   artifact. The ordering question is identical on either side of the boundary.
+
+The fix that does address it is at the core and in flight: the gjsify checkout is on
+`fix/xgettext-catalog-guards` with an untracked `xgettext.spec.ts` whose cases are *"fails
+on a pattern that matches no files"* and *"refuses to prune catalogs a collapsed POT would
+empty"*. At the time of writing the spec exists and `xgettext.ts` is unchanged, so this is
+work in progress, not a landed fact. Learn6502 PR #176 (the catalog validator) is open,
+not merged.
+
+### The four arguments, tested
+
+**1. "The widget knowledge exists twice."** Counted with a script over
+`gtk-host/src/generated/props.ts` against the four `propertyNames` arrays in the
+serializer:
+
+| list | serializer | gtk-host (own, writable) | overlap | serializer-only |
+|---|---|---|---|---|
+| `GtkWidget` | 34 | 30 | 29 | `has-default`, `has-focus`, `parent`, `root`, `scale-factor` |
+| `GtkLabel` | 20 | 19 | 19 | `mnemonic-keyval` |
+| `GtkBox` | 4 | 4 | 4 | — |
+| `GtkOrientable` | 1 | 1 | 1 | — |
+
+59 hand-typed names, 53 shared. The six serializer-only names are all **read-only** in
+the GIR — gtk-host excludes them by construction; the serializer would emit them and
+GtkBuilder would refuse the file at load. That is a real defect in the hand list, and it
+has never fired, because the MDX component set uses **14** of the 59. The duplication is
+real; its cost at this content and this churn rounds to zero. It is also the wrong shape
+to fix by moving code: the list is a runtime allow-list in a component that also carries
+`SourceView`. If it is worth removing, the cheap removal is a compile-time `Pick<>` over
+gtk-host's `GtkLabelProps` — which needs Learn6502 on a gjsify that ships gtk-host
+(0.4x, against an installed 0.16.3), a version jump the serializer alone does not justify.
+
+**2. "The i18n pipeline is split across repos."** Emitting is in Learn6502, extracting
+and compiling in gjsify, validating (PR #176) in Learn6502. Tested above: the split is
+not what created the trap and moving the emitter would not close it. What closes it is a
+plugin that refuses to run on an empty pattern (gjsify, in flight) and a build invocation
+that pre-builds its declared dependency (`-t`, exists). The validator in PR #176 is about
+`.po` **content** (markup parses, `<tt>` survives) and reads only catalogs; it belongs
+with the catalogs.
+
+**3. "Rendering at runtime would lose one-msgid-per-paragraph."** False, by the
+measurement in § *The internationalisation property*: the msgid is derived before any
+target is chosen, and the Android target already performs a runtime lookup on exactly that
+string. A runtime renderer on gtk-host would keep the property if the build kept
+**extracting** — a generated artifact `xgettext` can read (a `.ui`, or a generated `.ts`
+of `_("…")` per paragraph) — and called `Gettext.gettext(msgid)` once per block at render
+time. The msgid derivation would then have to live in one place both the extractor and
+the renderer import, which is a headless function of ~60 lines, not a serializer. What
+gjsify does not have is that renderer: no package renders markdown onto gtk-host today.
+The design space for one was surveyed (label + Pango markup, `GtkTextBuffer` +
+`insert_markup`, or hybrid block-widgets/inline-Pango — the shapes gnome-software,
+`AdwAboutDialog` and Fractal/Tuba use); those notes are working notes, not repository
+facts, and are marked here as inference. A runtime design is possible; it is a different
+project from the one proposed.
+
+**4. "This is a niche of one."** Checked every consumer in the workspace for markdown or
+MDX UI content and for translatable templates:
+
+| consumer | `.blp` files | `_("…")` in `.blp` | markdown/MDX UI content |
+|---|---|---|---|
+| `pixel-rpg/map-editor` | 0 | 0 | none |
+| `buchhaltung/app` | 15 | 0 | none (the only `markdown` hit is LLM output handling) |
+| `bauplaner` | 0 | 0 | none |
+| `troedler/app` | 0 | 0 | none |
+| `postbote` (`projects/mail/app`) | 0 | 0 | none |
+| `templates/*` in gjsify | — | — | none |
+
+Nobody else has long-form authored content in a GTK app, and nobody else marks a single
+string translatable in a template. The second consumer ADR 0003 requires for promotion
+out of Tier 3 does not exist, and a package written for one consumer is the shape ADR 0003
+§ 3 puts at Tier 3 "no matter how promising" — with nothing to promote it.
+
+### What ADR 0033 says about this
+
+ADR 0033 prefers a template file for the tree and TypeScript for the behaviour, and it
+names the honest imperative cases: *"a tree whose shape is computed, a widget built from
+data."* A generated `.ui` sits between the two: the tree IS computed from data, and it is
+also a template, registered through `GObject.registerClass({ Template })` with only
+behaviour in `MdxView`. Nothing in 0033 objects to a generated template; 0033 did not
+contemplate one. This ADR records that a template generated by the owner of the content is
+an instance of 0033's preferred form, not an exception to it — and that the generator is
+part of the content's build, which is the sentence the rest of this ADR rests on.
+
+ADR 0034 § 8 says the repository's answer to the translator problem is *"write the tree
+ONCE in the vocabulary that runs and emit the dialects."* Learn6502 does that — one MDX,
+three dialects — and 0034 also measured why the dialects cannot be a mechanical
+translation of each other (12 attribute *semantics* diverge, none a spelling). The
+Learn6502 emitters diverge in the same way: the NativeScript target packs a whole paragraph
+into an `HtmlView`'s `html` attribute and localises at runtime, the GTK target into a
+Pango-markup label with `translatable`, the web target keeps real nested HTML. Three
+targets, three semantics, one source. That is the shape 0034 endorses, and it is already
+where 0034 wants it: in the hands of the source's owner.
+
+## Decision
+
+**gjsify does not take on build-time serialization of a component tree into declarative
+UI files.** No `@gjsify/ui-serializer`, no MDX toolchain, no nano-jsx dependency. The
+Learn6502 emitter stays in `JumpLink/Learn6502`, where the content, the `SourceView`, the
+catalogs and all three consumers already are.
+
+Four reasons, each resting on a measurement above rather than on a preference:
+
+1. The property that makes the serializer worth having — one shared msgid per paragraph —
+   is produced by a 60-line inline-markup step, not by GtkBuilder XML emission. Moving
+   the emitter moves the wrong 2 000 lines.
+2. The ordering trap that raised the question is not a repository-boundary problem. The
+   dependency is declared, the tool that honours it exists, and the guard that makes the
+   failure loud is being built at the core, in the plugin that owns `xgettext`.
+3. The duplicated widget knowledge is 53 names of which 14 are used, in code that changed
+   three times since 2025. Its correct removal is a type import, not a package move.
+4. There is one consumer, 39.5 % of the code is that consumer's `SourceView`, and no
+   second consumer exists in the workspace or is in sight.
+
+**What gjsify owns instead**, all of it already the plugin's job:
+
+- `@gjsify/vite-plugin-gettext`'s `xgettextPlugin` **fails on a `sources` pattern that
+  matches no file** and **refuses an `autoUpdatePo` merge that would empty catalogs**. Both
+  are the cases in the in-flight spec; landing them is the whole of gjsify's answer to the
+  incident. A plugin that cannot see its input must say so, not report success.
+- The plugin's README documents that a `sources` entry pointing at a sibling package's
+  build artifact is a **declared dependency to be built first**, and names
+  `gjsify workspace -t` as the way to do that. That sentence is the one that was missing.
+
+**What Learn6502 does** (recorded here because the ADR is about a boundary, and the other
+side of the boundary has obligations too — tracked in Learn6502, not in gjsify's
+`open-todos`):
+
+- Invoke `translations build` with `-t`, or make `learn build` an explicit prerequisite in
+  the script, so the order is written down where it is executed.
+- Add the test that does not exist: a golden-output test over `dist/tutorial.ui`,
+  `dist/tutorial.ns.xml` and `dist/tutorial.html`, plus one assertion that the msgid set of
+  the `.ui` equals the `html="…"` set of the `.ns.xml`. That test is what any future move
+  of this code would need first, and it protects three consumers today.
+- Optionally, trim the six read-only names out of the property lists or replace the lists
+  with a `Pick<>` over gtk-host's generated props when Learn6502 next bumps gjsify. Not
+  before: the bump is 0.16 → 0.4x and the serializer is not the reason to make it.
+
+**What reopens this decision** — two conditions, either sufficient:
+
+1. **A second consumer** in the ecosystem ships translatable long-form content in a GTK or
+   NativeScript app from a markdown source. At that point the shared part is *not* the
+   serializer but the headless MDX→block/inline model whose inline serialization defines
+   the msgid; it would be declared `gjsify.headless: true` (ADR 0015), sit under
+   `packages/framework/` or `packages/web/` as ADR 0004 places behaviour cores, and the
+   three Learn6502 emitters would become adapters over it — the `StoryViewBase<TNode>`
+   seam pattern ADR 0004 already names. That is a new ADR, and it starts at Tier 3.
+2. **A runtime markdown renderer on gtk-host lands** in gjsify. The same headless model
+   is then the piece both the runtime renderer and any build-time extractor import, and
+   the question becomes whether Learn6502's GTK target moves to runtime rendering (which
+   would give it selectable text and a real tree for the bidi handling that is regex
+   surgery today — inferred from the RTL fixes in `mdx-view.ts`, not measured). The web and
+   Android targets are unaffected either way.
+
+Until one of those holds, a gjsify package here would be a second execution model with
+one user, and ADR 0003 already says where that lands and why it does not leave.
+
+## Consequences
+
+- gjsify keeps one execution model for UI trees — runtime materialisation — and one
+  place where translatable text is reasoned about: `xgettext` over templates and `_()`.
+  No MDX, nano-jsx or SSR dependency enters the release train.
+- The Learn6502 serializer stays a private package with a private toolchain, and its
+  property lists stay hand-typed. The cost of that is measured at 6 unused read-only
+  names and 3 commits since 2025; it is recorded so it is not rediscovered as "drift".
+- The i18n pipeline stays split: emit in Learn6502, extract/compile in gjsify, validate
+  `.po` content in Learn6502. The split is by ownership of the data each step reads, and
+  after the plugin guard lands an empty input is loud on either side.
+- The three consumers of `dist/*` are untouched; nothing migrates and no migration risk is
+  taken. The absence of a test over those outputs is a Learn6502 gap that this decision
+  neither creates nor closes, and it is named above so it does not stay invisible.
+- A future markdown-on-gtk-host track inherits a finding it would otherwise have to
+  re-measure: the msgid derivation is target-neutral, and it is the one piece that must be
+  written once. Learn6502's `utils.ts` + the inline mapping is the reference.
+- The rejected alternative is recorded: a `@gjsify/ui-serializer` at Tier 3 with
+  Learn6502 as sole consumer, carrying nano-jsx and `@mdx-js/rollup`, whose GTK half
+  would duplicate the vocabulary gtk-host already generates and whose `SourceView` half
+  could not move at all. Unblocker: condition 1 or 2 above.
+
+## Implementation
+
+Since the decision is a refusal, the implementation is the set of things that make the
+refusal safe, in the order they should land.
+
+1. **gjsify — land the `xgettext` guards.** Finish `fix/xgettext-catalog-guards`:
+   `xgettextPlugin.buildStart` throws when any `sources` pattern matches zero files, and
+   `autoUpdatePo` refuses a merge that would drop entries a collapsed POT no longer
+   carries. The spec's own entry counting stays independent of the implementation's
+   counter, as its header requires. This is the only code change in gjsify.
+2. **gjsify — one paragraph in `packages/infra/vite-plugin-gettext/README.md`:** a
+   `sources` entry into another package's `dist/` is a build-order dependency; declare it
+   in `package.json` and run with `gjsify workspace -t`. Cite the 902-line incident in one
+   sentence so the rule keeps its reason.
+3. **Learn6502 — order and test.** `-t` on the translations build; a golden test over the
+   three outputs and the msgid-set equality between `.ui` and `.ns.xml`; run
+   `translations build` in CI in a mode that fails on a changed POT, so the extraction path
+   is exercised where the check path already is. (Today `ci.yml` runs `check` at line 93
+   and `learn build` at line 103, and `build` never.)
+4. **No package, no move, no `open-todos` entry in gjsify** beyond step 1's PR. The
+   reopening conditions are the tracking mechanism: a second consumer or a runtime renderer
+   is a visible event, not a date.
+
+### What this ADR could not determine from the code
+
+- Whether the empty-glob incident is the only silent-failure path in the catalog
+  pipeline. `po2json` and `gettextPlugin` were not audited for the same class; the spec in
+  flight covers `xgettext` only.
+- Whether a runtime markdown renderer on gtk-host is wanted at all. The survey of GTK
+  markdown architectures exists as working notes, not as repository status, and no issue
+  tracks it (`gh issue list --search markdown` on `gjsify/gjsify`: two unrelated hits).
+- The exact set of MDX elements the content uses. The map has 19 keys; the outputs show
+  headings, paragraphs, ordered/unordered lists, inline `em`/`strong`/`code`/`a`, and
+  fenced code; tables and images are 0 (measured). Sub/sup are mapped but their use was
+  not counted.
+- Whether Learn6502's `^0.10.0` declaration against an installed 0.16.3 is deliberate; it
+  affects only the cost of the optional `Pick<>` cleanup, not the decision.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -61,6 +61,7 @@ the TODO records the *what's left*.
 | [0038](0038-shipped-application-fonts.md) | A shipped application font: one payload directory, and the declarative mechanism each OS actually has | Accepted |
 | [0039](0039-react-native-prop-surface.md) | The React Native PROP surface is published as a subpath; a refused prop keeps throwing | Proposed |
 | [0040](0040-gui-launcher-and-the-macos-seal.md) | A GUI-subsystem launcher `gjsify ship` writes itself, and the three macOS steps that were refused for a wrong reason | Proposed |
+| [0041](0041-build-time-serializer-stays-with-the-application.md) | A build-time serializer of a component tree into declarative UI files stays with the application that owns the content | Proposed |
 
 Source review: [docs/reports/2026-07-01-architecture-review.md](../reports/2026-07-01-architecture-review.md)
 (condensed findings + prioritized backlog).

--- a/packages/infra/vite-plugin-gettext/README.md
+++ b/packages/infra/vite-plugin-gettext/README.md
@@ -39,6 +39,22 @@ xgettextPlugin({
 });
 ```
 
+### A `sources` pattern reaching into a sibling package is a build dependency
+
+`sources` is read at extraction time, so a pattern like `../learn/dist/**/*.ui` requires that the
+sibling package has already been built. Declaring it in `dependencies` is not enough on its own:
+building the one package (`gjsify workspace <name> build`) does not build what it depends on.
+Either run the extracting package with `-t`, which pre-builds its workspace dependencies in
+topological order:
+
+```bash
+gjsify workspace @scope/translations build -t
+```
+
+or make the dependency's build an explicit step of the script that needs it. Without one of the
+two, the artifact is whatever the last run left behind, which is the state the pattern guard above
+exists to catch.
+
 ## Usage
 
 ```typescript

--- a/packages/infra/vite-plugin-gettext/README.md
+++ b/packages/infra/vite-plugin-gettext/README.md
@@ -16,6 +16,29 @@ yarn add @gjsify/vite-plugin-gettext
 
 Requires `gettext` tools (`msgfmt`, `xgettext`) to be installed on the system.
 
+## Extraction refuses to destroy translations
+
+`xgettextPlugin` fails the build instead of writing a POT that would silently gut the catalogs:
+
+- **Every `sources` pattern must match at least one file.** A pattern that matches nothing is
+  almost always a build-order or path mistake — typically it points at a build artifact of another
+  package that has not been built yet — and extracting anyway drops that whole group of strings.
+  A group that really is optional is named in `optionalSources`, one pattern at a time.
+- **`autoUpdatePo` will not prune a catalog set beyond `maxCatalogEntryLoss`** (default `1/3`).
+  `msgmerge` moves every entry the POT lost into `#~` comments, which `msgfmt` ignores, so a POT
+  that came out short costs real translations. A run that really does delete that many strings
+  raises the option.
+
+```typescript
+xgettextPlugin({
+    sources: ['src/**/*.blp', 'data/**/*.desktop.in'],
+    output: 'po/messages.pot',
+    autoUpdatePo: true,
+    // optionalSources: ['plugins/**/*.ui'],
+    // maxCatalogEntryLoss: 0.5,
+});
+```
+
 ## Usage
 
 ```typescript

--- a/packages/infra/vite-plugin-gettext/README.md
+++ b/packages/infra/vite-plugin-gettext/README.md
@@ -20,10 +20,12 @@ Requires `gettext` tools (`msgfmt`, `xgettext`) to be installed on the system.
 
 `xgettextPlugin` fails the build instead of writing a POT that would silently gut the catalogs:
 
-- **Every `sources` pattern must match at least one file.** A pattern that matches nothing is
-  almost always a build-order or path mistake — typically it points at a build artifact of another
-  package that has not been built yet — and extracting anyway drops that whole group of strings.
-  A group that really is optional is named in `optionalSources`, one pattern at a time.
+- **Every `sources` pattern must match at least one file**, and the run as a whole must find at
+  least one. A pattern that matches nothing is almost always a build-order or path mistake —
+  typically it points at a build artifact of another package that has not been built yet — and
+  extracting anyway drops that whole group of strings. A group that really is optional is named in
+  `optionalSources`, one pattern at a time. Negated patterns (`!plugins/**/*.ui`) are exclusions
+  over the whole set, not groups of their own, so they are never required to match.
 - **`autoUpdatePo` will not prune a catalog set beyond `maxCatalogEntryLoss`** (default `1/3`).
   `msgmerge` moves every entry the POT lost into `#~` comments, which `msgfmt` ignores, so a POT
   that came out short costs real translations. A run that really does delete that many strings
@@ -31,7 +33,7 @@ Requires `gettext` tools (`msgfmt`, `xgettext`) to be installed on the system.
 
 ```typescript
 xgettextPlugin({
-    sources: ['src/**/*.blp', 'data/**/*.desktop.in'],
+    sources: ['src/**/*.blp', 'data/**/*.desktop.in', '!src/**/*.generated.blp'],
     output: 'po/messages.pot',
     autoUpdatePo: true,
     // optionalSources: ['plugins/**/*.ui'],

--- a/packages/infra/vite-plugin-gettext/README.md
+++ b/packages/infra/vite-plugin-gettext/README.md
@@ -44,6 +44,10 @@ xgettextPlugin({
 });
 ```
 
+Both guards throw. `xgettext`, `msgcat` and `msgmerge` failures are no longer reported to the
+console beside a zero exit code either — a build that could not write the catalogs it was asked to
+write fails.
+
 ### A `sources` pattern reaching into a sibling package is a build dependency
 
 `sources` is read at extraction time, so a pattern like `../learn/dist/**/*.ui` requires that the

--- a/packages/infra/vite-plugin-gettext/README.md
+++ b/packages/infra/vite-plugin-gettext/README.md
@@ -27,9 +27,12 @@ Requires `gettext` tools (`msgfmt`, `xgettext`) to be installed on the system.
   `optionalSources`, one pattern at a time. Negated patterns (`!plugins/**/*.ui`) are exclusions
   over the whole set, not groups of their own, so they are never required to match.
 - **`autoUpdatePo` will not prune a catalog set beyond `maxCatalogEntryLoss`** (default `1/3`).
-  `msgmerge` moves every entry the POT lost into `#~` comments, which `msgfmt` ignores, so a POT
-  that came out short costs real translations. A run that really does delete that many strings
-  raises the option.
+  What is compared is the *set of msgids* the new POT still carries against the largest catalog's,
+  because that is what `msgmerge` acts on: it moves every entry the POT no longer has into `#~`
+  comments, which `msgfmt` ignores. A POT that came out short costs real translations, and so does
+  one that is the same length but re-worded — `msgmerge` fuzzy-matches those, and `msgfmt` leaves
+  fuzzy entries out of the `.mo`. A run that really does replace that many strings raises the
+  option.
 
 ```typescript
 xgettextPlugin({
@@ -37,7 +40,7 @@ xgettextPlugin({
     output: 'po/messages.pot',
     autoUpdatePo: true,
     // optionalSources: ['plugins/**/*.ui'],
-    // maxCatalogEntryLoss: 0.5,
+    // maxCatalogEntryLoss: 0.5, // a FRACTION, not a percentage; 1 turns the check off
 });
 ```
 

--- a/packages/infra/vite-plugin-gettext/package.json
+++ b/packages/infra/vite-plugin-gettext/package.json
@@ -16,9 +16,12 @@
         "lib"
     ],
     "scripts": {
-        "clear": "gjsify clear lib tsconfig.tsbuildinfo",
+        "clear": "gjsify clear lib tsconfig.tsbuildinfo test.node.mjs",
         "check": "gjsify tsc --noEmit",
-        "build": "gjsify tsc"
+        "build": "gjsify tsc -p tsconfig.build.json",
+        "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "test": "gjsify run build:test:node && gjsify run test:node",
+        "test:node": "node test.node.mjs"
     },
     "repository": {
         "type": "git",
@@ -56,6 +59,8 @@
         }
     },
     "devDependencies": {
+        "@gjsify/cli": "workspace:^",
+        "@gjsify/unit": "workspace:^",
         "@types/gettext-parser": "^9.0.0",
         "@types/node": "^25.9.2",
         "typescript": "^6.0.3",

--- a/packages/infra/vite-plugin-gettext/src/guards.spec.ts
+++ b/packages/infra/vite-plugin-gettext/src/guards.spec.ts
@@ -5,11 +5,15 @@
 
 import { describe, expect, it } from '@gjsify/unit';
 import {
+    activeMsgids,
     assertCatalogsSurviveMerge,
     assertEverySourcePatternMatched,
     CatalogShrinkError,
     countActiveEntries,
+    DEFAULT_MAX_CATALOG_ENTRY_LOSS,
     EmptySourcePatternError,
+    InvalidEntryLossError,
+    resolveMaxEntryLoss,
 } from './guards.js';
 
 const context = { pluginName: 'vite-plugin-xgettext', cwd: '/workspace' };
@@ -77,9 +81,16 @@ export default async () => {
     });
 
     await describe('assertCatalogsSurviveMerge', async () => {
-        const merge = (potEntries: number, catalogs: Array<{ language: string; entries: number }>, max?: number) =>
+        /** `count` distinct msgids; `prefix` is what makes two sets disjoint. */
+        const ids = (count: number, prefix = 'm') => new Set(Array.from({ length: count }, (_, i) => `${prefix}${i}`));
+
+        const merge = (
+            potMsgids: Set<string>,
+            catalogs: Array<{ language: string; msgids: Set<string> }>,
+            max?: number,
+        ) =>
             assertCatalogsSurviveMerge({
-                potEntries,
+                potMsgids,
                 catalogs,
                 potFile: 'po/messages.pot',
                 pluginName: 'vite-plugin-xgettext',
@@ -87,20 +98,33 @@ export default async () => {
             });
 
         await it('lets a first run through when there is nothing to lose', async () => {
-            merge(120, []);
-            merge(120, [{ language: 'de', entries: 0 }]);
+            merge(ids(120), []);
+            merge(ids(120), [{ language: 'de', msgids: ids(0) }]);
         });
 
         await it('lets growth and ordinary churn through', async () => {
-            merge(140, [{ language: 'de', entries: 120 }]);
-            merge(117, [{ language: 'de', entries: 120 }]);
+            merge(ids(140), [{ language: 'de', msgids: ids(120) }]);
+            merge(ids(117), [{ language: 'de', msgids: ids(120) }]);
         });
 
         await it('refuses the loss the Learn6502 incident produced', async () => {
-            const thrown = thrownBy(() => merge(41, [{ language: 'de', entries: 340 }]));
+            const thrown = thrownBy(() => merge(ids(41), [{ language: 'de', msgids: ids(340) }]));
             expect(thrown instanceof CatalogShrinkError).toBe(true);
             expect((thrown as Error).message).toContain('88%');
             expect((thrown as Error).message).toContain('33%');
+        });
+
+        await it('refuses a run that replaced the msgids without shrinking', async () => {
+            // The case a COUNT cannot see, and the one Learn6502 is closest to: its
+            // msgids are whitespace-normalised renders of markdown, so a change in
+            // the inline-markup step re-msgids every paragraph at a constant total.
+            // msgmerge fuzzy-matches those and msgfmt then leaves every fuzzy entry
+            // out of the .mo, so the translations are just as gone (measured on
+            // gettext 0.26: `0 translated, 1 fuzzy`).
+            const thrown = thrownBy(() => merge(ids(100, 'rendered-'), [{ language: 'de', msgids: ids(100, 'old-') }]));
+            expect(thrown instanceof CatalogShrinkError).toBe(true);
+            expect((thrown as CatalogShrinkError).lostEntries).toBe(100);
+            expect((thrown as CatalogShrinkError).catalogEntries).toBe(100);
         });
 
         await it('measures against the LARGEST catalog', async () => {
@@ -108,28 +132,59 @@ export default async () => {
             // yardstick that excuses gutting the rest.
             expect(
                 thrownBy(() =>
-                    merge(60, [
-                        { language: 'fr', entries: 0 },
-                        { language: 'de', entries: 100 },
+                    merge(ids(60), [
+                        { language: 'fr', msgids: ids(0) },
+                        { language: 'de', msgids: ids(100) },
                     ]),
                 ) instanceof CatalogShrinkError,
             ).toBe(true);
         });
 
         await it('draws the line at the documented default', async () => {
-            merge(2, [{ language: 'de', entries: 3 }]); // exactly one third, allowed
-            expect(thrownBy(() => merge(66, [{ language: 'de', entries: 100 }])) instanceof CatalogShrinkError).toBe(
-                true,
-            );
+            merge(ids(2), [{ language: 'de', msgids: ids(3) }]); // exactly one third, allowed
+            expect(
+                thrownBy(() => merge(ids(66), [{ language: 'de', msgids: ids(100) }])) instanceof CatalogShrinkError,
+            ).toBe(true);
         });
 
         await it('lets a project raise the limit deliberately', async () => {
-            merge(10, [{ language: 'de', entries: 100 }], 0.95);
-            merge(0, [{ language: 'de', entries: 100 }], 1);
+            merge(ids(10), [{ language: 'de', msgids: ids(100) }], 0.95);
+            merge(ids(0), [{ language: 'de', msgids: ids(100) }], 1);
+        });
+
+        await it('refuses a limit that is not a fraction, before reading any catalog', async () => {
+            // No catalogs at all: the option still has to be judged here, or a typo
+            // stays invisible until the run it was supposed to protect.
+            expect(thrownBy(() => merge(ids(1), [], 50)) instanceof InvalidEntryLossError).toBe(true);
         });
     });
 
-    await describe('countActiveEntries', async () => {
+    await describe('resolveMaxEntryLoss', async () => {
+        await it('defaults to a third', async () => {
+            expect(resolveMaxEntryLoss(undefined, 'p')).toBe(DEFAULT_MAX_CATALOG_ENTRY_LOSS);
+        });
+
+        await it('accepts both ends of the fraction', async () => {
+            expect(resolveMaxEntryLoss(0, 'p')).toBe(0);
+            expect(resolveMaxEntryLoss(1, 'p')).toBe(1);
+        });
+
+        await it('refuses a percentage, which would wave everything through', async () => {
+            const thrown = thrownBy(() => resolveMaxEntryLoss(50, 'p'));
+            expect(thrown instanceof InvalidEntryLossError).toBe(true);
+            expect((thrown as Error).message).toContain('not a percentage');
+        });
+
+        await it('refuses the values that would make the guard fire on a clean run', async () => {
+            // NaN loses every comparison, so the guard fails a build that lost
+            // nothing — and gets raised out of the way for the wrong reason.
+            expect(thrownBy(() => resolveMaxEntryLoss(Number.NaN, 'p')) instanceof InvalidEntryLossError).toBe(true);
+            expect(thrownBy(() => resolveMaxEntryLoss(-0.1, 'p')) instanceof InvalidEntryLossError).toBe(true);
+            expect(thrownBy(() => resolveMaxEntryLoss(Infinity, 'p')) instanceof InvalidEntryLossError).toBe(true);
+        });
+    });
+
+    await describe('activeMsgids', async () => {
         await it('does not count the header', async () => {
             expect(countActiveEntries('msgid ""\nmsgstr ""\n"Language: de\\n"\n')).toBe(0);
             expect(countActiveEntries('')).toBe(0);
@@ -149,7 +204,7 @@ export default async () => {
                 '#~ msgstr "Entfernt"',
                 '',
             ].join('\n');
-            expect(countActiveEntries(po)).toBe(1);
+            expect([...activeMsgids(po)]).toStrictEqual(['Kept']);
         });
 
         await it('counts a multi-line, plural, contextual entry exactly once', async () => {
@@ -166,10 +221,38 @@ export default async () => {
                 'msgstr[1] ""',
                 '',
             ].join('\n');
-            // The wrapped halves of the caption are bare string lines, and
-            // `msgid_plural` is a different keyword: neither opens an entry, so
-            // the only two that do are the header and this one.
-            expect(countActiveEntries(po)).toBe(1);
+            // `msgid_plural` is a different keyword and the wrapped halves are bare
+            // string lines: neither opens an entry, so the only two that do are the
+            // header and this one.
+            expect([...activeMsgids(po)]).toStrictEqual([
+                'toolbar\u0004A caption long enough that xgettext wrapped it onto a second line.',
+            ]);
+        });
+
+        await it('reads a wrapped msgid to the same value as an unwrapped one', async () => {
+            // A POT and a catalog wrap at different points — `--no-wrap`, a longer
+            // location comment — so only the JOINED value is comparable, and the
+            // guard compares a POT with a catalog for a living.
+            const wrapped = ['msgid ""', '"Hello, "', '"world."', 'msgstr ""'].join('\n');
+            const flat = 'msgid "Hello, world."\nmsgstr ""';
+            expect([...activeMsgids(wrapped)]).toStrictEqual([...activeMsgids(flat)]);
+        });
+
+        await it('keeps two entries that differ only in context apart', async () => {
+            const po = [
+                'msgctxt "verb"',
+                'msgid "Open"',
+                'msgstr ""',
+                '',
+                'msgctxt "adjective"',
+                'msgid "Open"',
+                'msgstr ""',
+                '',
+                'msgid "Open"',
+                'msgstr ""',
+            ].join('\n');
+            expect(activeMsgids(po).size).toBe(3);
+            expect(activeMsgids(po).has('Open')).toBe(true);
         });
     });
 };

--- a/packages/infra/vite-plugin-gettext/src/guards.spec.ts
+++ b/packages/infra/vite-plugin-gettext/src/guards.spec.ts
@@ -1,0 +1,175 @@
+// The guard decisions on their own — no gettext, no filesystem. `xgettext.spec.ts`
+// proves the plugin WIRES them; these cases pin down what they answer, including
+// the shapes that only show up once and are therefore the ones a later
+// "simplification" quietly changes.
+
+import { describe, expect, it } from '@gjsify/unit';
+import {
+    assertCatalogsSurviveMerge,
+    assertEverySourcePatternMatched,
+    CatalogShrinkError,
+    countActiveEntries,
+    EmptySourcePatternError,
+} from './guards.js';
+
+const context = { pluginName: 'vite-plugin-xgettext', cwd: '/workspace' };
+
+/** What `fn` threw, so a case can assert the TYPE and the message it carries. */
+function thrownBy(fn: () => void): unknown {
+    try {
+        fn();
+    } catch (error) {
+        return error;
+    }
+    return undefined;
+}
+
+export default async () => {
+    await describe('assertEverySourcePatternMatched', async () => {
+        await it('accepts a run where every pattern found something', async () => {
+            assertEverySourcePatternMatched(
+                [
+                    { pattern: 'src/**/*.blp', fileCount: 24 },
+                    { pattern: 'dist/**/*.ui', fileCount: 3 },
+                ],
+                context,
+            );
+        });
+
+        await it('names every empty pattern, not just the first', async () => {
+            const thrown = thrownBy(() =>
+                assertEverySourcePatternMatched(
+                    [
+                        { pattern: 'src/**/*.blp', fileCount: 24 },
+                        { pattern: '../learn/dist/**/*.ui', fileCount: 0 },
+                        { pattern: 'data/**/*.desktop.in', fileCount: 0 },
+                    ],
+                    context,
+                ),
+            );
+
+            // Reporting one at a time turns a single misconfiguration into a
+            // build-fix-build loop, which is how a guard earns a `catch`.
+            expect(thrown instanceof EmptySourcePatternError).toBe(true);
+            expect((thrown as EmptySourcePatternError).patterns).toStrictEqual([
+                '../learn/dist/**/*.ui',
+                'data/**/*.desktop.in',
+            ]);
+            expect((thrown as Error).message).toContain('../learn/dist/**/*.ui');
+            expect((thrown as Error).message).toContain('data/**/*.desktop.in');
+            expect((thrown as Error).message).toContain('/workspace');
+        });
+
+        await it('exempts only the patterns optionalSources names', async () => {
+            const matches = [
+                { pattern: 'optional/**/*.ui', fileCount: 0 },
+                { pattern: 'src/**/*.blp', fileCount: 0 },
+            ];
+
+            const thrown = thrownBy(() =>
+                assertEverySourcePatternMatched(matches, { ...context, optionalSources: ['optional/**/*.ui'] }),
+            );
+            expect(thrown instanceof EmptySourcePatternError).toBe(true);
+            expect((thrown as EmptySourcePatternError).patterns).toStrictEqual(['src/**/*.blp']);
+
+            assertEverySourcePatternMatched([matches[0]], { ...context, optionalSources: ['optional/**/*.ui'] });
+        });
+    });
+
+    await describe('assertCatalogsSurviveMerge', async () => {
+        const merge = (potEntries: number, catalogs: Array<{ language: string; entries: number }>, max?: number) =>
+            assertCatalogsSurviveMerge({
+                potEntries,
+                catalogs,
+                potFile: 'po/messages.pot',
+                pluginName: 'vite-plugin-xgettext',
+                maxEntryLoss: max,
+            });
+
+        await it('lets a first run through when there is nothing to lose', async () => {
+            merge(120, []);
+            merge(120, [{ language: 'de', entries: 0 }]);
+        });
+
+        await it('lets growth and ordinary churn through', async () => {
+            merge(140, [{ language: 'de', entries: 120 }]);
+            merge(117, [{ language: 'de', entries: 120 }]);
+        });
+
+        await it('refuses the loss the Learn6502 incident produced', async () => {
+            const thrown = thrownBy(() => merge(41, [{ language: 'de', entries: 340 }]));
+            expect(thrown instanceof CatalogShrinkError).toBe(true);
+            expect((thrown as Error).message).toContain('88%');
+            expect((thrown as Error).message).toContain('33%');
+        });
+
+        await it('measures against the LARGEST catalog', async () => {
+            // A catalog an earlier bad run already gutted must not become the
+            // yardstick that excuses gutting the rest.
+            expect(
+                thrownBy(() =>
+                    merge(60, [
+                        { language: 'fr', entries: 0 },
+                        { language: 'de', entries: 100 },
+                    ]),
+                ) instanceof CatalogShrinkError,
+            ).toBe(true);
+        });
+
+        await it('draws the line at the documented default', async () => {
+            merge(2, [{ language: 'de', entries: 3 }]); // exactly one third, allowed
+            expect(thrownBy(() => merge(66, [{ language: 'de', entries: 100 }])) instanceof CatalogShrinkError).toBe(
+                true,
+            );
+        });
+
+        await it('lets a project raise the limit deliberately', async () => {
+            merge(10, [{ language: 'de', entries: 100 }], 0.95);
+            merge(0, [{ language: 'de', entries: 100 }], 1);
+        });
+    });
+
+    await describe('countActiveEntries', async () => {
+        await it('does not count the header', async () => {
+            expect(countActiveEntries('msgid ""\nmsgstr ""\n"Language: de\\n"\n')).toBe(0);
+            expect(countActiveEntries('')).toBe(0);
+        });
+
+        await it('does not count what msgfmt will not read', async () => {
+            // The whole reason a LINE count cannot do this job: msgmerge keeps the
+            // pruned entries in the file, commented out, and msgfmt ignores them.
+            const po = [
+                'msgid ""',
+                'msgstr ""',
+                '',
+                'msgid "Kept"',
+                'msgstr "Behalten"',
+                '',
+                '#~ msgid "Pruned"',
+                '#~ msgstr "Entfernt"',
+                '',
+            ].join('\n');
+            expect(countActiveEntries(po)).toBe(1);
+        });
+
+        await it('counts a multi-line, plural, contextual entry exactly once', async () => {
+            const po = [
+                'msgid ""',
+                'msgstr ""',
+                '',
+                'msgctxt "toolbar"',
+                'msgid ""',
+                '"A caption long enough that xgettext wrapped it onto "',
+                '"a second line."',
+                'msgid_plural "captions"',
+                'msgstr[0] ""',
+                'msgstr[1] ""',
+                '',
+            ].join('\n');
+            // The wrapped halves of the caption are bare string lines, and
+            // `msgid_plural` is a different keyword: neither opens an entry, so
+            // the only two that do are the header and this one.
+            expect(countActiveEntries(po)).toBe(1);
+        });
+    });
+};

--- a/packages/infra/vite-plugin-gettext/src/guards.ts
+++ b/packages/infra/vite-plugin-gettext/src/guards.ts
@@ -1,0 +1,180 @@
+// What must be true before a POT is written over catalogs people have already
+// translated.
+//
+// THE INCIDENT (JumpLink/Learn6502, 2026-09-03). Its `xgettext` sources included
+// `../learn/dist/**/*.ui`, a build artifact of a SIBLING workspace package.
+// Build `@learn6502/translations` before `@learn6502/learn` and that pattern
+// matches nothing — the whole `ui` group silently ceases to exist. `xgettext`
+// happily extracted the rest, `msgcat` wrote a POT 902 lines shorter, and
+// `autoUpdatePo` then ran `msgmerge --update` over all 16 catalogs, which moved
+// every entry the POT had lost into `#~` obsolete comments: ~1573 lines per
+// language, every MDX-derived tutorial string among them. `msgfmt` ignores `#~`,
+// so those translations were gone. Exit code 0, no warning. It was caught by
+// reading the diff before committing; in CI, or on a machine with a stale
+// `dist/`, it would have landed.
+//
+// The build-order dependency is real and implicit — extraction reads an artifact
+// another package produces and nothing declares that edge — so the fix cannot be
+// "order the build correctly". It has to be that the mistake FAILS.
+//
+// The decisions live here, apart from the I/O that feeds them, so they can be
+// tested without gettext installed and without a filesystem.
+
+/** Base class so the plugin can rethrow a guard verbatim instead of wrapping it. */
+export class GettextGuardError extends Error {}
+
+/** A `sources` pattern matched nothing, and was not declared optional. */
+export class EmptySourcePatternError extends GettextGuardError {
+    constructor(
+        message: string,
+        /** The patterns that matched no files, verbatim as configured. */
+        readonly patterns: readonly string[],
+    ) {
+        super(message);
+        this.name = 'EmptySourcePatternError';
+    }
+}
+
+/** The new POT is too much smaller than the catalogs `msgmerge` would rewrite. */
+export class CatalogShrinkError extends GettextGuardError {
+    constructor(
+        message: string,
+        readonly potEntries: number,
+        readonly catalogEntries: number,
+    ) {
+        super(message);
+        this.name = 'CatalogShrinkError';
+    }
+}
+
+/** One `sources` pattern and how many files it actually resolved to. */
+export interface SourcePatternMatch {
+    /** The pattern verbatim as configured — it is what an error has to name. */
+    pattern: string;
+    fileCount: number;
+}
+
+/** A catalog's language and the number of entries it currently still uses. */
+export interface CatalogSize {
+    language: string;
+    entries: number;
+}
+
+/**
+ * Fraction of its entries a catalog set may lose in one extraction.
+ *
+ * Why a RATIO: an absolute count cannot be right for both a twelve-string dialog
+ * and a nine-hundred-string tutorial. Why a THIRD: the two populations this has
+ * to separate are far apart. Ordinary churn between two runs of the same build is
+ * a handful of strings — single-digit percent of any real catalog — while the
+ * failure above drops a whole source group at once. A third sits in the empty
+ * space between them. Half, the other candidate, is worse: a project with two
+ * source groups of similar size loses one of them at ~50% and slips under.
+ *
+ * A deliberate rewrite that really does delete more says so with
+ * `maxCatalogEntryLoss`, which is the point of it being an option.
+ */
+export const DEFAULT_MAX_CATALOG_ENTRY_LOSS = 1 / 3;
+
+/**
+ * Fails unless every source pattern resolved to at least one file.
+ *
+ * FAILING IS THE DEFAULT ON PURPOSE. A pattern that matches nothing is almost
+ * always a build-order or path mistake, and the cost of being wrong is
+ * asymmetric: a false failure costs one build, a missed one costs every
+ * translation the group carried. A project that genuinely has an optional group
+ * names those patterns in `optionalSources` — per pattern, never a blanket
+ * boolean, so the guard stays armed for every other entry.
+ */
+export function assertEverySourcePatternMatched(
+    matches: readonly SourcePatternMatch[],
+    context: { pluginName: string; cwd: string; optionalSources?: readonly string[] },
+): void {
+    const optional = new Set(context.optionalSources ?? []);
+    const empty = matches
+        .filter((match) => match.fileCount === 0 && !optional.has(match.pattern))
+        .map((match) => match.pattern);
+
+    if (empty.length === 0) {
+        return;
+    }
+
+    const list = empty.map((pattern) => `  - ${pattern}`).join('\n');
+    throw new EmptySourcePatternError(
+        `[${context.pluginName}] ${empty.length === 1 ? 'a source pattern' : `${empty.length} source patterns`} matched no files:\n` +
+            `${list}\n` +
+            `Resolved relative to ${context.cwd}.\n` +
+            'Nothing was extracted. Extracting anyway writes a POT without those strings, and with ' +
+            'autoUpdatePo that prunes the same strings out of every catalog. Usual cause: the pattern ' +
+            'points at a build artifact of another package that has not been built yet.\n' +
+            "If the group really is optional, list the pattern verbatim in the plugin's `optionalSources`.",
+        empty,
+    );
+}
+
+/**
+ * Fails when the freshly written POT would cost the catalogs more entries than
+ * `maxEntryLoss` allows.
+ *
+ * The reference is the LARGEST catalog rather than each one in turn: after a
+ * successful merge every catalog carries the POT's msgid set, so the biggest one
+ * is the best evidence of what the project had before this run. Comparing per
+ * language would let one catalog that a previous bad run already gutted excuse
+ * gutting the rest.
+ */
+export function assertCatalogsSurviveMerge(args: {
+    potEntries: number;
+    catalogs: readonly CatalogSize[];
+    potFile: string;
+    pluginName: string;
+    maxEntryLoss?: number;
+}): void {
+    const limit = args.maxEntryLoss ?? DEFAULT_MAX_CATALOG_ENTRY_LOSS;
+    const reference = args.catalogs.reduce<CatalogSize | undefined>(
+        (largest, candidate) => (largest && largest.entries >= candidate.entries ? largest : candidate),
+        undefined,
+    );
+
+    // No catalogs yet, or an empty one: there is nothing a merge can destroy, and
+    // a ratio against zero is not a number.
+    if (!reference || reference.entries === 0) {
+        return;
+    }
+
+    const lost = reference.entries - args.potEntries;
+    if (lost <= 0 || lost / reference.entries <= limit) {
+        return;
+    }
+
+    const percent = (value: number) => `${Math.round(value * 100)}%`;
+    throw new CatalogShrinkError(
+        `[${args.pluginName}] refusing to update the catalogs: ${args.potFile} holds ${args.potEntries} ` +
+            `entries, but ${reference.language}.po already holds ${reference.entries}. That is a loss of ` +
+            `${percent(lost / reference.entries)}, over the ${percent(limit)} this build allows, across ` +
+            `${args.catalogs.length} ${args.catalogs.length === 1 ? 'catalog' : 'catalogs'}.\n` +
+            'msgmerge would move every missing entry into `#~` comments, which msgfmt ignores — the ' +
+            'translations would be gone. Usual cause: a source group went missing from this run.\n' +
+            "If the strings really were deleted, raise the plugin's `maxCatalogEntryLoss` for the run that does it.",
+        args.potEntries,
+        reference.entries,
+    );
+}
+
+/**
+ * Entries a PO/POT file still USES.
+ *
+ * Obsolete entries (`#~ msgid`) are excluded because `msgfmt` excludes them: a
+ * gutted catalog keeps every line and loses every translation, so a line count
+ * would report it as healthy. One `msgid` line per entry holds for multi-line and
+ * `msgctxt`-qualified entries alike, and `msgid_plural` does not match — the
+ * subtracted one is the header, whose msgid is empty.
+ */
+export function countActiveEntries(text: string): number {
+    let heads = 0;
+    for (const line of text.split('\n')) {
+        if (/^msgid[ \t]/.test(line)) {
+            heads++;
+        }
+    }
+    return Math.max(0, heads - 1);
+}

--- a/packages/infra/vite-plugin-gettext/src/guards.ts
+++ b/packages/infra/vite-plugin-gettext/src/guards.ts
@@ -35,15 +35,24 @@ export class EmptySourcePatternError extends GettextGuardError {
     }
 }
 
-/** The new POT is too much smaller than the catalogs `msgmerge` would rewrite. */
+/** `msgmerge` would obsolete more of the catalogs than this build allows. */
 export class CatalogShrinkError extends GettextGuardError {
     constructor(
         message: string,
-        readonly potEntries: number,
+        /** Entries the reference catalog holds that the new POT no longer carries. */
+        readonly lostEntries: number,
         readonly catalogEntries: number,
     ) {
         super(message);
         this.name = 'CatalogShrinkError';
+    }
+}
+
+/** A `maxCatalogEntryLoss` that is not a fraction — the guard cannot act on it. */
+export class InvalidEntryLossError extends GettextGuardError {
+    constructor(message: string) {
+        super(message);
+        this.name = 'InvalidEntryLossError';
     }
 }
 
@@ -54,10 +63,10 @@ export interface SourcePatternMatch {
     fileCount: number;
 }
 
-/** A catalog's language and the number of entries it currently still uses. */
-export interface CatalogSize {
+/** A catalog's language and the msgids it currently still uses. */
+export interface CatalogMsgids {
     language: string;
-    entries: number;
+    msgids: ReadonlySet<string>;
 }
 
 /**
@@ -120,68 +129,156 @@ export function assertEverySourcePatternMatched(
 }
 
 /**
- * Fails when the freshly written POT would cost the catalogs more entries than
- * `maxEntryLoss` allows.
+ * Reads `maxCatalogEntryLoss`, which has to be a FRACTION.
  *
- * The reference is the LARGEST catalog rather than each one in turn: after a
- * successful merge every catalog carries the POT's msgid set, so the biggest one
- * is the best evidence of what the project had before this run. Comparing per
- * language would let one catalog that a previous bad run already gutted excuse
- * gutting the rest.
+ * Validated separately, and before the catalogs are looked at, because the two
+ * ways of getting it wrong both end in silence. `50` — the option read as a
+ * percentage — is `<= 50` for every possible ratio, so the guard passes
+ * everything and reports nothing; `NaN` fails every comparison, so the guard
+ * fires on a build that lost nothing and gets raised out of the way. Neither
+ * would ever be traced back to the option.
+ */
+export function resolveMaxEntryLoss(value: number | undefined, pluginName: string): number {
+    if (value === undefined) {
+        return DEFAULT_MAX_CATALOG_ENTRY_LOSS;
+    }
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
+        throw new InvalidEntryLossError(
+            `[${pluginName}] maxCatalogEntryLoss must be a fraction between 0 and 1, and is ${String(value)}. ` +
+                'It is a fraction, not a percentage: a third is 0.33, half is 0.5, and 1 turns the check off.',
+        );
+    }
+    return value;
+}
+
+/**
+ * Fails when merging the freshly written POT would obsolete more of the catalogs
+ * than `maxEntryLoss` allows.
+ *
+ * What is measured is the SET of msgids the POT no longer carries, not how much
+ * shorter it got. `msgmerge` matches by msgid, so an equally long POT whose
+ * strings have changed obsoletes just as much as a short one — and measured on
+ * gettext 0.26, a msgid that only gained a space is fuzzy-matched, keeps its
+ * translation, and is then excluded from the `.mo` by `msgfmt` anyway. A count
+ * cannot see that; a set difference is the quantity `msgmerge` acts on.
+ *
+ * The reference is the LARGEST catalog rather than each one in turn: `msgmerge`
+ * gives every catalog the POT's msgid set (measured — a 1-entry and a 2-entry
+ * catalog both came back with the POT's 3), so the biggest one is the best
+ * evidence of what the project had before this run. Comparing per language would
+ * let one catalog that a previous bad run already gutted excuse gutting the rest.
  */
 export function assertCatalogsSurviveMerge(args: {
-    potEntries: number;
-    catalogs: readonly CatalogSize[];
+    potMsgids: ReadonlySet<string>;
+    catalogs: readonly CatalogMsgids[];
     potFile: string;
     pluginName: string;
     maxEntryLoss?: number;
 }): void {
-    const limit = args.maxEntryLoss ?? DEFAULT_MAX_CATALOG_ENTRY_LOSS;
-    const reference = args.catalogs.reduce<CatalogSize | undefined>(
-        (largest, candidate) => (largest && largest.entries >= candidate.entries ? largest : candidate),
+    const limit = resolveMaxEntryLoss(args.maxEntryLoss, args.pluginName);
+    const reference = args.catalogs.reduce<CatalogMsgids | undefined>(
+        (largest, candidate) => (largest && largest.msgids.size >= candidate.msgids.size ? largest : candidate),
         undefined,
     );
 
     // No catalogs yet, or an empty one: there is nothing a merge can destroy, and
     // a ratio against zero is not a number.
-    if (!reference || reference.entries === 0) {
+    if (!reference || reference.msgids.size === 0) {
         return;
     }
 
-    const lost = reference.entries - args.potEntries;
-    if (lost <= 0 || lost / reference.entries <= limit) {
+    const held = reference.msgids.size;
+    let lost = 0;
+    for (const msgid of reference.msgids) {
+        if (!args.potMsgids.has(msgid)) {
+            lost++;
+        }
+    }
+    if (lost === 0 || lost / held <= limit) {
         return;
     }
 
     const percent = (value: number) => `${Math.round(value * 100)}%`;
     throw new CatalogShrinkError(
-        `[${args.pluginName}] refusing to update the catalogs: ${args.potFile} holds ${args.potEntries} ` +
-            `entries, but ${reference.language}.po already holds ${reference.entries}. That is a loss of ` +
-            `${percent(lost / reference.entries)}, over the ${percent(limit)} this build allows, across ` +
-            `${args.catalogs.length} ${args.catalogs.length === 1 ? 'catalog' : 'catalogs'}.\n` +
+        `[${args.pluginName}] refusing to update the catalogs: ${args.potFile} no longer carries ${lost} of the ` +
+            `${held} entries ${reference.language}.po holds. That is a loss of ${percent(lost / held)}, over the ` +
+            `${percent(limit)} this build allows, across ${args.catalogs.length} ` +
+            `${args.catalogs.length === 1 ? 'catalog' : 'catalogs'}.\n` +
             'msgmerge would move every missing entry into `#~` comments, which msgfmt ignores — the ' +
             'translations would be gone. Usual cause: a source group went missing from this run.\n' +
             "If the strings really were deleted, raise the plugin's `maxCatalogEntryLoss` for the run that does it.",
-        args.potEntries,
-        reference.entries,
+        lost,
+        held,
     );
 }
 
 /**
- * Entries a PO/POT file still USES.
+ * The msgids a PO/POT file still USES, keyed the way gettext keys them.
  *
  * Obsolete entries (`#~ msgid`) are excluded because `msgfmt` excludes them: a
  * gutted catalog keeps every line and loses every translation, so a line count
- * would report it as healthy. One `msgid` line per entry holds for multi-line and
- * `msgctxt`-qualified entries alike, and `msgid_plural` does not match — the
- * subtracted one is the header, whose msgid is empty.
+ * would report it as healthy. The header is excluded by being the one entry whose
+ * msgid is empty and uncontextualised.
+ *
+ * Continuation lines are CONCATENATED rather than counted, which is what makes a
+ * POT comparable with a catalog at all: the same string is wrapped differently
+ * depending on `--no-wrap` and on how long the surrounding lines were, and only
+ * the joined value is stable. `msgctxt` joins its msgid through gettext's own
+ * `\u0004` separator, so two entries that differ only in context stay two.
+ */
+export function activeMsgids(text: string): Set<string> {
+    const msgids = new Set<string>();
+    let reading: 'msgctxt' | 'msgid' | undefined;
+    let pieces: string[] = [];
+    let context: string | undefined;
+
+    const finish = () => {
+        if (reading === 'msgctxt') {
+            context = pieces.join('');
+        } else if (reading === 'msgid') {
+            const msgid = pieces.join('');
+            if (msgid !== '' || context !== undefined) {
+                msgids.add(context === undefined ? msgid : `${context}\u0004${msgid}`);
+            }
+            context = undefined;
+        }
+        reading = undefined;
+        pieces = [];
+    };
+
+    for (const line of text.split('\n')) {
+        const opener = /^(msgctxt|msgid)[ \t]/.exec(line);
+        if (opener) {
+            finish();
+            reading = opener[1] as 'msgctxt' | 'msgid';
+            pieces = [literal(line)];
+            continue;
+        }
+        // A bare string literal continues whatever keyword opened the entry. An
+        // obsolete entry's own continuations are prefixed `#~ `, so they never
+        // reach here and never re-open one either.
+        if (reading && /^[ \t]*"/.test(line)) {
+            pieces.push(literal(line));
+            continue;
+        }
+        finish();
+    }
+    finish();
+
+    return msgids;
+}
+
+/** The quoted payload of a PO line, unescaped no further than both files are. */
+function literal(line: string): string {
+    const first = line.indexOf('"');
+    const last = line.lastIndexOf('"');
+    return first < 0 || last <= first ? '' : line.slice(first + 1, last);
+}
+
+/**
+ * Entries a PO/POT file still USES — the size of {@link activeMsgids}, and the
+ * same measurement, so the number and the set can never disagree.
  */
 export function countActiveEntries(text: string): number {
-    let heads = 0;
-    for (const line of text.split('\n')) {
-        if (/^msgid[ \t]/.test(line)) {
-            heads++;
-        }
-    }
-    return Math.max(0, heads - 1);
+    return activeMsgids(text).size;
 }

--- a/packages/infra/vite-plugin-gettext/src/guards.ts
+++ b/packages/infra/vite-plugin-gettext/src/guards.ts
@@ -88,7 +88,7 @@ export const DEFAULT_MAX_CATALOG_ENTRY_LOSS = 1 / 3;
  */
 export function assertEverySourcePatternMatched(
     matches: readonly SourcePatternMatch[],
-    context: { pluginName: string; cwd: string; optionalSources?: readonly string[] },
+    context: { pluginName: string; cwd: string; optionalSources?: readonly string[]; ignore?: readonly string[] },
 ): void {
     const optional = new Set(context.optionalSources ?? []);
     const empty = matches
@@ -100,10 +100,17 @@ export function assertEverySourcePatternMatched(
     }
 
     const list = empty.map((pattern) => `  - ${pattern}`).join('\n');
+    // The negated patterns are named whenever there are any: a pattern whose every
+    // hit was excluded looks exactly like a wrong path, and the two have different
+    // fixes.
+    const excluded = context.ignore?.length
+        ? `After excluding ${context.ignore.map((pattern) => `!${pattern}`).join(', ')}.\n`
+        : '';
     throw new EmptySourcePatternError(
         `[${context.pluginName}] ${empty.length === 1 ? 'a source pattern' : `${empty.length} source patterns`} matched no files:\n` +
             `${list}\n` +
             `Resolved relative to ${context.cwd}.\n` +
+            excluded +
             'Nothing was extracted. Extracting anyway writes a POT without those strings, and with ' +
             'autoUpdatePo that prunes the same strings out of every catalog. Usual cause: the pattern ' +
             'points at a build artifact of another package that has not been built yet.\n' +

--- a/packages/infra/vite-plugin-gettext/src/index.ts
+++ b/packages/infra/vite-plugin-gettext/src/index.ts
@@ -1,3 +1,4 @@
+export { CatalogShrinkError, EmptySourcePatternError, GettextGuardError } from './guards.js';
 export { gettextPlugin } from './gettext.js';
 export { msgfmtPlugin } from './msgfmt.js';
 export { xgettextPlugin } from './xgettext.js';

--- a/packages/infra/vite-plugin-gettext/src/index.ts
+++ b/packages/infra/vite-plugin-gettext/src/index.ts
@@ -1,4 +1,4 @@
-export { CatalogShrinkError, EmptySourcePatternError, GettextGuardError } from './guards.js';
+export { CatalogShrinkError, EmptySourcePatternError, GettextGuardError, InvalidEntryLossError } from './guards.js';
 export { gettextPlugin } from './gettext.js';
 export { msgfmtPlugin } from './msgfmt.js';
 export { xgettextPlugin } from './xgettext.js';

--- a/packages/infra/vite-plugin-gettext/src/test.mts
+++ b/packages/infra/vite-plugin-gettext/src/test.mts
@@ -1,0 +1,6 @@
+import { run } from '@gjsify/unit';
+
+import guardsSuite from './guards.spec.js';
+import xgettextSuite from './xgettext.spec.js';
+
+run({ guardsSuite, xgettextSuite });

--- a/packages/infra/vite-plugin-gettext/src/types.ts
+++ b/packages/infra/vite-plugin-gettext/src/types.ts
@@ -5,6 +5,19 @@
 export interface XGettextPluginOptions {
     /** Glob patterns for source files to extract strings from */
     sources: string[];
+    /**
+     * Entries of `sources` that are allowed to match no files.
+     *
+     * Every other pattern that matches nothing fails the build — see
+     * `assertEverySourcePatternMatched`. Listed per pattern rather than as one
+     * boolean so declaring one group optional does not disarm the rest.
+     */
+    optionalSources?: string[];
+    /**
+     * Fraction of its entries the catalog set may lose in one run before
+     * `autoUpdatePo` refuses to merge. Defaults to 1/3; `1` disables the check.
+     */
+    maxCatalogEntryLoss?: number;
     /** Output path for the POT template file */
     output: string;
     /** The gettext domain name, defaults to 'messages' */

--- a/packages/infra/vite-plugin-gettext/src/types.ts
+++ b/packages/infra/vite-plugin-gettext/src/types.ts
@@ -3,7 +3,12 @@
  * Used to extract translatable strings from source files
  */
 export interface XGettextPluginOptions {
-    /** Glob patterns for source files to extract strings from */
+    /**
+     * Glob patterns for source files to extract strings from.
+     *
+     * fast-glob syntax: a leading `!` excludes, and applies to the whole set
+     * rather than standing on its own as a group.
+     */
     sources: string[];
     /**
      * Entries of `sources` that are allowed to match no files.

--- a/packages/infra/vite-plugin-gettext/src/types.ts
+++ b/packages/infra/vite-plugin-gettext/src/types.ts
@@ -21,6 +21,9 @@ export interface XGettextPluginOptions {
     /**
      * Fraction of its entries the catalog set may lose in one run before
      * `autoUpdatePo` refuses to merge. Defaults to 1/3; `1` disables the check.
+     *
+     * A FRACTION, not a percentage — `50` would wave every possible loss through,
+     * so anything outside 0…1 is refused rather than obeyed.
      */
     maxCatalogEntryLoss?: number;
     /** Output path for the POT template file */

--- a/packages/infra/vite-plugin-gettext/src/xgettext.spec.ts
+++ b/packages/infra/vite-plugin-gettext/src/xgettext.spec.ts
@@ -104,6 +104,53 @@ export default async () => {
                 await fs.rm(dir, { recursive: true, force: true });
             }
         });
+
+        await it('keeps a negated pattern excluding instead of failing', async () => {
+            // fast-glob reads a leading `!` as an ignore filter over the whole
+            // list and returns NOTHING for a list of only negations — so globbing
+            // patterns one at a time turns an exclusion into a group that matched
+            // no files, and the guard would fail a build that was configured
+            // correctly. Declaring it optional to shut the guard up would be worse
+            // still: the excluded file would then be extracted.
+            const dir = await fixture();
+            try {
+                await write(dir, 'src/window.blp', blueprint('Real'));
+                await write(dir, 'src/generated.blp', blueprint('Generated'));
+                const output = path.join(dir, 'po', 'messages.pot');
+
+                await runBuildStart({
+                    sources: [path.join(dir, 'src', '**', '*.blp'), `!${path.join(dir, 'src', 'generated.blp')}`],
+                    output,
+                    keywords: ['_'],
+                });
+
+                const pot = await fs.readFile(output, 'utf-8');
+                expect(pot.includes('"Real"')).toBe(true);
+                expect(pot.includes('"Generated"')).toBe(false);
+            } finally {
+                await fs.rm(dir, { recursive: true, force: true });
+            }
+        });
+
+        await it('fails when nothing is left to extract from at all', async () => {
+            // The hole the per-pattern check leaves open: every pattern declared
+            // optional and every one empty. Extraction would run over no files,
+            // write an empty POT and prune every catalog against it.
+            const dir = await fixture();
+            try {
+                const pattern = path.join(dir, 'src', '**', '*.blp');
+                await expect(
+                    runBuildStart({
+                        sources: [pattern],
+                        optionalSources: [pattern],
+                        output: path.join(dir, 'po', 'messages.pot'),
+                        keywords: ['_'],
+                    }),
+                ).rejects.toThrow(/no source file to extract from/);
+            } finally {
+                await fs.rm(dir, { recursive: true, force: true });
+            }
+        });
     });
 
     await describe('xgettextPlugin — autoUpdatePo', async () => {

--- a/packages/infra/vite-plugin-gettext/src/xgettext.spec.ts
+++ b/packages/infra/vite-plugin-gettext/src/xgettext.spec.ts
@@ -9,16 +9,19 @@
 //
 // These cases drive the REAL `buildStart` against real gettext binaries, because
 // what went wrong was the orchestration — which patterns are globbed, and what
-// is allowed to reach `msgmerge` — not a parser. The entry counting here is
-// deliberately its own three lines rather than the implementation's counter: a
-// test that judged the fix with the fix's own arithmetic could not see it be
-// wrong.
+// is allowed to reach `msgmerge` — not a parser. The entry counting is
+// `gettext-parser`'s, not the implementation's: judging the fix with the fix's
+// own arithmetic could not see it be wrong, and a hand-rolled copy of that
+// arithmetic could not either — it shares every blind spot it was supposed to
+// check. A separate upstream parser is the only one of the three that is
+// actually an independent oracle.
 
 import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from '@gjsify/unit';
+import { po as poParser } from 'gettext-parser';
 import type { XGettextPluginOptions } from './types.js';
 import { xgettextPlugin } from './xgettext.js';
 
@@ -70,13 +73,21 @@ function catalog(...msgids: string[]): string {
 }
 
 /**
- * Entries a catalog still USES. `msgmerge` does not delete what the POT lost, it
- * comments it out as `#~`, and `msgfmt` ignores those — so a line count would
- * report a gutted catalog as healthy.
+ * Entries a catalog still USES, according to `gettext-parser`.
+ *
+ * `msgmerge` does not delete what the POT lost, it comments it out as `#~`, and
+ * `msgfmt` ignores those — so a line count would report a gutted catalog as
+ * healthy. `gettext-parser` drops obsolete entries for the same reason msgfmt
+ * does (verified against a `#~` fixture), and it is a different parser by a
+ * different author, which is the whole point of using it here.
  */
-function activeEntries(po: string): number {
-    const heads = po.split('\n').filter((line) => /^msgid\s/.test(line));
-    return heads.length - 1; // the header entry is `msgid ""`
+function activeEntries(text: string): number {
+    const parsed = poParser.parse(text);
+    return Object.entries(parsed.translations).reduce(
+        (total, [context, entries]) =>
+            total + Object.keys(entries).filter((msgid) => !(context === '' && msgid === '')).length,
+        0,
+    );
 }
 
 /** The `change` handler `configureServer` registers, with a way to fire it. */

--- a/packages/infra/vite-plugin-gettext/src/xgettext.spec.ts
+++ b/packages/infra/vite-plugin-gettext/src/xgettext.spec.ts
@@ -1,0 +1,158 @@
+// The two ways this plugin used to destroy translations while exiting 0.
+//
+// Measured 2026-09-03 in JumpLink/Learn6502: one `sources` entry pointed at
+// `../learn/dist/**/*.ui`, a build artifact of a SIBLING workspace package.
+// Built in the wrong order that pattern matches nothing, so the `ui` group
+// simply did not exist — 902 lines left the POT and ~1573 left each of 16
+// catalogs, every MDX-derived tutorial string among them. Nothing failed; it was
+// caught by reading the diff before committing.
+//
+// These cases drive the REAL `buildStart` against real gettext binaries, because
+// what went wrong was the orchestration — which patterns are globbed, and what
+// is allowed to reach `msgmerge` — not a parser. The entry counting here is
+// deliberately its own three lines rather than the implementation's counter: a
+// test that judged the fix with the fix's own arithmetic could not see it be
+// wrong.
+
+import { existsSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from '@gjsify/unit';
+import type { XGettextPluginOptions } from './types.js';
+import { xgettextPlugin } from './xgettext.js';
+
+/** Calls the plugin's real `buildStart`, which is where extraction is driven from. */
+async function runBuildStart(options: XGettextPluginOptions): Promise<void> {
+    const plugin = xgettextPlugin(options) as unknown as { buildStart: () => Promise<void> };
+    await plugin.buildStart();
+}
+
+async function fixture(): Promise<string> {
+    return await fs.mkdtemp(path.join(tmpdir(), 'gjsify-xgettext-'));
+}
+
+async function write(dir: string, relative: string, content: string): Promise<string> {
+    const file = path.join(dir, relative);
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, content, 'utf-8');
+    return file;
+}
+
+/** A Blueprint template whose captions are the msgids a case is about. */
+function blueprint(...msgids: string[]): string {
+    const labels = msgids.slice(1).map((id) => `  Gtk.Label { label: _("${id}"); }`);
+    return [
+        'using Gtk 4.0;',
+        '',
+        'template $Window : Gtk.ApplicationWindow {',
+        `  title: _("${msgids[0]}");`,
+        ...labels,
+        '}',
+        '',
+    ].join('\n');
+}
+
+/** A translated catalog, so a prune shows up as lost TRANSLATIONS, not lost msgids. */
+function catalog(...msgids: string[]): string {
+    const header = [
+        'msgid ""',
+        'msgstr ""',
+        '"Project-Id-Version: messages\\n"',
+        '"MIME-Version: 1.0\\n"',
+        '"Content-Type: text/plain; charset=UTF-8\\n"',
+        '"Content-Transfer-Encoding: 8bit\\n"',
+        '"Language: de\\n"',
+        '',
+    ];
+    const entries = msgids.flatMap((id) => [`msgid "${id}"`, `msgstr "${id} auf Deutsch"`, '']);
+    return [...header, ...entries].join('\n');
+}
+
+/**
+ * Entries a catalog still USES. `msgmerge` does not delete what the POT lost, it
+ * comments it out as `#~`, and `msgfmt` ignores those — so a line count would
+ * report a gutted catalog as healthy.
+ */
+function activeEntries(po: string): number {
+    const heads = po.split('\n').filter((line) => /^msgid\s/.test(line));
+    return heads.length - 1; // the header entry is `msgid ""`
+}
+
+export default async () => {
+    await describe('xgettextPlugin — source patterns', async () => {
+        await it('fails on a pattern that matches no files', async () => {
+            const dir = await fixture();
+            try {
+                await write(dir, 'src/window.blp', blueprint('Hello'));
+                const output = path.join(dir, 'po', 'messages.pot');
+
+                // The Learn6502 shape exactly: one good pattern, one pointing at a
+                // sibling package's not-yet-built `dist/`.
+                await expect(
+                    runBuildStart({
+                        sources: [path.join(dir, 'src', '**', '*.blp'), path.join(dir, 'dist', '**', '*.ui')],
+                        output,
+                        keywords: ['_'],
+                    }),
+                ).rejects.toThrow(/matched no files/);
+
+                // A partial POT must not exist either: the next run would diff
+                // against it and read the loss as intentional.
+                expect(existsSync(output)).toBe(false);
+            } finally {
+                await fs.rm(dir, { recursive: true, force: true });
+            }
+        });
+    });
+
+    await describe('xgettextPlugin — autoUpdatePo', async () => {
+        await it('refuses to prune catalogs a collapsed POT would empty', async () => {
+            const dir = await fixture();
+            try {
+                await write(dir, 'src/window.blp', blueprint('Hello'));
+                await write(dir, 'po/LINGUAS', 'de\n');
+                const poFile = await write(dir, 'po/de.po', catalog('Hello', 'Second', 'Third', 'Fourth'));
+                const before = await fs.readFile(poFile, 'utf-8');
+
+                await expect(
+                    runBuildStart({
+                        sources: [path.join(dir, 'src', '**', '*.blp')],
+                        output: path.join(dir, 'po', 'messages.pot'),
+                        keywords: ['_'],
+                        autoUpdatePo: true,
+                    }),
+                ).rejects.toThrow(/catalog/i);
+
+                expect(await fs.readFile(poFile, 'utf-8')).toBe(before);
+                expect(activeEntries(await fs.readFile(poFile, 'utf-8'))).toBe(4);
+            } finally {
+                await fs.rm(dir, { recursive: true, force: true });
+            }
+        });
+
+        await it('still merges when the POT holds what the catalogs hold', async () => {
+            const dir = await fixture();
+            try {
+                await write(dir, 'src/window.blp', blueprint('Hello', 'Second', 'Third'));
+                await write(dir, 'po/LINGUAS', 'de\n');
+                const poFile = await write(dir, 'po/de.po', catalog('Hello', 'Second'));
+                const output = path.join(dir, 'po', 'messages.pot');
+
+                await runBuildStart({
+                    sources: [path.join(dir, 'src', '**', '*.blp')],
+                    output,
+                    keywords: ['_'],
+                    autoUpdatePo: true,
+                });
+
+                expect(activeEntries(await fs.readFile(output, 'utf-8'))).toBe(3);
+                const merged = await fs.readFile(poFile, 'utf-8');
+                expect(activeEntries(merged)).toBe(3);
+                expect(merged.includes('Hello auf Deutsch')).toBe(true);
+            } finally {
+                await fs.rm(dir, { recursive: true, force: true });
+            }
+        });
+    });
+};

--- a/packages/infra/vite-plugin-gettext/src/xgettext.spec.ts
+++ b/packages/infra/vite-plugin-gettext/src/xgettext.spec.ts
@@ -79,6 +79,27 @@ function activeEntries(po: string): number {
     return heads.length - 1; // the header entry is `msgid ""`
 }
 
+/** The `change` handler `configureServer` registers, with a way to fire it. */
+function watchedServer(options: XGettextPluginOptions) {
+    let onChange: ((file: string) => Promise<void>) | undefined;
+    const server = {
+        watcher: {
+            add() {},
+            on(event: string, handler: (file: string) => Promise<void>) {
+                if (event === 'change') {
+                    onChange = handler;
+                }
+            },
+        },
+    };
+    const plugin = xgettextPlugin(options) as unknown as { configureServer: (server: unknown) => void };
+    plugin.configureServer(server);
+    if (!onChange) {
+        throw new Error('configureServer registered no change handler');
+    }
+    return onChange;
+}
+
 export default async () => {
     await describe('xgettextPlugin — source patterns', async () => {
         await it('fails on a pattern that matches no files', async () => {
@@ -147,6 +168,55 @@ export default async () => {
                         keywords: ['_'],
                     }),
                 ).rejects.toThrow(/no source file to extract from/);
+            } finally {
+                await fs.rm(dir, { recursive: true, force: true });
+            }
+        });
+    });
+
+    await describe('xgettextPlugin — the dev-server watch path', async () => {
+        await it('re-extracts on a source change, and only for a source', async () => {
+            // `configureServer` matched with `file.match(pattern)`, which compiles
+            // the glob as a REGEXP — and `**` in one is `Nothing to repeat`, so
+            // every change event threw a SyntaxError before deciding anything.
+            // Re-extraction in `vite dev` had never run, and neither guard had ever
+            // been reached from here.
+            const dir = await fixture();
+            try {
+                const source = await write(dir, 'src/window.blp', blueprint('Hello', 'Second'));
+                const output = path.join(dir, 'po', 'messages.pot');
+                const onChange = watchedServer({
+                    sources: [path.join(dir, 'src', '**', '*.blp')],
+                    output,
+                    keywords: ['_'],
+                });
+
+                await onChange(path.join(dir, 'README.md'));
+                expect(existsSync(output)).toBe(false);
+
+                await onChange(source);
+                expect(activeEntries(await fs.readFile(output, 'utf-8'))).toBe(2);
+            } finally {
+                await fs.rm(dir, { recursive: true, force: true });
+            }
+        });
+
+        await it('arms the catalog guard on that path too', async () => {
+            const dir = await fixture();
+            try {
+                const source = await write(dir, 'src/window.blp', blueprint('Hello'));
+                await write(dir, 'po/LINGUAS', 'de\n');
+                const poFile = await write(dir, 'po/de.po', catalog('Hello', 'Second', 'Third', 'Fourth'));
+                const before = await fs.readFile(poFile, 'utf-8');
+                const onChange = watchedServer({
+                    sources: [path.join(dir, 'src', '**', '*.blp')],
+                    output: path.join(dir, 'po', 'messages.pot'),
+                    keywords: ['_'],
+                    autoUpdatePo: true,
+                });
+
+                await expect(onChange(source)).rejects.toThrow(/catalog/i);
+                expect(await fs.readFile(poFile, 'utf-8')).toBe(before);
             } finally {
                 await fs.rm(dir, { recursive: true, force: true });
             }

--- a/packages/infra/vite-plugin-gettext/src/xgettext.ts
+++ b/packages/infra/vite-plugin-gettext/src/xgettext.ts
@@ -8,6 +8,7 @@ import {
     assertCatalogsSurviveMerge,
     assertEverySourcePatternMatched,
     countActiveEntries,
+    EmptySourcePatternError,
     GettextGuardError,
 } from './guards.js';
 import type { XGettextPluginOptions } from './types.js';
@@ -122,24 +123,50 @@ export function xgettextPlugin(options: XGettextPluginOptions): Plugin {
 }
 
 /**
- * Resolves `sources` to files, globbing each pattern SEPARATELY.
+ * Resolves `sources` to files, globbing each POSITIVE pattern separately under
+ * the negative ones.
  *
  * The union `glob(options.sources)` used to return cannot say WHICH pattern came
  * up empty, and in the incident `guards.ts` records only one of several did — so
  * the union was non-empty and there was nothing left to notice. Per-pattern is
  * what makes the guard able to name the offender.
+ *
+ * The negative patterns have to stay a property of the WHOLE set, though.
+ * fast-glob reads a leading `!` as an ignore filter over the other patterns, and
+ * returns nothing at all for a list that is only negations — so globbing one on
+ * its own yields zero files, which the guard would report as a missing source
+ * group, and silencing that with `optionalSources` would then extract the very
+ * files the `!` was there to keep out. They are lifted into `ignore` instead,
+ * which is what fast-glob does with them internally.
  */
 async function resolveSources(options: XGettextPluginOptions, pluginName: string): Promise<string[]> {
-    const perPattern = await Promise.all(options.sources.map((pattern) => glob(pattern)));
+    const included = options.sources.filter((pattern) => !pattern.startsWith('!'));
+    const ignore = options.sources.filter((pattern) => pattern.startsWith('!')).map((pattern) => pattern.slice(1));
+    const perPattern = await Promise.all(included.map((pattern) => glob(pattern, { ignore })));
 
     assertEverySourcePatternMatched(
-        options.sources.map((pattern, index) => ({ pattern, fileCount: perPattern[index].length })),
-        { pluginName, cwd: process.cwd(), optionalSources: options.optionalSources },
+        included.map((pattern, index) => ({ pattern, fileCount: perPattern[index].length })),
+        { pluginName, cwd: process.cwd(), optionalSources: options.optionalSources, ignore },
     );
 
     // Two patterns may legitimately reach the same file; xgettext would then scan
     // it twice and msgcat would have to fold the duplicate back out.
-    return [...new Set(perPattern.flat())];
+    const files = [...new Set(perPattern.flat())];
+
+    // The one hole the per-pattern guard leaves: no positive pattern at all, or
+    // every pattern declared optional and every one empty. Extraction would run
+    // over nothing, write an empty POT and prune every catalog against it — the
+    // incident again, reached by a different route.
+    if (files.length === 0) {
+        throw new EmptySourcePatternError(
+            `[${pluginName}] no source file to extract from: ${options.sources.length} pattern(s) resolved to ` +
+                `nothing under ${process.cwd()}.\n` +
+                'Extracting anyway writes an empty POT, and with autoUpdatePo that empties every catalog.',
+            options.sources,
+        );
+    }
+
+    return files;
 }
 
 async function generatePotfiles(files: string[], outputDir: string, pluginName: string, verbose = false) {

--- a/packages/infra/vite-plugin-gettext/src/xgettext.ts
+++ b/packages/infra/vite-plugin-gettext/src/xgettext.ts
@@ -197,14 +197,14 @@ async function generatePotfiles(files: string[], outputDir: string, pluginName: 
         const potfilePath = path.join(outputDir, `${group}.POTFILES`);
         const content = groupFiles.join('\n');
 
-        try {
-            await fs.writeFile(potfilePath, content);
-            potFiles.push(potfilePath);
-            if (verbose) {
-                console.log(`[${pluginName}] Generated ${group}.POTFILES with ${groupFiles.length} source files`);
-            }
-        } catch (error) {
-            console.error(`[${pluginName}] Error writing ${group}.POTFILES:`, error);
+        // Deliberately unguarded. A caught write failure used to leave the group
+        // out of `potFiles`, so xgettext never ran for it and the whole group left
+        // the POT — the incident in `guards.ts`, reached without any pattern being
+        // wrong. Nothing here can be recovered from; it has to end the build.
+        await fs.writeFile(potfilePath, content);
+        potFiles.push(potfilePath);
+        if (verbose) {
+            console.log(`[${pluginName}] Generated ${group}.POTFILES with ${groupFiles.length} source files`);
         }
     }
 
@@ -495,39 +495,43 @@ async function assertCatalogsSurviveNextMerge(options: XGettextPluginOptions, pl
     });
 }
 
+/**
+ * Merges the POT into every catalog LINGUAS declares.
+ *
+ * Deliberately unguarded, like `generatePotfiles`. A caught error here used to be
+ * one `console.error` beside exit 0 — and by then `msgmerge --update` may already
+ * have rewritten the catalogs it got to, so "an error was printed" and "the
+ * catalogs are intact" were unrelated facts.
+ */
 async function updatePoFiles(potFile: string, pluginName: string, verbose: boolean, options: XGettextPluginOptions) {
-    try {
-        for (const { file: poFile } of await listCatalogs(potFile)) {
+    for (const { file: poFile } of await listCatalogs(potFile)) {
+        if (verbose) {
+            console.log(`[${pluginName}] Updating ${poFile}`);
+        }
+        const baseMsgmergeArgs = ['--update', '--backup=none', poFile, potFile];
+        const args = buildCommandArgs(baseMsgmergeArgs, {
+            noLocation: options.noLocation,
+            noWrap: options.noWrap,
+        });
+
+        const env = { ...process.env };
+        if (options.deterministic) {
+            const epoch = typeof options.sourceDateEpoch === 'number' ? options.sourceDateEpoch : 0;
+            env.SOURCE_DATE_EPOCH = String(epoch);
+        }
+
+        await execa('msgmerge', args, { env });
+
+        // Post-process with msgcat to unwrap existing wrapped lines
+        if (options.noWrap) {
+            const tempFile = poFile + '.tmp';
+            const msgcatArgs = ['--width=0', '--no-wrap', '-o', tempFile, poFile];
+            await execa('msgcat', msgcatArgs, { env });
+            await fs.rename(tempFile, poFile);
             if (verbose) {
-                console.log(`[${pluginName}] Updating ${poFile}`);
-            }
-            const baseMsgmergeArgs = ['--update', '--backup=none', poFile, potFile];
-            const args = buildCommandArgs(baseMsgmergeArgs, {
-                noLocation: options.noLocation,
-                noWrap: options.noWrap,
-            });
-
-            const env = { ...process.env };
-            if (options.deterministic) {
-                const epoch = typeof options.sourceDateEpoch === 'number' ? options.sourceDateEpoch : 0;
-                env.SOURCE_DATE_EPOCH = String(epoch);
-            }
-
-            await execa('msgmerge', args, { env });
-
-            // Post-process with msgcat to unwrap existing wrapped lines
-            if (options.noWrap) {
-                const tempFile = poFile + '.tmp';
-                const msgcatArgs = ['--width=0', '--no-wrap', '-o', tempFile, poFile];
-                await execa('msgcat', msgcatArgs, { env });
-                await fs.rename(tempFile, poFile);
-                if (verbose) {
-                    console.log(`[${pluginName}] Unwrapped lines in ${poFile}`);
-                }
+                console.log(`[${pluginName}] Unwrapped lines in ${poFile}`);
             }
         }
-    } catch (error) {
-        console.error(`[${pluginName}] Error updating PO files:`, error);
     }
 }
 

--- a/packages/infra/vite-plugin-gettext/src/xgettext.ts
+++ b/packages/infra/vite-plugin-gettext/src/xgettext.ts
@@ -110,13 +110,21 @@ export function xgettextPlugin(options: XGettextPluginOptions): Plugin {
             server.watcher.add(options.sources);
 
             server.watcher.on('change', async (file) => {
-                if (options.sources.some((pattern) => file.match(pattern))) {
-                    if (options.verbose) {
-                        console.log(`[${pluginName}] Source file changed: ${file}, re-running extraction`);
-                    }
-                    const files = await resolveSources(options, pluginName);
-                    await extractStrings(files, options, pluginName);
+                // Membership in the RESOLVED set, not `file.match(pattern)`: that
+                // compiled the glob as a regular expression, and any `**` in it is
+                // `Nothing to repeat`, so every change event threw a SyntaxError
+                // before it could decide anything. Re-extraction in `vite dev` had
+                // never run, which is also why the guards below had never been
+                // reached from here.
+                const files = await resolveSources(options, pluginName);
+                const changed = path.resolve(file);
+                if (!files.some((candidate) => path.resolve(candidate) === changed)) {
+                    return;
                 }
+                if (options.verbose) {
+                    console.log(`[${pluginName}] Source file changed: ${file}, re-running extraction`);
+                }
+                await extractStrings(files, options, pluginName);
             });
         },
     };

--- a/packages/infra/vite-plugin-gettext/src/xgettext.ts
+++ b/packages/infra/vite-plugin-gettext/src/xgettext.ts
@@ -5,9 +5,9 @@ import fs from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import glob from 'fast-glob';
 import {
+    activeMsgids,
     assertCatalogsSurviveMerge,
     assertEverySourcePatternMatched,
-    countActiveEntries,
     EmptySourcePatternError,
     GettextGuardError,
 } from './guards.js';
@@ -482,12 +482,12 @@ async function assertCatalogsSurviveNextMerge(options: XGettextPluginOptions, pl
     const sizes = await Promise.all(
         catalogs.map(async ({ language, file }) => ({
             language,
-            entries: countActiveEntries(await readTextOrEmpty(file)),
+            msgids: activeMsgids(await readTextOrEmpty(file)),
         })),
     );
 
     assertCatalogsSurviveMerge({
-        potEntries: countActiveEntries(await readTextOrEmpty(options.output)),
+        potMsgids: activeMsgids(await readTextOrEmpty(options.output)),
         catalogs: sizes,
         potFile: options.output,
         pluginName,

--- a/packages/infra/vite-plugin-gettext/src/xgettext.ts
+++ b/packages/infra/vite-plugin-gettext/src/xgettext.ts
@@ -4,6 +4,12 @@ import path from 'node:path';
 import fs from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import glob from 'fast-glob';
+import {
+    assertCatalogsSurviveMerge,
+    assertEverySourcePatternMatched,
+    countActiveEntries,
+    GettextGuardError,
+} from './guards.js';
 import type { XGettextPluginOptions } from './types.js';
 import { checkDependencies, ensureDirectory, processFilename } from './utils.js';
 
@@ -95,7 +101,7 @@ export function xgettextPlugin(options: XGettextPluginOptions): Plugin {
 
         async buildStart() {
             await checkDependencies('xgettext', pluginName, options.verbose ?? false);
-            const files = await glob(options.sources);
+            const files = await resolveSources(options, pluginName);
             await extractStrings(files, options, pluginName);
         },
 
@@ -107,12 +113,33 @@ export function xgettextPlugin(options: XGettextPluginOptions): Plugin {
                     if (options.verbose) {
                         console.log(`[${pluginName}] Source file changed: ${file}, re-running extraction`);
                     }
-                    const files = await glob(options.sources);
+                    const files = await resolveSources(options, pluginName);
                     await extractStrings(files, options, pluginName);
                 }
             });
         },
     };
+}
+
+/**
+ * Resolves `sources` to files, globbing each pattern SEPARATELY.
+ *
+ * The union `glob(options.sources)` used to return cannot say WHICH pattern came
+ * up empty, and in the incident `guards.ts` records only one of several did — so
+ * the union was non-empty and there was nothing left to notice. Per-pattern is
+ * what makes the guard able to name the offender.
+ */
+async function resolveSources(options: XGettextPluginOptions, pluginName: string): Promise<string[]> {
+    const perPattern = await Promise.all(options.sources.map((pattern) => glob(pattern)));
+
+    assertEverySourcePatternMatched(
+        options.sources.map((pattern, index) => ({ pattern, fileCount: perPattern[index].length })),
+        { pluginName, cwd: process.cwd(), optionalSources: options.optionalSources },
+    );
+
+    // Two patterns may legitimately reach the same file; xgettext would then scan
+    // it twice and msgcat would have to fold the duplicate back out.
+    return [...new Set(perPattern.flat())];
 }
 
 async function generatePotfiles(files: string[], outputDir: string, pluginName: string, verbose = false) {
@@ -363,20 +390,79 @@ async function extractStrings(files: string[], options: XGettextPluginOptions, p
         }
 
         if (options.autoUpdatePo) {
+            await assertCatalogsSurviveNextMerge(options, pluginName);
             await updatePoFiles(options.output, pluginName, options.verbose || false, options);
         }
     } catch (error) {
+        // A guard's message IS the guard — wrapping it in "Failed to extract
+        // translations: Error: …" buries the instruction that makes it useful.
+        if (error instanceof GettextGuardError) {
+            throw error;
+        }
         throw new Error(`Failed to extract translations: ${error}`);
     }
 }
 
+/** The catalogs LINGUAS declares beside a POT. */
+async function listCatalogs(potFile: string): Promise<Array<{ language: string; file: string }>> {
+    const directory = path.dirname(potFile);
+    const linguas = await readTextOrEmpty(path.join(directory, 'LINGUAS'));
+
+    return linguas
+        .split('\n')
+        .filter(Boolean)
+        .map((language) => ({ language, file: path.join(directory, `${language}.po`) }));
+}
+
+/**
+ * A file that is not there yet reads as empty rather than as a failure: a project
+ * with no LINGUAS has no translations, and a language named in LINGUAS before its
+ * catalog exists holds no entries. Both are states a first run is legitimately
+ * in, and neither is something a merge can destroy.
+ */
+async function readTextOrEmpty(file: string): Promise<string> {
+    try {
+        return await fs.readFile(file, 'utf-8');
+    } catch (error) {
+        // ONLY "not there yet" reads as empty. A permission or I/O error must not:
+        // an unreadable catalog counted as holding nothing is the guard talking
+        // itself out of firing.
+        if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') {
+            return '';
+        }
+        throw error;
+    }
+}
+
+/**
+ * Reads what `msgmerge` is about to rewrite and hands the counts to the pure
+ * check.
+ *
+ * Called from `extractStrings` BEFORE `updatePoFiles` and outside that function's
+ * catch — a refusal that became one more `console.error` beside a zero exit code
+ * would be the exact silence this guards against.
+ */
+async function assertCatalogsSurviveNextMerge(options: XGettextPluginOptions, pluginName: string): Promise<void> {
+    const catalogs = await listCatalogs(options.output);
+    const sizes = await Promise.all(
+        catalogs.map(async ({ language, file }) => ({
+            language,
+            entries: countActiveEntries(await readTextOrEmpty(file)),
+        })),
+    );
+
+    assertCatalogsSurviveMerge({
+        potEntries: countActiveEntries(await readTextOrEmpty(options.output)),
+        catalogs: sizes,
+        potFile: options.output,
+        pluginName,
+        maxEntryLoss: options.maxCatalogEntryLoss,
+    });
+}
+
 async function updatePoFiles(potFile: string, pluginName: string, verbose: boolean, options: XGettextPluginOptions) {
     try {
-        const linguasPath = path.join(path.dirname(potFile), 'LINGUAS');
-        const languages = (await fs.readFile(linguasPath, 'utf-8')).split('\n').filter(Boolean);
-
-        for (const lang of languages) {
-            const poFile = path.join(path.dirname(potFile), `${lang}.po`);
+        for (const { file: poFile } of await listCatalogs(potFile)) {
             if (verbose) {
                 console.log(`[${pluginName}] Updating ${poFile}`);
             }

--- a/packages/infra/vite-plugin-gettext/tsconfig.build.json
+++ b/packages/infra/vite-plugin-gettext/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["src/test.mts", "src/**/*.spec.ts", "src/**/*.spec.mts"]
+}

--- a/packages/infra/vite-plugin-gettext/tsconfig.json
+++ b/packages/infra/vite-plugin-gettext/tsconfig.json
@@ -11,5 +11,12 @@
         "skipLibCheck": true,
         "types": ["node"]
     },
-    "include": ["src/**/*"]
+    "include": ["src/**/*"],
+    "comment": [
+        "Specs stay INCLUDED here on purpose, so `check` type-checks them; only",
+        "`tsconfig.build.json` drops them, because `files` publishes `lib/` and an",
+        "emitted spec would ship. The test ENTRY is excluded from both: it is",
+        "compiled by the test task, which resolves `@gjsify/unit` for it."
+    ],
+    "exclude": ["src/test.mts"]
 }


### PR DESCRIPTION
## The defect

`xgettextPlugin` could destroy every translation in a project and exit 0.

`buildStart` globbed `options.sources` as one union. When a single pattern matched nothing, the union was still non-empty, so extraction ran over an incomplete file set, wrote a POT missing that group's strings, and — with `autoUpdatePo` — ran `msgmerge --update <lang>.po <pot>` over every language in `LINGUAS`. `msgmerge` moves every entry the POT lost into `#~` comments, and `msgfmt` ignores those, so the translations are gone.

Measured 2026-09-03 in `JumpLink/Learn6502`: its `sources` included `../learn/dist/**/*.ui`, a build artifact of a *sibling* workspace package. Build `@learn6502/translations` before `@learn6502/learn` and that pattern matches nothing. 902 lines left the POT and roughly 1573 left each of 16 catalogs, every MDX-derived tutorial entry among them. It was caught only by reading the diff before committing; in CI, or on a machine with a stale `dist/`, it would have landed.

An earlier draft of this description said the dependency edge was undeclared. That is wrong, and worth correcting rather than quietly dropping, because it changes what the fix is for. `@learn6502/translations` does declare `@learn6502/learn` in its `dependencies`, and `gjsify workspace <name> <script> -t` walks exactly that graph. What happened is narrower: `gjsify workspace @learn6502/translations build` without `-t` builds the one package and not what it depends on, so the artifact was whatever the previous run left behind.

That makes "order the build correctly" a real instruction rather than a missing one, and it is now in the plugin's README. It still is not a fix. A build that silently produces a wrong result when invoked a legal way has to fail instead.

## The two guards

**Every `sources` pattern must match at least one file.** Patterns are now globbed separately, which is what lets the error name the offender; the union never could. Failing is the default: the cost of being wrong is asymmetric — a false failure costs one build, a missed one costs every translation the group carried. A project that genuinely has an optional group lists those patterns in the new `optionalSources`, one at a time, so declaring one optional leaves the guard armed for the rest.

**`autoUpdatePo` will not prune a catalog set past `maxCatalogEntryLoss`.** Before merging, the msgids the largest catalog holds are diffed against the fresh POT's, and the merge is refused when the share that would be lost exceeds the limit.

A set difference rather than a count, because `msgmerge` matches by msgid. An equally long POT of re-worded strings obsoletes just as much while a count sees a loss of zero, and that is not hypothetical here: Learn6502's msgids are whitespace-normalised markdown renders, so a change in its inline-markup step re-msgids every paragraph at a constant total. Measured on gettext 0.26, a msgid that gained one space is fuzzy-matched, keeps its text, and `msgfmt` then reports it `0 translated, 1 fuzzy` and leaves it out of the `.mo`.

The largest catalog is the reference because `msgmerge --update` gives every catalog the POT's msgid set, so the biggest one is the best evidence of what the project had; comparing per language would let a catalog an earlier bad run already gutted excuse gutting the rest. Verified rather than assumed: a 1-entry and a 2-entry catalog both came back carrying the POT's 3.

The default is **one third**. A ratio, because an absolute count cannot be right for both a twelve-string dialog and a nine-hundred-string tutorial. One third, because the two populations it separates are far apart: churn between two runs of the same build is single-digit percent, while the failure this exists for drops a whole source group at once. Half is worse — a project with two source groups of similar size loses one at ~50% and slips under. No catalogs, a missing `LINGUAS` and an empty largest catalog all return early; an already-gutted set self-heals, since the POT is then the larger side. The option itself is validated before any catalog is read, because `50` read as a percentage is above every possible ratio and would silently pass everything.

Both guard errors derive from a `GettextGuardError` base and are rethrown unwrapped, so `Failed to extract translations: Error: …` does not bury the instruction that makes them useful. `updatePoFiles`' `LINGUAS` read is lifted into a shared `listCatalogs`, and a missing file reads as empty only on `ENOENT` — an unreadable catalog counted as holding nothing would be the guard talking itself out of firing.

## Tests

The package had no test script. It now follows `vite-plugin-blueprint`'s setup exactly (`build:test:node` / `test` / `test:node`, a `tsconfig.build.json` that keeps specs out of `lib/`).

- `guards.spec.ts` — the decisions on their own, no gettext and no filesystem.
- `xgettext.spec.ts` — the real `buildStart` against real gettext binaries in a temp tree, because what went wrong was the orchestration. Its entry counting goes through `gettext-parser`, already a dependency: a different parser by a different author, rather than a hand-rolled copy of the implementation's arithmetic that would share every blind spot it is meant to check.

**Before/after check.** The two integration cases were written first and run against the unfixed plugin: both failed (no throw), while the happy-path case passed. A probe on the same unfixed build confirmed the destruction the second case is about — the catalog went from 4 active entries to 1, silently. After the fix all 24 assertions pass. Neutering each guard body in turn then fails 9 of 14 cases, including both integration cases; the one case that does not discriminate against a *loosened* `countActiveEntries` is `does not count the header`, which is a boundary case covered by the two beside it.

## Fixed in review

An independent pass over this branch found four defects in it, three of them in the guards themselves.

**Negated `sources` patterns stopped working.** Globbing each pattern separately changed what `!pattern` means: fast-glob reads a leading `!` as an ignore filter over the whole list, so a negation globbed alone matches nothing and the guard rejected it. Worse, the escape hatch made it silent — listing the negation in `optionalSources` suppressed the error and then extracted the very file the `!` existed to exclude. Negations now go into fast-glob's `ignore`, so the resolved set is identical to the old union and only positive patterns have to match. This would have broken every project using an exclusion.

**The dev-server watch path had never run.** `configureServer` compiled each glob as a RegExp to test a changed file, and any `**` is `Nothing to repeat`, so every change event threw into a dropped promise. Pre-existing, but it meant the guards were armed on one path out of two. It now asks the resolved set for membership.

**Two swallowed failures in the same file, the same defect class as the incident.** A failed `POTFILES` write was caught and the build continued without that group, which reaches the incident with no pattern wrong at all; and `updatePoFiles` caught everything `msgmerge` could raise, after some catalogs had already been rewritten. Both removed.

**`maxCatalogEntryLoss` was unvalidated**, and every-pattern-optional-and-empty resolved to an empty POT to prune against. Both now fail.

Tests went from 24 to 46. Every mutant written against the new code is caught, including one that reverts the msgid diff to a count.

## Also in this PR

**A README section on build order.** The pattern guard says a `sources` entry matched nothing; it did not say what to do about the usual cause. Declaring the sibling in `dependencies` is not enough on its own, so the README now names `-t` and the explicit-step alternative.

**ADR 0041.** The incident raised a second question: should gjsify host the build-time MDX-to-declarative-UI serializer that Learn6502 carries, so that emitting, extracting and validating live together? It is answered here rather than left open, because leaving it open is how a 2000-line package migrates by drift.

The answer is no, and each argument for it was measured, then re-derived in review against the commands that produced it. Several numbers were wrong and are corrected in the ADR; one of them mattered. "The msgid is target-neutral, so a runtime renderer would keep it" rested on a three-sample. Over all of them the GTK and NativeScript msgid sets share a minority: inline code becomes `<tt>` on one target and a whole `SourceView` element on the other, so most Android strings have no catalog entry at all. That is a defect the ADR now records against Learn6502 rather than a reason to move code. The conclusion does not turn on it; the sentence it rested on did. The property worth sharing is a 59-line inline-markup step that defines the msgid, not the XML emission around it. The ordering trap is not a repository boundary, per the correction above. The duplicated widget knowledge is 53 overlapping names of which 14 are ever emitted, in code that changed three times since 2025. And there is one consumer, 39.5% of whose lines are its own `SourceView`.

The ADR names the two conditions that reopen it — a second consumer with translatable long-form content, or a runtime markdown renderer on the GTK host — and records that in either case the shared piece would be the headless block/inline model, not the serializer. It also carries the strongest argument against its own conclusion, which is that ADR 0034 § 8 states "write the tree once, emit the dialects" as a repository principle whose most complete instance then lives outside this repository.

The ADR is in the same PR as the guards because it concludes that the guards are the whole of gjsify's answer to the incident. Landing the decision separately from the thing it decides would invite re-litigating it.

## Validation

`gjsify workspace @gjsify/vite-plugin-gettext check` · the package's `test` (24/24) · `gjsify format --check` and `gjsify lint` clean from the repo root · `check-node-test-registration` sees both new specs · `check-comment-budget` advisory, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URLYj1wgGxVNRbBpNT8xAV


