### PR TITLE
fix(react-native): see through child wrappers

### DIFF
--- a/packages/framework/react-native/README.md
+++ b/packages/framework/react-native/README.md
@@ -97,6 +97,34 @@ the table rather than only here.
 L2 is exported (`import { primitives } from '@gjsify/react-native'`) so any binding
 can render the same vocabulary without going through the React components.
 
+### What a parent asks about its children, and what stays transparent
+
+A few decisions cannot be taken by the element that authored them. `position: absolute`
+is the clearest: it positions the element on top of its parent, so the **parent** has
+to be a `Gtk.Overlay` — and a `View` becomes one as soon as one of its children asks.
+The same shape decides whether a text child competes with a prop for a widget's text
+sink, and `justify-between` is refused on a child count.
+
+React's parent renders before its children exist, so it reads their **descriptors**.
+Three things are therefore transparent to that read, and each is transparent because
+an application writes it without meaning to change anything:
+
+- **a Fragment.** `<>…</>` is transparent to layout in React, so it is transparent
+  here: it is expanded away before anything is counted, its children keeping their own
+  keys composed behind its own. A card whose `overlay={<>…</>}` holds the absolutely
+  positioned child gets the overlay it asked for.
+- **an array**, which is the same statement in a different spelling.
+- **an `<Animated.View>`.** Its style carries `Animated.Value`s, which is exactly what
+  the style partition refuses on a plain element — so a parent reads it through the
+  same split the component itself uses. An animated fade and an `absolute` compose.
+
+What is NOT transparent is a foreign composite component: `<MyCard className="…">` may
+carry any vocabulary at all, and a parent must not throw for one it cannot route, so it
+answers "no" and the child — if it ever reaches L2 — is refused by name. That boundary
+is enumerated in `src/child-facts.spec.ts` as every fact a parent reads × every wrapper
+it can arrive in, with the fact list derived from the record itself: a new fact has no
+row until someone adds one, and the suite says so.
+
 ### The split is measured, not asserted
 
 `@gjsify/react-native/solid` exports the same seven primitives as SolidJS components

--- a/packages/framework/react-native/src/child-facts.spec.ts
+++ b/packages/framework/react-native/src/child-facts.spec.ts
@@ -32,11 +32,11 @@ import { describe, expect, it } from '@gjsify/unit';
 import { MINIMAL_TOKENS, type StyleTokens } from '@gjsify/gtk-host/style';
 import { createElement, Fragment, type ReactNode } from 'react';
 
-import { childFacts, childNodes } from './child-facts.js';
+import { childFacts, childNodes, readableProps } from './child-facts.js';
 import { AnimatedValue } from './animated/value.js';
 // `AnimatedView` is the exported name; `Animated.View` is what an application writes.
 import { AnimatedView, Text, View } from './components.js';
-import type { ChildFacts } from './primitives/resolve.js';
+import { declaresAbsolute, type ChildFacts } from './primitives/resolve.js';
 
 const TOKENS: StyleTokens = { ...MINIMAL_TOKENS, spacing: { ...MINIMAL_TOKENS.spacing, '2': '8px' } };
 
@@ -243,7 +243,32 @@ export default async () => {
                 createElement(Fragment, { key: 'group' }, createElement(View, { key: 'inner' })),
             ]);
             expect((nodes[0] as { key: string | null }).key).toBe('.$sibling');
-            expect((nodes[1] as { key: string | null }).key).toBe('.$group.$inner');
+            expect((nodes[1] as { key: string | null }).key).toBe('.$group:.$inner');
+        });
+
+        await it('cannot compose a key a SIBLING can also be authored to have', async () => {
+            // The separator, and the case that says why it is not the empty string.
+            // MEASURED with the halves concatenated: `<Fragment key="row">` around an
+            // unkeyed child produced `.$row.0` and a sibling authored `key="row.0"`
+            // produced `.$row.0` too — the composite key a `.map()` over grouped data
+            // writes, not an adversarial spelling. React answers a duplicate key by
+            // matching the two POSITIONALLY (measured: on a reorder they swap their
+            // content and keep each other's widgets), so anything the widget holds and
+            // the descriptor does not — a cursor, a scroll position, an
+            // `Animated.Value` binding — follows the wrong element. Nothing reports it:
+            // React's duplicate-key warning goes to a console GJS does not have.
+            const collide = (fragmentKey: string, innerKey: string | undefined, siblingKey: string): string[] => {
+                const inner =
+                    innerKey === undefined ? createElement(View, null) : createElement(View, { key: innerKey });
+                const nodes = childNodes([
+                    createElement(Fragment, { key: fragmentKey }, inner),
+                    createElement(View, { key: siblingKey }),
+                ]);
+                return nodes.map((node) => String((node as { key: string | null }).key));
+            };
+            for (const keys of [collide('row', undefined, 'row.0'), collide('a', 'b', 'a.$b')]) {
+                expect(`${keys.join(' ')} → ${new Set(keys).size}`).toBe(`${keys.join(' ')} → 2`);
+            }
         });
     });
 
@@ -251,10 +276,32 @@ export default async () => {
         await it('answers “not absolute” for a FOREIGN child whose vocabulary is not this layer’s', async () => {
             // The `catch` in `isAbsoluteChild` earns its keep here and nowhere else: a
             // composite that never reaches L2 may carry any class list at all, and a
-            // parent must not throw for it. The child itself is refused by name if it
-            // ever does reach L2.
+            // parent must not throw for it.
+            //
+            // THE FIRST ASSERTION IS THE DISCRIMINATOR AND NOT A SECOND OPINION. On its
+            // own, "the parent answers 0" is green whether the read threw or simply
+            // said no — so it would still pass for a `catch` with no throw path left,
+            // which is the state this repo does not allow one to sit in.
             const Card = (): null => null;
-            expect(factsOf(createElement(Card, { className: 'card-lg-not-a-utility' })).absolute).toBe(0);
+            const card = createElement(Card, { className: 'card-lg-not-a-utility' });
+            expect(() => declaresAbsolute(readableProps(card), TOKENS)).toThrow(/card-lg-not-a-utility/);
+            expect(factsOf(card).absolute).toBe(0);
+        });
+
+        await it('loses nothing by swallowing: the same read names the child’s own token', async () => {
+            // Why the swallow is safe, rather than a claim that it never happens. The
+            // parent's read is a SUBSET of the child's own resolution — the same
+            // `normalise` over the same `className`/`style`, with the child's prop
+            // routes on top — so every throw this `catch` eats is raised again, by
+            // name, when the child resolves itself. These two are shapes THIS package
+            // renders, which is the half the foreign-composite case cannot cover.
+            for (const [token, child] of [
+                ['totally-not-a-utility', createElement(View, { className: 'absolute totally-not-a-utility' })],
+                ['shadowColor', createElement(View, { className: 'absolute', style: { shadowColor: '#000' } })],
+            ] as const) {
+                expect(() => declaresAbsolute(readableProps(child), TOKENS)).toThrow(new RegExp(token));
+                expect(`${token}: ${factsOf(child).absolute}`).toBe(`${token}: 0`);
+            }
         });
     });
 };

--- a/packages/framework/react-native/src/child-facts.spec.ts
+++ b/packages/framework/react-native/src/child-facts.spec.ts
@@ -1,0 +1,260 @@
+// Every fact a parent reads off its children, against every wrapper it can arrive in.
+//
+// THE MECHANISM, NOT THE CASE. #1451 reported ONE shape — an absolutely positioned
+// child wrapped in a `<>…</>` — and a second one was measured beside it in a consumer
+// (an `<Animated.View className="absolute" style={{ opacity: value }}>`, which is the
+// same defect through an unrelated door). The two share a class: a parent reading
+// somebody else's descriptor answers a question it cannot always answer, and "cannot
+// tell" was spelled the same way as "no". So this file does not test the two shapes.
+// It enumerates the CROSS PRODUCT of
+//
+//   every fact `childFacts` produces  ×  every way an application can wrap a child
+//
+// and the coverage case below derives the fact list from the RECORD ITSELF, so a
+// fourth field added to `ChildFacts` fails here until it has a row. That is the half
+// that keeps this a mechanism: the wrapper list is a judgement about authoring, but
+// nobody has to remember to extend it when the facts grow.
+//
+// EVERY FACT IS DISCRIMINATED, and without that this whole file is worthless: a reader
+// answering `true` to everything would pass the positive matrix completely. So a FLAG
+// fact also declares a child that does NOT carry it, asserted through the same
+// wrappers — `absolute` must be 0 for a `mt-2` child inside a Fragment and `text` must
+// stay false for an element child. `count` needs no negative case because its assertion
+// is an equality against a number two wrappers in the table disagree about.
+//
+// PURE DATA, SO IT RUNS EVERYWHERE. Nothing here mounts anything: `childFacts` is the
+// parent's question and its answer is a record. The claim that the answer then builds
+// a real `Gtk.Overlay` with the child in its `add_overlay` slot is
+// `primitives/widgets.spec.ts`' business, and the claim that React and Solid agree
+// about a transparent wrapper is `solid/solid.spec.ts`' — both read real widget trees.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { MINIMAL_TOKENS, type StyleTokens } from '@gjsify/gtk-host/style';
+import { createElement, Fragment, type ReactNode } from 'react';
+
+import { childFacts, childNodes } from './child-facts.js';
+import { AnimatedValue } from './animated/value.js';
+// `AnimatedView` is the exported name; `Animated.View` is what an application writes.
+import { AnimatedView, Text, View } from './components.js';
+import type { ChildFacts } from './primitives/resolve.js';
+
+const TOKENS: StyleTokens = { ...MINIMAL_TOKENS, spacing: { ...MINIMAL_TOKENS.spacing, '2': '8px' } };
+
+/** The parent's answer for one authored `children` value. */
+const factsOf = (children: ReactNode): ChildFacts => childFacts(childNodes(children), TOKENS);
+
+/**
+ * One way an application wraps a child without meaning to change anything about it.
+ *
+ * `count` is what the wrapper contributes to `ChildFacts.count` — the number of REAL
+ * children behind it. A Fragment contributes its contents, never itself, which is what
+ * makes it transparent. Nothing in L2 reads `count` today; it is asserted anyway
+ * because it was WRONG through a Fragment before any reader could exist, and because
+ * L2 is entitled to assume its inputs are coherent (`solid/index.ts` says so from the
+ * other side: `absolute: 1, count: 0` is not a state any tree can be in).
+ */
+interface Wrapper {
+    readonly name: string;
+    readonly wrap: (child: ReactNode) => ReactNode;
+    readonly count: number;
+}
+
+const WRAPPERS: readonly Wrapper[] = [
+    { name: 'authored directly', wrap: (child) => child, count: 1 },
+    { name: 'a Fragment', wrap: (child) => createElement(Fragment, null, child), count: 1 },
+    // A keyed Fragment is what a `.map()` emits, and its key is what the expanded
+    // child's key is composed behind.
+    { name: 'a keyed Fragment', wrap: (child) => createElement(Fragment, { key: 'group' }, child), count: 1 },
+    {
+        name: 'two nested Fragments',
+        wrap: (child) => createElement(Fragment, null, createElement(Fragment, null, child)),
+        count: 1,
+    },
+    {
+        name: 'a Fragment holding a sibling too',
+        wrap: (child) => createElement(Fragment, null, createElement(View, { key: 'sibling' }), child),
+        count: 2,
+    },
+    // An array is what `Children.toArray` already flattened before this defect
+    // existed, and it is in the table as the control that says so.
+    { name: 'an array', wrap: (child) => [child], count: 1 },
+    {
+        name: 'a Fragment inside an array',
+        wrap: (child) => [createElement(Fragment, { key: 'g' }, child)],
+        count: 1,
+    },
+];
+
+/** A child that carries a fact, authored the way an application authors it. */
+interface Carrier {
+    readonly name: string;
+    readonly node: ReactNode;
+}
+
+/** One child-answered fact, the children that carry it, and the child that does not. */
+interface Fact {
+    readonly key: keyof ChildFacts;
+    readonly carriers: readonly Carrier[];
+    /** Is the fact intact, given the wrapper it arrived through? */
+    readonly intact: (facts: ChildFacts, wrapper: Wrapper) => boolean;
+    /**
+     * The discriminator: a child WITHOUT the fact, which must not report it.
+     *
+     * Absent only where the positive assertion is already discriminating — `count` is
+     * an equality against a number two wrappers in the table disagree about, so a
+     * reader that always said yes fails it. A FLAG fact has no such property, and one
+     * without a negative case here is a green check that checks nothing.
+     */
+    readonly absent?: Carrier;
+    readonly quiet?: (facts: ChildFacts) => boolean;
+}
+
+/**
+ * `Animated.View`'s carriers, and why they are here rather than in `animated.spec.ts`.
+ *
+ * `Animated.View` is not a row in the primitive table — it resolves AS a `View` and
+ * takes the animated entries out of its style first (`components.ts`). That made its
+ * descriptor unreadable to a parent: an `Animated.Value` in a style is exactly what L2
+ * refuses on a plain element, so asking L2 to read the raw props threw, and the throw
+ * was swallowed as "not absolute". MEASURED in a consumer (the CORRECTIV desktop app,
+ * a 160 ms header cross-fade): swapping a plain `<View className="absolute …">` for an
+ * `<Animated.View>` was the only change needed to lose the overlay.
+ */
+const animatedCarriers = (): readonly Carrier[] => [
+    {
+        name: 'an Animated.View with an absolute className',
+        node: createElement(AnimatedView, {
+            className: 'absolute',
+            style: { opacity: new AnimatedValue(0) },
+        }),
+    },
+    {
+        name: 'an Animated.View with position in its style',
+        node: createElement(AnimatedView, {
+            style: [{ position: 'absolute' }, { opacity: new AnimatedValue(1) }],
+        }),
+    },
+];
+
+const FACTS: readonly Fact[] = [
+    {
+        key: 'absolute',
+        carriers: [
+            { name: 'a View with an absolute className', node: createElement(View, { className: 'absolute' }) },
+            {
+                name: 'a Text with position in its style',
+                node: createElement(Text, { style: { position: 'absolute' } }, 'badge'),
+            },
+            ...animatedCarriers(),
+        ],
+        intact: (facts) => facts.absolute === 1,
+        absent: { name: 'a View with an ordinary margin', node: createElement(View, { className: 'mt-2' }) },
+        quiet: (facts) => facts.absolute === 0,
+    },
+    {
+        key: 'text',
+        carriers: [
+            { name: 'a string', node: 'hello' },
+            { name: 'a number', node: 41 },
+        ],
+        intact: (facts) => facts.text,
+        absent: { name: 'an element', node: createElement(View, null) },
+        quiet: (facts) => !facts.text,
+    },
+    {
+        key: 'count',
+        // `count`'s carrier is any child at all, and its assertion is an EQUALITY
+        // rather than a flag — so the wrappers disagreeing about the number are its
+        // discriminator, and it declares no negative case.
+        carriers: [{ name: 'a plain View', node: createElement(View, null) }],
+        intact: (facts, wrapper) => facts.count === wrapper.count,
+    },
+];
+
+export default async () => {
+    await describe('a wrapper is transparent to the facts a parent reads (#1451)', async () => {
+        await it('covers every fact the parent actually produces — a new one is a row here', async () => {
+            // DERIVED from the record, never a written list: `childFacts` is the only
+            // party that knows what it answers, and a field added to it without a row
+            // above is a fact nothing holds against a wrapper.
+            expect(FACTS.map((fact) => fact.key).sort()).toStrictEqual(Object.keys(factsOf(null)).sort());
+        });
+
+        for (const fact of FACTS) {
+            for (const carrier of fact.carriers) {
+                for (const wrapper of WRAPPERS) {
+                    await it(`${fact.key}: ${carrier.name} inside ${wrapper.name}`, async () => {
+                        expect(fact.intact(factsOf(wrapper.wrap(carrier.node)), wrapper)).toBe(true);
+                    });
+                }
+            }
+            const absent = fact.absent;
+            const quiet = fact.quiet;
+            if (absent === undefined || quiet === undefined) continue;
+            for (const wrapper of WRAPPERS) {
+                await it(`${fact.key}: ${absent.name} inside ${wrapper.name} does NOT report it`, async () => {
+                    expect(quiet(factsOf(wrapper.wrap(absent.node)))).toBe(true);
+                });
+            }
+        }
+    });
+
+    await describe('what expanding a Fragment must not change', async () => {
+        await it('keeps every child key unique, composed behind its Fragment’s', async () => {
+            // A collision is a remount on every update, and React reports it as a
+            // duplicate-key warning at best — which nothing in a GJS process reads.
+            const nodes = childNodes(
+                createElement(
+                    Fragment,
+                    null,
+                    createElement(Fragment, { key: 'left' }, createElement(View, { key: 'row' })),
+                    createElement(Fragment, { key: 'right' }, createElement(View, { key: 'row' })),
+                ),
+            );
+            const keys = nodes.map((node) => (node as { key: string | null }).key);
+            expect(keys.length).toBe(2);
+            expect(new Set(keys).size).toBe(2);
+        });
+
+        await it('keeps the expanded child’s own props, ref included', async () => {
+            const ref = (): void => undefined;
+            const nodes = childNodes(
+                createElement(Fragment, null, createElement(View, { className: 'absolute', ref })),
+            );
+            const props = (nodes[0] as { props: Record<string, unknown> }).props;
+            expect(props.className).toBe('absolute');
+            expect(props.ref).toBe(ref);
+        });
+
+        await it('still drops what Children.toArray drops', async () => {
+            // `{cond && <Row/>}` short-circuiting must not become a child under the
+            // expansion either, or `count` disagrees with Solid's for a tree neither
+            // author would call different (`solid/index.ts`' `factsOf`).
+            expect(factsOf(createElement(Fragment, null, false, null, undefined)).count).toBe(0);
+        });
+
+        await it('re-keys ONLY what came out of a Fragment', async () => {
+            // A blanket re-key would change the identity of every sibling of a
+            // Fragment, and React answers a changed key by unmounting the subtree and
+            // building it again — a remount on every render, which looks like a slow
+            // application rather than a bug.
+            const nodes = childNodes([
+                createElement(View, { key: 'sibling' }),
+                createElement(Fragment, { key: 'group' }, createElement(View, { key: 'inner' })),
+            ]);
+            expect((nodes[0] as { key: string | null }).key).toBe('.$sibling');
+            expect((nodes[1] as { key: string | null }).key).toBe('.$group.$inner');
+        });
+    });
+
+    await describe('what a parent still refuses to judge', async () => {
+        await it('answers “not absolute” for a FOREIGN child whose vocabulary is not this layer’s', async () => {
+            // The `catch` in `isAbsoluteChild` earns its keep here and nowhere else: a
+            // composite that never reaches L2 may carry any class list at all, and a
+            // parent must not throw for it. The child itself is refused by name if it
+            // ever does reach L2.
+            const Card = (): null => null;
+            expect(factsOf(createElement(Card, { className: 'card-lg-not-a-utility' })).absolute).toBe(0);
+        });
+    });
+};

--- a/packages/framework/react-native/src/child-facts.ts
+++ b/packages/framework/react-native/src/child-facts.ts
@@ -1,0 +1,142 @@
+// What a parent asks about its children — and everything that must not hide the answer.
+//
+// THE ONE PLACE THE QUESTION IS ASKED, and it needs to be one place because it is
+// asked TWICE about the same tree: `usePlan` counts the absolutely positioned children
+// to decide whether a `View` becomes a `Gtk.Overlay`, and `render` filters the same
+// children to fill that overlay's `add_overlay` slot. A count and a placement that
+// disagree build an overlay with nothing in it, or a box holding a child GTK will
+// position against the wrong widget.
+//
+// WHY REACT NEEDS THIS FILE AND SOLID DOES NOT. The two L3s build a tree in opposite
+// directions (`solid/index.ts` writes the pair out): Solid's children exist BEFORE
+// their parent, so each one stamps ITSELF from its own plan — `SLOTTED`, a `WeakSet`
+// of nodes that resolved to an overlay slot, and nothing guesses. React's parent
+// renders FIRST and has only descriptors, so it has to read somebody else's props and
+// answer a question about them. That asymmetry is where the whole defect class lives:
+// a descriptor this reader cannot interpret used to answer "no", and "no" is a
+// perfectly plausible answer that nothing anywhere reports.
+//
+// THE CLASS, AND WHY THE FIX IS TWO TRANSPARENCIES AND NOT TWO SPECIAL CASES (#1451).
+// Two shapes an application writes every day were unreadable, for two unrelated
+// reasons, and both came back as "not absolute":
+//
+//   <>…</>                      a Fragment answers for ITSELF. Its props are
+//                               `{ children }` — no `style`, no `className` — so a
+//                               parent read no `absolute` on it and none on the child
+//                               it hides. `Children.toArray` does NOT descend into
+//                               one (measured: react 19, a Fragment survives as an
+//                               element whose type is `Symbol(react.fragment)`).
+//   <Animated.View style={{      an `Animated.Value` in a style is exactly what L2
+//     opacity: value }}          refuses on a plain element, so asking L2 to read the
+//     className="absolute" />    raw props THREW — and the `catch` below turned the
+//                               throw into `false`.
+//
+// A Fragment is transparent to layout in React, so it is made transparent here:
+// `childNodes` expands it away before anything counts. An `Animated.View` is a `View`
+// whose style carries values L2 reads through `splitAnimatedStyle` — so the parent's
+// read uses the same split the element itself does. Neither is a rule about `absolute`:
+// the same two blindnesses hid `text` (a text run inside a Fragment, which competes
+// with a prop for a widget's text sink) and `count` — which nothing reads yet, and is
+// the fact `justify-between`'s refusal names as the one it does not have, so it was
+// wrong before any reader could exist. `child-facts.spec.ts` holds every fact this
+// record carries against every wrapper shape rather than the one that was reported.
+//
+// WHAT THE `catch` IS STILL FOR, and it is not defensive padding: a parent asking
+// about a FOREIGN composite child — `<MyCard className="card-lg">`, a component that
+// never reaches L2 — must not throw for a vocabulary that is not this layer's. What is
+// no longer allowed is a shape THIS package can render coming back unreadable, and that
+// is the boundary the spec enumerates.
+
+import { Children, cloneElement, Fragment, isValidElement, type ReactElement, type ReactNode } from 'react';
+import type { StyleTokens } from '@gjsify/gtk-host/style';
+
+import { declaresAbsolute, type ChildFacts, type PrimitiveProps } from './primitives/resolve.js';
+import { splitAnimatedStyle, type StyleInput } from './primitives/style.js';
+
+/** A text run, which is a child a widget's text sink has to answer for. */
+export const isTextNode = (child: ReactNode): boolean => typeof child === 'string' || typeof child === 'number';
+
+const isFragment = (node: ReactNode): node is ReactElement<{ readonly children?: ReactNode }> =>
+    isValidElement(node) && node.type === Fragment;
+
+/**
+ * `props.children` → the children a parent actually has, Fragments expanded away.
+ *
+ * `Children.toArray` first, for what it does do: it drops `null`, `undefined` and
+ * booleans (a `{cond && <Row/>}` that short-circuited is not a child) and gives every
+ * survivor a key. What it does not do is descend into a Fragment, so that half is here.
+ *
+ * KEYS ARE COMPOSED, NEVER REASSIGNED. An expanded child keeps its own key behind its
+ * Fragment's — `.1` + `.$badge` — so two Fragments cannot collide and a re-render
+ * derives the same key from the same tree. Dropping the keys instead would make every
+ * update look like a reorder to React, and remount the subtree.
+ *
+ * The array is rebuilt only when there IS a Fragment to expand: this runs for every
+ * element in the tree on every render, and the common case has to cost a scan.
+ */
+export function childNodes(children: ReactNode): readonly ReactNode[] {
+    return expand(Children.toArray(children));
+}
+
+function expand(nodes: readonly ReactNode[]): readonly ReactNode[] {
+    if (!nodes.some(isFragment)) return nodes;
+    const out: ReactNode[] = [];
+    for (const node of nodes) {
+        if (!isFragment(node)) {
+            out.push(node);
+            continue;
+        }
+        const prefix = node.key ?? '';
+        for (const inner of expand(Children.toArray(node.props.children))) {
+            out.push(isValidElement(inner) ? cloneElement(inner, { key: `${prefix}${inner.key ?? ''}` }) : inner);
+        }
+    }
+    return out;
+}
+
+/**
+ * A child element's props, in the spelling L2 can read.
+ *
+ * The ONE transformation this package's own components make to a style before L2 sees
+ * it: `Animated.View` takes the animated entries out (`components.ts`' binding pass
+ * does the same split for the other half). A parent reading the raw props would hand
+ * L2 a value it refuses by design and get a throw instead of an answer.
+ */
+export function readableProps(element: ReactElement): PrimitiveProps {
+    const props = element.props as PrimitiveProps;
+    if (props.style === undefined) return props;
+    const { plain, animated } = splitAnimatedStyle(props.style as StyleInput);
+    return Object.keys(animated).length === 0 ? props : { ...props, style: plain };
+}
+
+/**
+ * Does this child declare `position: absolute`?
+ *
+ * The predicate is L2's, so the COUNT the parent takes here and the PLACEMENT it makes
+ * later cannot disagree — and it runs the real resolution rather than testing for the
+ * literal string `absolute`, because the syntactic test is exact only while L1's
+ * vocabulary has one spelling for it. It has two today (`absolute`, and
+ * `style={{ position: 'absolute' }}`) and nothing stops it having three.
+ *
+ * The `catch` is for a FOREIGN child only — the header says why, and why that is no
+ * longer where this package's own shapes end up.
+ */
+export function isAbsoluteChild(child: ReactNode, tokens: StyleTokens): boolean {
+    if (!isValidElement(child)) return false;
+    try {
+        return declaresAbsolute(readableProps(child), tokens);
+    } catch {
+        return false;
+    }
+}
+
+/** The children a parent has → the facts L2 asks about them. */
+export function childFacts(children: readonly ReactNode[], tokens: StyleTokens): ChildFacts {
+    let absolute = 0;
+    let text = false;
+    for (const child of children) {
+        if (isTextNode(child)) text = true;
+        else if (isAbsoluteChild(child, tokens)) absolute++;
+    }
+    return { absolute, count: children.length, text };
+}

--- a/packages/framework/react-native/src/child-facts.ts
+++ b/packages/framework/react-native/src/child-facts.ts
@@ -46,6 +46,14 @@
 // never reaches L2 — must not throw for a vocabulary that is not this layer's. What is
 // no longer allowed is a shape THIS package can render coming back unreadable, and that
 // is the boundary the spec enumerates.
+//
+// AND IT CANNOT HIDE A DEFECT, which is a property of the read rather than a promise:
+// the parent's read is a SUBSET of the child's own resolution — the same `normalise`
+// over the same `className`/`style`, with the child's prop routes added on top — so
+// every throw swallowed here is raised again, naming the child's own token, when that
+// child resolves itself. The spec holds both halves against two shapes this package
+// renders; without that pair, "the parent answered no" stays green whether the `catch`
+// has a throw path or none at all.
 
 import { Children, cloneElement, Fragment, isValidElement, type ReactElement, type ReactNode } from 'react';
 import type { StyleTokens } from '@gjsify/gtk-host/style';
@@ -67,9 +75,9 @@ const isFragment = (node: ReactNode): node is ReactElement<{ readonly children?:
  * survivor a key. What it does not do is descend into a Fragment, so that half is here.
  *
  * KEYS ARE COMPOSED, NEVER REASSIGNED. An expanded child keeps its own key behind its
- * Fragment's — `.1` + `.$badge` — so two Fragments cannot collide and a re-render
- * derives the same key from the same tree. Dropping the keys instead would make every
- * update look like a reorder to React, and remount the subtree.
+ * Fragment's — `.$group` + `:` + `.$badge` — so a re-render derives the same key from
+ * the same tree. Dropping the keys instead would make every update look like a reorder
+ * to React, and remount the subtree.
  *
  * The array is rebuilt only when there IS a Fragment to expand: this runs for every
  * element in the tree on every render, and the common case has to cost a scan.
@@ -77,6 +85,26 @@ const isFragment = (node: ReactNode): node is ReactElement<{ readonly children?:
 export function childNodes(children: ReactNode): readonly ReactNode[] {
     return expand(Children.toArray(children));
 }
+
+/**
+ * What separates a Fragment's key from its child's, and why composing needs one.
+ *
+ * MEASURED, react 19: `Children.toArray` ESCAPES a colon in an authored key (`a:b`
+ * becomes `.$a=2b`, and `=` becomes `=0`), gives an unkeyed child `.<index base 36>`,
+ * and touches neither `.` nor `/`. So a colon cannot occur inside any key it produces,
+ * and the one below is the only one in a composed key — which is what makes the
+ * composition INJECTIVE and two different authored trees unable to land on one key.
+ *
+ * Concatenating the halves directly is not injective, and the collision is ordinary
+ * authoring rather than an adversarial spelling: `<Fragment key="row">` around an
+ * unkeyed child produced `.$row.0`, and so did a plain sibling authored `key="row.0"` —
+ * the composite key a `.map()` over grouped data writes. React answers a duplicate key
+ * by matching those two children POSITIONALLY (measured: they swap content and keep
+ * each other's widgets on a reorder), so a `TextInput`'s cursor, a scroll position or
+ * an `Animated.Value` binding follows the wrong element — and React's own
+ * duplicate-key warning goes to a console a GJS process does not have.
+ */
+const KEY_SEPARATOR = ':';
 
 function expand(nodes: readonly ReactNode[]): readonly ReactNode[] {
     if (!nodes.some(isFragment)) return nodes;
@@ -88,7 +116,13 @@ function expand(nodes: readonly ReactNode[]): readonly ReactNode[] {
         }
         const prefix = node.key ?? '';
         for (const inner of expand(Children.toArray(node.props.children))) {
-            out.push(isValidElement(inner) ? cloneElement(inner, { key: `${prefix}${inner.key ?? ''}` }) : inner);
+            // A text run has no key to compose and needs none: `Children.toArray` keeps
+            // its position, and only elements carry an identity React reconciles by.
+            if (!isValidElement(inner)) {
+                out.push(inner);
+                continue;
+            }
+            out.push(cloneElement(inner, { key: `${prefix}${KEY_SEPARATOR}${inner.key ?? ''}` }));
         }
     }
     return out;

--- a/packages/framework/react-native/src/components.ts
+++ b/packages/framework/react-native/src/components.ts
@@ -31,9 +31,7 @@
 
 import Gio from 'gi://Gio?version=2.0';
 import {
-    Children,
     createElement,
-    isValidElement,
     useContext,
     useEffect,
     useMemo,
@@ -46,16 +44,15 @@ import {
 
 import { accessor } from './accessor.js';
 import { onLiveRegion } from './announce.js';
+import { childFacts, childNodes, isAbsoluteChild, isTextNode } from './child-facts.js';
 import { ParentContext, ParentProvider } from './parent-context.js';
 import { onGesture, onPressStateChange } from './press.js';
 import type { ClassNameInput } from './primitives/classes.js';
 import { PrimitiveError } from './primitives/errors.js';
 import { createHandle, type TextInputHandle } from './primitives/handles.js';
 import {
-    declaresAbsolute,
     resolvePrimitive,
     type ChildContext,
-    type ChildFacts,
     type PrimitivePlan,
     type PrimitiveProps,
     type ResolvedAnnouncement,
@@ -64,8 +61,7 @@ import {
     type ResolvedGesture,
     type WidgetNode,
 } from './primitives/resolve.js';
-import { flattenStyle, type StyleAuthored, type StyleInput, type StyleObject } from './primitives/style.js';
-import { isAnimatedValue } from './animated/brand.js';
+import { splitAnimatedStyle, type StyleAuthored, type StyleInput, type StyleObject } from './primitives/style.js';
 import { animatedProperty, assertNoStaticClash } from './animated/properties.js';
 import type { AnimatedValue } from './animated/value.js';
 import { styleConfig } from './style-config.js';
@@ -89,40 +85,6 @@ export interface CommonProps {
 }
 
 type AnyProps = Readonly<Record<string, unknown>>;
-
-const isTextNode = (child: ReactNode): boolean => typeof child === 'string' || typeof child === 'number';
-
-/**
- * Does this child declare `position: absolute`?
- *
- * The predicate is L2's, so the COUNT the parent takes here and the PLACEMENT it
- * makes later cannot disagree. The `catch` is the one place in this package where
- * swallowing is correct, and it is not defensive padding: the parent is asking a
- * question about SOMEBODY ELSE'S props, and a composite child whose `style` carries
- * a property L1 does not route (`<MyCard style={{ shadowColor }}/>`, a component
- * that never reaches L2) would otherwise make the PARENT throw for a defect that is
- * not its own. Nothing is lost — a child that really is absolute and answered
- * `false` here lands under a parent that stayed a `Gtk.Box`, and `resolveIntent`
- * refuses it by name: "the PARENT has to be a `Gtk.Overlay`, and it is not".
- */
-function isAbsoluteChild(child: ReactNode, tokens: StyleTokens): boolean {
-    if (!isValidElement(child)) return false;
-    try {
-        return declaresAbsolute(child.props as PrimitiveProps, tokens);
-    } catch {
-        return false;
-    }
-}
-
-function childFacts(children: readonly ReactNode[], tokens: StyleTokens): ChildFacts {
-    let absolute = 0;
-    let text = false;
-    for (const child of children) {
-        if (isTextNode(child)) text = true;
-        else if (isAbsoluteChild(child, tokens)) absolute++;
-    }
-    return { absolute, count: children.length, text };
-}
 
 /**
  * L2's `events` → host props, with STABLE identities.
@@ -216,7 +178,7 @@ export function usePlan(primitive: string, authored: object): Rendered {
     const props = authored as AnyProps;
     const parent = useContext(ParentContext);
     const config = styleConfig();
-    const children = Children.toArray((props as { children?: ReactNode }).children);
+    const children = childNodes((props as { children?: ReactNode }).children);
     const plan = resolvePrimitive(primitive, props as PrimitiveProps, {
         tokens: config.tokens,
         sheet: config.sheet,
@@ -857,33 +819,37 @@ interface AnimatedBinding {
 }
 
 /**
- * An authored style → the plain half and the animated half.
+ * An authored style → the plain half and the bindings the effect below attaches.
+ *
+ * The SPLIT is L2's (`primitives/style.ts`' `splitAnimatedStyle`) and the BINDINGS are
+ * this file's, because the split has a second reader: a parent counting its absolutely
+ * positioned children reads an `<Animated.View>`'s style through the same function
+ * (`child-facts.ts`). Two copies of it were how a Fragment and an animated fade both
+ * came back as "not absolutely positioned" — #1451.
  *
  * The split has to happen BEFORE the partition, and that is measured rather than
  * tidy: `@gjsify/gtk-host/style`'s `partitionPaint` pushes `${cssName}: ${value}`
  * with no check on the value's type, so an `Animated.Value` left in the object
  * becomes the GTK CSS declaration `opacity: [object Object]` — which GTK's parser
- * drops in silence. `primitives/style.ts` now refuses a non-scalar style value for
- * the same reason, which is what makes forgetting the `Animated.` on a plain
- * `<View>` a named error instead of a screen where nothing moves.
+ * drops in silence. `primitives/style.ts` refuses a non-scalar style value for the
+ * same reason, which is what makes forgetting the `Animated.` on a plain `<View>` a
+ * named error instead of a screen where nothing moves.
  */
-function splitAnimatedStyle(
+function animatedBindings(
     primitive: string,
     style: AnimatedStyleInput | undefined,
 ): { readonly plain: StyleObject; readonly bindings: readonly AnimatedBinding[] } {
-    const flat = flattenStyle(style as StyleInput);
-    const plain: Record<string, unknown> = {};
+    const { plain, animated } = splitAnimatedStyle(style as StyleInput);
     const bindings: AnimatedBinding[] = [];
-    for (const [key, value] of Object.entries(flat)) {
-        if (!isAnimatedValue(value)) {
-            plain[key] = value;
-            continue;
-        }
+    for (const [key, value] of Object.entries(animated)) {
         // The refusal for an unanimatable key fires here, at the element, rather than
         // inside the effect that would have bound it: an effect's stack names the
         // effect, and an author needs the element.
         animatedProperty(primitive, key);
-        bindings.push({ key, value: value as AnimatedValue });
+        // `AnimatedValueLike` is the BRAND, which is all L2 may know (`animated/brand.ts`),
+        // and `AnimatedValue` is its only implementer — whose private fields make the two
+        // structurally disjoint. The narrowing belongs here because this file owns the class.
+        bindings.push({ key, value: value as unknown as AnimatedValue });
     }
     return { plain, bindings };
 }
@@ -906,7 +872,7 @@ function splitAnimatedStyle(
  */
 export function AnimatedView(props: AnimatedViewProps): ReactElement {
     const config = styleConfig();
-    const { plain, bindings } = splitAnimatedStyle('Animated.View', props.style);
+    const { plain, bindings } = animatedBindings('Animated.View', props.style);
     const authored: AnimatedViewProps = { ...props, style: plain };
     assertNoStaticClash(
         'Animated.View',

--- a/packages/framework/react-native/src/primitives/style.ts
+++ b/packages/framework/react-native/src/primitives/style.ts
@@ -26,7 +26,7 @@
 import { partition, resolveUtilities, type Partitioned, type StyleProps } from '@gjsify/gtk-host/style';
 import type { StyleTokens } from '@gjsify/gtk-host/style';
 
-import { isAnimatedValue } from '../animated/brand.js';
+import { isAnimatedValue, type AnimatedValueLike } from '../animated/brand.js';
 import { splitVariants, type ClassGroups, type ClassNameInput } from './classes.js';
 import { PrimitiveError } from './errors.js';
 
@@ -55,6 +55,37 @@ export function flattenStyle(style: StyleInput): StyleObject {
     const out: Record<string, unknown> = {};
     for (const entry of style as StyleInputArray) Object.assign(out, flattenStyle(entry));
     return out;
+}
+
+/**
+ * A style → its plain entries and its `Animated.Value`s, split before the partition.
+ *
+ * L2's and not `components.ts`', because TWO readers need this split and one of them
+ * is a PARENT. `Animated.View` needs the animated half to bind; a parent counting its
+ * absolutely positioned children needs to be able to READ an
+ * `<Animated.View className="absolute" style={{ opacity: value }}>` at all, and
+ * `normalise` refuses a non-scalar style value by design (`scalarOnly`). So the raw
+ * style handed to `declaresAbsolute` threw where the parent wanted an answer, the
+ * throw was swallowed as "not absolute", and the child then got the refusal that names
+ * the PARENT for something the parent could not see — #1451, and the reason two
+ * finished features (a 160 ms fade and `absolute`) did not compose.
+ *
+ * Dropping the animated half hides nothing. An `Animated.Value` under a plain `<View>`
+ * is still refused BY NAME when that element resolves its own style, which is the
+ * element that authored it — the parent's read is a question about somebody else's
+ * props and never the place that judges them.
+ */
+export function splitAnimatedStyle(style: StyleInput): {
+    readonly plain: StyleObject;
+    readonly animated: Readonly<Record<string, AnimatedValueLike>>;
+} {
+    const plain: Record<string, unknown> = {};
+    const animated: Record<string, AnimatedValueLike> = {};
+    for (const [key, value] of Object.entries(flattenStyle(style))) {
+        if (isAnimatedValue(value)) animated[key] = value;
+        else plain[key] = value;
+    }
+    return { plain, animated };
 }
 
 /**

--- a/packages/framework/react-native/src/primitives/widgets.spec.ts
+++ b/packages/framework/react-native/src/primitives/widgets.spec.ts
@@ -585,6 +585,52 @@ export default async () => {
                 );
             });
 
+            await it('re-renders through a Fragment without rebuilding a single widget', async () => {
+                // WHAT THE KEY SPELLING IS A PROXY FOR. `child-facts.spec.ts` asserts
+                // that an expanded child keeps its own key composed behind its
+                // Fragment's rather than reassigned; this is the effect that assertion
+                // exists for, and the only half an application feels. React answers a
+                // key that changed between renders by unmounting the subtree and
+                // building it again — new GObjects, and with them everything the widget
+                // holds that the descriptor does not: a cursor, a scroll position, an
+                // animation binding. The tree LOOKS identical either way, which is why
+                // the vector reads identities and not shape.
+                const tree = (n: number): ReactNode =>
+                    createElement(
+                        View,
+                        { className: 'p-2' },
+                        createElement(Text, { key: 'body' }, `body ${n}`),
+                        createElement(
+                            Fragment,
+                            { key: 'group' },
+                            createElement(Text, { key: 'badge', className: 'absolute inset-0' }, `badge ${n}`),
+                        ),
+                    );
+                const container = new Gtk.Box();
+                const root = createRoot(container);
+                try {
+                    root.render(tree(0));
+                    const overlay = gtkChildren(container)[0] as Gtk.Overlay;
+                    const box = overlay.get_child() as Gtk.Box;
+                    const body = gtkChildren(box)[0] as Gtk.Label;
+                    const badge = gtkChildren(overlay).find((child) => child !== box) as Gtk.Label;
+                    expect([body.label, badge.label]).toStrictEqual(['body 0', 'badge 0']);
+
+                    flushSync(() => root.render(tree(1)));
+
+                    // Read off the SAME references: a rebuild leaves these two holding
+                    // the old widgets, still labelled 0, so this line is the assertion
+                    // and the discriminator at once.
+                    expect([body.label, badge.label]).toStrictEqual(['body 1', 'badge 1']);
+                    const after = gtkChildren(container)[0] as Gtk.Overlay;
+                    expect(after === overlay).toBe(true);
+                    expect(after.get_child() === box).toBe(true);
+                    expect(gtkChildren(after).find((child) => child !== box) === badge).toBe(true);
+                } finally {
+                    root.unmount();
+                }
+            });
+
             await it('becomes a Gtk.FlowBox for a wrap, and puts its children INSIDE it', async () => {
                 // The tag is half the claim. The other half is that the host can
                 // actually place children in the swapped-in class — a `Gtk.FlowBox`

--- a/packages/framework/react-native/src/primitives/widgets.spec.ts
+++ b/packages/framework/react-native/src/primitives/widgets.spec.ts
@@ -32,13 +32,14 @@ import { lookupWidget, paramSpecs, registerBuiltinWidgets } from '@gjsify/gtk-ho
 import { descriptorProblems, dumpTree, gtkChildren, installDiagnosticsGate } from '@gjsify/gtk-host/conformance';
 import { MINIMAL_TOKENS, StyleSheet as GeneratedStyleSheet, type StyleTokens } from '@gjsify/gtk-host/style';
 import { createRoot, flushSync } from '@gjsify/gtk-host/react';
-import { createElement, type ReactNode } from 'react';
+import { createElement, Fragment, type ReactNode } from 'react';
 
 import { PrimitiveError } from './errors.js';
 import { createHandle, type TextInputHandle } from './handles.js';
 import { PRIMITIVES, type PrimitiveSpec } from './table.js';
 import {
     ActivityIndicator,
+    AnimatedView,
     Button,
     Image,
     ImageBackground,
@@ -55,6 +56,7 @@ import {
     View,
 } from '../components.js';
 import type { ImageProps, PressableState } from '../components.js';
+import { AnimatedValue } from '../animated/value.js';
 import { resetWindowMetricsCache } from '../apis/display.js';
 import { useWindowDimensions } from '../hooks.js';
 import { liveRegionWatchCount } from '../announce.js';
@@ -507,6 +509,78 @@ export default async () => {
                         // overlay child positioned against the padding box.
                         expect(generatedClasses(overlay).length).toBe(1);
                         expect(generatedClasses(box)).toStrictEqual([]);
+                    },
+                );
+            });
+
+            await it('sees an absolute child through a Fragment, and still becomes an Overlay', async () => {
+                // #1451, read off the REAL tree. A Fragment answers for itself, so the
+                // parent used to count zero absolutely positioned children, stay a
+                // `Gtk.Box`, and hand the child L2's refusal that names the PARENT —
+                // for something the child's wrapper did. `card.overlay={<>…</>}` is
+                // ordinary React and there is no prop on a Fragment to fix.
+                mounted(
+                    createElement(
+                        View,
+                        { className: 'p-2' },
+                        createElement(Text, { key: 'body' }, 'body'),
+                        createElement(
+                            Fragment,
+                            { key: 'group' },
+                            createElement(Text, { key: 'badge', className: 'absolute inset-0' }, 'badge'),
+                        ),
+                    ),
+                    (container) => {
+                        const overlay = gtkChildren(container)[0] as Gtk.Overlay;
+                        expect(typeOf(overlay)).toBe('GtkOverlay');
+                        const box = overlay.get_child() as Gtk.Box;
+                        expect(gtkChildren(box).map((c) => (c as Gtk.Label).label)).toStrictEqual(['body']);
+                        // The badge is in the `add_overlay` slot beside the box, not
+                        // inside it — which is the half a plan comparison cannot see.
+                        const badge = gtkChildren(overlay).find((c) => c !== box) as Gtk.Label;
+                        expect(badge.label).toBe('badge');
+                        expect(badge.halign).toBe(Gtk.Align.FILL);
+                    },
+                );
+            });
+
+            await it('sees an absolute Animated.View, whose first frame is already written', async () => {
+                // The second half of #1451, and an independent door into it: an
+                // `Animated.Value` in a style is what L2 refuses on a plain element, so
+                // a parent reading the raw props got a throw where it wanted an answer
+                // and answered "not absolute". MEASURED in a consumer as the only
+                // difference between a working absolute header and a refused one.
+                const opacity = new AnimatedValue(0.25);
+                mounted(
+                    createElement(
+                        View,
+                        { className: 'p-2' },
+                        createElement(Text, { key: 'body' }, 'body'),
+                        createElement(AnimatedView, {
+                            key: 'fade',
+                            className: 'absolute inset-0',
+                            style: { opacity },
+                        }),
+                    ),
+                    (container) => {
+                        const overlay = gtkChildren(container)[0] as Gtk.Overlay;
+                        expect(typeOf(overlay)).toBe('GtkOverlay');
+                        const box = overlay.get_child() as Gtk.Box;
+                        const fade = gtkChildren(overlay).find((child) => child !== box) as Gtk.Box;
+                        expect(typeOf(fade)).toBe('GtkBox');
+                        expect(fade.halign).toBe(Gtk.Align.FILL);
+                        // The two features composing is the point: the element is in
+                        // the overlay slot AND carries the value's current number as a
+                        // widget property, from the render rather than from the effect.
+                        //
+                        // 64/255 AND NOT 0.25, and the quantisation is the discriminator
+                        // rather than an annoyance. MEASURED on gtk 4.22.4:
+                        // `Gtk.Widget:opacity` is a `gdouble` in the ParamSpec and 8-bit
+                        // internally, so a number that really went through GObject comes
+                        // back rounded. A plain JS expando — which is what a misspelled
+                        // property name produces, silently (`animated/properties.ts`) —
+                        // would read back exactly 0.25.
+                        expect(fade.opacity).toBe(64 / 255);
                     },
                 );
             });

--- a/packages/framework/react-native/src/solid/solid.spec.ts
+++ b/packages/framework/react-native/src/solid/solid.spec.ts
@@ -37,7 +37,7 @@ import { dumpTree, gtkChildren, installDiagnosticsGate } from '@gjsify/gtk-host/
 import { MINIMAL_TOKENS, type StyleTokens } from '@gjsify/gtk-host/style';
 import { createRoot } from '@gjsify/gtk-host/react';
 import { For, createComponent, mount } from '@gjsify/gtk-host/solid';
-import { createElement as createReactElement, type ReactNode } from 'react';
+import { createElement as createReactElement, Fragment, type ReactNode } from 'react';
 import { createSignal } from 'solid-js';
 
 import { PrimitiveError } from '../primitives/errors.js';
@@ -69,8 +69,26 @@ type PrimitiveName = 'View' | 'Text' | 'Pressable' | 'ScrollView' | 'ActivityInd
 interface Authored {
     readonly primitive: PrimitiveName;
     readonly props?: Readonly<Record<string, unknown>>;
-    readonly children?: readonly (Authored | string)[];
+    readonly children?: readonly AuthoredChild[];
 }
+
+/**
+ * A wrapper that is meant to add NOTHING to the widget tree.
+ *
+ * Each framework has its own spelling for it — a `<>…</>` in React, a plain array in
+ * Solid — so the authored tree cannot name either. What the vector then measures is
+ * whether both frameworks agree that it is transparent, which is not a given: Solid's
+ * `resolveChildren` flattens nested arrays and its children stamp themselves, so the
+ * whole class was invisible there, while React's parent reads DESCRIPTORS and
+ * `Children.toArray` does not descend into a Fragment (#1451).
+ */
+interface Group {
+    readonly group: readonly AuthoredChild[];
+}
+
+type AuthoredChild = Authored | Group | string;
+
+const isGroup = (child: Authored | Group): child is Group => 'group' in child;
 
 /**
  * The properties a snapshot reads, in GJS' accessor spelling.
@@ -204,7 +222,14 @@ const ownTypes = (tree: readonly Snapshot[]): string[] => {
 
 // --- the two front ends, and nothing else in this file knows a framework ------
 
-function toReact(node: Authored, key?: string): ReactNode {
+function toReact(node: Authored | Group, key?: string): ReactNode {
+    if (isGroup(node)) {
+        return createReactElement(
+            Fragment,
+            key === undefined ? null : { key },
+            ...node.group.map((child, index) => (typeof child === 'string' ? child : toReact(child, String(index)))),
+        );
+    }
     const children = (node.children ?? []).map((child, index) =>
         typeof child === 'string' ? child : toReact(child, String(index)),
     );
@@ -225,7 +250,8 @@ function toReact(node: Authored, key?: string): ReactNode {
  * plain value here would have hidden the one L2 change this milestone needed, because
  * `Object.entries` over plain values has no side effect.
  */
-function toSolid(node: Authored): unknown {
+function toSolid(node: Authored | Group): unknown {
+    if (isGroup(node)) return node.group.map((child) => (typeof child === 'string' ? child : toSolid(child)));
     const component = solid[node.primitive] as unknown as (props: object) => unknown;
     const props: Record<string, unknown> = { ...node.props };
     if (node.children !== undefined) {
@@ -371,6 +397,23 @@ const VECTORS: readonly Vector[] = [
             children: [
                 { primitive: 'Text', children: ['body'] },
                 { primitive: 'Text', props: { className: 'absolute inset-0' }, children: ['badge'] },
+            ],
+        },
+        types: ['GtkOverlay', 'GtkBox', 'GtkLabel', 'GtkLabel'],
+    },
+    {
+        // The same tree with the absolute child inside a transparent wrapper, which is
+        // the one authoring shape that used to produce two DIFFERENT trees: Solid saw
+        // through its array and built the overlay, React did not see through the
+        // Fragment and refused the child by name. Parity is the assertion that the
+        // wrapper is transparent under both, not that either is merely non-empty.
+        name: 'an absolute child inside a transparent wrapper',
+        tree: {
+            primitive: 'View',
+            props: { className: 'p-2' },
+            children: [
+                { primitive: 'Text', children: ['body'] },
+                { group: [{ primitive: 'Text', props: { className: 'absolute inset-0' }, children: ['badge'] }] },
             ],
         },
         types: ['GtkOverlay', 'GtkBox', 'GtkLabel', 'GtkLabel'],

--- a/packages/framework/react-native/src/test.mts
+++ b/packages/framework/react-native/src/test.mts
@@ -3,6 +3,7 @@ import { run } from '@gjsify/unit';
 import animatedSuite from './animated/animated.spec.js';
 import easingSuite from './animated/easing.spec.js';
 import apisSuite from './apis/apis.spec.js';
+import childFactsSuite from './child-facts.spec.js';
 import eventEmitterSuite from './event-emitter.spec.js';
 import listsSuite from './lists/lists.spec.js';
 import classesSuite from './primitives/classes.spec.js';
@@ -25,6 +26,7 @@ run({
     unsupportedSuite,
     eventEmitterSuite,
     classesSuite,
+    childFactsSuite,
     defaultsSuite,
     stylesheetSuite,
     primitivesSuite,


### PR DESCRIPTION
A parent decides whether it becomes a `Gtk.Overlay` from its children's **descriptors** — React renders the parent before the children exist — and two shapes an application writes every day came back unreadable. Both were answered as *"not absolutely positioned"*, which is a perfectly plausible answer that nothing anywhere reports.

## The two holes, and they are independent

**1 — a Fragment answers for itself.** Its props are `{ children }`: no `style`, no `className`. And `Children.toArray` does **not** descend into one (measured, react 19: a Fragment survives as an element whose type is `Symbol(react.fragment)`). So `<>…</>` around an absolutely positioned child hid it, the parent stayed a `Gtk.Box`, and the child then got L2's refusal — which names the **parent** for something the child's wrapper did, with no prop on a Fragment to fix. That is #1451 as reported.

**2 — an `Animated.Value` in a style is exactly what L2 refuses on a plain element.** So a parent reading an `<Animated.View className="absolute" style={{ opacity }}>`'s raw props **threw**, and the swallowing `catch` in `isAbsoluteChild` turned the throw into `false`. This needs no Fragment at all: the matrix row *"an Animated.View with an absolute className, authored directly"* fails on the pre-fix reader. It is what the CORRECTIV desktop app measured — swapping a plain `<View className="absolute …">` for the phone's `<Animated.View>` was the only change needed to lose the overlay, and it is why two finished features (`Animated` since 0.46, `absolute`) did not compose.

The same two blindnesses also hid `text` (a text run inside a Fragment, which competes with a prop for a widget's text sink) and `count` — which nothing in L2 reads yet, and which `justify-between`'s refusal names as the fact it does not have, so it was wrong before a reader could exist. Neither had been reported.

## What changed

- **`src/child-facts.ts`** — new, and it owns the parent's whole question, asked once for the count that decides the overlay and for the placement that fills its `add_overlay` slot. Fragments are expanded away with keys **composed** behind their Fragment's (`.$group` + `:` + `.$badge`), so no sibling is re-keyed and nothing remounts.
- **`splitAnimatedStyle` moved into L2** (`src/primitives/style.ts`), so `Animated.View` and its parent read *one* copy of the split. Two copies were the defect. Dropping the animated half in the parent's read hides nothing: the element itself is still refused by name if it is not an `Animated.View`.
- The `catch` stays, scoped to what it was always for: a **foreign** composite child (`<MyCard className="card-lg">`) may carry any vocabulary, and a parent must not throw for one it cannot route. What is no longer allowed is a shape *this package can render* coming back unreadable.

The issue offered two ways out. This is the first one — resolve through Fragments — because it is what React means by a Fragment, and because the Solid binding already behaved that way: its children stamp themselves and `resolveChildren` flattens arrays, so the class was invisible there. The two frameworks genuinely produced different trees for one authored tree.

## The mechanism, proven red before green

`src/child-facts.spec.ts` does not test the two shapes. It enumerates **every fact `childFacts` produces × every wrapper a child can arrive in** (7 wrappers: bare, Fragment, keyed Fragment, nested Fragments, Fragment with a sibling, array, Fragment in an array), and the **fact list is derived from the record itself** — so a fourth field on `ChildFacts` has no row until someone adds one, and the coverage case says so. Each flag fact carries a **negative** case through the same wrappers; without one, a reader that always answered yes would pass the entire positive matrix.

Measured on gjs 1.88.1 / GTK 4.22.4, same specs, only the reader swapped:

| | result |
|---|---|
| pre-fix reader (`Children.toArray`, raw props) | **42 of 2242 failed**, exit 1 |
| with the fix | **2257 of 2257**, exit 0, zero GTK diagnostics |

The 42 include the two new real-tree mount vectors in `primitives/widgets.spec.ts` (which read the actual `Gtk.Overlay`, its main child and its overlay slot, not a plan) and the new React/Solid parity vector in `solid/solid.spec.ts` — a transparent wrapper, spelled as a Fragment in React and as an array in Solid, which used to build two different widget trees.

Also verified: `gjsify tsc --noEmit` clean, repo-wide `oxlint` exit 0, `oxfmt --check` clean, and `check-rn-surface` / `check-vocabulary-alignment` / `check-agent-context-size` / `check-rn-icon-targets` all exit 0.

## One GTK measurement that fell out

`Gtk.Widget:opacity` is a `gdouble` in the ParamSpec and **8-bit internally**: an animated `0.25` reads back as `64/255`. The vector asserts the quantised value, which is also the discriminator — a misspelled property name becomes a silent JS expando and would read back exactly `0.25`.

## Deliberately not done

- **No new ADR.** The design this restores is ADR 0032 § 6's; nothing about the layer boundary changed.
- **`packages/framework/AGENTS.md` untouched.** It sits at 32752 of the 32768-byte cap (16 bytes of headroom), and its budget-ledger line is a counter two concurrent PRs would collide on. The rule and its incident are in the package README and in `child-facts.ts`' header instead.
- **`docs/release-notes/next.md` untouched**, per its own header.
- **No Solid-side change.** Solid was already transparent here; the parity vector is what says so rather than an assertion.
- **The node leg (`test:gjs-on-node`) could not run locally** — `@gjsify/node-gi` is not installed in this worktree. In CI that leg is a `continue-on-error` probe in `gtk-os-suites.yml`; the gating gjs leg is what is measured above.

Closes #1451

---

## Review follow-ups (2 commits on top)

**`fix(react-native): make composed keys injective`.** Concatenating the two halves is not
injective, and the collision is ordinary authoring: `<Fragment key="row">` around an unkeyed
child produced `.$row.0`, and so did a plain sibling authored `key="row.0"` — the composite key
a `.map()` over grouped data writes. MEASURED (react 19): React answers the duplicate by
matching those two children POSITIONALLY — on a reorder they swap their content and keep each
other's widgets — so a cursor, a scroll position or an `Animated.Value` binding follows the
wrong element, and React's duplicate-key warning goes to a console GJS does not have. A colon
separates the halves and is the one character that can: `Children.toArray` escapes `:` in an
authored key to `=2` (and `=` to `=0`), gives an unkeyed child `.<index base 36>`, and touches
neither `.` nor `/`.

Two spec rows came with it, both red first: the collisions above, and a strengthened
foreign-composite case — the old assertion (`absolute` is 0) stayed green whether or not the
`catch` had a throw path, so it now asserts the read really THROWS, plus the pair that makes
swallowing safe (the parent's read is a SUBSET of the child's own resolution, so every throw
it eats is raised again naming the child's own token).

**`test(react-native): read identities, not key spelling`.** "Nothing remounts" was held by
asserting key STRINGS. The real tree says it now: render, `flushSync` a second render, read the
labels off the SAME GObject references — a rebuild leaves them holding the old widgets.
Verified red by composing an unstable key.

2269 of 2269 on gjs 1.88.1 / GTK 4.22.4, exit 0; `oxfmt --check`, `oxlint`, `gjsify tsc
--noEmit`, `check-rn-surface`, `check-vocabulary-alignment`, `check-agent-context-size`,
`check-rn-icon-targets` and `check-comment-budget` all clean.

Two findings left OUT of this PR, for their own issues: a foreign composite that *renders* an
absolute child still produces #1451's unactionable refusal (it names the parent, and every
branch of its explanation is wrong for that tree), and `<Pressable style={({pressed}) => …}>`
— React Native's documented API — renders a `GtkButton` with the style silently dropped.
