### PR TITLE
fix(cli): the payload the runtime cannot load

### DIFF
--- a/docs/adr/0024-ship-installable-artifacts.md
+++ b/docs/adr/0024-ship-installable-artifacts.md
@@ -1513,6 +1513,29 @@ schema but the current one, in both directions, and says so ("Re-run the `--stag
 gjsify"). A second copy of the check at pack time would be a guard watching another mechanism,
 which § Governance names as the smell.
 
+**Three things the first cut got wrong, each found by running it rather than reading it.** All
+three are the same shape as the defect the amendment is about — an answer that looks like a
+measurement:
+
+1. **The scanner over-approximated on a real minified bundle.** Bindings of `@gjsify/node-gi/gi`
+   were kept in ONE set, and a minifier gives an `import * as gi` and a callback parameter the same
+   short name in different scopes — so `function render(e,t){return e(t)+e(`Zzqfoo`)}` produced the
+   namespace `Zzqfoo` and `deriveDepends` refused to package a correct project. A module namespace
+   object is not callable at all, so the two sets are now split by what a binding can BE: only
+   `requireGi` itself (named or default import) is a callee, everything else is an object of
+   `.requireGi(…)`.
+2. **The foreign-entry exclusion could drop the target's OWN entry.** The set was compared as
+   declared strings, and `dist/app.mjs`, `./dist/app.mjs`, `dist/../dist/app.mjs` and an absolute
+   path are four spellings of one file. Measured: a payload with the launcher in it and no bundle.
+   The comparison is a resolved PATH now, which is the only spelling nothing can work around.
+3. **The pair check accepted #1545's own pair for a legacy GJS bundle.** An application reaching GI
+   through the ambient `imports.gi` object carries no `gi://`, and a `--app gjs` build of one
+   imports `system` — measured on a real build, whose whole evidence is `{"gi":["system"]}`. Node
+   refuses a bare GJS built-in as a missing package (`ERR_MODULE_NOT_FOUND`), so it is the same
+   kind of evidence and is read as such. The ambient `imports` object deliberately is NOT: node
+   fails on it at the first USE rather than at load, so a refusal citing it would claim more than
+   it can keep.
+
 **Correction to § A22, kept as the record per § 7's precedent.** Its closing paragraph is now
 false: the bundle is no longer one path, and the discriminator it called nonexistent is
 `utils/ship/entry-interpreter.ts`. Its diagnosis was right about where the difficulty sits — the

--- a/docs/adr/0024-ship-installable-artifacts.md
+++ b/docs/adr/0024-ship-installable-artifacts.md
@@ -1487,6 +1487,32 @@ decision: a bundle declared for one OS is dropped from every other OS's payload.
 not tidiness — `discoverPayload` stages the whole directory the entry lives in, so without it each
 artifact carries a bundle its own interpreter cannot load, on macOS inside the signed `.app`.
 
+**What a bundler does to the discriminator, measured after the first cut passed its own tests.**
+The `requireGi` reader keyed on a callee named `require`, which is what the plugin emits and what a
+hand-written fixture keeps — and what a bundle never has. Built through the real plugin:
+
+```
+unminified   const require$1 = createRequire(import.meta.url);
+             … require$1("@gjsify/node-gi/gi").requireGi("Gtk", "4.0")
+minified     const n = e(import.meta.url);
+             … n(`@gjsify/node-gi/gi`).requireGi(`Gtk`, `4.0`)
+```
+
+Two shims in one bundle means two `require` bindings, so the second is renamed even without
+`--minify`, which is the default. The identifier-keyed reader answered `["Adw-1"]` unminified and
+`[]` minified — a legal answer either way, so the artifact would have shipped with no typelib
+`Depends:` and the fix would have reported success. The module STRING is what survives every
+rename, so that is the discriminator: a call taking `'@gjsify/node-gi/gi'` as its first argument is
+a load of that module under any name. The spec now asserts against both real outputs verbatim,
+because a hand-written shim cannot stand in for the file that ships — which is the same sentence
+this amendment already carries about the fixtures, one level in.
+
+**What `--from-stage` needs, which is nothing.** The pair is checked where it is decided, and a
+stage assembled by an older gjsify cannot reach the packer at all: `readStageManifest` refuses any
+schema but the current one, in both directions, and says so ("Re-run the `--stage` phase with this
+gjsify"). A second copy of the check at pack time would be a guard watching another mechanism,
+which § Governance names as the smell.
+
 **Correction to § A22, kept as the record per § 7's precedent.** Its closing paragraph is now
 false: the bundle is no longer one path, and the discriminator it called nonexistent is
 `utils/ship/entry-interpreter.ts`. Its diagnosis was right about where the difficulty sits — the

--- a/docs/adr/0024-ship-installable-artifacts.md
+++ b/docs/adr/0024-ship-installable-artifacts.md
@@ -1405,3 +1405,91 @@ project that is GJS on Linux and Node on Windows builds two bundles — `dist/<n
 `dist/<name>.node.mjs` is the layout this tree documents as normal, and `discoverPayload` stages
 both — but every layout's launcher names the same one of them. That is the next axis, and it is a
 separate question with a separate config surface; `status/open-todos.md` carries it.
+
+## Amendment, 2026-09-04 — the runtime and the payload are ONE decision
+
+§ A22 ends by naming what it did not do: the runtime became per target and the bundle stayed one
+path. That sentence describes a gap, and the gap was measured before this amendment was written —
+`gjsify ship` 0.47.0, a React-Native-on-GTK application, `gjsify.ship.app.darwin: "node"`, and a
+`.app` that cannot start (#1545).
+
+### A23. `gjsify.ship.bundle` is per target too, and the pair is CHECKED
+
+**What the run printed, in full, on the subject of the runtime:**
+
+```
+[gjsify ship] runtime for darwin: node — `gjsify.ship.app.darwin` overrides `gjsify.app`.
+```
+
+That line is correct. The launcher it produced ends `exec node "$contents/Resources/lib/app.gjs.mjs"`,
+and `app.gjs.mjs` is a `--app gjs` bundle, because `main` is what the payload comes from and Linux
+is that project's primary target. Measured directly, the artifact dies before a line of application
+code:
+
+```
+Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are
+supported by the default ESM loader. Received protocol 'gi:'
+```
+
+So ship honoured both keys, they contradicted each other, and the only output on the subject read
+as confirmation. `--skip-build` changes nothing: the choice is `main`, not a build artifact ship
+selects.
+
+**The decision, in the shape § A22 already established.** `gjsify.ship.bundle` accepts the table
+`{linux,darwin,win32}` beside its existing scalar form, `resolveShipBundle` is `resolveShipApp`'s
+twin — same OS vocabulary, same mis-keyed-key refusal, same "which key answered" in the result —
+and `commands/ship.ts` resolves the pair in one place before anything is staged. Fall-through, not
+requirement: a target with no key keeps `gjsify.main`, so every single-host project is untouched
+and nothing new is mandatory.
+
+Two alternatives were rejected where #1545 raised them. **Deriving the entry from the runtime by
+filename** (`app.node.mjs` beside `app.gjs.mjs`) is a heuristic over an output name the project
+owns, and this tree already refuses that guess elsewhere. **Having ship invoke `gjsify build --app
+<runtime>`** cannot serve the phase that needs it most: `--from-stage` packs on a host with no
+project, no bundler and no sources (§ A2). A declaration works in both phases, and the stage
+manifest already carries the RESOLVED value, so nothing there changes.
+
+**The discriminator exists, which § A22's follow-up said it did not.** It is the module scheme, and
+it is exact in both directions because each host's loader refuses the other's — measured on GJS
+1.86 and Node 24:
+
+| the entry imports | under `node` | under `gjs` |
+|---|---|---|
+| `gi://Gtk?version=4.0` | `ERR_UNSUPPORTED_ESM_URL_SCHEME … Received protocol 'gi:'` | resolves |
+| `node:fs` | resolves | `ImportError: Unsupported URI scheme for importing: node` |
+
+Neither is a claim about how the bundle was built: it is the specifier the running loader rejects,
+read out of the file that will be installed. `assertEntryRunsUnder` refuses on evidence FOR the
+wrong host and never on its absence — a bundle naming neither scheme passes, because nothing was
+observed to contradict. That asymmetry is `assertLauncherMatchesInterpreter`'s, and for its reason:
+a guard that turns working packages into failures buys nothing over the defect it prevents.
+
+**A second defect fell out of writing the discriminator, and it is the more expensive one.**
+`scanGiNamespaces` — the source of every artifact's typelib `Depends:` (§ 6) — read `gi://`
+specifiers only. A `--app node` bundle has none: `gjsGiNodePlugin` rewrites each one into
+`require('@gjsify/node-gi/gi').requireGi("Ns", "Ver")`. So every node-target artifact derived an
+EMPTY typelib dependency set, installed cleanly, and died at its first GI call — the exact failure
+the bare-side-effect-import fix in that module was written to prevent, arriving again through the
+other build target. The scanner now reads both emitted forms in one acorn pass, binding-traced
+rather than name-matched, because over-approximating a namespace fails the build.
+
+**Why nothing caught it.** Every ship fixture's "node bundle" was hand-written with `gi://` imports
+in it — a shape `gjsify build --app node` cannot emit and node cannot run. The fixture now imports
+`giNodeShimSource` from the plugin that writes it, so the text under test is the text that ships,
+and it carries the second real shape too (an application written against `@gjsify/node-gi`
+directly, whose import survives into the output because the addon is external).
+
+**What the e2e suite said before the fix.** `tests/e2e/ship`'s per-target-runtime case scaffolded
+`gjsify.ship.app.win32: "node"` with the payload left on `gjsify.main` — this defect, encoded as a
+passing test, with a comment saying the launcher's choice of file "is a separate axis … so this
+test says nothing about it". It now declares the win32 entry, and asserts the other half of the
+decision: a bundle declared for one OS is dropped from every other OS's payload. That exclusion is
+not tidiness — `discoverPayload` stages the whole directory the entry lives in, so without it each
+artifact carries a bundle its own interpreter cannot load, on macOS inside the signed `.app`.
+
+**Correction to § A22, kept as the record per § 7's precedent.** Its closing paragraph is now
+false: the bundle is no longer one path, and the discriminator it called nonexistent is
+`utils/ship/entry-interpreter.ts`. Its diagnosis was right about where the difficulty sits — the
+bundle path is read before the settings are resolved — which is why the resolver runs beside
+`resolveShipApp` and feeds `discoverPayload` rather than being derived from the settings it
+precedes.

--- a/docs/ship-formats.md
+++ b/docs/ship-formats.md
@@ -371,6 +371,23 @@ There is deliberately no per-LAYOUT default: an absent override means `gjsify.ap
 reason: `gjsify.ship.app.windows` resolves to nothing and would leave that target silently on the
 project-wide answer.
 
+**AND SO IS THE ENTRY** (#1545, ADR 0024 § A23). The runtime a target execs and the bundle it hands
+that runtime are one decision, and declaring only the first is what produced a `.app` that could not
+start: `gjsify.ship.app.darwin: "node"` moved the launcher, the payload stayed on `gjsify.main` — a
+`--app gjs` bundle, because Linux was that project's primary target — and node's ESM loader refused
+`gi:` before a line of application code ran. `gjsify.ship.bundle` therefore takes the same
+`{linux,darwin,win32}` table beside its scalar form, resolved by `resolveShipBundle`,
+`resolveShipApp`'s twin in every respect including the refusal of a key nothing reads. A target with
+no key keeps `gjsify.main`.
+
+Two things follow that are worth stating because neither is obvious. `assertEntryRunsUnder`
+(`utils/ship/entry-interpreter.ts`) reads the entry's module SCHEMES and refuses the pair that
+cannot work — `gi://` under `node`, `node:` under `gjs` — on evidence for the wrong host and never
+on its absence, so a bundle naming neither passes. And a bundle declared for one OS is dropped from
+every OTHER OS's payload: `discoverPayload` stages the whole directory the entry lives in, so
+without that the `.app` carries the Linux bundle inside its signed tree. Only the declared entries
+are dropped, never a guess at which sibling chunks belong to them.
+
 `utils/ship/payload.ts`'s `readLauncherInterpreters` strips a surrounding shell quote before taking
 the basename, and that is not tidiness: without it `"$here/node"` read back as `node"`, which is
 neither known interpreter, so `assertLauncherMatchesInterpreter` took its "a program that is

--- a/packages/infra/cli/AGENTS.md
+++ b/packages/infra/cli/AGENTS.md
@@ -85,6 +85,21 @@ where no project exists. The packers take `PackSettings` — the half that cross
 Every omission from that closure fails silently at exit 0, which is why `tests/e2e/ship-from-stage`
 DELETES the project between the phases; without the deletion a reach-back succeeds and proves nothing.
 
+**THE RUNTIME AND THE ENTRY ARE ONE DECISION, and both are per target** (ADR 0024 § A22, § A23).
+`gjsify.ship.app.<os>` overrides `gjsify.app`; `gjsify.ship.bundle.<os>` overrides `gjsify.main`;
+`resolveShipApp` and `resolveShipBundle` are twins — same OS vocabulary, same refusal of a key
+nothing reads, same "which key answered" in the result — and `commands/ship.ts` resolves the pair
+before anything is staged. Declaring only the first is what shipped a `.app` whose launcher execs
+`node` over a `--app gjs` bundle: built, reported as built, dead on its first import (#1545).
+`assertEntryRunsUnder` refuses that pair on the module SCHEME each host's loader rejects (`gi://`
+under node, `node:` under gjs) — on evidence FOR the wrong host, never on its absence, like
+`assertLauncherMatchesInterpreter`. A bundle declared for one OS is dropped from every other OS's
+payload, fall-through entries included, because `discoverPayload` stages the whole directory the
+entry lives in. **A reader of an emitted bundle must key on the module STRING, never on a callee
+name**: two `gi://` shims in one bundle means two `require` bindings, so the second is renamed even
+without `--minify`, and `scanGiNamespaces` — the source of every artifact's typelib `Depends:` —
+answered `[]` for real node bundles for exactly that reason.
+
 **`--sign <identity>` is a MUTATION of the payload and its ORDER is load-bearing** (ADR 0024 § A12-§ A17). It takes the string `codesign`/`signtool` resolves a key by — never a certificate, so nothing here can leak — and an absent identity SKIPS loudly at exit 0. `readStage` compares staged file SIZES, so it must validate BEFORE anything re-signs: `signPayload` therefore takes `readStage`'s output and returns the packer's input, in scratch, never in the arriving stage. **The darwin leg signs every Mach-O and THEN seals the `<App>.app`** (ADR 0040) — a seal hashes what it seals — so the payload may GROW, in one enumerated place (`sealAddPrefix`, decided by the pure `partitionSignedFileSet`); the seal was refused for a measured-wrong reason, the extended-attribute rule being Apple's for a LOOSE file. Table + oracle + what stays UNVERIFIED (signtool, notarytool, every darwin claim — no macOS host): [docs/ship-formats.md](../../../docs/ship-formats.md) § Signing.
 
 **The windows layout OWNS A PROGRAM, and emitting it is what closed the console window** (ADR 0040). `cmd.exe` is a console-subsystem image whatever `node.exe` is, so the console is allocated before the interpreter starts: `Subsystem`-patching `node.exe` fixes nothing and discards every byte the app writes. `utils/ship/pe-launcher.ts` emits a GUI-subsystem PE the way `deb.ts`/`msi.ts` emit their formats — no vendored binary, no toolchain, nobody's licence but ours — staged through the windows `Layout.metadata` seam, running the `.cmd` rather than reimplementing it. Both its probes were measured wrong first (`GetConsoleWindow` answers NULL for a WINDOWLESS console). No CI leg sees any of it; the window count is `win11-gjsify`, session 1.

--- a/packages/infra/cli/src/commands/ship.ts
+++ b/packages/infra/cli/src/commands/ship.ts
@@ -71,6 +71,7 @@ import { isUnder, SHARE } from '../utils/ship/share-dirs.js';
 import { compileSchemasForStage } from '../utils/ship/schemas.js';
 import { buildMsi, MSI_PAYLOAD_DIR } from '../utils/ship/msi.js';
 import { buildZip, zipEntriesFromPayload } from '../utils/ship/zip.js';
+import { assertEntryRunsUnder } from '../utils/ship/entry-interpreter.js';
 import { scanGiNamespaces } from '../utils/ship/gi-namespaces.js';
 import {
     assertLauncherMatchesInterpreter,
@@ -94,8 +95,8 @@ import {
 import { renderLauncher } from '../utils/ship/launcher.js';
 import { buildRpm } from '../utils/ship/rpm.js';
 import {
-    declaredBundlePath,
     resolveShipApp,
+    resolveShipBundle,
     resolveShipSettings,
     type ShipPackageManifest,
 } from '../utils/ship/settings.js';
@@ -375,12 +376,24 @@ async function assemble(args: ShipOptions): Promise<void> {
 
     if (!args['skip-build']) await runProjectBuild(projectDir);
 
+    // THE OTHER HALF of the resolution above, and they are one decision: the
+    // runtime a target execs and the entry it hands that runtime (#1545). Two
+    // keys, resolved by two twin functions, compared by `assertEntryRunsUnder`
+    // as soon as both answers and the file exist.
+    const resolvedBundle = resolveShipBundle({ pkg, ship, layoutOs: layout.os });
+    if (resolvedBundle.overridden) {
+        console.log(
+            `${LOG} entry for ${layout.name}: ${resolvedBundle.declared} — \`${resolvedBundle.key}\` ` +
+                'overrides `gjsify.main`.',
+        );
+    }
     const discovered = discoverPayload({
         projectDir,
         pkg,
         ship,
         flatpakIcon: flatpak.icon,
-        declaredBundle: declaredBundlePath(pkg, ship),
+        declaredBundle: resolvedBundle.declared,
+        foreignBundles: resolvedBundle.foreign,
     });
     const { settings, metadata, warnings } = resolveShipSettings({
         projectDir,
@@ -401,6 +414,22 @@ async function assemble(args: ShipOptions): Promise<void> {
     // runtime does not have is already wrong, and it is the stage that crosses to
     // the packing host.
     for (const format of formats) assertFormatCanRunInterpreter(format, settings.app);
+
+    // The entry, read ONCE: the pair check below and the namespace scan further
+    // down both ask what this file imports, and a bundle is the biggest file in
+    // the project.
+    const bundleSource = readFileSync(settings.bundlePath, 'utf-8');
+    // BEFORE anything is staged, for the reason above and one more: this is the
+    // refusal that says the artifact could never have started, and the run that
+    // reports it must not also print a stage path.
+    assertEntryRunsUnder({
+        interpreter: settings.app,
+        source: bundleSource,
+        entry: relative(projectDir, settings.bundlePath) || settings.bundlePath,
+        appKey: resolvedApp.key,
+        bundleKey: resolvedBundle.key,
+        layoutOs: layout.os,
+    });
 
     const mtime = buildTimestamp(settings.bundlePath);
     const metadataInputs = {
@@ -573,7 +602,7 @@ async function assemble(args: ShipOptions): Promise<void> {
     // `gi://` specifiers are what the emitted `Depends:` is derived from
     // (ADR 0024 § 6), and the packing host has the staged copy but no way to
     // tell which staged file is the entry.
-    const namespaces = scanGiNamespaces(readFileSync(settings.bundlePath, 'utf-8'));
+    const namespaces = scanGiNamespaces(bundleSource);
     if (args.verbose) console.log(`${LOG} gi namespaces: ${namespaces.join(', ') || '(none)'}`);
 
     // PLACED, like the payload, and through the same map. `planOverlay` answers a

--- a/packages/infra/cli/src/test.mts
+++ b/packages/infra/cli/src/test.mts
@@ -16,6 +16,7 @@ import shipPayloadSuite from './utils/ship/payload.spec.js';
 import shipLauncherSuite from './utils/ship/launcher.spec.js';
 import shipPeLauncherSuite from './utils/ship/pe-launcher.spec.js';
 import shipSettingsSuite from './utils/ship/settings.spec.js';
+import shipEntryInterpreterSuite from './utils/ship/entry-interpreter.spec.js';
 import shipLocalesSuite from './utils/ship/discover-locales.spec.js';
 import shipFontsSuite from './utils/ship/discover-fonts.spec.js';
 import msgfmtMergeSuite from './utils/msgfmt-merge.spec.js';
@@ -228,6 +229,7 @@ run(
         shipLauncherSuite,
         shipPeLauncherSuite,
         shipSettingsSuite,
+        shipEntryInterpreterSuite,
         shipLocalesSuite,
         shipFontsSuite,
         msgfmtMergeSuite,

--- a/packages/infra/cli/src/test.mts
+++ b/packages/infra/cli/src/test.mts
@@ -21,6 +21,7 @@ import shipLocalesSuite from './utils/ship/discover-locales.spec.js';
 import shipFontsSuite from './utils/ship/discover-fonts.spec.js';
 import msgfmtMergeSuite from './utils/msgfmt-merge.spec.js';
 import shipTypelibsSuite from './utils/ship/discover-typelibs.spec.js';
+import shipBundleDiscoverySuite from './utils/ship/discover-bundle.spec.js';
 import shipMimeSuite from './utils/ship/mime.spec.js';
 import shipLicenseSuite from './utils/ship/discover-license.spec.js';
 import shipDependsSuite from './utils/ship/depends.spec.js';
@@ -226,6 +227,7 @@ run(
         shipLayoutSuite,
         shipPayloadSuite,
         shipTypelibsSuite,
+        shipBundleDiscoverySuite,
         shipLauncherSuite,
         shipPeLauncherSuite,
         shipSettingsSuite,

--- a/packages/infra/cli/src/types/config-data.ts
+++ b/packages/infra/cli/src/types/config-data.ts
@@ -458,8 +458,14 @@ export interface ConfigDataShip extends AppMetadata {
     /**
      * The built bundle `bin/<name>` executes. Default: `gjsify.main`, then
      * `package.json#main`. Its whole directory is staged into `lib/<name>/`.
+     *
+     * A STRING is one entry for every target; a TABLE names one per OS, keyed
+     * like {@link ShipAppOptions} and resolved beside it. An application with two
+     * hosts has two bundles built from one source — `gjsify.app` decides which
+     * runtime a target execs, and this decides which of those bundles it hands
+     * that runtime (#1545).
      */
-    bundle?: string;
+    bundle?: string | ShipBundleOptions;
     /** Icon file, or a directory of them. Sizes are read from the path or the filename. */
     icon?: string;
     /** A `*.gschema.xml` file, or a directory of them. */
@@ -599,6 +605,30 @@ export interface ShipAppOptions {
     darwin?: 'gjs' | 'node';
     /** What a Windows program directory carries. `node` is the only value its formats accept. */
     win32?: 'gjs' | 'node';
+}
+
+/**
+ * `gjsify.ship.bundle` — the ENTRY per OS, the twin of {@link ShipAppOptions}.
+ *
+ * The two answer one question between them, and answering only half of it is
+ * what #1545 measured: `gjsify.ship.app.darwin: "node"` pointed the launcher at
+ * `node` while the payload stayed the project's `main` — a `--app gjs` bundle,
+ * because Linux is that project's primary target. Both halves were honoured,
+ * they contradicted each other, and the `.app` died on its first import.
+ *
+ * Same OS spelling as everywhere else in this block (`process.platform`), and
+ * the same fall-through: a target with no key here keeps `gjsify.main`. What it
+ * does NOT keep is another target's entry — a bundle declared for one OS is
+ * dropped from every other OS's payload, since no interpreter but that one can
+ * load it.
+ */
+export interface ShipBundleOptions {
+    /** The entry a `.deb`/`.rpm`/Flatpak installs. */
+    linux?: string;
+    /** The entry `<App>.app/Contents/Resources/lib/` carries. */
+    darwin?: string;
+    /** The entry the Windows program directory carries. */
+    win32?: string;
 }
 
 /**

--- a/packages/infra/cli/src/utils/cli-runtime-closure.ts
+++ b/packages/infra/cli/src/utils/cli-runtime-closure.ts
@@ -99,14 +99,19 @@ export interface SpecifierNode {
 }
 
 /**
- * The string a module specifier node names, or `null` when it is computed.
+ * The string a node names statically, or `null` when it is computed.
  *
  * A substitution-free TEMPLATE LITERAL is as static as a quoted string, and
  * skipping it is not hypothetical: the minifier rewrites `await
  * import('gi://GLib?version=2.0')` to a backtick form, so a Literal-only reader
  * silently loses every dynamic import in a built bundle.
+ *
+ * Not named for specifiers, because it does not only read them: the same
+ * question is asked of a CALL ARGUMENT by `utils/ship/gi-namespaces.ts`, whose
+ * `requireGi("Gtk", "4.0")` carries a namespace and a version in exactly the two
+ * spellings above.
  */
-export function literalSpecifier(node: SpecifierNode | undefined): string | null {
+export function staticStringValue(node: SpecifierNode | undefined): string | null {
     if (node?.type === 'Literal') return typeof node.value === 'string' ? node.value : null;
     if (node?.type === 'TemplateLiteral' && node.expressions?.length === 0) {
         const cooked = node.quasis?.[0]?.value?.cooked;
@@ -155,18 +160,32 @@ export function walkModuleAst(code: string, visit: (node: AstNode) => void): voi
     descend(ast);
 }
 
+/**
+ * The module `node` imports from, or `null` when `node` is not an import at all.
+ *
+ * FOUR node types, in one place. Every reader of a built bundle in this tree asks
+ * the same question of the same four — a static `import`, both `export … from`
+ * forms and `import()` — and each copy of that list is a chance for one reader to
+ * miss a form the others catch. The bare side-effect `import "gi://Soup"` is what
+ * that costs when it happens (`utils/ship/gi-namespaces.ts`).
+ */
+export function importedSpecifier(node: AstNode): string | null {
+    if (
+        node.type !== 'ImportDeclaration' &&
+        node.type !== 'ExportNamedDeclaration' &&
+        node.type !== 'ExportAllDeclaration' &&
+        node.type !== 'ImportExpression'
+    ) {
+        return null;
+    }
+    return staticStringValue(node.source as SpecifierNode | undefined);
+}
+
 export function moduleSpecifiers(code: string): string[] {
     const out: string[] = [];
     walkModuleAst(code, (node) => {
-        if (
-            node.type === 'ImportDeclaration' ||
-            node.type === 'ExportNamedDeclaration' ||
-            node.type === 'ExportAllDeclaration' ||
-            node.type === 'ImportExpression'
-        ) {
-            const specifier = literalSpecifier(node.source as SpecifierNode | undefined);
-            if (specifier !== null) out.push(specifier);
-        }
+        const specifier = importedSpecifier(node);
+        if (specifier !== null) out.push(specifier);
     });
     return out;
 }

--- a/packages/infra/cli/src/utils/cli-runtime-closure.ts
+++ b/packages/infra/cli/src/utils/cli-runtime-closure.ts
@@ -91,7 +91,7 @@ function splitWorkspaceSpecifier(
  * own entry is a bin (`#!/usr/bin/env node`), and a parse failure yields NO
  * specifiers, which under-selects rather than mis-selects.
  */
-interface SpecifierNode {
+export interface SpecifierNode {
     type?: string;
     value?: unknown;
     expressions?: unknown[];
@@ -106,7 +106,7 @@ interface SpecifierNode {
  * import('gi://GLib?version=2.0')` to a backtick form, so a Literal-only reader
  * silently loses every dynamic import in a built bundle.
  */
-function literalSpecifier(node: SpecifierNode | undefined): string | null {
+export function literalSpecifier(node: SpecifierNode | undefined): string | null {
     if (node?.type === 'Literal') return typeof node.value === 'string' ? node.value : null;
     if (node?.type === 'TemplateLiteral' && node.expressions?.length === 0) {
         const cooked = node.quasis?.[0]?.value?.cooked;
@@ -115,36 +115,59 @@ function literalSpecifier(node: SpecifierNode | undefined): string | null {
     return null;
 }
 
-export function moduleSpecifiers(code: string): string[] {
+/** One node of the walk: whatever acorn produced, seen as a bag of properties. */
+export type AstNode = { type?: string } & Record<string, unknown>;
+
+/**
+ * Parse `code` as a module and call `visit` for every node in it.
+ *
+ * Exported because a SECOND parse is how the two readers of a built bundle
+ * would drift apart: {@link moduleSpecifiers} answers "what does this file
+ * import" and `utils/ship/gi-namespaces.ts` answers "which GI namespaces does
+ * it load", and the second question has an answer the first cannot see — a
+ * `--app node` bundle carries no `gi://` specifier at all, only the
+ * `requireGi()` calls the bundler rewrote them into. One walker, two readers.
+ *
+ * A parse failure yields NO nodes rather than throwing: every caller is
+ * summarising a file it did not write, and under-selecting is the failure mode
+ * that keeps a correct project buildable.
+ */
+export function walkModuleAst(code: string, visit: (node: AstNode) => void): void {
     let ast: acorn.Program;
     try {
         ast = acorn.parse(code, { ecmaVersion: 'latest', sourceType: 'module', allowHashBang: true });
     } catch {
-        return [];
+        return;
     }
-    const out: string[] = [];
-    const visit = (node: unknown): void => {
+    const descend = (node: unknown): void => {
         if (!node || typeof node !== 'object') return;
         if (Array.isArray(node)) {
-            for (const child of node) visit(child);
+            for (const child of node) descend(child);
             return;
         }
-        const n = node as { type?: string; source?: SpecifierNode };
-        if (
-            n.type === 'ImportDeclaration' ||
-            n.type === 'ExportNamedDeclaration' ||
-            n.type === 'ExportAllDeclaration' ||
-            n.type === 'ImportExpression'
-        ) {
-            const specifier = literalSpecifier(n.source);
-            if (specifier !== null) out.push(specifier);
-        }
+        const n = node as AstNode;
+        visit(n);
         for (const [key, value] of Object.entries(n)) {
             if (key === 'type' || key === 'start' || key === 'end' || key === 'loc') continue;
-            visit(value);
+            descend(value);
         }
     };
-    visit(ast);
+    descend(ast);
+}
+
+export function moduleSpecifiers(code: string): string[] {
+    const out: string[] = [];
+    walkModuleAst(code, (node) => {
+        if (
+            node.type === 'ImportDeclaration' ||
+            node.type === 'ExportNamedDeclaration' ||
+            node.type === 'ExportAllDeclaration' ||
+            node.type === 'ImportExpression'
+        ) {
+            const specifier = literalSpecifier(node.source as SpecifierNode | undefined);
+            if (specifier !== null) out.push(specifier);
+        }
+    });
     return out;
 }
 

--- a/packages/infra/cli/src/utils/ship/depends.spec.ts
+++ b/packages/infra/cli/src/utils/ship/depends.spec.ts
@@ -316,6 +316,52 @@ export default async () => {
             ).toStrictEqual([]);
         });
 
+        await it('finds the namespaces a --app node bundle carries', async () => {
+            // `gjsGiNodePlugin` rewrites every `gi://` into this shim, so a node
+            // bundle carries NO `gi://` specifier and the scanner that read only
+            // that form derived an EMPTY dependency set: the package installed
+            // and died at its first GI call. Verbatim from the emitted shim,
+            // including the `require` the bundle keeps external.
+            const shim = [
+                `import { createRequire } from 'node:module';`,
+                `const require = createRequire(import.meta.url);`,
+                `let cached;`,
+                `function load() {`,
+                `  if (cached === undefined) {`,
+                `    cached = require('@gjsify/node-gi/gi').requireGi("Gtk", "4.0");`,
+                `  }`,
+                `  return cached;`,
+                `}`,
+            ].join('\n');
+            expect(scanGiNamespaces(shim)).toStrictEqual(['Gtk-4.0']);
+        });
+
+        await it('finds requireGi through every binding node-gi exports it under', async () => {
+            // A hand-written node-gi application does not go through the shim,
+            // and `requireGi` is both the named and the DEFAULT export
+            // (`packages/node-gi/node-gi/gi.d.ts`), so all three spellings reach
+            // the same function and all three must derive the same dependency.
+            const named = `import { requireGi } from '@gjsify/node-gi/gi';\nconst Gtk = requireGi('Gtk', '4.0');`;
+            const renamed = `import { requireGi as gi } from '@gjsify/node-gi/gi';\nconst A = gi('Adw', '1');`;
+            const asDefault = `import gi from '@gjsify/node-gi/gi';\nconst S = gi('Soup', '3.0');`;
+            const namespace = `import * as gi from '@gjsify/node-gi/gi';\nconst G = gi.requireGi('GLib');`;
+            expect(scanGiNamespaces(named)).toStrictEqual(['Gtk-4.0']);
+            expect(scanGiNamespaces(renamed)).toStrictEqual(['Adw-1']);
+            expect(scanGiNamespaces(asDefault)).toStrictEqual(['Soup-3.0']);
+            expect(scanGiNamespaces(namespace)).toStrictEqual(['GLib']);
+        });
+
+        await it('does not read a foreign requireGi, because over-approximating fails the build', async () => {
+            // BINDING-TRACED, not name-matched. An unmapped namespace is a build
+            // failure, so a method that merely shares the name would make a
+            // correct project unpackageable — the same asymmetry the `gi://`
+            // string case below is about.
+            expect(
+                scanGiNamespaces(`import { requireGi } from 'somewhere-else';\nrequireGi('Gtk', '4.0');`),
+            ).toStrictEqual([]);
+            expect(scanGiNamespaces(`plugins.requireGi('Gtk', '4.0');`)).toStrictEqual([]);
+        });
+
         await it('parses a specifier with and without a version', async () => {
             expect(parseGiSpecifier('gi://Gtk?version=4.0')).toBe('Gtk-4.0');
             expect(parseGiSpecifier('gi://Gtk')).toBe('Gtk');

--- a/packages/infra/cli/src/utils/ship/depends.spec.ts
+++ b/packages/infra/cli/src/utils/ship/depends.spec.ts
@@ -336,6 +336,32 @@ export default async () => {
             expect(scanGiNamespaces(shim)).toStrictEqual(['Gtk-4.0']);
         });
 
+        await it('finds them in the bundle a real `gjsify build --app node` writes', async () => {
+            // VERBATIM from `gjsify build src/app.ts --app node` on a two-import
+            // app, both spellings, and this is the case a hand-written shim cannot
+            // stand in for. TWO shims in one bundle means two `require` bindings,
+            // so the second is renamed even without `--minify` — which is the
+            // DEFAULT, and there the loader is called `n` and the arguments are
+            // template literals. A reader keyed on the identifier `require` answers
+            // `[]` here, which is a legal answer, so the artifact ships with no
+            // typelib `Depends:` and nothing says a word.
+            const unminified = [
+                `import { createRequire } from "node:module";`,
+                `const require$1 = createRequire(import.meta.url);`,
+                `let cached$1;`,
+                `function load$1() {`,
+                `	if (cached$1 === void 0) cached$1 = require$1("@gjsify/node-gi/gi").requireGi("Gtk", "4.0");`,
+                `	return cached$1;`,
+                `}`,
+            ].join('\n');
+            const minified =
+                'import{createRequire as e}from"node:module";var t=Object.defineProperty,' +
+                '__name=(e,n)=>t(e,`name`,{value:n,configurable:!0});const n=e(import.meta.url);let r;' +
+                'function load$1(){return r===void 0&&(r=n(`@gjsify/node-gi/gi`).requireGi(`Gtk`,`4.0`)),r}';
+            expect(scanGiNamespaces(unminified)).toStrictEqual(['Gtk-4.0']);
+            expect(scanGiNamespaces(minified)).toStrictEqual(['Gtk-4.0']);
+        });
+
         await it('finds requireGi through every binding node-gi exports it under', async () => {
             // A hand-written node-gi application does not go through the shim,
             // and `requireGi` is both the named and the DEFAULT export

--- a/packages/infra/cli/src/utils/ship/depends.spec.ts
+++ b/packages/infra/cli/src/utils/ship/depends.spec.ts
@@ -377,6 +377,20 @@ export default async () => {
             expect(scanGiNamespaces(namespace)).toStrictEqual(['GLib']);
         });
 
+        await it("does not read a minified callback that borrowed the namespace import's name", async () => {
+            // MEASURED on `gjsify build --app node` output. The minifier gives an
+            // `import * as gi` and a callback PARAMETER the same short name in
+            // different scopes, and this reader has no scope analysis — so a flat
+            // set of bindings read `e(`Zzqfoo`)` as a namespace, and `deriveDepends`
+            // then refused to package a correct project. A module namespace object
+            // is not callable at all, which is what makes the split exact rather
+            // than a heuristic.
+            const minified =
+                'import*as e from"@gjsify/node-gi/gi";const t=e.requireGi(`Gtk`,`4.0`);' +
+                'function render(e,n){return e(n)+e(`Zzqfoo`)}';
+            expect(scanGiNamespaces(minified)).toStrictEqual(['Gtk-4.0']);
+        });
+
         await it('does not read a foreign requireGi, because over-approximating fails the build', async () => {
             // BINDING-TRACED, not name-matched. An unmapped namespace is a build
             // failure, so a method that merely shares the name would make a

--- a/packages/infra/cli/src/utils/ship/discover-bundle.spec.ts
+++ b/packages/infra/cli/src/utils/ship/discover-bundle.spec.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+// Which files beside the entry become payload, and which one never may not.
+//
+// `discoverPayload` stages the whole directory the entry lives in, which is what
+// makes a two-host project ship each artifact the other's bundle (#1545) — and
+// what makes the exclusion that fixes it dangerous in the other direction. The
+// foreign set is built from DECLARED strings, and `dist/app.mjs`,
+// `./dist/app.mjs`, `dist/../dist/app.mjs` and an absolute path are four
+// spellings of one file. Comparing strings drops the target's own entry and
+// stages a launcher pointing at a bundle that is not there: an artifact strictly
+// worse than the one the exclusion exists to prevent.
+//
+// So every case here is about the boundary rather than the rule, and it runs
+// against a real directory for `discover-typelibs.spec.ts`'s reason: the subject
+// is what a directory MEANS.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { discoverPayload } from './discover.js';
+
+/** A project whose `dist/` holds the entry, a shared chunk and a second bundle. */
+function project(): string {
+    const root = mkdtempSync(join(tmpdir(), 'gjsify-ship-bundle-'));
+    mkdirSync(join(root, 'dist'), { recursive: true });
+    writeFileSync(join(root, 'dist', 'app.mjs'), '// the entry\n');
+    writeFileSync(join(root, 'dist', 'chunk-abc.mjs'), '// a shared chunk\n');
+    writeFileSync(join(root, 'dist', 'app.node.mjs'), '// the other target\n');
+    return root;
+}
+
+function staged(root: string, foreignBundles: readonly string[]): string[] {
+    return discoverPayload({
+        projectDir: root,
+        pkg: { name: 'hello', version: '1.0.0' },
+        ship: {},
+        declaredBundle: 'dist/app.mjs',
+        foreignBundles,
+    }).bundleFiles;
+}
+
+export default async () => {
+    await describe('the payload beside the entry', async () => {
+        await it("drops another target's entry and keeps everything else", async () => {
+            const root = project();
+            try {
+                expect(staged(root, ['dist/app.node.mjs'])).toStrictEqual(['app.mjs', 'chunk-abc.mjs']);
+            } finally {
+                rmSync(root, { recursive: true, force: true });
+            }
+        });
+
+        await it("keeps THIS target's entry under every spelling of it", async () => {
+            // Measured, and it produced a payload with no bundle in it: the
+            // launcher shipped, the file it execs did not, and the run reported
+            // the artifact as built.
+            const root = project();
+            try {
+                for (const spelling of ['./dist/app.mjs', 'dist/../dist/app.mjs', join(root, 'dist', 'app.mjs')]) {
+                    // Nothing is dropped: the only name in the foreign set IS this
+                    // target's entry, under a spelling a string comparison misses.
+                    expect(staged(root, [spelling])).toStrictEqual(['app.mjs', 'app.node.mjs', 'chunk-abc.mjs']);
+                }
+                // …and the exclusion still works when a real foreign entry rides
+                // along with the misspelt own one.
+                expect(staged(root, ['./dist/app.mjs', 'dist/app.node.mjs'])).toStrictEqual([
+                    'app.mjs',
+                    'chunk-abc.mjs',
+                ]);
+            } finally {
+                rmSync(root, { recursive: true, force: true });
+            }
+        });
+
+        await it('keeps a shared chunk, which no rule here can tell from an application file', async () => {
+            const root = project();
+            try {
+                const files = staged(root, ['dist/app.node.mjs']);
+                expect(files.includes('chunk-abc.mjs')).toBe(true);
+            } finally {
+                rmSync(root, { recursive: true, force: true });
+            }
+        });
+
+        await it('ignores a foreign entry that is not in this payload at all', async () => {
+            // Another target may build somewhere else entirely; there is then
+            // nothing here to subtract, and no reason to say so.
+            const root = project();
+            try {
+                expect(staged(root, ['../elsewhere/app.node.mjs'])).toStrictEqual([
+                    'app.mjs',
+                    'app.node.mjs',
+                    'chunk-abc.mjs',
+                ]);
+            } finally {
+                rmSync(root, { recursive: true, force: true });
+            }
+        });
+    });
+};

--- a/packages/infra/cli/src/utils/ship/discover.ts
+++ b/packages/infra/cli/src/utils/ship/discover.ts
@@ -45,8 +45,17 @@ export interface DiscoverInput {
     ship: ConfigDataShip;
     /** `gjsify.flatpak.icon`, the pre-existing spelling of the same thing. */
     flatpakIcon?: string;
-    /** The bundle path the project declares. */
+    /** The bundle path the project declares FOR THIS TARGET. */
     declaredBundle?: string;
+    /**
+     * The entries other targets declare, which this one must not carry.
+     *
+     * See {@link withoutForeignEntries} — same class as the locale tree below,
+     * with a sharper edge: a foreign entry is not merely dead weight, it is a
+     * bundle this target's interpreter cannot load, inside an artifact that says
+     * it can.
+     */
+    foreignBundles?: readonly string[];
 }
 
 export function discoverPayload(input: DiscoverInput): DiscoveredPayload {
@@ -67,7 +76,12 @@ export function discoverPayload(input: DiscoverInput): DiscoveredPayload {
         // Measured on a probe package: the same `.mo` appeared at both paths. The `lib/` copy is
         // dead weight — nothing looks there — and it is the same failure that once shipped the test
         // suite: whatever is beside the bundle gets carried whether or not it belongs in a package.
-        bundleFiles: withoutLocaleTree(listFilesRecursive(bundleDir), bundleDir, projectDir, ship.localeDir),
+        bundleFiles: withoutForeignEntries(
+            withoutLocaleTree(listFilesRecursive(bundleDir), bundleDir, projectDir, ship.localeDir),
+            bundleDir,
+            projectDir,
+            input.foreignBundles ?? [],
+        ),
         iconFiles: discoverIcons(projectDir, ship.icon ?? input.flatpakIcon),
         schemaFiles: discoverSchemas(projectDir, ship.schemas),
         typelibFiles: discoverTypelibs(projectDir, ship.bundledTypelibs),
@@ -197,6 +211,40 @@ function discoverLocales(projectDir: string, dir: string | undefined): { rel: st
         );
     }
     return out;
+}
+
+/**
+ * Drop the entries declared for OTHER targets from this target's payload.
+ *
+ * `gjsify.ship.bundle` is per OS (#1545), so a project with two hosts builds
+ * `dist/app.gjs.mjs` and `dist/app.node.mjs` into ONE directory — and staging
+ * that directory wholesale hands each artifact the other's bundle. It is not
+ * dead weight like the locale copy: on macOS it lands inside the signed `.app`,
+ * and it is a file whose only property is that this artifact's interpreter
+ * cannot load it.
+ *
+ * Only the declared entries themselves, never a guess at what else belongs to
+ * them: a bundle's shared chunks are indistinguishable from the application's
+ * own files, and dropping one would break the artifact this list exists to keep
+ * whole.
+ */
+function withoutForeignEntries(
+    bundleFiles: string[],
+    bundleDir: string,
+    projectDir: string,
+    foreign: readonly string[],
+): string[] {
+    if (foreign.length === 0) return bundleFiles;
+    const dropped = new Set<string>();
+    for (const entry of foreign) {
+        const rel = relative(bundleDir, isAbsolute(entry) ? entry : resolve(projectDir, entry));
+        // Outside this payload — another target may build somewhere else entirely,
+        // and then there is nothing here to subtract. Same shape as the locale
+        // tree above, including the POSIX normalisation Windows needs.
+        if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) continue;
+        dropped.add(rel.split(sep).join(posix.sep));
+    }
+    return bundleFiles.filter((file) => !dropped.has(file));
 }
 
 function resolveBundle(input: DiscoverInput): string {

--- a/packages/infra/cli/src/utils/ship/discover.ts
+++ b/packages/infra/cli/src/utils/ship/discover.ts
@@ -81,6 +81,7 @@ export function discoverPayload(input: DiscoverInput): DiscoveredPayload {
             bundleDir,
             projectDir,
             input.foreignBundles ?? [],
+            bundlePath,
         ),
         iconFiles: discoverIcons(projectDir, ship.icon ?? input.flatpakIcon),
         schemaFiles: discoverSchemas(projectDir, ship.schemas),
@@ -233,11 +234,20 @@ function withoutForeignEntries(
     bundleDir: string,
     projectDir: string,
     foreign: readonly string[],
+    bundlePath: string,
 ): string[] {
     if (foreign.length === 0) return bundleFiles;
     const dropped = new Set<string>();
     for (const entry of foreign) {
-        const rel = relative(bundleDir, isAbsolute(entry) ? entry : resolve(projectDir, entry));
+        const abs = isAbsolute(entry) ? entry : resolve(projectDir, entry);
+        // THIS TARGET'S OWN ENTRY, under another spelling. The foreign set is
+        // compared as declared STRINGS, and `./dist/app.mjs`, `dist/../dist/app.mjs`
+        // and an absolute path are three spellings of one file — dropping it would
+        // stage a launcher whose bundle is not in the payload, which is a worse
+        // artifact than the one this exclusion exists to prevent. Paths are the
+        // only comparison that cannot be spelled around.
+        if (abs === bundlePath) continue;
+        const rel = relative(bundleDir, abs);
         // Outside this payload — another target may build somewhere else entirely,
         // and then there is nothing here to subtract. Same shape as the locale
         // tree above, including the POSIX normalisation Windows needs.

--- a/packages/infra/cli/src/utils/ship/entry-interpreter.spec.ts
+++ b/packages/infra/cli/src/utils/ship/entry-interpreter.spec.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+// The pair `gjsify ship` never compared: the interpreter a target execs and the
+// entry it hands that interpreter (#1545).
+//
+// The evidence in every case below is a MODULE SCHEME, and the two refusals are
+// symmetric because the two loaders are. Measured on GJS 1.86 and Node 24:
+//
+//     node   ← import … from 'gi://Gtk?version=4.0'
+//              ERR_UNSUPPORTED_ESM_URL_SCHEME … Received protocol 'gi:'
+//     gjs    ← import … from 'node:fs'
+//              ImportError: Unsupported URI scheme for importing: node
+//
+// So the `--app gjs` fixtures here are not a stand-in for a real bundle: they
+// carry the one specifier that decides the case, which is the same thing a real
+// bundle carries. What a real bundle adds is size.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { assertEntryRunsUnder, entryEvidence } from './entry-interpreter.js';
+
+const check = (interpreter: 'gjs' | 'node', source: string): (() => void) => {
+    return () =>
+        assertEntryRunsUnder({
+            interpreter,
+            source,
+            entry: 'dist/app.gjs.mjs',
+            appKey: 'gjsify.ship.app.darwin',
+            bundleKey: 'gjsify.main',
+            layoutOs: 'darwin',
+        });
+};
+
+export default async () => {
+    await describe('ship entry ↔ interpreter', async () => {
+        await it('refuses a gjs bundle on a target that execs node', async () => {
+            // The measured case: `gjsify.ship.app.darwin: "node"` with the payload
+            // left on `gjsify.main`, which for a Linux-first project is its GJS
+            // bundle. The artifact was built, reported as built, and died on its
+            // first import.
+            const source = 'import Gtk from "gi://Gtk?version=4.0";\nexport default Gtk;\n';
+            expect(check('node', source)).toThrow('imports gi://Gtk?version=4.0');
+            expect(check('node', source)).toThrow('ERR_UNSUPPORTED_ESM_URL_SCHEME');
+            // The fix names the key that selects an entry PER TARGET, not the
+            // project-wide one: sending the reader to `gjsify.main` would move
+            // every other layout's payload with it.
+            expect(check('node', source)).toThrow('gjsify.ship.bundle.darwin');
+        });
+
+        await it('refuses a node bundle on a target that execs gjs', async () => {
+            const source = 'import { readFileSync } from "node:fs";\nexport default readFileSync;\n';
+            expect(check('gjs', source)).toThrow('imports node:fs');
+            expect(check('gjs', source)).toThrow('Unsupported URI scheme for importing: node');
+        });
+
+        await it('passes each bundle to the interpreter that can load it', async () => {
+            expect(check('gjs', 'import Gtk from "gi://Gtk?version=4.0";\n')).not.toThrow();
+            expect(check('node', 'import { readFileSync } from "node:fs";\n')).not.toThrow();
+        });
+
+        await it('passes a bundle that names neither scheme', async () => {
+            // Absence of evidence is not evidence: a pure-JS CLI, or one whose GI
+            // reach is all dynamic, has nothing here to contradict. Refusing it
+            // would turn working packages into failures, which is the correction
+            // `assertLauncherMatchesInterpreter` already carries.
+            expect(check('node', 'export default 1 + 1;\n')).not.toThrow();
+            expect(check('gjs', 'const m = await import(`gi://${ns}`);\n')).not.toThrow();
+        });
+
+        await it('reads the scheme only where a loader would', async () => {
+            // A mention in a diagnostic string is not an import, and the whole
+            // reason this is an acorn pass rather than a regex: over-approximating
+            // here refuses a correct project.
+            expect(check('node', 'throw new Error("gi://Nautilus is not supported");\n')).not.toThrow();
+            expect(entryEvidence('const s = "node:fs";').node).toStrictEqual([]);
+        });
+
+        await it('reads the shapes a MINIFIED bundle emits', async () => {
+            const minified = 'import e from"gi://Gtk?version=4.0";const n=await import(`gi://GLib?version=2.0`);';
+            expect(entryEvidence(minified).gi).toStrictEqual(['gi://GLib?version=2.0', 'gi://Gtk?version=4.0']);
+        });
+
+        await it('names at most three specifiers, then counts the rest', async () => {
+            // A bundle can import a dozen namespaces; a refusal that pastes all of
+            // them buries the sentence that says what to do about it.
+            const many = ['Gtk', 'Adw', 'Gio', 'GLib', 'Gdk'].map((ns) => `import ${ns} from "gi://${ns}";`).join('\n');
+            expect(check('node', many)).toThrow('and 2 more');
+        });
+    });
+};

--- a/packages/infra/cli/src/utils/ship/entry-interpreter.spec.ts
+++ b/packages/infra/cli/src/utils/ship/entry-interpreter.spec.ts
@@ -57,6 +57,19 @@ export default async () => {
             expect(check('node', 'import { readFileSync } from "node:fs";\n')).not.toThrow();
         });
 
+        await it('refuses a legacy-`imports.gi` GJS bundle, which names no scheme at all', async () => {
+            // The case that walked through the first cut of this guard: a GJS
+            // application reaching GI through the ambient `imports` object carries
+            // no `gi://`, and a `--app gjs` build of it imports `system` and
+            // nothing else. Node refuses that bare specifier as a missing package —
+            // so it is evidence of the same kind, and #1545's exact pair was
+            // passing until it was read.
+            const legacy = "import system from 'system';\nconst { Gtk } = imports.gi;\nexport default Gtk;\n";
+            expect(check('node', legacy)).toThrow('imports system');
+            expect(check('node', legacy)).toThrow('ERR_MODULE_NOT_FOUND');
+            expect(check('gjs', legacy)).not.toThrow();
+        });
+
         await it('passes a bundle that names neither scheme', async () => {
             // Absence of evidence is not evidence: a pure-JS CLI, or one whose GI
             // reach is all dynamic, has nothing here to contradict. Refusing it

--- a/packages/infra/cli/src/utils/ship/entry-interpreter.ts
+++ b/packages/infra/cli/src/utils/ship/entry-interpreter.ts
@@ -16,21 +16,31 @@
 // class this repository pays most for: a step that reports success while having
 // measured nothing.
 //
-// THE DISCRIMINATOR IS THE MODULE SCHEME, and it is exact in both directions
-// because each host's loader refuses the other's — measured on this machine,
-// GJS 1.86 / Node 24:
+// THE DISCRIMINATOR IS THE SPECIFIER THE OTHER HOST'S LOADER REFUSES, and it is
+// exact in both directions — measured on this machine, GJS 1.86 / Node 24:
 //
 //     node   ← `import … from 'gi://Gtk?version=4.0'`
 //              ERR_UNSUPPORTED_ESM_URL_SCHEME … Received protocol 'gi:'
+//     node   ← `import system from 'system'`
+//              ERR_MODULE_NOT_FOUND — a GJS built-in is not a package
 //     gjs    ← `import … from 'node:fs'`
 //              ImportError: Unsupported URI scheme for importing: node
 //
-// Neither is a heuristic about how the bundle was built: it is the specifier the
-// running loader rejects, read out of the file that will be installed. And
-// neither can appear in a bundle the OTHER target built for itself — `--app node`
-// rewrites every `gi://` into `requireGi()` (`gjs-gi-node.ts`), `--app gjs`
-// resolves every `node:` builtin to its `@gjsify/*` implementation — so the
-// evidence is present exactly when the pair is wrong.
+// None is a heuristic about how the bundle was built: it is the specifier the
+// running loader rejects, read out of the file that will be installed. And none
+// can appear in a bundle the OTHER target built for itself — `--app node`
+// rewrites every `gi://` into `requireGi()` and every bare GJS built-in into an
+// `@gjsify/node-gi` shim (`gjs-gi-node.ts`), `--app gjs` resolves every `node:`
+// builtin to its `@gjsify/*` implementation — so the evidence is present exactly
+// when the pair is wrong.
+//
+// THE BARE BUILT-INS ARE NOT DECORATION. A GJS bundle that reaches GI through the
+// legacy `imports.gi` object carries no `gi://` at all, and a `--app gjs` build of
+// one imports `system` and nothing else this reader would have seen — so #1545's
+// own pair (a GJS payload under a node launcher) passed the guard written for it
+// until they were added. What is deliberately NOT read is the ambient `imports`
+// object itself: node fails on it at the first USE, not at load, so a refusal
+// citing it would be making a claim this file cannot keep.
 //
 // WHY A REFUSAL AND NOT A WARNING. There is no reading of this artifact under
 // which it works. A warning at the end of a `ship` run competes with the
@@ -42,9 +52,19 @@ import type { HostOs } from './types.js';
 /** What a shipped artifact's `bin/<name>` can exec. */
 export type ShipInterpreter = 'gjs' | 'node';
 
+/**
+ * The GJS built-in modules, which are bare specifiers rather than a scheme.
+ *
+ * `cairo` is deliberately absent: it is also an ordinary npm package name, so a
+ * node bundle can legitimately import it and refusing that would fail a working
+ * artifact. `system` and `gettext` have no npm counterpart a real project
+ * imports, which is what makes them evidence rather than a guess.
+ */
+const GJS_BUILTINS = new Set(['system', 'gettext']);
+
 /** The specifiers in an entry that only ONE of the two hosts can resolve. */
 export interface EntryEvidence {
-    /** `gi://…` specifiers — resolvable under GJS, refused by node's ESM loader. */
+    /** `gi://…` and the bare GJS built-ins — resolvable under GJS, refused by node. */
     gi: string[];
     /** `node:…` specifiers — resolvable under Node, refused by GJS's loader. */
     node: string[];
@@ -57,7 +77,7 @@ export function entryEvidence(source: string): EntryEvidence {
     walkModuleAst(source, (astNode) => {
         const specifier = importedSpecifier(astNode);
         if (specifier === null) return;
-        if (specifier.startsWith('gi://')) gi.add(specifier);
+        if (specifier.startsWith('gi://') || GJS_BUILTINS.has(specifier)) gi.add(specifier);
         else if (specifier.startsWith('node:')) node.add(specifier);
     });
     return { gi: [...gi].sort(), node: [...node].sort() };
@@ -101,11 +121,17 @@ export function assertEntryRunsUnder(input: EntryCheckInput): void {
     if (refused.length === 0) return;
 
     const other: ShipInterpreter = input.interpreter === 'node' ? 'gjs' : 'node';
+    // The error the reader will actually see, which differs WITHIN the node case:
+    // a `gi:` specifier is refused as an unknown URL scheme, a bare GJS built-in
+    // as a package that does not exist. Naming the wrong one sends them looking
+    // for the wrong thing in a log they have not opened yet.
     const loader =
-        input.interpreter === 'node'
-            ? 'node\'s ESM loader refuses it: ERR_UNSUPPORTED_ESM_URL_SCHEME, "Only URLs with a scheme in: ' +
-              'file, data, and node are supported by the default ESM loader"'
-            : 'GJS\'s loader refuses it: ImportError, "Unsupported URI scheme for importing: node"';
+        input.interpreter === 'gjs'
+            ? 'GJS\'s loader refuses it: ImportError, "Unsupported URI scheme for importing: node"'
+            : refused.some((specifier) => specifier.startsWith('gi://'))
+              ? 'node\'s ESM loader refuses it: ERR_UNSUPPORTED_ESM_URL_SCHEME, "Only URLs with a scheme in: ' +
+                'file, data, and node are supported by the default ESM loader"'
+              : "node's ESM loader refuses it: ERR_MODULE_NOT_FOUND — a GJS built-in is not a package";
     const shown = refused.slice(0, 3).join(', ');
     const more = refused.length > 3 ? `, and ${refused.length - 3} more` : '';
 

--- a/packages/infra/cli/src/utils/ship/entry-interpreter.ts
+++ b/packages/infra/cli/src/utils/ship/entry-interpreter.ts
@@ -36,7 +36,8 @@
 // which it works. A warning at the end of a `ship` run competes with the
 // artifact path printed beside it, and the artifact is what gets uploaded.
 
-import { literalSpecifier, walkModuleAst, type SpecifierNode } from '../cli-runtime-closure.js';
+import { importedSpecifier, walkModuleAst } from '../cli-runtime-closure.js';
+import type { HostOs } from './types.js';
 
 /** What a shipped artifact's `bin/<name>` can exec. */
 export type ShipInterpreter = 'gjs' | 'node';
@@ -54,15 +55,7 @@ export function entryEvidence(source: string): EntryEvidence {
     const gi = new Set<string>();
     const node = new Set<string>();
     walkModuleAst(source, (astNode) => {
-        if (
-            astNode.type !== 'ImportDeclaration' &&
-            astNode.type !== 'ExportNamedDeclaration' &&
-            astNode.type !== 'ExportAllDeclaration' &&
-            astNode.type !== 'ImportExpression'
-        ) {
-            return;
-        }
-        const specifier = literalSpecifier(astNode.source as SpecifierNode | undefined);
+        const specifier = importedSpecifier(astNode);
         if (specifier === null) return;
         if (specifier.startsWith('gi://')) gi.add(specifier);
         else if (specifier.startsWith('node:')) node.add(specifier);
@@ -82,8 +75,15 @@ export interface EntryCheckInput {
     appKey: string;
     /** The config key the entry came from — `gjsify.main`, `gjsify.ship.bundle[.<os>]`, … */
     bundleKey: string;
-    /** The layout being assembled, which is the key a per-target fix goes under. */
-    layoutOs: string;
+    /**
+     * The layout being assembled, which is the key a per-target fix goes under.
+     *
+     * {@link HostOs} and not `string`: an OS spelling this command does not
+     * assemble for is the silent defect the two resolvers refuse by name, and a
+     * message that offers `gjsify.ship.bundle.<whatever-was-passed>` as the fix
+     * would be the one place that hands the reader the typo back.
+     */
+    layoutOs: HostOs;
 }
 
 /**

--- a/packages/infra/cli/src/utils/ship/entry-interpreter.ts
+++ b/packages/infra/cli/src/utils/ship/entry-interpreter.ts
@@ -1,0 +1,123 @@
+// Can the interpreter this target execs load the entry this target ships?
+//
+// THE DEFECT (#1545, measured on a React-Native-on-GTK application at 0.47.0).
+// `gjsify ship` chose the runtime and the payload independently and never
+// compared them. `gjsify.ship.app.darwin: "node"` made the `.app`'s launcher
+// `exec node`, while the payload came from the project's `main`, which for a
+// project whose primary target is Linux is its `--app gjs` bundle. The run
+// printed one line on the subject and it read as CONFIRMATION —
+// "runtime for darwin: node — `gjsify.ship.app.darwin` overrides `gjsify.app`" —
+// then produced an artifact that dies before a line of application code:
+//
+//     Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file,
+//     data, and node are supported by the default ESM loader. Received protocol 'gi:'
+//
+// So the artifact is built, reported as built, and cannot start. That is the
+// class this repository pays most for: a step that reports success while having
+// measured nothing.
+//
+// THE DISCRIMINATOR IS THE MODULE SCHEME, and it is exact in both directions
+// because each host's loader refuses the other's — measured on this machine,
+// GJS 1.86 / Node 24:
+//
+//     node   ← `import … from 'gi://Gtk?version=4.0'`
+//              ERR_UNSUPPORTED_ESM_URL_SCHEME … Received protocol 'gi:'
+//     gjs    ← `import … from 'node:fs'`
+//              ImportError: Unsupported URI scheme for importing: node
+//
+// Neither is a heuristic about how the bundle was built: it is the specifier the
+// running loader rejects, read out of the file that will be installed. And
+// neither can appear in a bundle the OTHER target built for itself — `--app node`
+// rewrites every `gi://` into `requireGi()` (`gjs-gi-node.ts`), `--app gjs`
+// resolves every `node:` builtin to its `@gjsify/*` implementation — so the
+// evidence is present exactly when the pair is wrong.
+//
+// WHY A REFUSAL AND NOT A WARNING. There is no reading of this artifact under
+// which it works. A warning at the end of a `ship` run competes with the
+// artifact path printed beside it, and the artifact is what gets uploaded.
+
+import { literalSpecifier, walkModuleAst, type SpecifierNode } from '../cli-runtime-closure.js';
+
+/** What a shipped artifact's `bin/<name>` can exec. */
+export type ShipInterpreter = 'gjs' | 'node';
+
+/** The specifiers in an entry that only ONE of the two hosts can resolve. */
+export interface EntryEvidence {
+    /** `gi://…` specifiers — resolvable under GJS, refused by node's ESM loader. */
+    gi: string[];
+    /** `node:…` specifiers — resolvable under Node, refused by GJS's loader. */
+    node: string[];
+}
+
+/** Host-only specifiers of `source`, deduplicated and sorted. */
+export function entryEvidence(source: string): EntryEvidence {
+    const gi = new Set<string>();
+    const node = new Set<string>();
+    walkModuleAst(source, (astNode) => {
+        if (
+            astNode.type !== 'ImportDeclaration' &&
+            astNode.type !== 'ExportNamedDeclaration' &&
+            astNode.type !== 'ExportAllDeclaration' &&
+            astNode.type !== 'ImportExpression'
+        ) {
+            return;
+        }
+        const specifier = literalSpecifier(astNode.source as SpecifierNode | undefined);
+        if (specifier === null) return;
+        if (specifier.startsWith('gi://')) gi.add(specifier);
+        else if (specifier.startsWith('node:')) node.add(specifier);
+    });
+    return { gi: [...gi].sort(), node: [...node].sort() };
+}
+
+/** Everything the refusal names, so it can point at the key that decides each half. */
+export interface EntryCheckInput {
+    /** The resolved interpreter of THIS target. */
+    interpreter: ShipInterpreter;
+    /** The entry's source, as it will be installed. */
+    source: string;
+    /** How the entry is spelled in the project, for the message. */
+    entry: string;
+    /** The config key the interpreter came from — `gjsify.app` or `gjsify.ship.app.<os>`. */
+    appKey: string;
+    /** The config key the entry came from — `gjsify.main`, `gjsify.ship.bundle[.<os>]`, … */
+    bundleKey: string;
+    /** The layout being assembled, which is the key a per-target fix goes under. */
+    layoutOs: string;
+}
+
+/**
+ * Refuse a payload the target's own interpreter cannot load.
+ *
+ * ASYMMETRIC LIKE `assertLauncherMatchesInterpreter`, and for the same reason:
+ * evidence FOR the wrong host is a refusal, absence of evidence is not. A bundle
+ * that imports neither scheme — a pure-JS CLI, a bundle whose GI reach is all
+ * dynamic — passes, because nothing here observed a contradiction. This function
+ * reports what it read, never what it failed to read.
+ */
+export function assertEntryRunsUnder(input: EntryCheckInput): void {
+    const evidence = entryEvidence(input.source);
+    const refused = input.interpreter === 'node' ? evidence.gi : evidence.node;
+    if (refused.length === 0) return;
+
+    const other: ShipInterpreter = input.interpreter === 'node' ? 'gjs' : 'node';
+    const loader =
+        input.interpreter === 'node'
+            ? 'node\'s ESM loader refuses it: ERR_UNSUPPORTED_ESM_URL_SCHEME, "Only URLs with a scheme in: ' +
+              'file, data, and node are supported by the default ESM loader"'
+            : 'GJS\'s loader refuses it: ImportError, "Unsupported URI scheme for importing: node"';
+    const shown = refused.slice(0, 3).join(', ');
+    const more = refused.length > 3 ? `, and ${refused.length - 3} more` : '';
+
+    throw new Error(
+        `gjsify ship: this target execs \`${input.interpreter}\` (\`${input.appKey}\`), and the entry it ` +
+            `would ship — ${input.entry} (\`${input.bundleKey}\`) — imports ${shown}${more}.\n` +
+            `    ${loader}, before a line of application code runs.\n` +
+            '    The artifact would be built, reported as built, and fail at launch on every machine.\n' +
+            `    Either ship this target the \`--app ${input.interpreter}\` build of the app — ` +
+            `\`gjsify.ship.bundle.${input.layoutOs}\` selects the entry per target, the way ` +
+            `\`gjsify.ship.app.${input.layoutOs}\` selects the runtime —\n` +
+            `    or set \`gjsify.ship.app.${input.layoutOs}\` to "${other}" if this bundle is the one ` +
+            'that should ship.',
+    );
+}

--- a/packages/infra/cli/src/utils/ship/gi-namespaces.ts
+++ b/packages/infra/cli/src/utils/ship/gi-namespaces.ts
@@ -55,7 +55,22 @@ const NAMESPACE = /^[A-Za-z][A-Za-z\d_]*$/;
  */
 export function scanGiNamespaces(source: string): string[] {
     const found = new Set<string>();
-    const bindings = new Set<string>();
+    // TWO SETS, because the two kinds of binding are not interchangeable and
+    // treating them as one over-approximated on a real minified bundle. A
+    // namespace object (`import * as gi`) and a required module object are only
+    // ever the OBJECT of `.requireGi(…)`: calling a module namespace is a
+    // TypeError, so a bare `gi(…)` is never one of ours. Only `requireGi` itself
+    // — the named import, or the default export, which IS `requireGi` — is
+    // callable on its own.
+    //
+    // Measured on `gjsify build --app node` (minify is the DEFAULT): a file with
+    // `import * as gi from '@gjsify/node-gi/gi'` and a callback parameter emitted
+    // as `function render(e,t){return e(t)+e(\`Zzqfoo\`)}` — where the minifier
+    // gave the import and the parameter the SAME short name in different scopes.
+    // Read as one set, `e(\`Zzqfoo\`)` became the namespace `Zzqfoo`, and
+    // `deriveDepends` then refused to package a correct project.
+    const callable = new Set<string>();
+    const objects = new Set<string>();
     const calls: AstNode[] = [];
 
     walkModuleAst(source, (node) => {
@@ -64,13 +79,15 @@ export function scanGiNamespaces(source: string): string[] {
             const key = parseGiSpecifier(specifier);
             if (key !== null) found.add(key);
             if (node.type === 'ImportDeclaration' && specifier === NODE_GI_MODULE) {
-                collectNodeGiBindings(node, bindings);
+                collectNodeGiBindings(node, callable, objects);
             }
             return;
         }
         if (node.type === 'VariableDeclarator' && loadsNodeGiModule(node.init)) {
             const id = node.id as AstNode | undefined;
-            if (id?.type === 'Identifier' && typeof id.name === 'string') bindings.add(id.name);
+            // An OBJECT: `const gi = require('@gjsify/node-gi/gi')` is the module,
+            // reached as `gi.requireGi(…)` and never called directly.
+            if (id?.type === 'Identifier' && typeof id.name === 'string') objects.add(id.name);
             return;
         }
         // Collected rather than resolved in place: a call can precede the
@@ -81,7 +98,7 @@ export function scanGiNamespaces(source: string): string[] {
     });
 
     for (const call of calls) {
-        const key = requireGiNamespace(call, bindings);
+        const key = requireGiNamespace(call, callable, objects);
         if (key !== null) found.add(key);
     }
     return [...found].sort();
@@ -99,26 +116,25 @@ export function parseGiSpecifier(specifier: string): string | null {
 }
 
 /**
- * The local names an `import … from '@gjsify/node-gi/gi'` binds to `requireGi`.
+ * What an `import … from '@gjsify/node-gi/gi'` binds, split by what it can BE.
  *
- * All three spellings, because all three appear in real code and the default
- * export IS `requireGi` (`packages/node-gi/node-gi/gi.d.ts`): the named import
- * (under any local name, since `import { requireGi as gi }` renames it), the
- * default import, and the namespace object — whose member access
- * {@link requireGiNamespace} handles, which is why the namespace binding is
- * collected here too.
+ * All three spellings appear in real code and the default export IS `requireGi`
+ * (`packages/node-gi/node-gi/gi.d.ts`), so the named import (under any local
+ * name — `import { requireGi as gi }` renames it) and the default import are
+ * CALLABLE. A namespace import is not: calling a module namespace object throws,
+ * so it can only ever be the object of `.requireGi(…)`, and putting it in the
+ * callable set is what let a minified callback parameter of the same name be
+ * read as a `requireGi` call.
  */
-function collectNodeGiBindings(node: AstNode, out: Set<string>): void {
+function collectNodeGiBindings(node: AstNode, callable: Set<string>, objects: Set<string>): void {
     const specifiers = (node.specifiers as AstNode[] | undefined) ?? [];
     for (const specifier of specifiers) {
         const local = specifier.local as AstNode | undefined;
         if (local?.type !== 'Identifier' || typeof local.name !== 'string') continue;
         const imported = specifier.imported as AstNode | undefined;
-        if (specifier.type === 'ImportDefaultSpecifier' || specifier.type === 'ImportNamespaceSpecifier') {
-            out.add(local.name);
-        } else if (imported?.type === 'Identifier' && imported.name === 'requireGi') {
-            out.add(local.name);
-        }
+        if (specifier.type === 'ImportNamespaceSpecifier') objects.add(local.name);
+        else if (specifier.type === 'ImportDefaultSpecifier') callable.add(local.name);
+        else if (imported?.type === 'Identifier' && imported.name === 'requireGi') callable.add(local.name);
     }
 }
 
@@ -165,22 +181,26 @@ function loadsNodeGiModule(node: unknown): boolean {
  * always has: the shim carries its own `require`, and a hand-written node-gi app
  * carries its own import.
  *
- * Shadowing is the one gap left, and it is bounded rather than open: a local
- * function named after the imported one would have to be called with a
- * GI-shaped string literal to be misread at all.
+ * Shadowing is the one gap left, and the split above is what makes it small.
+ * This reader has no scope analysis, so a local binding that reuses the name of
+ * the CALLABLE import — `requireGi` itself, or the default import — and is called
+ * with a GI-shaped string literal would still be read as one. A minifier can
+ * manufacture exactly that collision, which is why the two shapes it produces
+ * most (the namespace object and the required module object) are the two that no
+ * longer count as callees.
  */
-function requireGiNamespace(call: AstNode, bindings: ReadonlySet<string>): string | null {
+function requireGiNamespace(call: AstNode, callable: ReadonlySet<string>, objects: ReadonlySet<string>): string | null {
     const callee = call.callee as AstNode | undefined;
     let reached = false;
     if (callee?.type === 'Identifier') {
-        reached = typeof callee.name === 'string' && bindings.has(callee.name);
+        reached = typeof callee.name === 'string' && callable.has(callee.name);
     } else if (callee?.type === 'MemberExpression' && callee.computed !== true) {
         const property = callee.property as AstNode | undefined;
         if (property?.type !== 'Identifier' || property.name !== 'requireGi') return null;
         const object = callee.object as AstNode | undefined;
         reached =
             loadsNodeGiModule(object) ||
-            (object?.type === 'Identifier' && typeof object.name === 'string' && bindings.has(object.name));
+            (object?.type === 'Identifier' && typeof object.name === 'string' && objects.has(object.name));
     }
     if (!reached) return null;
 

--- a/packages/infra/cli/src/utils/ship/gi-namespaces.ts
+++ b/packages/infra/cli/src/utils/ship/gi-namespaces.ts
@@ -1,10 +1,24 @@
 // Which GI namespaces does this bundle actually load?
 //
-// Read off the emitted `--app gjs` bundle, because that is the file that gets
-// installed. `gi://` is a real module protocol under GJS, so the bundler keeps
-// those specifiers in the output verbatim (`rolldown-plugin-gjsify`'s externals
-// plugin) — the artifact carries its own dependency list and nothing has to be
-// declared twice.
+// Read off the EMITTED bundle, because that is the file that gets installed —
+// and the emitted form is not one form but two, which is the correction this
+// header carries. Under `--app gjs`, `gi://` is a real module protocol, so the
+// bundler keeps those specifiers in the output verbatim
+// (`rolldown-plugin-gjsify`'s externals plugin) and the artifact carries its own
+// dependency list. Under `--app node` there is no such protocol:
+// `gjsGiNodePlugin` rewrites every `gi://Ns?version=X` into a shim whose body is
+// `require('@gjsify/node-gi/gi').requireGi("Ns", "X")`, so the specifier this
+// scanner was written to find is gone from the file by construction.
+//
+// WHAT THAT COST, and why reading one form is not "mostly right": these
+// namespaces are what `depends.ts` maps to `gir1.2-gtk-4.0` and friends
+// (ADR 0024 § 6). A `--app node` project therefore derived an EMPTY typelib
+// dependency set — the package installed cleanly and died at its first GI call,
+// which is the same failure the bare-side-effect-import fix below was written to
+// prevent, arriving again through the other build target. Nothing caught it
+// because every ship fixture's "node bundle" was hand-written with `gi://`
+// imports in it: a shape `gjsify build --app node` cannot emit and node cannot
+// run.
 //
 // PARSED, not pattern-matched, and the first version of this file is why. A
 // regex over the bundle text got it wrong in both directions at once:
@@ -17,11 +31,17 @@
 //     `from`, and since an unmapped namespace fails the build, that made a
 //     correct project unbuildable.
 //
-// `moduleSpecifiers` answers the question exactly, and it is the same acorn
-// pass the CLI already uses to compute its own runtime closure — so there is
-// one definition of "what does this file import" rather than two.
+// `walkModuleAst` answers both questions in ONE pass, and it is the same acorn
+// pass the CLI already uses to compute its own runtime closure — so there is one
+// definition of "what does this file import" rather than two.
 
-import { moduleSpecifiers } from '../cli-runtime-closure.js';
+import { literalSpecifier, walkModuleAst, type AstNode, type SpecifierNode } from '../cli-runtime-closure.js';
+
+/** The module a `--app node` bundle reaches GI through. */
+const NODE_GI_MODULE = '@gjsify/node-gi/gi';
+
+/** Namespaces are GI identifiers; anything else is a call this reader misread. */
+const NAMESPACE = /^[A-Za-z][A-Za-z\d_]*$/;
 
 /**
  * Extract the GI namespaces a bundle imports, as `Ns-Version` when the
@@ -29,8 +49,38 @@ import { moduleSpecifiers } from '../cli-runtime-closure.js';
  */
 export function scanGiNamespaces(source: string): string[] {
     const found = new Set<string>();
-    for (const specifier of moduleSpecifiers(source)) {
-        const key = parseGiSpecifier(specifier);
+    const bindings = new Set<string>();
+    const calls: AstNode[] = [];
+
+    walkModuleAst(source, (node) => {
+        if (
+            node.type === 'ImportDeclaration' ||
+            node.type === 'ExportNamedDeclaration' ||
+            node.type === 'ExportAllDeclaration' ||
+            node.type === 'ImportExpression'
+        ) {
+            const specifier = literalSpecifier(node.source as SpecifierNode | undefined);
+            const key = specifier === null ? null : parseGiSpecifier(specifier);
+            if (key !== null) found.add(key);
+            if (node.type === 'ImportDeclaration' && specifier === NODE_GI_MODULE) {
+                collectNodeGiBindings(node, bindings);
+            }
+            return;
+        }
+        if (node.type === 'VariableDeclarator' && isNodeGiRequire(node.init)) {
+            const id = node.id as AstNode | undefined;
+            if (id?.type === 'Identifier' && typeof id.name === 'string') bindings.add(id.name);
+            return;
+        }
+        // Collected rather than resolved in place: a call can precede the
+        // `require` that binds its callee (the shim's `load()` is hoisted above
+        // nothing, but a minifier is free to reorder declarations), so the
+        // binding set has to be complete before any call is judged.
+        if (node.type === 'CallExpression') calls.push(node);
+    });
+
+    for (const call of calls) {
+        const key = requireGiNamespace(call, bindings);
         if (key !== null) found.add(key);
     }
     return [...found].sort();
@@ -41,8 +91,81 @@ export function parseGiSpecifier(specifier: string): string | null {
     if (!specifier.startsWith('gi://')) return null;
     const rest = specifier.slice('gi://'.length);
     const [namespace, query] = rest.split('?', 2);
-    if (namespace === undefined || !/^[A-Za-z][A-Za-z0-9_]*$/.test(namespace)) return null;
+    if (namespace === undefined || !NAMESPACE.test(namespace)) return null;
     if (query === undefined) return namespace;
     const version = /(?:^|&)version=([^&]+)/.exec(query)?.[1];
     return version === undefined ? namespace : `${namespace}-${version}`;
+}
+
+/**
+ * The local names an `import … from '@gjsify/node-gi/gi'` binds to `requireGi`.
+ *
+ * All three spellings, because all three appear in real code and the default
+ * export IS `requireGi` (`packages/node-gi/node-gi/gi.d.ts`): the named import
+ * (under any local name, since `import { requireGi as gi }` renames it), the
+ * default import, and the namespace object — whose member access
+ * {@link requireGiNamespace} handles, which is why the namespace binding is
+ * collected here too.
+ */
+function collectNodeGiBindings(node: AstNode, out: Set<string>): void {
+    const specifiers = (node.specifiers as AstNode[] | undefined) ?? [];
+    for (const specifier of specifiers) {
+        const local = specifier.local as AstNode | undefined;
+        if (local?.type !== 'Identifier' || typeof local.name !== 'string') continue;
+        const imported = specifier.imported as AstNode | undefined;
+        if (specifier.type === 'ImportDefaultSpecifier' || specifier.type === 'ImportNamespaceSpecifier') {
+            out.add(local.name);
+        } else if (imported?.type === 'Identifier' && imported.name === 'requireGi') {
+            out.add(local.name);
+        }
+    }
+}
+
+/** `require('@gjsify/node-gi/gi')` — the form the bundler's own shim emits. */
+function isNodeGiRequire(node: unknown): boolean {
+    if (!node || typeof node !== 'object') return false;
+    const call = node as AstNode;
+    if (call.type !== 'CallExpression') return false;
+    const callee = call.callee as AstNode | undefined;
+    if (callee?.type !== 'Identifier' || callee.name !== 'require') return false;
+    const args = (call.arguments as AstNode[] | undefined) ?? [];
+    return literalSpecifier(args[0] as SpecifierNode | undefined) === NODE_GI_MODULE;
+}
+
+/**
+ * The namespace a `requireGi(…)` call names, or `null` when this is not one.
+ *
+ * BINDING-TRACED rather than name-matched, and the asymmetry is deliberate: a
+ * bare `.requireGi(…)` on any object would over-approximate, and
+ * over-approximating is NOT the harmless direction here — an unmapped namespace
+ * fails the build, so a foreign method sharing the name would make a correct
+ * project unpackageable. Every accepted shape traces back to an import or
+ * require of `@gjsify/node-gi/gi` in this same file, which is what a bundle
+ * always has: the shim carries its own `require`, and a hand-written node-gi app
+ * carries its own import.
+ *
+ * Shadowing is the one gap left, and it is bounded rather than open: a local
+ * function named after the imported one would have to be called with a
+ * GI-shaped string literal to be misread at all.
+ */
+function requireGiNamespace(call: AstNode, bindings: ReadonlySet<string>): string | null {
+    const callee = call.callee as AstNode | undefined;
+    let reached = false;
+    if (callee?.type === 'Identifier') {
+        reached = typeof callee.name === 'string' && bindings.has(callee.name);
+    } else if (callee?.type === 'MemberExpression' && callee.computed !== true) {
+        const property = callee.property as AstNode | undefined;
+        if (property?.type !== 'Identifier' || property.name !== 'requireGi') return null;
+        const object = callee.object as AstNode | undefined;
+        reached =
+            isNodeGiRequire(object) ||
+            (object?.type === 'Identifier' && typeof object.name === 'string' && bindings.has(object.name));
+    }
+    if (!reached) return null;
+
+    const args = (call.arguments as AstNode[] | undefined) ?? [];
+    const namespace = literalSpecifier(args[0] as SpecifierNode | undefined);
+    if (namespace === null || !NAMESPACE.test(namespace)) return null;
+    const version = literalSpecifier(args[1] as SpecifierNode | undefined);
+    return version === null ? namespace : `${namespace}-${version}`;
 }

--- a/packages/infra/cli/src/utils/ship/gi-namespaces.ts
+++ b/packages/infra/cli/src/utils/ship/gi-namespaces.ts
@@ -35,7 +35,13 @@
 // pass the CLI already uses to compute its own runtime closure — so there is one
 // definition of "what does this file import" rather than two.
 
-import { literalSpecifier, walkModuleAst, type AstNode, type SpecifierNode } from '../cli-runtime-closure.js';
+import {
+    importedSpecifier,
+    staticStringValue,
+    walkModuleAst,
+    type AstNode,
+    type SpecifierNode,
+} from '../cli-runtime-closure.js';
 
 /** The module a `--app node` bundle reaches GI through. */
 const NODE_GI_MODULE = '@gjsify/node-gi/gi';
@@ -53,21 +59,16 @@ export function scanGiNamespaces(source: string): string[] {
     const calls: AstNode[] = [];
 
     walkModuleAst(source, (node) => {
-        if (
-            node.type === 'ImportDeclaration' ||
-            node.type === 'ExportNamedDeclaration' ||
-            node.type === 'ExportAllDeclaration' ||
-            node.type === 'ImportExpression'
-        ) {
-            const specifier = literalSpecifier(node.source as SpecifierNode | undefined);
-            const key = specifier === null ? null : parseGiSpecifier(specifier);
+        const specifier = importedSpecifier(node);
+        if (specifier !== null) {
+            const key = parseGiSpecifier(specifier);
             if (key !== null) found.add(key);
             if (node.type === 'ImportDeclaration' && specifier === NODE_GI_MODULE) {
                 collectNodeGiBindings(node, bindings);
             }
             return;
         }
-        if (node.type === 'VariableDeclarator' && isNodeGiRequire(node.init)) {
+        if (node.type === 'VariableDeclarator' && loadsNodeGiModule(node.init)) {
             const id = node.id as AstNode | undefined;
             if (id?.type === 'Identifier' && typeof id.name === 'string') bindings.add(id.name);
             return;
@@ -121,15 +122,35 @@ function collectNodeGiBindings(node: AstNode, out: Set<string>): void {
     }
 }
 
-/** `require('@gjsify/node-gi/gi')` — the form the bundler's own shim emits. */
-function isNodeGiRequire(node: unknown): boolean {
+/**
+ * A call that LOADS `@gjsify/node-gi/gi` — recognised by its argument, never by
+ * the name of the callee.
+ *
+ * THE CALLEE NAME DOES NOT SURVIVE BUNDLING, and reading it is how the first cut
+ * of this function passed its own tests while answering `[]` for every real
+ * artifact. Measured on `gjsify build --app node` output for a two-import app,
+ * which is the exact input this module exists to read:
+ *
+ *     unminified   const require$1 = createRequire(import.meta.url);
+ *                  … require$1("@gjsify/node-gi/gi").requireGi("Gtk", "4.0")
+ *     minified     const n = e(import.meta.url);
+ *                  … n(`@gjsify/node-gi/gi`).requireGi(`Gtk`, `4.0`)
+ *
+ * Two shims in one bundle means two `require` bindings, so the second is renamed
+ * even without `--minify` (which is the DEFAULT). A reader keyed on the
+ * identifier `require` therefore loses one namespace unminified and both
+ * minified — silently, since an empty namespace list is a legal answer.
+ *
+ * The module STRING is what survives every rename, and it is a precise
+ * discriminator: a call taking `'@gjsify/node-gi/gi'` as its first argument is a
+ * load of that module under any name a bundler gives the loader.
+ */
+function loadsNodeGiModule(node: unknown): boolean {
     if (!node || typeof node !== 'object') return false;
     const call = node as AstNode;
     if (call.type !== 'CallExpression') return false;
-    const callee = call.callee as AstNode | undefined;
-    if (callee?.type !== 'Identifier' || callee.name !== 'require') return false;
     const args = (call.arguments as AstNode[] | undefined) ?? [];
-    return literalSpecifier(args[0] as SpecifierNode | undefined) === NODE_GI_MODULE;
+    return staticStringValue(args[0] as SpecifierNode | undefined) === NODE_GI_MODULE;
 }
 
 /**
@@ -158,14 +179,14 @@ function requireGiNamespace(call: AstNode, bindings: ReadonlySet<string>): strin
         if (property?.type !== 'Identifier' || property.name !== 'requireGi') return null;
         const object = callee.object as AstNode | undefined;
         reached =
-            isNodeGiRequire(object) ||
+            loadsNodeGiModule(object) ||
             (object?.type === 'Identifier' && typeof object.name === 'string' && bindings.has(object.name));
     }
     if (!reached) return null;
 
     const args = (call.arguments as AstNode[] | undefined) ?? [];
-    const namespace = literalSpecifier(args[0] as SpecifierNode | undefined);
+    const namespace = staticStringValue(args[0] as SpecifierNode | undefined);
     if (namespace === null || !NAMESPACE.test(namespace)) return null;
-    const version = literalSpecifier(args[1] as SpecifierNode | undefined);
+    const version = staticStringValue(args[1] as SpecifierNode | undefined);
     return version === null ? namespace : `${namespace}-${version}`;
 }

--- a/packages/infra/cli/src/utils/ship/settings.spec.ts
+++ b/packages/infra/cli/src/utils/ship/settings.spec.ts
@@ -278,6 +278,21 @@ export default async () => {
             expect(resolveShipBundle({ pkg: {}, ship: shared, layoutOs: 'darwin' }).foreign).toStrictEqual([]);
         });
 
+        await it("names the FALL-THROUGH entry too, which is #1545's own project shape", async () => {
+            // Only darwin declares an entry; linux and win32 both resolve
+            // `gjsify.main`. Reading the table alone would call darwin's payload
+            // clean and leave the GJS bundle inside the signed `.app` — the exact
+            // artifact the issue was filed about, minus the launcher.
+            const pkg = { gjsify: { main: 'dist/app.gjs.mjs' } };
+            const ship = { bundle: { darwin: 'dist/app.node.mjs' } };
+            expect(resolveShipBundle({ pkg, ship, layoutOs: 'darwin' }).foreign).toStrictEqual(['dist/app.gjs.mjs']);
+            // …and the targets that kept the fall-through have nothing to drop:
+            // darwin's entry is theirs to exclude, once.
+            expect(resolveShipBundle({ pkg, ship, layoutOs: 'linux' }).foreign).toStrictEqual(['dist/app.node.mjs']);
+            // A project with no table at all resolves one entry everywhere.
+            expect(resolveShipBundle({ pkg, ship: {}, layoutOs: 'darwin' }).foreign).toStrictEqual([]);
+        });
+
         await it('refuses a key it does not read, on the run that does not read it either', async () => {
             // Same silence as `gjsify.ship.app.windows`, one key over: the target
             // keeps `gjsify.main` and every gate stays green.

--- a/packages/infra/cli/src/utils/ship/settings.spec.ts
+++ b/packages/infra/cli/src/utils/ship/settings.spec.ts
@@ -13,10 +13,11 @@ import {
     descriptionParagraphs,
     deriveBinaryName,
     resolveShipApp,
+    resolveShipBundle,
     resolveShipSettings,
     type SettingsInput,
 } from './settings.js';
-import type { ShipAppOptions } from '../../types/config-data.js';
+import type { ConfigDataShip, ShipAppOptions } from '../../types/config-data.js';
 import { normaliseVersion } from './version.js';
 
 function input(overrides: Partial<SettingsInput> = {}): SettingsInput {
@@ -218,6 +219,74 @@ export default async () => {
             // check that only fires on the mis-keyed OS never fires at all.
             expect(() => resolveShipApp({ project: 'gjs', perTarget: misKeyed, layoutOs: 'linux' })).toThrow(
                 '`gjsify.ship.app.windows` is not an OS',
+            );
+        });
+    });
+
+    await describe('resolveShipBundle', async () => {
+        await it('keeps every single-host project on gjsify.main', async () => {
+            // Fall-through, not requirement: the table is what a two-host project
+            // needs, and nothing about it is mandatory for one host.
+            expect(resolveShipBundle({ pkg: { main: 'dist/app.js' }, ship: {}, layoutOs: 'linux' })).toStrictEqual({
+                declared: 'dist/app.js',
+                key: 'main',
+                overridden: false,
+                foreign: [],
+            });
+            const gjsifyMain = { main: 'lib/index.js', gjsify: { main: 'dist/app.gjs.mjs' } };
+            const resolved = resolveShipBundle({ pkg: gjsifyMain, ship: {}, layoutOs: 'linux' });
+            expect(resolved.declared).toBe('dist/app.gjs.mjs');
+            expect(resolved.key).toBe('gjsify.main');
+        });
+
+        await it('gives each target its own entry, and names the key that answered', async () => {
+            // The pair `gjsify.ship.app` makes necessary: that key moves the
+            // launcher to `node`, and before #1545 nothing moved the payload with
+            // it — so the `.app` shipped the GJS bundle and died on first import.
+            const ship = { bundle: { darwin: 'dist/app.node.mjs', win32: 'dist/app.node.mjs' } };
+            const darwin = resolveShipBundle({
+                pkg: { gjsify: { main: 'dist/app.gjs.mjs' } },
+                ship,
+                layoutOs: 'darwin',
+            });
+            expect(darwin.declared).toBe('dist/app.node.mjs');
+            expect(darwin.key).toBe('gjsify.ship.bundle.darwin');
+            expect(darwin.overridden).toBe(true);
+            const linux = resolveShipBundle({ pkg: { gjsify: { main: 'dist/app.gjs.mjs' } }, ship, layoutOs: 'linux' });
+            expect(linux.declared).toBe('dist/app.gjs.mjs');
+            expect(linux.key).toBe('gjsify.main');
+            expect(linux.overridden).toBe(false);
+        });
+
+        await it('reads a plain string as one entry for every target', async () => {
+            const ship = { bundle: 'dist/app.gjs.mjs' };
+            expect(resolveShipBundle({ pkg: {}, ship, layoutOs: 'darwin' }).key).toBe('gjsify.ship.bundle');
+            expect(resolveShipBundle({ pkg: {}, ship, layoutOs: 'darwin' }).foreign).toStrictEqual([]);
+        });
+
+        await it("names the OTHER targets' entries, which this payload must not carry", async () => {
+            // Both bundles are built into ONE directory and `discoverPayload`
+            // stages that directory whole, so without this list each artifact
+            // carries the other's bundle — on macOS inside the signed `.app`.
+            const ship = { bundle: { linux: 'dist/app.gjs.mjs', darwin: 'dist/app.node.mjs' } };
+            expect(resolveShipBundle({ pkg: {}, ship, layoutOs: 'darwin' }).foreign).toStrictEqual([
+                'dist/app.gjs.mjs',
+            ]);
+            // One file named for two targets is one file: dropping it would strip
+            // the entry the artifact runs.
+            const shared = { bundle: { linux: 'dist/app.mjs', darwin: 'dist/app.mjs' } };
+            expect(resolveShipBundle({ pkg: {}, ship: shared, layoutOs: 'darwin' }).foreign).toStrictEqual([]);
+        });
+
+        await it('refuses a key it does not read, on the run that does not read it either', async () => {
+            // Same silence as `gjsify.ship.app.windows`, one key over: the target
+            // keeps `gjsify.main` and every gate stays green.
+            const misKeyed = { bundle: { windows: 'dist/app.node.mjs' } } as unknown as ConfigDataShip;
+            expect(() => resolveShipBundle({ pkg: {}, ship: misKeyed, layoutOs: 'win32' })).toThrow(
+                '`gjsify.ship.bundle.windows` is not an OS',
+            );
+            expect(() => resolveShipBundle({ pkg: {}, ship: misKeyed, layoutOs: 'linux' })).toThrow(
+                '`gjsify.ship.bundle.windows` is not an OS',
             );
         });
     });

--- a/packages/infra/cli/src/utils/ship/settings.ts
+++ b/packages/infra/cli/src/utils/ship/settings.ts
@@ -384,9 +384,11 @@ export function resolveShipBundle(input: {
                 '`gjsify.main` with nothing to say so.',
         );
     }
-    const override = perTarget[input.layoutOs];
     const projectWide = typeof declaredTable === 'string' ? declaredTable : undefined;
-    const declared = override ?? projectWide ?? input.pkg.gjsify?.main ?? input.pkg.main;
+    const fallback = input.pkg.gjsify?.main ?? input.pkg.main;
+    const entryFor = (os: HostOs): string | undefined => perTarget[os] ?? projectWide ?? fallback;
+    const override = perTarget[input.layoutOs];
+    const declared = entryFor(input.layoutOs);
     const key =
         override !== undefined
             ? `gjsify.ship.bundle.${input.layoutOs}`
@@ -395,9 +397,20 @@ export function resolveShipBundle(input: {
               : input.pkg.gjsify?.main !== undefined
                 ? 'gjsify.main'
                 : 'main';
-    const foreign = Object.entries(perTarget)
-        .filter(([os, entry]) => os !== input.layoutOs && entry !== undefined && entry !== declared)
-        .map(([, entry]) => entry as string);
+    // RESOLVED per OS, not read off the table — because the entry another target
+    // ships is as often the FALL-THROUGH as it is a declared one, and that is
+    // #1545's own project shape: `main` is the GJS bundle, only darwin declares
+    // its own, and reading the table alone leaves the GJS bundle sitting inside
+    // the signed `.app` with nothing to name it. When nothing is keyed per OS
+    // every target resolves the same entry and this set is empty by construction.
+    const foreign = [
+        ...new Set(
+            (Object.keys(SHIP_APP_OSES) as HostOs[])
+                .filter((os) => os !== input.layoutOs)
+                .map(entryFor)
+                .filter((entry): entry is string => entry !== undefined && entry !== declared),
+        ),
+    ];
     return { declared, key, overridden: override !== undefined, foreign };
 }
 

--- a/packages/infra/cli/src/utils/ship/settings.ts
+++ b/packages/infra/cli/src/utils/ship/settings.ts
@@ -19,6 +19,7 @@ import type {
     ConfigDataShip,
     DescriptionBlock,
     ShipAppOptions,
+    ShipBundleOptions,
 } from '../../types/config-data.js';
 import { DEFAULT_GJS_FLOOR, DEFAULT_NODE_FLOOR } from './depends.js';
 import { resolveShipFlatpakSettings } from './flatpak-config.js';
@@ -322,9 +323,82 @@ export function resolveShipSettings(input: SettingsInput): ResolvedSettings {
     return { settings, metadata, warnings };
 }
 
-/** The bundle path a project declares, in the order the rest of the CLI reads them. */
-export function declaredBundlePath(pkg: ShipPackageManifest, ship: ConfigDataShip): string | undefined {
-    return ship.bundle ?? pkg.gjsify?.main ?? pkg.main;
+/** The entry one ship target installs, which key named it, and what it must NOT carry. */
+export interface ResolvedShipBundle {
+    /** The declared path as written — project-relative or absolute. */
+    declared?: string;
+    /** The config key the answer came from — named in the refusal and in the notice. */
+    key: string;
+    /** Whether a per-target key overrode the project default. */
+    overridden: boolean;
+    /**
+     * The entries OTHER targets declared, as written.
+     *
+     * Not decoration: `discoverPayload` stages the whole directory the entry
+     * lives in, so a project that keeps `dist/app.gjs.mjs` beside
+     * `dist/app.node.mjs` ships both to both targets. One of them is a bundle
+     * that target's interpreter cannot load, in an artifact advertising that it
+     * can — and on macOS it is inside the signed bundle.
+     */
+    foreign: string[];
+}
+
+/**
+ * The ONE place a ship target's ENTRY is decided — {@link resolveShipApp}'s twin.
+ *
+ * The two are twins because they answer one question between them, and #1545 is
+ * what answering only half of it costs: `gjsify.ship.app.darwin: "node"` moved
+ * the launcher to `node` while the payload stayed `gjsify.main`, which for a
+ * project whose primary target is Linux is its `--app gjs` bundle. Both keys
+ * were honoured, they contradicted each other, and the `.app` died on its first
+ * import with the only line of output on the subject reading as confirmation.
+ *
+ * A DECLARATION rather than a derivation, and both alternatives were considered
+ * where the issue raised them. Deriving the entry from the runtime by filename
+ * convention (`app.node.mjs` beside `app.gjs.mjs`) is a heuristic on an output
+ * name the project owns — the same guess `tests/e2e/ship`'s fixture exists to
+ * refuse. Having ship invoke `gjsify build --app <runtime>` itself cannot work
+ * for the phase that needs it most: `--from-stage` packs on a host with no
+ * project, no bundler and no sources (ADR 0024 § A2).
+ *
+ * Fall-through, not requirement: a target with no key keeps `gjsify.main`, so
+ * every single-host project is unaffected and nothing new is mandatory.
+ */
+export function resolveShipBundle(input: {
+    pkg: ShipPackageManifest;
+    ship: ConfigDataShip;
+    layoutOs: HostOs;
+}): ResolvedShipBundle {
+    const declaredTable = input.ship.bundle;
+    const perTarget: ShipBundleOptions =
+        typeof declaredTable === 'object' && declaredTable !== null ? declaredTable : {};
+    // The WHOLE table, for the reason `resolveShipApp` gives: a mis-keyed
+    // override is silent by construction, so the run that must report `windows`
+    // is the one assembling some OTHER layout.
+    for (const os of Object.keys(perTarget)) {
+        if (Object.hasOwn(SHIP_APP_OSES, os)) continue;
+        throw new Error(
+            `gjsify ship: \`gjsify.ship.bundle.${os}\` is not an OS this command assembles for. Known: ` +
+                `${Object.keys(SHIP_APP_OSES).join(', ')} — the \`process.platform\` spelling, not the ` +
+                "`gjsify ship <os>` positional's. An entry under a key nothing reads leaves that target on " +
+                '`gjsify.main` with nothing to say so.',
+        );
+    }
+    const override = perTarget[input.layoutOs];
+    const projectWide = typeof declaredTable === 'string' ? declaredTable : undefined;
+    const declared = override ?? projectWide ?? input.pkg.gjsify?.main ?? input.pkg.main;
+    const key =
+        override !== undefined
+            ? `gjsify.ship.bundle.${input.layoutOs}`
+            : projectWide !== undefined
+              ? 'gjsify.ship.bundle'
+              : input.pkg.gjsify?.main !== undefined
+                ? 'gjsify.main'
+                : 'main';
+    const foreign = Object.entries(perTarget)
+        .filter(([os, entry]) => os !== input.layoutOs && entry !== undefined && entry !== declared)
+        .map(([, entry]) => entry as string);
+    return { declared, key, overridden: override !== undefined, foreign };
 }
 
 /** npm package name → a package/binary name both dpkg and rpm accept. */

--- a/packages/infra/manifest-conformance/lib/rules/ship.mjs
+++ b/packages/infra/manifest-conformance/lib/rules/ship.mjs
@@ -97,7 +97,13 @@ const PATH_KEYS = ['icon', 'schemas', 'licenseFile'];
 const SIGN_OSES = new Set(['darwin', 'win32']);
 
 /**
- * The OSes `gjsify.ship.app` may be keyed on, and the runtimes it may name.
+ * The OSes `gjsify.ship.app` and `gjsify.ship.bundle` may be keyed on, and the
+ * runtimes the first of them may name.
+ *
+ * ONE set for both, because they are one decision split over two keys: the
+ * runtime a target execs and the entry it hands that runtime. A vocabulary that
+ * drifted between them would let a project name darwin's entry under a key
+ * darwin's runtime is not read from.
  *
  * The `process.platform` spelling again, for the reason `SIGN_OSES` gives: the
  * value that resolves is chosen by the LAYOUT being assembled. All three are in,
@@ -172,6 +178,38 @@ export function auditShip(ctx) {
                     `${pkg.rel}/package.json: \`gjsify.ship.targets\` names "${target}", which \`gjsify ship\` cannot ` +
                         `build. Known targets: ${[...TARGETS].join(', ')}.`,
                 );
+            }
+        }
+
+        // `bundle` as a TABLE, which is the only half of it this rule can judge.
+        // The paths themselves stay unchecked for the reason PATH_KEYS gives —
+        // they are build outputs, absent in a clean checkout — but a key nothing
+        // reads is exactly as silent here as it is on `app`, and costs more: the
+        // target keeps the project's entry and ships a bundle its own
+        // interpreter cannot load (#1545).
+        const bundle = block.bundle;
+        if (bundle !== undefined && typeof bundle !== 'string') {
+            if (bundle === null || typeof bundle !== 'object' || Array.isArray(bundle)) {
+                failures.push(
+                    `${pkg.rel}/package.json: \`gjsify.ship.bundle\` must be a path or an object keyed by OS — ` +
+                        `one entry for every target, or one per target.`,
+                );
+            } else {
+                for (const [os, entry] of Object.entries(bundle)) {
+                    if (!APP_OSES.has(os)) {
+                        failures.push(
+                            `${pkg.rel}/package.json: \`gjsify.ship.bundle.${os}\` is not an OS \`gjsify ship\` ` +
+                                `assembles for. Known: ${[...APP_OSES].join(', ')} — the \`process.platform\` ` +
+                                `spelling, not the \`gjsify ship <os>\` positional's. An entry under a key nothing ` +
+                                `reads leaves that target on \`gjsify.main\` with nothing to say so.`,
+                        );
+                    } else if (typeof entry !== 'string' || entry.length === 0) {
+                        failures.push(
+                            `${pkg.rel}/package.json: \`gjsify.ship.bundle.${os}\` must be a path to the built ` +
+                                `bundle that target installs.`,
+                        );
+                    }
+                }
             }
         }
 

--- a/status/agent-context-budget.json
+++ b/status/agent-context-budget.json
@@ -3,7 +3,7 @@
     "packages/dom/AGENTS.md": 2081,
     "packages/framework/AGENTS.md": 32718,
     "packages/infra/AGENTS.md": 1131,
-    "packages/infra/cli/AGENTS.md": 24760,
+    "packages/infra/cli/AGENTS.md": 26093,
     "packages/infra/resolve-npm/AGENTS.md": 7270,
     "packages/infra/rolldown-plugin-gjsify/AGENTS.md": 23558,
     "packages/napi/AGENTS.md": 7179,

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -1094,6 +1094,31 @@ misled. These are the upstream source of that claim, and a stale comment is how 
 grows back. Left for a commit of its own because both files path-filter CI job
 selection, and editing them from a docs branch is churn where it is riskiest.
 
+### The payload is "the directory the entry lives in", and that ships a scratch tree
+
+`discoverPayload` stages every file beside the resolved entry, minus the locale tree and minus
+the entries other targets declared (#1545). Everything else in that directory is payload by
+definition, and nobody declared it.
+
+**Measured on the application #1545 was filed from**: `Contents/Resources/lib/` was the project's
+`dist/` verbatim — the two bundles plus **20 PNG screenshots, a `sweep/` directory, four
+debug-probe bundles and a `node_modules`**. The `.app` came to 12 007 054 bytes and most of it is
+not the application. `--verbose` lists the files without commenting on them.
+
+**Why this is not simply "add an ignore list".** The obvious exclusions are wrong in both
+directions. `node_modules` beside the entry is REQUIRED for a `--app node` artifact —
+`utils/ship/app-runtime.ts` stages `@gjsify/node-gi`'s JavaScript into exactly such a directory,
+because the bundle keeps that package external and a `.app` has no consumer `node_modules` to
+resolve it against. And a bundle's own shared chunks are indistinguishable from a project's stray
+files by any rule this tree can write, which is why the foreign-entry exclusion is deliberately
+limited to the DECLARED entries and nothing around them.
+
+So the question is what a payload IS, and the honest answers are a declaration
+(`gjsify.ship.include`/`exclude`, keyed like the two per-target tables) or a build that writes its
+artifacts somewhere the project does not also use as scratch. Both are config surface, so both want
+the ADR treatment rather than a filter someone adds in passing. Until then the fat is visible only
+to a reader of `--verbose`, which is how it stayed unnoticed in the first place.
+
 ### `gjsify ship --sign`: three things M6 did not prove, each with what WAS measured
 
 The signing interface landed whole (ADR 0024 § A12-§ A17) and its darwin half is

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -1094,32 +1094,6 @@ misled. These are the upstream source of that claim, and a stale comment is how 
 grows back. Left for a commit of its own because both files path-filter CI job
 selection, and editing them from a docs branch is churn where it is riskiest.
 
-### `gjsify ship`: the RUNTIME is per target, the BUNDLE is still one path
-
-The runtime half is closed (#1486, ADR 0024 § A22): `gjsify.ship.app.{linux,darwin,win32}`
-overrides `gjsify.app` per target, one resolver answers, and every generator reads the
-runtime of ITS OWN target — so stating macOS's answer no longer moves the Linux
-`Depends:`. What that makes askable is the next question, and it is genuinely a different
-one.
-
-**`gjsify.ship.bundle` is a single path**, falling back to `gjsify.main` then
-`package.json#main`, and every layout's launcher names the file it resolves to. A project
-that is GJS on Linux and Node on Windows has TWO bundles — `dist/<name>.gjs.js` beside
-`dist/<name>.node.mjs` is the layout `resolve-gjs-entry.ts` documents as normal — and
-`discoverPayload` already stages both, because it takes the whole directory beside the
-bundle. So the payload is right and the launcher's exec line is not: the Windows `.cmd`
-runs `node` over whichever single file the project declared.
-
-**What makes it non-obvious rather than a five-line follow-up.** The bundle path is read
-before the settings are resolved (`declaredBundlePath` feeds `discoverPayload`), several
-other keys are addressed relative to it, and `assertLauncherMatchesInterpreter` compares
-the launcher with the DEPENDENCY — never with the bundle's dialect, which nothing reads.
-So the failure mode is silent in exactly the way the runtime one was: a `.app` or a
-program directory that assembles, packs and installs, and dies at first launch on a
-machine nobody here owns. A fix wants the same shape as § A22 — one resolver, per target,
-with the resolved value in the stage manifest — plus a discriminator that can tell a GJS
-bundle from a Node one, which is the part that does not exist yet.
-
 ### `gjsify ship --sign`: three things M6 did not prove, each with what WAS measured
 
 The signing interface landed whole (ADR 0024 § A12-§ A17) and its darwin half is

--- a/tests/e2e/ship/fixture.mjs
+++ b/tests/e2e/ship/fixture.mjs
@@ -40,17 +40,46 @@ export const BUNDLE = [
 ].join('\n');
 
 /**
+ * The shim `--app node` compiles a `gi://` import into, IMPORTED from the plugin
+ * that emits it.
+ *
+ * Not restated, for `STAGE_MANIFEST_FILE`'s reason one level up: this is the
+ * exact text a node bundle carries where a GJS bundle carries a `gi://`
+ * specifier, and a fixture holding its own copy of it would keep agreeing with
+ * itself after the plugin moved.
+ */
+const { giNodeShimSource } = await import(
+    pathToFileURL(
+        join(MONOREPO_ROOT, 'packages', 'infra', 'rolldown-plugin-gjsify', 'lib', 'plugins', 'gjs-gi-node.js'),
+    ).href
+);
+
+/**
  * The `--app node` twin of {@link BUNDLE}.
  *
- * `gi://` imports on purpose: a Node bundle still reaches GI through
- * `@gjsify/node-gi`, so the typelib dependencies must be derived for it exactly
- * as for a GJS one. A plain `console.log` bundle would have proved only that the
- * interpreter line changed.
+ * GI reach on purpose: a Node bundle still reaches GI through `@gjsify/node-gi`,
+ * so the typelib dependencies must be derived for it exactly as for a GJS one. A
+ * plain `console.log` bundle would have proved only that the interpreter line
+ * changed.
+ *
+ * BUT NOT THROUGH `gi://`, which is what this fixture used to say and what made
+ * it a fixture no build can produce and no interpreter can run: `--app node`
+ * rewrites every `gi://` into the shim above, and node's ESM loader refuses the
+ * scheme outright (ERR_UNSUPPORTED_ESM_URL_SCHEME). Written the old way, this
+ * file asserted that a `.deb` derives `gir1.2-gtk-4.0` from a bundle whose real
+ * counterpart derives nothing — which is exactly the defect that survived
+ * (#1545, `utils/ship/gi-namespaces.ts`).
  */
 export const NODE_BUNDLE = [
-    `import Gtk from 'gi://Gtk?version=4.0';`,
-    `import Adw from 'gi://Adw?version=1';`,
-    `console.log(Gtk, Adw);`,
+    // The rewritten `gi://` import, verbatim from the plugin that writes it.
+    giNodeShimSource('Gtk', '4.0').replace('export default', 'const Gtk ='),
+    // And the OTHER shape a shipped node bundle has: an application written
+    // against `@gjsify/node-gi` directly. `@gjsify/node-gi/gi` is external in
+    // every `--app node` build (a native addon cannot be bundled), so this import
+    // survives into the output exactly as written. One fixture, both readers.
+    `import { requireGi } from '@gjsify/node-gi/gi';`,
+    `const Adw = requireGi('Adw', '1');`,
+    `console.log(typeof Gtk, typeof Adw);`,
     '',
 ].join('\n');
 

--- a/tests/e2e/ship/fixture.mjs
+++ b/tests/e2e/ship/fixture.mjs
@@ -70,9 +70,29 @@ const { giNodeShimSource } = await import(
  * counterpart derives nothing — which is exactly the defect that survived
  * (#1545, `utils/ship/gi-namespaces.ts`).
  */
+/**
+ * The shim, bound to a name instead of exported — and REFUSING to no-op.
+ *
+ * The import above exists so this text cannot drift from the plugin, and a bare
+ * `.replace()` would give that back: if the shim ever stops ending in an
+ * `export default`, the replacement silently matches nothing, the fixture keeps
+ * two default exports, and no assertion in either ship suite reads the bundle
+ * closely enough to notice.
+ */
+const boundShim = (namespace, version) => {
+    const source = giNodeShimSource(namespace, version);
+    if (!source.includes('export default')) {
+        throw new Error(
+            `ship fixture: giNodeShimSource no longer emits \`export default\`, so binding it to a name ` +
+                `is now guesswork. Read the plugin and update this helper.`,
+        );
+    }
+    return source.replace('export default', `const ${namespace} =`);
+};
+
 export const NODE_BUNDLE = [
     // The rewritten `gi://` import, verbatim from the plugin that writes it.
-    giNodeShimSource('Gtk', '4.0').replace('export default', 'const Gtk ='),
+    boundShim('Gtk', '4.0'),
     // And the OTHER shape a shipped node bundle has: an application written
     // against `@gjsify/node-gi` directly. `@gjsify/node-gi/gi` is external in
     // every `--app node` build (a native addon cannot be bundled), so this import

--- a/tests/e2e/ship/run.mjs
+++ b/tests/e2e/ship/run.mjs
@@ -744,16 +744,26 @@ describe('CLI ship E2E', { timeout: 10 * 60 * 1000 }, () => {
         const dir = scaffold(join(tmpDir, 'per-target-runtime'), (pkg, at) => {
             pkg.gjsify.app = 'gjs';
             pkg.gjsify.ship.app = { win32: 'node' };
-            // The sibling a cross-OS project really builds. Staged either way —
-            // `discoverPayload` takes the whole directory — and which one the
-            // launcher NAMES is a separate axis (`gjsify.ship.bundle` is still one
-            // path), so this test says nothing about it.
+            // The sibling a cross-OS project really builds — and the entry the
+            // win32 target hands the runtime it just chose. Declaring only the
+            // runtime is what #1545 measured: the launcher moved to `node`, the
+            // payload stayed on `gjsify.main`, and the artifact died on its first
+            // import. This test used to encode that state as a passing case.
+            pkg.gjsify.ship.bundle = { win32: 'dist/app.node.mjs' };
             writeFileSync(join(at, 'dist', 'app.node.mjs'), NODE_BUNDLE);
         });
 
         // ── the target that said NOTHING, and must therefore have changed nothing
         runCliSync(CLI_ENTRY, ['ship', 'linux', '--skip-build', '--out', 'ship-linux'], { cwd: dir });
         assert.match(readFileSync(join(dir, 'ship-linux', 'stage', 'bin', 'ship-demo'), 'utf-8'), /exec gjs -m /);
+        // …except for the one thing a per-target entry DOES change here: the
+        // win32 bundle is not in the Linux payload. `gjs` cannot load it, and the
+        // test above proves an UNDECLARED sibling is still carried, so this
+        // asserts the declaration and not the directory walk.
+        assert.ok(
+            !listPayload(join(dir, 'ship-linux', 'stage')).includes('lib/ship-demo/app.node.mjs'),
+            'the win32 entry must not ship inside the Linux package',
+        );
 
         if (probe('ar') && probe('tar')) {
             const extracted = join(tmpDir, 'per-target-deb');


### PR DESCRIPTION
Closes #1545.

## The defect

`gjsify ship` chose the runtime and the entry independently and never compared them. Measured on a React-Native-on-GTK application at 0.47.0: `gjsify.ship.app.darwin: "node"` moved the launcher to `node`, the payload stayed on `gjsify.main` — a `--app gjs` bundle, because Linux is that project's primary target — and the `.app` died before a line of application code:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are
supported by the default ESM loader. Received protocol 'gi:'
```

The artifact was built, reported as built, and the only line of output on the subject read as confirmation.

## What this does

**`gjsify.ship.bundle` is per target**, the same `{linux,darwin,win32}` table as `gjsify.ship.app`, resolved by `resolveShipBundle` — `resolveShipApp`'s twin in every respect: same OS vocabulary, same refusal of a key nothing reads, same "which key answered" in the result. Fall-through, not requirement: a target with no key keeps `gjsify.main`, so every single-host project is untouched.

Both alternatives #1545 raised are rejected in ADR 0024 § A23: deriving the entry from a filename is a heuristic over an output name the project owns, and having ship invoke `gjsify build` cannot serve `--from-stage`, which packs on a host with no project and no sources.

**The pair is checked.** `assertEntryRunsUnder` refuses on the module scheme each host's loader rejects — measured on GJS 1.86 and Node 24:

| the entry imports | under `node` | under `gjs` |
|---|---|---|
| `gi://Gtk?version=4.0` | `ERR_UNSUPPORTED_ESM_URL_SCHEME … Received protocol 'gi:'` | resolves |
| `node:fs` | resolves | `ImportError: Unsupported URI scheme for importing: node` |

Asymmetric like `assertLauncherMatchesInterpreter`: evidence FOR the wrong host is a refusal, absence of evidence is not. A bundle naming neither scheme passes.

## The second defect, found while writing the discriminator

`scanGiNamespaces` — the source of every artifact's typelib `Depends:` (ADR 0024 § 6) — read `gi://` specifiers only. **A `--app node` bundle has none**: `gjsGiNodePlugin` rewrites each one into `require('@gjsify/node-gi/gi').requireGi("Ns", "Ver")`. So every node-target artifact derived an EMPTY typelib dependency set, installed cleanly, and died at its first GI call — the same failure the bare-side-effect-import fix in that module exists to prevent, arriving through the other build target.

The scanner reads both emitted forms in one acorn pass now, binding-traced rather than name-matched: over-approximating a namespace fails the build, so a foreign `.requireGi()` must not be read as one.

## Why nothing caught either

Every ship fixture's "node bundle" was hand-written with `gi://` imports in it — a shape `gjsify build --app node` cannot emit and node cannot run. It now imports `giNodeShimSource` from the plugin that writes it, so the text under test is the text that ships, plus the second real shape (an app written against `@gjsify/node-gi` directly, whose import survives because the addon is external).

And `tests/e2e/ship`'s per-target-runtime case **scaffolded this defect as a passing test**, with a comment saying the launcher's choice of file "is a separate axis … so this test says nothing about it". It now declares the win32 entry, and asserts the other half of the decision: a bundle declared for one OS is dropped from every other OS's payload. Not tidiness — `discoverPayload` stages the whole directory the entry lives in, so without it each artifact carries a bundle its own interpreter cannot load, on macOS inside the signed `.app`.

## Measured here

- `@gjsify/cli` unit suite: 3703 completed, 0 failed (Node 24)
- `tests/e2e/{ship,ship-from-stage,ship-layout,ship-declaration,ship-windows,ship-macos,ship-signing}`: exit 0
- every `audit-runtimes.yml` script: exit 0 · `gjsify format --check`, `gjsify lint`: clean
- `tests/e2e/ship-msi` is red on this workstation for an environmental reason that predates the branch — no `wixl`, and the suite refuses to run vacuously

Ledger: the `open-todos` entry that carried this axis is deleted, and ADR 0024 gains § A23, including the correction to § A22's closing paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtCcG3LLsz9voXAG9DVjhD