### PR TITLE
fix(gtk-host): quote a font family GTK refuses

### DIFF
--- a/packages/framework/gtk-host/src/style/font-family.ts
+++ b/packages/framework/gtk-host/src/style/font-family.ts
@@ -1,0 +1,288 @@
+// How a `font-family` VALUE becomes GTK CSS text.
+//
+// Every other paint property carries a colour, a length, a number or a keyword —
+// none of which can contain a character that ends the value early. `font-family`
+// carries a NAME, and a name is the one thing a project supplies verbatim. So this
+// is the only property whose value has to be SERIALISED rather than interpolated,
+// and `CSS_VALUE_KIND` in `paint.ts` is where that judgement is written down and
+// machine-held.
+//
+// THE INCIDENT. `font-family: Source Sans 3` — a real family, on Pango's default
+// font map, `load_font()` answering `Source Sans 3 700` — reaches GTK's parser as
+// `Junk at end of value for font-family`. GTK refuses the DECLARATION, the
+// containment probe in `document.ts` refuses the whole generated rule, and a React
+// tree dies with no boundary between the `<Text>` and the screen. Shipping a brand
+// typeface and having a multi-word family name are close to the same event, so this
+// arrives the moment an application adopts its own fonts.
+//
+// WHAT ACTUALLY BREAKS, MEASURED (GTK 4.22.4, gjs 1.88.1) — and it is NOT "more than
+// one word". CSS lets an unquoted family be a SEQUENCE of identifiers, and GTK
+// implements that faithfully: `Noto Sans`, `DejaVu Sans`, `Fira Code`,
+// `Liberation Serif`, `SF Pro Text` and `Roboto Condensed` all parse bare. What
+// fails is a component that is not a valid CSS identifier — overwhelmingly one that
+// starts with a DIGIT (`Source Sans 3`, `M PLUS 1p`, `Press Start 2P`,
+// `Helvetica Neue LT Std 55 Roman`; a leading digit on the first component reports
+// `Expected a string` instead), and otherwise one carrying a character idents cannot
+// hold (`Foo.Bar`, `Foo/Bar`). That distinction is why the first encounter reads as
+// a problem with the specific font: most multi-word families work.
+//
+// So the rule is not "quote when there is a space". It is CSSOM's rule — quote every
+// family NAME, leave every KEYWORD bare — which cannot be wrong about the identifier
+// grammar because it never consults it.
+//
+// THREE THINGS THAT MUST SURVIVE UNTOUCHED, each measured:
+//
+//   1. **A fallback stack.** `'Source Sans 3', sans-serif` is a legitimate value.
+//      The commas stay, each member is decided on its own, and `sans-serif` stays
+//      BARE — a quoted keyword is a family name and no longer a keyword. On GTK the
+//      difference is not observable (its own serialiser flattens `sans-serif` to
+//      `"sans-serif"`, so it has no generic-family concept at all and hands both to
+//      Pango, which resolves the alias); it is kept because the value is CSS and
+//      correct CSS is what this emits.
+//   2. **A value that is already quoted.** Consumers quote defensively while a fix
+//      is in flight, and double-quoting turns `"Source Sans 3"` into a family whose
+//      name contains quote marks.
+//   3. **A `var()` reference.** `font-family: var(--font-sans)` parses on GTK and is
+//      the shape a Tailwind v4 `@theme` produces, exactly as the colour scales
+//      already arrive as `rgb(var(--…))`. Quoting it would emit a family literally
+//      called `var(--font-sans)` — a silent wrong font rather than a refusal. Its
+//      fallback form `var(--f, sans-serif)` also carries a COMMA, which is why the
+//      split below tracks parenthesis depth instead of calling `split(',')`.
+
+import { UnknownUtilityError } from './errors.js';
+
+/**
+ * The generic families, which are keywords wherever they appear in the list.
+ *
+ * CSS Fonts 4 § 2.1.1. Quoting one would make it a family name — the failure is
+ * silent, because a name nobody has is simply skipped in favour of the next member.
+ */
+const GENERIC_FAMILIES: ReadonlySet<string> = new Set([
+    'serif',
+    'sans-serif',
+    'monospace',
+    'cursive',
+    'fantasy',
+    'system-ui',
+    'ui-serif',
+    'ui-sans-serif',
+    'ui-monospace',
+    'ui-rounded',
+    'math',
+    'fangsong',
+    'emoji',
+]);
+
+/**
+ * The CSS-wide keywords, which are keywords ONLY as the whole value.
+ *
+ * `font-family: inherit` is inheritance; `font-family: inherit, sans-serif` is not
+ * valid CSS at all, and reading the first member as a family name is the closest
+ * thing to what was written. Measured: GTK honours `inherit`, `initial` and `unset`
+ * (its serialiser keeps them bare) and does NOT implement `revert` — it comes back
+ * as the string `"revert"`, i.e. a family name. It stays listed anyway, because the
+ * value this emits is CSS and `revert` is a keyword in CSS.
+ */
+const CSS_WIDE_KEYWORDS: ReadonlySet<string> = new Set(['inherit', 'initial', 'unset', 'revert', 'revert-layer']);
+
+/** A member that is ALREADY a CSS string, escapes included. A raw newline disqualifies it — CSS strings cannot hold one. */
+const QUOTED = /^"(?:[^"\\\n]|\\[\s\S])*"$|^'(?:[^'\\\n]|\\[\s\S])*'$/;
+
+/** A member that is a function call, `var(--x)` above all. A bare family name cannot contain a parenthesis. */
+const FUNCTION = /^[a-zA-Z-][\w-]*\(/;
+
+/**
+ * One family name → a CSS string.
+ *
+ * The control-character half is not decoration. A raw newline inside a string is
+ * `Unterminated block at end of document` (measured) — the failure mode that takes
+ * every rule AFTER it with it, reported by nothing but the containment probe. The
+ * `\<hex> ` form is what GTK reads back correctly (`"Two\A Lines"` round-trips), and
+ * the trailing space is the escape's own terminator rather than part of the name.
+ *
+ * Character by character rather than by regex: a character class holding the control
+ * range is what `no-control-regex` is for, and the loop says the same thing without
+ * a suppression.
+ */
+function quote(name: string): string {
+    let out = '"';
+    for (const char of name) {
+        const code = char.codePointAt(0) ?? 0;
+        if (char === '"' || char === '\\') out += `\\${char}`;
+        else if (code < 0x20 || code === 0x7f) out += `\\${code.toString(16)} `;
+        else out += char;
+    }
+    return `${out}"`;
+}
+
+/**
+ * Split on the commas that separate LIST MEMBERS, and on no others.
+ *
+ * A comma inside a string (`"Foo, Bar"` is a legal family name) or inside a function
+ * (`var(--f, sans-serif)`) does not separate anything. Splitting on it would hand
+ * `var(--f` to the quoter and emit a rule GTK refuses — the same bug being fixed
+ * here, one layer along.
+ */
+function members(value: string): string[] {
+    const out: string[] = [];
+    let start = 0;
+    let depth = 0;
+    let quoteChar: string | null = null;
+    for (let index = 0; index < value.length; index++) {
+        const char = value[index];
+        if (quoteChar !== null) {
+            if (char === '\\') index++;
+            else if (char === quoteChar) quoteChar = null;
+            continue;
+        }
+        if (char === '"' || char === "'") quoteChar = char;
+        else if (char === '(') depth++;
+        else if (char === ')' && depth > 0) depth--;
+        else if (char === ',' && depth === 0) {
+            out.push(value.slice(start, index));
+            start = index + 1;
+        }
+    }
+    out.push(value.slice(start));
+    return out;
+}
+
+/**
+ * A `font-family` value → the text that goes into the declaration.
+ *
+ * Exported because a consumer that has been quoting defensively (see the incident in
+ * the header) can call this instead and stop, and because both routes into the
+ * partition — a `style={{ fontFamily }}` object and a `font-*` utility resolving
+ * against `tokens.fontFamily` — must go through exactly this one function.
+ */
+export function serialiseFontFamily(value: string): string {
+    const list = members(value);
+    const whole = list.length === 1;
+    return list
+        .map((member) => {
+            const name = member.trim();
+            if (name === '') {
+                throw new UnknownUtilityError(
+                    value,
+                    'is a font-family list with an empty member. GTK answers a missing family with "Expected a string" ' +
+                        'and drops the whole declaration, so the list is refused here instead',
+                );
+            }
+            if (QUOTED.test(name) || FUNCTION.test(name)) return name;
+            const keyword = name.toLowerCase();
+            if (GENERIC_FAMILIES.has(keyword)) return name;
+            if (whole && CSS_WIDE_KEYWORDS.has(keyword)) return name;
+            return quote(name);
+        })
+        .join(', ');
+}
+
+/**
+ * What GTK does with an authored value that was NOT serialised.
+ *
+ * Three states rather than a boolean, and the third one is why. `refused` is the
+ * loud bug — GTK rejects the declaration, the containment probe rejects the rule,
+ * and the screen is gone. `misread` is the QUIET one: GTK accepts the bare text and
+ * resolves a DIFFERENT family, so the application renders in a substituted font with
+ * no diagnostic anywhere. A boolean column would have merged `misread` into
+ * `accepted` and asserted that serialising changes nothing — which is false for
+ * exactly the vectors where changing something is the whole point.
+ */
+export type BareReading = 'refused' | 'accepted' | 'misread';
+
+/** One authored `font-family` value, what it must become, and what GTK does with it unserialised. */
+export interface FontFamilyVector {
+    /** What a `tokens.fontFamily` entry or a `style={{ fontFamily }}` carries. */
+    readonly authored: string;
+    /** What {@link serialiseFontFamily} must emit for it. */
+    readonly emitted: string;
+    /**
+     * What GTK does with `authored` AS IT STANDS.
+     *
+     * The column that makes this table a test rather than a restatement, and every
+     * state of it is RE-MEASURED against the running GTK by `gtk-css.spec.ts`:
+     * `refused` must be rejected, `accepted` must parse to the same computed value
+     * as `emitted`, and `misread` must parse to a DIFFERENT one. So the state is a
+     * finding and not a claim, and a vector cannot quietly stop exercising the rule.
+     */
+    readonly bare: BareReading;
+}
+
+/**
+ * The conformance set for `font-family` values.
+ *
+ * WHY THIS TABLE EXISTS, and it is the whole finding behind #1539. `gtk-css.ts`
+ * probed `['font-family', 'Cantarell']` — ONE word, valid as a bare identifier, and
+ * therefore the single family for which the missing quoting is invisible. The suite
+ * asserted that `font-family` is emitted and never that it is emitted CORRECTLY, so
+ * it would have gone green against an implementation that quoted nothing. A vector
+ * whose value cannot exercise the rule reads exactly like a vector that passed.
+ *
+ * So the set carries, deliberately: a family that NEEDS quoting, a family that does
+ * not, a bare multi-identifier family GTK already accepted (the case a
+ * quote-on-space reading would call broken), a stack mixing a quoted family with a
+ * bare keyword, a value already quoted, a `var()` reference, and a value GTK MISREADS
+ * rather than refuses. `bare` is re-measured by `gtk-css.spec.ts`, which also refuses
+ * a table that has lost its refused or its misread vectors.
+ */
+export const FONT_FAMILY_VECTORS: readonly FontFamilyVector[] = [
+    // THE REPORTED FAILURE. `3` is not an identifier, so the sequence ends there and
+    // everything after it is junk.
+    { authored: 'Source Sans 3', emitted: '"Source Sans 3"', bare: 'refused' },
+    // The same shape from three more directions: another digit-led component, a
+    // leading digit on the FIRST component (GTK says `Expected a string` rather than
+    // `Junk at end of value`), and a character no identifier can hold.
+    { authored: 'M PLUS 1p', emitted: '"M PLUS 1p"', bare: 'refused' },
+    { authored: '8514oem', emitted: '"8514oem"', bare: 'refused' },
+    { authored: 'Foo.Bar', emitted: '"Foo.Bar"', bare: 'refused' },
+    // NEEDS NOTHING, and it is the vector the old table consisted of.
+    { authored: 'Cantarell', emitted: '"Cantarell"', bare: 'accepted' },
+    // MORE THAN ONE WORD AND ALREADY FINE — the pair that disproves "quote when
+    // there is a space" and keeps this from being a fix aimed at the wrong rule.
+    { authored: 'Fira Code', emitted: '"Fira Code"', bare: 'accepted' },
+    { authored: 'Liberation Serif', emitted: '"Liberation Serif"', bare: 'accepted' },
+    // KEYWORDS, bare and staying bare.
+    { authored: 'sans-serif', emitted: 'sans-serif', bare: 'accepted' },
+    { authored: 'monospace', emitted: 'monospace', bare: 'accepted' },
+    { authored: 'system-ui', emitted: 'system-ui', bare: 'accepted' },
+    // Case-insensitively, because CSS keywords are.
+    { authored: 'Sans-Serif', emitted: 'Sans-Serif', bare: 'accepted' },
+    // A CSS-wide keyword, which is a keyword only as the whole value.
+    { authored: 'inherit', emitted: 'inherit', bare: 'accepted' },
+    // A FALLBACK STACK: the quoting is per member, and the commas survive.
+    { authored: 'Source Sans 3, sans-serif', emitted: '"Source Sans 3", sans-serif', bare: 'refused' },
+    { authored: "'Source Sans 3', sans-serif", emitted: "'Source Sans 3', sans-serif", bare: 'accepted' },
+    {
+        authored: 'Fira Code, ui-monospace, monospace',
+        emitted: '"Fira Code", ui-monospace, monospace',
+        bare: 'accepted',
+    },
+    // ALREADY QUOTED, in both spellings, and left exactly as written.
+    { authored: '"Source Sans 3"', emitted: '"Source Sans 3"', bare: 'accepted' },
+    { authored: "'Noto Sans'", emitted: "'Noto Sans'", bare: 'accepted' },
+    // A quoted family whose NAME contains a comma. Splitting on every comma would
+    // tear this in half.
+    { authored: '"Foo, Bar", sans-serif', emitted: '"Foo, Bar", sans-serif', bare: 'accepted' },
+    // A `var()` reference, including the fallback form whose comma is INSIDE the
+    // parentheses. Quoting either would emit a family nobody has, silently.
+    { authored: 'var(--font-sans)', emitted: 'var(--font-sans)', bare: 'accepted' },
+    { authored: 'var(--font-sans, sans-serif)', emitted: 'var(--font-sans, sans-serif)', bare: 'accepted' },
+    // A name that has to be ESCAPED rather than merely wrapped. An ident sequence
+    // cannot also contain a string, so GTK refuses this one.
+    { authored: 'Say "Ah"', emitted: '"Say \\"Ah\\""', bare: 'refused' },
+    // THE TWO QUIET ONES, and they are why `bare` is not a boolean. Both were
+    // MEASURED here after the table first claimed GTK refuses them, and it does not:
+    //
+    //   - `Back\slash` bare is the CSS escape for the identifier `Backslash`, so GTK
+    //     accepts it and looks for a family that is not the one that was named.
+    //   - a raw newline is WHITESPACE outside a string, so `Two⏎Lines` bare is the
+    //     ident sequence `Two Lines`. Inside a string the same byte is
+    //     `Unterminated block at end of document` — the failure that takes every rule
+    //     after it and is reported by nothing but the containment probe — which is
+    //     why the escaped `\a ` form is what gets emitted.
+    //
+    // Neither produces a diagnostic unserialised. They are the shape the whole
+    // partition exists against: green run, wrong window.
+    { authored: 'Back\\slash', emitted: '"Back\\\\slash"', bare: 'misread' },
+    { authored: 'Two\nLines', emitted: '"Two\\a Lines"', bare: 'misread' },
+];

--- a/packages/framework/gtk-host/src/style/font-family.ts
+++ b/packages/framework/gtk-host/src/style/font-family.ts
@@ -48,6 +48,14 @@
 //      called `var(--font-sans)` — a silent wrong font rather than a refusal. Its
 //      fallback form `var(--f, sans-serif)` also carries a COMMA, which is why the
 //      split below tracks parenthesis depth instead of calling `split(',')`.
+//
+// BOTH PASSTHROUGHS ARE NARROW, because a member that goes out verbatim is
+// declaration text this module did not write. `QUOTED` refuses a member carrying any
+// of CSS's three newlines rather than only `\n`, since a raw carriage return in a
+// defensively quoted token took the whole document. And a function is passed through
+// only when the call it opens CLOSES on the last character: `var(--x); color: red`
+// otherwise emits a second declaration, with no parse error and a surviving
+// containment sentinel, so nothing downstream ever sees it.
 
 import { UnknownUtilityError } from './errors.js';
 
@@ -85,11 +93,26 @@ const GENERIC_FAMILIES: ReadonlySet<string> = new Set([
  */
 const CSS_WIDE_KEYWORDS: ReadonlySet<string> = new Set(['inherit', 'initial', 'unset', 'revert', 'revert-layer']);
 
-/** A member that is ALREADY a CSS string, escapes included. A raw newline disqualifies it — CSS strings cannot hold one. */
-const QUOTED = /^"(?:[^"\\\n]|\\[\s\S])*"$|^'(?:[^'\\\n]|\\[\s\S])*'$/;
+/**
+ * A member that is ALREADY a CSS string, escapes included.
+ *
+ * A raw newline disqualifies it, because a CSS string cannot hold one — and CSS's
+ * newline is THREE characters, not one: line feed, CARRIAGE RETURN and form feed
+ * (Syntax 3 § 4.2). Measured, and the difference is the whole document: a raw CR
+ * inside an already-quoted member, passed through here, is `Expected a string`
+ * followed by `Unterminated block at end of document`, and the containment sentinel
+ * is GONE — every rule after it with it. Excluded, the member falls to
+ * {@link quote}, which escapes the character, and the sentinel survives. Matching
+ * only `\n` left the passthrough branch walking into the exact failure the escaping
+ * branch exists to prevent.
+ */
+const QUOTED = /^"(?:[^"\\\n\r\f]|\\[\s\S])*"$|^'(?:[^'\\\n\r\f]|\\[\s\S])*'$/;
 
-/** A member that is a function call, `var(--x)` above all. A bare family name cannot contain a parenthesis. */
+/** A member that OPENS like a function call, `var(--x)` above all. A bare family name cannot contain a parenthesis. */
 const FUNCTION = /^[a-zA-Z-][\w-]*\(/;
+
+/** CSS's whitespace (Syntax 3 § 4.2). What "nothing but space so far in this member" is measured against. */
+const WHITESPACE: ReadonlySet<string> = new Set([' ', '\t', '\n', '\r', '\f']);
 
 /**
  * One family name → a CSS string.
@@ -122,12 +145,25 @@ function quote(name: string): string {
  * (`var(--f, sans-serif)`) does not separate anything. Splitting on it would hand
  * `var(--f` to the quoter and emit a rule GTK refuses — the same bug being fixed
  * here, one layer along.
+ *
+ * A QUOTE ONLY OPENS A STRING WHERE A STRING CAN BEGIN: at the start of a member, or
+ * inside a function, where CSS tokenisation applies. Everywhere else it is a
+ * character of a bare name, because a bare member is a NAME supplied verbatim and
+ * not CSS text — that is the same reading `QUOTED` uses by anchoring at `^`, and the
+ * two disagreeing is a bug with no diagnostic anywhere. Measured: with a quote
+ * opening a string wherever it appears, `Marion's Hand, sans-serif` never splits,
+ * the whole value is quoted as one name, GTK accepts
+ * `font-family: "Marion's Hand, sans-serif"` without complaint, and the fallback
+ * stack is silently gone. Any name carrying an odd number of `'` or `"` — including
+ * `Say "Ah` next to a fallback — swallowed the rest of the list the same way.
  */
 function members(value: string): string[] {
     const out: string[] = [];
     let start = 0;
     let depth = 0;
     let quoteChar: string | null = null;
+    // Nothing but whitespace seen since this member began, so a quote here opens it.
+    let opening = true;
     for (let index = 0; index < value.length; index++) {
         const char = value[index];
         if (quoteChar !== null) {
@@ -135,16 +171,53 @@ function members(value: string): string[] {
             else if (char === quoteChar) quoteChar = null;
             continue;
         }
-        if (char === '"' || char === "'") quoteChar = char;
+        if ((opening || depth > 0) && (char === '"' || char === "'")) quoteChar = char;
         else if (char === '(') depth++;
         else if (char === ')' && depth > 0) depth--;
         else if (char === ',' && depth === 0) {
             out.push(value.slice(start, index));
             start = index + 1;
+            opening = true;
+            continue;
         }
+        if (!WHITESPACE.has(char)) opening = false;
     }
     out.push(value.slice(start));
     return out;
+}
+
+/**
+ * Is this member a SINGLE, COMPLETE function call — `var(--x)` and not `var(--x`?
+ *
+ * The passthrough branch hands a function to GTK verbatim, so what it accepts is
+ * declaration text this module did not write. Measured: `var(--x); color: red`
+ * passed through emits two declarations where one was asked for, with no parse error
+ * and a surviving containment sentinel — nothing downstream sees it. `var(--x) } .x
+ * {` opens a second RULE, and `var(--x` takes the whole document. Requiring the
+ * opening call to close on the last character keeps the branch to the shape it was
+ * added for; anything else is refused by name rather than quoted, because quoting it
+ * would mint a family nobody has and render the wrong font in silence.
+ */
+function isCompleteCall(member: string): boolean {
+    if (!FUNCTION.test(member)) return false;
+    let depth = 0;
+    let quoteChar: string | null = null;
+    for (let index = 0; index < member.length; index++) {
+        const char = member[index];
+        if (quoteChar !== null) {
+            if (char === '\\') index++;
+            else if (char === quoteChar) quoteChar = null;
+            continue;
+        }
+        if (char === '"' || char === "'") quoteChar = char;
+        else if (char === '(') depth++;
+        else if (char === ')') {
+            depth--;
+            if (depth === 0) return index === member.length - 1;
+            if (depth < 0) return false;
+        }
+    }
+    return false;
 }
 
 /**
@@ -168,7 +241,16 @@ export function serialiseFontFamily(value: string): string {
                         'and drops the whole declaration, so the list is refused here instead',
                 );
             }
-            if (QUOTED.test(name) || FUNCTION.test(name)) return name;
+            if (QUOTED.test(name)) return name;
+            if (FUNCTION.test(name)) {
+                if (isCompleteCall(name)) return name;
+                throw new UnknownUtilityError(
+                    value,
+                    'opens a function the member never closes. A function is the one member handed to GTK verbatim, ' +
+                        'so an unclosed one emits declaration text this module did not write — measured, ' +
+                        '"var(--x); color: red" emits a second declaration with no parse error at all',
+                );
+            }
             const keyword = name.toLowerCase();
             if (GENERIC_FAMILIES.has(keyword)) return name;
             if (whole && CSS_WIDE_KEYWORDS.has(keyword)) return name;
@@ -224,6 +306,14 @@ export interface FontFamilyVector {
  * bare keyword, a value already quoted, a `var()` reference, and a value GTK MISREADS
  * rather than refuses. `bare` is re-measured by `gtk-css.spec.ts`, which also refuses
  * a table that has lost its refused or its misread vectors.
+ *
+ * The three added after the first review are the shapes the SPLIT and the two
+ * PASSTHROUGHS have to survive rather than the quoter: a bare name carrying an odd
+ * quote character in front of a fallback, a nested `var()`, and an already-quoted
+ * member holding a carriage return. Each was emitted as something GTK accepted and
+ * was wrong about — so `gtk-css.spec.ts` also holds the three CLASSES directly, by
+ * asking GTK where the fallback member ended up, whether the document survived, and
+ * whether a declaration appeared that nothing here wrote.
  */
 export const FONT_FAMILY_VECTORS: readonly FontFamilyVector[] = [
     // THE REPORTED FAILURE. `3` is not an identifier, so the sequence ends there and
@@ -263,10 +353,22 @@ export const FONT_FAMILY_VECTORS: readonly FontFamilyVector[] = [
     // A quoted family whose NAME contains a comma. Splitting on every comma would
     // tear this in half.
     { authored: '"Foo, Bar", sans-serif', emitted: '"Foo, Bar", sans-serif', bare: 'accepted' },
+    // AN ODD QUOTE CHARACTER IN A BARE NAME, in front of a fallback. A bare member is
+    // a name supplied verbatim, so the `'` is a character of it and the comma after
+    // it still separates — but a split that opened a string at every quote never
+    // reached that comma, emitted `"Marion's Hand, sans-serif"` as ONE family, and
+    // GTK accepted it without a word. The fallback was gone with no diagnostic.
+    { authored: "Marion's Hand, sans-serif", emitted: '"Marion\'s Hand", sans-serif', bare: 'refused' },
     // A `var()` reference, including the fallback form whose comma is INSIDE the
-    // parentheses. Quoting either would emit a family nobody has, silently.
+    // parentheses, and the nested form that needs the depth counter rather than a
+    // flag. Quoting any of them would emit a family nobody has, silently.
     { authored: 'var(--font-sans)', emitted: 'var(--font-sans)', bare: 'accepted' },
     { authored: 'var(--font-sans, sans-serif)', emitted: 'var(--font-sans, sans-serif)', bare: 'accepted' },
+    {
+        authored: 'var(--a, var(--b, sans-serif))',
+        emitted: 'var(--a, var(--b, sans-serif))',
+        bare: 'accepted',
+    },
     // A name that has to be ESCAPED rather than merely wrapped. An ident sequence
     // cannot also contain a string, so GTK refuses this one.
     { authored: 'Say "Ah"', emitted: '"Say \\"Ah\\""', bare: 'refused' },
@@ -285,4 +387,11 @@ export const FONT_FAMILY_VECTORS: readonly FontFamilyVector[] = [
     // partition exists against: green run, wrong window.
     { authored: 'Back\\slash', emitted: '"Back\\\\slash"', bare: 'misread' },
     { authored: 'Two\nLines', emitted: '"Two\\a Lines"', bare: 'misread' },
+    // THE SAME BYTE, ALREADY QUOTED — and CSS's newline is three characters, not one.
+    // A carriage return inside a quoted member matched the passthrough while only
+    // `\n` was excluded, so it went out verbatim and GTK answered `Expected a string`
+    // plus `Unterminated block at end of document`: the containment sentinel gone and
+    // every rule after it with it. It is a vector because the passthrough branch had
+    // none carrying a character that ends a string.
+    { authored: '"Two\rLines"', emitted: '"\\"Two\\d Lines\\""', bare: 'refused' },
 ];

--- a/packages/framework/gtk-host/src/style/gtk-css.spec.ts
+++ b/packages/framework/gtk-host/src/style/gtk-css.spec.ts
@@ -13,6 +13,7 @@
 import Gtk from 'gi://Gtk?version=4.0';
 import { expect, it, on } from '@gjsify/unit';
 
+import { FONT_FAMILY_VECTORS } from './font-family.js';
 import { GTK_CSS_PROBES, NOT_GTK_CSS } from './gtk-css.js';
 import { GTK_HOSTS, gated } from '../testing/gate.mjs';
 import { installDiagnosticsGate } from '../conformance/index.js';
@@ -27,6 +28,20 @@ function parseError(property: string, value: string): string | null {
     provider.load_from_string(`.probe { ${property}: ${value}; }`);
     provider.disconnect(handler);
     return message;
+}
+
+/**
+ * What GTK computes for one declaration, in GTK's OWN spelling.
+ *
+ * The parsed value read back out, which is what makes an equivalence claim a
+ * measurement rather than a restatement of our expectation: `Fira Code` and
+ * `"Fira Code"` both come back as `font-family: "Fira Code"`, so serialising
+ * provably did not change what the widget will be painted with.
+ */
+function normalised(property: string, value: string): string {
+    const provider = new Gtk.CssProvider();
+    provider.load_from_string(`.probe { ${property}: ${value}; }`);
+    return provider.to_string().replace(/\s+/g, ' ').trim();
 }
 
 export default async () => {
@@ -59,6 +74,60 @@ export default async () => {
                 const error = parseError('text-align', 'center');
                 expect(error === null).toBe(false);
                 expect(String(error)).toContain('text-align');
+            });
+
+            await it('parses every serialised font-family value the table carries', async () => {
+                // The property name was never the problem in #1539: `font-family` is
+                // right and the VALUE took the rule down. So the value gets the same
+                // treatment the names get — measured against the running parser.
+                const rejected = FONT_FAMILY_VECTORS.filter(
+                    (vector) => parseError('font-family', vector.emitted) !== null,
+                ).map((vector) => `${vector.authored} -> ${vector.emitted}`);
+                expect(rejected).toStrictEqual([]);
+            });
+
+            await it('agrees with the table about what it does with each value UNSERIALISED', async () => {
+                // `bare` is a claim about another program, so all three of its states
+                // are re-measured here rather than trusted. It also records a finding
+                // the issue got wrong: a bare SEQUENCE of identifiers is legal CSS
+                // and GTK implements it, so `Fira Code` and `Liberation Serif` parse
+                // unquoted and only a component that is not an identifier — usually
+                // one starting with a digit — is refused.
+                //
+                // `misread` is the state that had to exist. Two vectors the table
+                // first called `refused` are in fact ACCEPTED and resolve a different
+                // family: `Back\slash` is the escape for the ident `Backslash`, and a
+                // raw newline is whitespace, so `Two⏎Lines` is the ident sequence
+                // `Two Lines`. Serialising MUST change what GTK computes for those,
+                // which is the opposite of what it must do for `accepted`.
+                const disagreed = FONT_FAMILY_VECTORS.filter((vector) => {
+                    const parses = parseError('font-family', vector.authored) === null;
+                    if (!parses) return vector.bare !== 'refused';
+                    const same =
+                        normalised('font-family', vector.authored) === normalised('font-family', vector.emitted);
+                    return vector.bare !== (same ? 'accepted' : 'misread');
+                }).map((vector) => `${JSON.stringify(vector.authored)} (table says ${vector.bare})`);
+                expect(disagreed).toStrictEqual([]);
+            });
+
+            await it('still carries a value GTK refuses AND one it misreads, so the set can fail', async () => {
+                // THE DISCRIMINATOR, and the reason this whole table exists. The old
+                // vector was `['font-family', 'Cantarell']` — one word, valid as a
+                // bare identifier, and therefore the single family for which the
+                // missing quoting is invisible. The suite asserted that font-family
+                // is emitted and never that it is emitted correctly, so it would have
+                // gone green against an implementation that quoted nothing.
+                //
+                // A vector whose value cannot exercise the rule reads exactly like a
+                // vector that passed, so the SET is held here instead of trusted. BOTH
+                // bug shapes are required: `refused` is the loud one that took the
+                // screen down, `misread` is the quiet one that renders the wrong font
+                // at exit 0 — and a table reduced to `accepted` rows would look
+                // exactly like a table that is testing something.
+                const byState = (state: string): readonly string[] =>
+                    FONT_FAMILY_VECTORS.filter((vector) => vector.bare === state).map((vector) => vector.authored);
+                expect(byState('refused')).toContain('Source Sans 3');
+                expect(byState('misread').length > 0).toBe(true);
             });
 
             await it('accepts the PHYSICAL spacings and refuses the LOGICAL ones, in one place', async () => {

--- a/packages/framework/gtk-host/src/style/gtk-css.spec.ts
+++ b/packages/framework/gtk-host/src/style/gtk-css.spec.ts
@@ -13,7 +13,7 @@
 import Gtk from 'gi://Gtk?version=4.0';
 import { expect, it, on } from '@gjsify/unit';
 
-import { FONT_FAMILY_VECTORS } from './font-family.js';
+import { FONT_FAMILY_VECTORS, serialiseFontFamily } from './font-family.js';
 import { GTK_CSS_PROBES, NOT_GTK_CSS } from './gtk-css.js';
 import { GTK_HOSTS, gated } from '../testing/gate.mjs';
 import { installDiagnosticsGate } from '../conformance/index.js';
@@ -42,6 +42,37 @@ function normalised(property: string, value: string): string {
     const provider = new Gtk.CssProvider();
     provider.load_from_string(`.probe { ${property}: ${value}; }`);
     return provider.to_string().replace(/\s+/g, ' ').trim();
+}
+
+/** A class name that cannot collide, so its survival means the parse reached the end. */
+const SENTINEL = 'gjsify-css-spec-sentinel';
+
+/**
+ * Does a rule carrying this declaration leave the rules AFTER it loadable?
+ *
+ * `parseError` is not the same question, and the gap is the expensive one: an
+ * unterminated string ends the DOCUMENT, and `document.ts` records a measured case
+ * where GTK reported no error at all while everything after was gone. Same shape as
+ * the runtime's containment probe, on one declaration rather than a whole sheet —
+ * its own sentinel, because what is being asserted is that the parse reached the
+ * end, not that the two spellings agree.
+ */
+function contained(property: string, value: string): boolean {
+    const provider = new Gtk.CssProvider();
+    provider.load_from_string(`.probe { ${property}: ${value}; }\n.${SENTINEL} { color: rgb(1 2 3); }`);
+    return provider.to_string().includes(SENTINEL);
+}
+
+/**
+ * The `font-family` value GTK computed, in GTK's own spelling.
+ *
+ * Read back out rather than counted in the serialiser, because how many members the
+ * serialiser thinks it made is the thing under test. Sound only for values whose
+ * names carry no semicolon — GTK does not escape one inside a string.
+ */
+function computedFamily(value: string): string {
+    const computed = /font-family:\s*([^;]*);/.exec(normalised('font-family', value));
+    return computed === null ? '' : computed[1];
 }
 
 export default async () => {
@@ -76,14 +107,125 @@ export default async () => {
                 expect(String(error)).toContain('text-align');
             });
 
-            await it('parses every serialised font-family value the table carries', async () => {
+            await it('parses every serialised font-family value the table carries, and CONTAINS it', async () => {
                 // The property name was never the problem in #1539: `font-family` is
                 // right and the VALUE took the rule down. So the value gets the same
                 // treatment the names get — measured against the running parser.
+                //
+                // Containment is the second half and it is not the same question. A
+                // raw carriage return inside an already-quoted member matched the
+                // passthrough while only `\n` was excluded, went out verbatim, and
+                // ended the DOCUMENT — and `document.ts` has a measured case of that
+                // happening with no error signal at all. An emitted value that parses
+                // and takes the rest of the sheet with it is still a bug.
                 const rejected = FONT_FAMILY_VECTORS.filter(
                     (vector) => parseError('font-family', vector.emitted) !== null,
                 ).map((vector) => `${vector.authored} -> ${vector.emitted}`);
                 expect(rejected).toStrictEqual([]);
+                const uncontained = FONT_FAMILY_VECTORS.filter(
+                    (vector) => !contained('font-family', vector.emitted),
+                ).map((vector) => `${vector.authored} -> ${vector.emitted}`);
+                expect(uncontained).toStrictEqual([]);
+            });
+
+            await it('never emits a value that ends the document, however the newline is spelled', async () => {
+                // THE OTHER CLASS, and the expensive one. A raw newline inside a
+                // string is an unterminated string, which ends the DOCUMENT — every
+                // rule after it silently absent, and `document.ts` records a measured
+                // case of GTK reporting no error at all. `quote` escapes the
+                // character; the already-quoted PASSTHROUGH did not, and its guard
+                // excluded only `\n` while CSS's newline is three characters
+                // (Syntax 3 § 4.2). A carriage return in a defensively quoted token
+                // was the whole sheet.
+                //
+                // Generated over the three characters rather than listed as vectors,
+                // because the table can only carry the spellings someone thought of
+                // and the failure is the same for all three.
+                const NEWLINES = ['\n', '\r', '\f'];
+                const uncontained = NEWLINES.flatMap((newline) => [
+                    `Two${newline}Lines`,
+                    `"Two${newline}Lines"`,
+                    `'Two${newline}Lines'`,
+                ])
+                    .filter((authored) => !contained('font-family', serialiseFontFamily(authored)))
+                    .map((authored) => JSON.stringify(authored));
+                expect(uncontained).toStrictEqual([]);
+            });
+
+            await it('never loses a fallback member, whatever the name in front of it carries', async () => {
+                // THE CLASS, not the three instances. Every fix here so far has been a
+                // vector added after the fact; this asks GTK the question the table
+                // can only answer one row at a time — put a name in front of a
+                // fallback, and check that GTK still ends up with the fallback AS ITS
+                // OWN MEMBER (`…, "sans-serif"`, GTK's spelling of the parsed
+                // keyword) rather than swallowed into the name.
+                //
+                // Counting commas would NOT do it, which is worth saying because it
+                // was the first attempt and it went green against the bug: the
+                // swallowed value is `"Marion's Hand, sans-serif"` and the comma is
+                // still there, inside the string. The separator has to be read where
+                // GTK puts it, not counted.
+                //
+                // The bug it holds is silent by construction: a split that opened a
+                // string at every quote never reached the comma after
+                // `Marion's Hand`, so the whole value went out as one quoted family,
+                // GTK accepted it, the containment probe accepted it, and the
+                // application lost its fallback with no diagnostic anywhere. Any
+                // character that has ever ended a value early belongs in this list.
+                const NAMES = [
+                    "Marion's Hand",
+                    'Say "Ah',
+                    'Foo\\"',
+                    'Back\\slash',
+                    'Source Sans 3',
+                    'Foo.Bar',
+                    'Foo (Bold)',
+                    'M PLUS 1p',
+                    '8514oem',
+                ];
+                const lost = NAMES.map((name) => ({
+                    name,
+                    computed: computedFamily(serialiseFontFamily(`${name}, sans-serif`)),
+                }))
+                    .filter((measured) => !measured.computed.endsWith(', "sans-serif"'))
+                    .map((measured) => `${JSON.stringify(measured.name)} -> ${measured.computed}`);
+                expect(lost).toStrictEqual([]);
+            });
+
+            await it('never lets a value add a declaration the partition did not write', async () => {
+                // THE THIRD CLASS, and it belongs to the two PASSTHROUGH branches: a
+                // member that goes out verbatim is declaration text nothing here
+                // wrote. Measured on the function branch — `var(--x); color: red`
+                // emitted a second declaration with NO parse error and a surviving
+                // containment sentinel, so every guard downstream saw a valid sheet.
+                //
+                // Asked of each member shape rather than of the one that broke, and
+                // asked of GTK: append a declaration to the value and check GTK does
+                // not come back with it. A named refusal is a pass — being loud is
+                // the point; emitting the extra declaration is the bug.
+                //
+                // The payload is looked for in GTK's PARSED spelling, `rgb(255,0,0)`,
+                // and that is the load-bearing part. Searching for the authored text
+                // matches the harmless case too — a quoted family called
+                // `Cantarell; color: rgb(255 0 0)` still contains every character of
+                // the payload — so the gate went red against the fixed code on its
+                // first run. Only a colour GTK actually parsed loses the spaces.
+                const PAYLOAD = '; color: rgb(255 0 0)';
+                const PARSED = 'rgb(255,0,0)';
+                const SHAPES = ['Cantarell', '"Cantarell"', "'Cantarell'", 'var(--font-sans)', 'sans-serif', 'inherit'];
+                const injected = SHAPES.filter((shape) => {
+                    let emitted: string;
+                    try {
+                        emitted = serialiseFontFamily(`${shape}${PAYLOAD}`);
+                    } catch {
+                        // `serialiseFontFamily` refuses by name — the loud answer, and
+                        // the one the function branch now gives. Nothing was emitted,
+                        // so nothing was injected.
+                        return false;
+                    }
+                    return normalised('font-family', emitted).includes(PARSED);
+                });
+                expect(injected).toStrictEqual([]);
             });
 
             await it('agrees with the table about what it does with each value UNSERIALISED', async () => {

--- a/packages/framework/gtk-host/src/style/index.ts
+++ b/packages/framework/gtk-host/src/style/index.ts
@@ -32,8 +32,10 @@ export {
 } from './tokens.js';
 export type { Scale, StyleTokens } from './tokens.js';
 export { UnknownUtilityError } from './errors.js';
-export { PAINT_PROPERTIES, partitionPaint, resolvePaintUtility } from './paint.js';
+export { CSS_VALUE, CSS_VALUE_KIND, PAINT_PROPERTIES, partitionPaint, resolvePaintUtility } from './paint.js';
 export type { PaintProps } from './paint.js';
+export { FONT_FAMILY_VECTORS, serialiseFontFamily } from './font-family.js';
+export type { FontFamilyVector } from './font-family.js';
 export { LAYOUT_PROPERTIES, partitionLayout, resolveLayoutUtility } from './layout.js';
 export type {
     AlignValue,

--- a/packages/framework/gtk-host/src/style/paint.spec.ts
+++ b/packages/framework/gtk-host/src/style/paint.spec.ts
@@ -13,9 +13,10 @@ import { describe, expect, it } from '@gjsify/unit';
 // says which half it is.
 import { MINIMAL_TOKENS, type StyleTokens } from './tokens.js';
 import { UnknownUtilityError } from './errors.js';
-import { CSS_NAME, resolvePaintUtility } from './paint.js';
+import { CSS_NAME, CSS_VALUE, CSS_VALUE_KIND, partitionPaint, resolvePaintUtility } from './paint.js';
 import { partition, resolveUtilities } from './resolve.js';
 import { GTK_CSS_PROPERTIES } from './gtk-css.js';
+import { FONT_FAMILY_VECTORS, serialiseFontFamily } from './font-family.js';
 
 const TOKENS: StyleTokens = {
     ...MINIMAL_TOKENS,
@@ -29,7 +30,9 @@ const TOKENS: StyleTokens = {
     fontSize: { ...MINIMAL_TOKENS.fontSize, s: '13px' },
     letterSpacing: { wide: '0.5px' },
     lineHeight: { snug: '1.3' },
-    fontFamily: { serif: 'Merriweather' },
+    // Two entries on purpose: one family that is fine bare and one that is not, so
+    // the UTILITY route is exercised by a value that can actually fail (#1539).
+    fontFamily: { serif: 'Merriweather', display: 'Source Sans 3' },
 };
 
 const threw = (fn: () => unknown): UnknownUtilityError => {
@@ -180,6 +183,74 @@ export default async () => {
             expect(threw(() => partition({ zIndex: '1' } as never)).message).toContain(
                 'not a property the style partition routes',
             );
+        });
+
+        await it('serialises a font family, by both routes into the partition', async () => {
+            // THE REPORTED FAILURE (#1539). `font-family: Source Sans 3` is refused
+            // by GTK in full — `Junk at end of value for font-family` — so the
+            // containment probe refuses the generated rule and a React tree dies
+            // with no boundary between the `<Text>` and the screen.
+            //
+            // Asserted through BOTH front ends because they are two routes to one
+            // emitter and a fix at either front end would leave the other one broken:
+            // a `style={{ fontFamily }}` object, and a `font-*` utility whose token
+            // resolves to the same value.
+            expect(partition({ fontFamily: 'Source Sans 3' }).css).toStrictEqual(['font-family: "Source Sans 3"']);
+            expect(partition(resolveUtilities(['font-display'], TOKENS)).css).toStrictEqual([
+                'font-family: "Source Sans 3"',
+            ]);
+            // THE CONTROL: the other `font-*` half still answers a weight, which is
+            // a number and is not serialised.
+            expect(partition(resolveUtilities(['font-bold'], TOKENS)).css).toStrictEqual(['font-weight: 700']);
+        });
+
+        await it('emits every vector in the conformance set exactly as the set says', async () => {
+            // The pure half of the mechanism. `gtk-css.spec.ts` holds the other half
+            // — that each `emitted` parses, that the `bare` column is what the
+            // running GTK actually does, and that the set still contains a value GTK
+            // refuses and one it misreads.
+            //
+            // THE KEYWORD RULE LIVES HERE AND CANNOT LIVE THERE. GTK has no
+            // generic-family concept — its serialiser answers bare `sans-serif` with
+            // `"sans-serif"` — so an implementation that quoted keywords passes every
+            // GTK-side assertion. The `emitted` column is the only thing that sees
+            // it, and it is kept because what this emits is CSS, where a quoted
+            // keyword is a family name and no longer a keyword.
+            const wrong = FONT_FAMILY_VECTORS.filter(
+                (vector) => serialiseFontFamily(vector.authored) !== vector.emitted,
+            ).map(
+                (vector) =>
+                    `${JSON.stringify(vector.authored)} -> ${JSON.stringify(serialiseFontFamily(vector.authored))}`,
+            );
+            expect(wrong).toStrictEqual([]);
+            // And through the emitter rather than only the function, because the
+            // wiring is the half a consumer meets.
+            const unwired = FONT_FAMILY_VECTORS.filter(
+                (vector) => partitionPaint({ fontFamily: vector.authored })[0] !== `font-family: ${vector.emitted}`,
+            ).map((vector) => vector.authored);
+            expect(unwired).toStrictEqual([]);
+        });
+
+        await it('refuses a font-family list with an empty member instead of emitting one', async () => {
+            // GTK answers a missing family with `Expected a string` and drops the
+            // declaration, so a trailing comma in a token would cost the whole rule.
+            expect(threw(() => serialiseFontFamily('Cantarell,')).message).toContain('empty member');
+            expect(threw(() => serialiseFontFamily('Cantarell, , sans-serif')).message).toContain('empty member');
+        });
+
+        await it('gives every NAME-valued property a serialiser, and only those', async () => {
+            // THE MECHANISM, not the fix. `font-family` was reachable with an
+            // unserialised value because nothing recorded that its value is a NAME
+            // while every other paint value is a colour, a length, a number or a
+            // keyword. Declaring the kind makes the next such property impossible to
+            // add quietly: the key set is `keyof PaintProps`, so it cannot be
+            // skipped, and this holds the two sets against each other.
+            const nameValued = Object.entries(CSS_VALUE_KIND)
+                .filter(([, kind]) => kind === 'name')
+                .map(([property]) => property)
+                .sort();
+            expect(nameValued).toStrictEqual(Object.keys(CSS_VALUE).sort());
+            expect(nameValued).toContain('fontFamily');
         });
 
         await it('maps every property onto a CSS name GTK actually accepts', async () => {

--- a/packages/framework/gtk-host/src/style/paint.spec.ts
+++ b/packages/framework/gtk-host/src/style/paint.spec.ts
@@ -238,6 +238,27 @@ export default async () => {
             expect(threw(() => serialiseFontFamily('Cantarell, , sans-serif')).message).toContain('empty member');
         });
 
+        await it('refuses a function the member never closes, rather than passing it through', async () => {
+            // A function is the ONE member handed to GTK verbatim, so it is the one
+            // member that can carry declaration text this module did not write.
+            // Measured: `var(--x); color: red` emits a SECOND declaration, with no
+            // parse error and a surviving containment sentinel — the whole guard
+            // chain sees a valid sheet. `var(--x) } .x {` opens another RULE, and the
+            // unterminated `var(--x` ends the document.
+            //
+            // Refused rather than quoted, because quoting it would mint a family
+            // nobody has and render the wrong font in silence — the loud half of the
+            // same choice `bare: 'misread'` exists to record.
+            expect(threw(() => serialiseFontFamily('var(--x); color: red')).message).toContain('never closes');
+            expect(threw(() => serialiseFontFamily('var(--x) } .injected { color: red')).message).toContain(
+                'never closes',
+            );
+            expect(threw(() => serialiseFontFamily('var(--x')).message).toContain('never closes');
+            // THE CONTROL: a call that does close is passed through untouched,
+            // nesting included.
+            expect(serialiseFontFamily('var(--a, var(--b, sans-serif))')).toBe('var(--a, var(--b, sans-serif))');
+        });
+
         await it('gives every NAME-valued property a serialiser, and only those', async () => {
             // THE MECHANISM, not the fix. `font-family` was reachable with an
             // unserialised value because nothing recorded that its value is a NAME

--- a/packages/framework/gtk-host/src/style/paint.ts
+++ b/packages/framework/gtk-host/src/style/paint.ts
@@ -23,6 +23,7 @@
 // part of its input is invisible in CI and obvious on screen.
 
 import { UnknownUtilityError } from './errors.js';
+import { serialiseFontFamily } from './font-family.js';
 import { GTK_CSS_PROPERTIES } from './gtk-css.js';
 import { lookupToken, requireToken, tailwindDefaultHint, type StyleTokens } from './tokens.js';
 
@@ -82,6 +83,65 @@ export const CSS_NAME: Readonly<Record<keyof PaintProps, string>> = {
     lineHeight: 'line-height',
     textDecorationLine: 'text-decoration-line',
     textTransform: 'text-transform',
+};
+
+/**
+ * What KIND of value each property carries — and therefore whether that value can
+ * end the declaration early.
+ *
+ * DECLARED, not derived, because it is a judgement about a vocabulary rather than
+ * something the code can compute. It is here so the judgement is machine-held: the
+ * key set is `keyof PaintProps`, so a new property cannot skip it, and
+ * `paint.spec.ts` asserts that the `name`-valued properties are EXACTLY the ones
+ * {@link CSS_VALUE} serialises. A colour, a length, a number and a keyword are all
+ * self-delimiting; a `name` is supplied verbatim by the project and is the only kind
+ * that can carry a space, a comma or a quote.
+ *
+ * The measured answer today is that `font-family` is the only one — checked against
+ * the layout half too, which emits margins and paddings and nothing else. The next
+ * candidate is not hypothetical: `background-image: url(…)` would be the second.
+ */
+export const CSS_VALUE_KIND: Readonly<Record<keyof PaintProps, 'colour' | 'length' | 'number' | 'keyword' | 'name'>> = {
+    backgroundColor: 'colour',
+    color: 'colour',
+    opacity: 'number',
+    borderRadius: 'length',
+    borderTopLeftRadius: 'length',
+    borderTopRightRadius: 'length',
+    borderBottomLeftRadius: 'length',
+    borderBottomRightRadius: 'length',
+    borderWidth: 'length',
+    borderTopWidth: 'length',
+    borderRightWidth: 'length',
+    borderBottomWidth: 'length',
+    borderLeftWidth: 'length',
+    borderColor: 'colour',
+    fontSize: 'length',
+    fontWeight: 'number',
+    fontFamily: 'name',
+    fontStyle: 'keyword',
+    letterSpacing: 'length',
+    lineHeight: 'number',
+    textDecorationLine: 'keyword',
+    textTransform: 'keyword',
+};
+
+/**
+ * The properties whose value is SERIALISED rather than interpolated.
+ *
+ * PER PROPERTY, and that is the design rather than an accident of there being one
+ * entry: a global rule would have to decide what a comma or a space means without
+ * knowing which property it is in, and it means something different in every one.
+ * The table is the seam a second such property joins at, and
+ * {@link CSS_VALUE_KIND} is what makes joining it compulsory.
+ *
+ * Both routes to a `font-family` — a `style={{ fontFamily }}` object and a `font-*`
+ * utility resolving against `tokens.fontFamily` — arrive at `partitionPaint`, so
+ * one entry here covers both. That is why the serialisation lives at the emitter
+ * and not at either front end.
+ */
+export const CSS_VALUE: Readonly<Partial<Record<keyof PaintProps, (value: string) => string>>> = {
+    fontFamily: serialiseFontFamily,
 };
 
 /**
@@ -298,6 +358,11 @@ export const PAINT_PROPERTIES: ReadonlySet<string> = new Set(Object.keys(CSS_NAM
  * GTK's parser with no diagnostic, which is the exact silence the whole partition
  * exists to avoid. The check is cheap and it has caught the one property that looks
  * like paint and is not.
+ *
+ * The VALUE gets the same treatment, per property, through {@link CSS_VALUE}. A
+ * checked name with an unserialised value is only half the guard: GTK refused the
+ * whole rule for `font-family: Source Sans 3` while the property name was right
+ * (#1539), and the value is the half a project supplies verbatim.
  */
 export function partitionPaint(props: PaintProps): readonly string[] {
     const css: string[] = [];
@@ -310,7 +375,8 @@ export function partitionPaint(props: PaintProps): readonly string[] {
         if (!GTK_CSS_PROPERTIES.has(name)) {
             throw new UnknownUtilityError(key, `maps to "${name}", which GTK does not accept — see gtk-css.ts`);
         }
-        css.push(`${name}: ${value}`);
+        const serialise = CSS_VALUE[key as keyof PaintProps];
+        css.push(`${name}: ${serialise === undefined ? value : serialise(value)}`);
     }
 
     // A WIDTH WITHOUT A STYLE PAINTS NOTHING, and it occupies nothing either. CSS's

--- a/packages/framework/gtk-host/src/style/sheet.spec.ts
+++ b/packages/framework/gtk-host/src/style/sheet.spec.ts
@@ -10,6 +10,7 @@ import Gtk from 'gi://Gtk?version=4.0';
 import { expect, it, on } from '@gjsify/unit';
 
 import { StyleSheetError } from './document.js';
+import { partition } from './resolve.js';
 import { StyleSheet } from './sheet.js';
 import { GTK_HOSTS, gated } from '../testing/gate.mjs';
 import { installDiagnosticsGate } from '../conformance/index.js';
@@ -81,6 +82,23 @@ export default async () => {
                 const sheet = new StyleSheet();
                 const error = threw(() => sheet.classFor(['font-family: "unterminated']));
                 expect(error.message).toContain('disable every rule after it');
+            });
+
+            await it('takes a multi-word font family end to end, which is what #1539 lost', async () => {
+                // THE WHOLE REPORTED SYMPTOM, in the layer where it was observed.
+                // `font-family: Source Sans 3` is refused by GTK, so the containment
+                // probe refused the generated rule and the `StyleSheetError` came out
+                // of `classFor` — inside a React render, with no boundary between the
+                // `<Text>` and the screen. The vectors in `paint.spec.ts` and
+                // `gtk-css.spec.ts` hold the serialiser and the parser separately;
+                // this holds the two of them joined, which is the only place the
+                // failure was ever visible.
+                const sheet = new StyleSheet();
+                const { css } = partition({ fontFamily: 'Source Sans 3', fontWeight: '700' });
+                const name = sheet.classFor(css);
+                expect(sheet.toString()).toContain('font-family: "Source Sans 3"');
+                expect(sheet.toString()).toContain(`.${name} {`);
+                sheet.flush();
             });
 
             await it('keeps the document loadable after a refusal', async () => {


### PR DESCRIPTION
Closes #1539.

## What is serialised, and what deliberately is not

A new module, `src/style/font-family.ts`, owns one question: how a `font-family`
value becomes GTK CSS text. `paint.ts` gains a per-property table, `CSS_VALUE`,
whose only entry is `fontFamily`, and `partitionPaint` consults it instead of
interpolating the value. Both routes to a `font-family` — a
`style={{ fontFamily }}` object and a `font-*` utility resolving against
`tokens.fontFamily` — already arrive at `partitionPaint`, so one entry covers both;
that is why the serialisation sits at the emitter and not at either front end.

The rule is CSSOM's, not "quote when there is a space": **quote every family NAME,
leave every KEYWORD bare.** It cannot be wrong about the CSS identifier grammar
because it never consults it.

Per member of the comma-separated list, in this order:

| member | what happens | why |
|---|---|---|
| already quoted (`"X"` / `'X'`) | passed through verbatim | consumers quote defensively while a fix is in flight; double-quoting invents a family whose name contains quote marks |
| a function call (`var(--font-sans)`) | passed through verbatim | parses on GTK, and is the shape a Tailwind v4 `@theme` produces — quoting it emits a family literally called `var(--font-sans)`, which is a *silent* wrong font |
| a generic family (`sans-serif`, `serif`, `monospace`, `cursive`, `fantasy`, `system-ui`, `ui-*`, `math`, `fangsong`, `emoji`) | left bare, matched case-insensitively | a quoted keyword is a family name and no longer a keyword |
| a CSS-wide keyword (`inherit`, `initial`, `unset`, `revert`, `revert-layer`) | left bare **only as the whole value** | `font-family: inherit, sans-serif` is not valid CSS; reading the first member as a name is the closest thing to what was written |
| anything else | quoted, with `"`, `\` and control characters escaped | this is the fix |
| empty (a trailing or doubled comma) | named refusal | GTK answers a missing family with `Expected a string` and drops the declaration, so the list is refused here instead |

Commas are split at top level only, tracking quotes and parenthesis depth.
`var(--f, sans-serif)` and `"Foo, Bar"` both carry a comma that separates nothing,
and a naive `split(',')` would hand `var(--f` to the quoter — the same bug one layer
along.

Not touched, deliberately: the theme document (`theme.ts`), which is the
application's own hand-written CSS and is already probed by `assertContained`; and
the layout half, which emits margins and paddings and nothing name-shaped.

## Is there a second property with this problem? No — and now it is machine-held

`CSS_VALUE_KIND` declares, per `PaintProps` key, whether the value is a `colour`,
`length`, `number`, `keyword` or `name`. Its key set is `keyof PaintProps`, so a new
property cannot skip it, and `paint.spec.ts` holds the `name`-valued set against the
`CSS_VALUE` set. `font-family` is the only `name` today; `background-image: url(…)`
would be the second, and it can no longer arrive quietly.

## The measurement corrects the issue's scope

Measured against GTK 4.22.4 / gjs 1.88.1 by asking the parser, not by reading the
spec. A bare **sequence of identifiers** is legal CSS and GTK implements it, so five
of the issue's six examples already parsed:

```
OK      font-family: Noto Sans / DejaVu Sans / Fira Code / Liberation Serif / SF Pro Text
REJECT  font-family: Source Sans 3            Junk at end of value for font-family
REJECT  font-family: M PLUS 1p                Junk at end of value for font-family
REJECT  font-family: 8514oem                  Expected a string
REJECT  font-family: Foo.Bar                  Junk at end of value for font-family
```

What fails is a component that is not a valid identifier — overwhelmingly one
starting with a **digit**. That is why the first encounter reads as a problem with
the specific font.

**Two values are worse than refused, and they were found by the new gate rather
than by reading.** The table first claimed GTK rejects them; it does not:

- `Back\slash` — bare, `\s` is the CSS escape for `s`, so GTK resolves the family
  `Backslash`.
- a raw newline — outside a string it is whitespace, so `Two⏎Lines` bare is the ident
  sequence `Two Lines`. *Inside* a string the same byte is `Unterminated block at end
  of document`, the failure that takes every rule after it and is reported by nothing
  but the containment probe, which is why the escaped `\a ` form is emitted.

Both rendered the wrong family at exit 0, no diagnostic. That is why the vector
column is three states — `refused` / `accepted` / `misread` — and not a boolean: a
boolean would have folded `misread` into `accepted` and asserted that serialising
changes nothing, which is false for exactly the rows where changing something is the
point.

## The mechanism, and red-before-green

`src/style/gtk-css.ts:72` was `['font-family', 'Cantarell']` — one word, valid bare,
the single family for which the missing quoting is invisible. The suite asserted that
`font-family` is emitted and never that it is emitted *correctly*, so it would have
gone green against an implementation that quoted nothing.

`FONT_FAMILY_VECTORS` (23 values) carries `authored`, `emitted` and `bare` per row,
and four gates read it:

1. **`gtk-css.spec.ts`** — every `emitted` parses through a real `Gtk.CssProvider`.
2. **`gtk-css.spec.ts`** — all three `bare` states re-measured: `refused` must be
   rejected, `accepted` must normalise (via `provider.to_string()`, GTK's own parsed
   value) to the same thing as `emitted`, `misread` must normalise to a *different*
   one. This is the gate that caught two wrong claims of mine on its first run.
3. **`gtk-css.spec.ts`** — **the discriminator**: the set must still contain a
   `refused` row (`Source Sans 3` by name) and a `misread` row. If it is ever reduced
   to values GTK accepts bare, this goes red. Both bug shapes are required, because
   the quiet one is the one a suite loses.
4. **`paint.spec.ts`** — the pure half: `serialiseFontFamily` and `partitionPaint`
   emit exactly the `emitted` column. The **keyword rule lives here and cannot live
   on the GTK side**: GTK has no generic-family concept at all (its serialiser
   answers bare `sans-serif` with `"sans-serif"`), so an implementation that quoted
   keywords passes every GTK-side assertion. The `emitted` column is the only thing
   that sees it.

Plus the reported symptom end to end in `sheet.spec.ts`: `classFor` over
`partition({ fontFamily: 'Source Sans 3', fontWeight: '700' })`, which is the call
that threw `StyleSheetError` inside a React render.

**Red before green, against GTK's own parser** — `test:gjs`, same spec set, only the
`partitionPaint` wiring removed:

| run | result |
|---|---|
| `origin/main` baseline | 483 tests, 2538 assertions, **exit 0** |
| new specs, emitter un-wired | **3 of the 8 new tests fail, exit 1** — the end-to-end one failing with GTK's own verdict, `GTK refused a declaration in a generated rule` |
| new specs, emitter wired | 491 tests (+8), 2553 assertions, **exit 0** |

The other five new tests pass in both, and that is correct: they measure the table
against GTK and call the serialiser directly, so they do not depend on the wiring.

`oxfmt --check .` clean over 3684 files; `oxlint` clean on the touched tree (two
pre-existing `consistent-type-imports` warnings in `sheet.ts`/`theme.ts` are
untouched); `gjsify tsc --noEmit` clean.

## Not in this PR

No ADR (no new package boundary and no changed published contract — the `./style`
exports are additive), no `AGENTS.md` edit, and `docs/release-notes/next.md`
untouched. `packages/framework`'s comment-budget ratio was already over its ceiling
on `main` and this moves it by about +0.002; it is advisory (`--warn`).
