### PR TITLE
fix(node-gi): the seed that matched nothing

### DIFF
--- a/docs/adr/0037-gtk-runtime-bundles-carry-the-uri-source.md
+++ b/docs/adr/0037-gtk-runtime-bundles-carry-the-uri-source.md
@@ -212,3 +212,49 @@ including over https.** Concretely:
 - Widening again needs the same evidence this did: a measured user-visible gap, a measured
   closure cost, and a gate that fails when the payload is absent. The list is not a
   starting point that grows by argument.
+
+## Amendment, 2026-09-04 — a seed that matched nothing, and the format claim behind it
+
+The last consequence above asks for "a gate that fails when the payload is absent". There was
+none for the list as a whole, and #1544 is what that cost: `@gjsify/gtk-runtime-win32-x64@0.47.0`
+shipped without `mpg123`, `vorbis`, `flac` and `wasapi2`, with **no line about any of them**, and
+a desktop application played neither its bundled mp3 nor its mp3 stream.
+
+**Why the existing checks could not see it.** Three of them looked, and each answers a different
+question: the count refuses a bundle with zero plugins, `missingRequiredGstPlugins` asks for the
+three whose absence is silent (`app`, `playback`, `soup`), and the builders log every plugin they
+SKIPPED. The last is the one that reads like coverage and is not — **a builder logs what it
+skipped out of what it WALKED**, and a plugin the source archive never contained is never walked.
+A seed that matches nothing is byte-identical to a seed that matched, which is the same shape
+#1097 named for the win32 GL patterns.
+
+The comparison that can see it is the DECLARATION against what was copied, which is a set
+difference: `missingBundledGstPlugins(shipped, target)`. Both builders run it now, and it splits
+the answer three ways rather than two:
+
+- **undeclared** — declared in `GST_AUDIO_PLUGINS`, absent from the payload, nobody said why:
+  the build fails.
+- **declared** — an entry in `GST_PLUGIN_GAPS[target]` with what it costs: printed on every
+  build, `check-committed-musl`'s shape. The four win32 names are seeded there with their
+  measurement, because the payload question is a decision (where the three decoders come from on
+  a gvsbuild prefix) and a silently incomplete bundle is not the way to wait for it.
+- **retired** — a declared gap whose plugin DID arrive: also a failure, so an entry cannot
+  outlive the archive that justified it.
+
+A platform's own sink is not the other's gap — `GST_PLATFORM_SINKS` keeps `osxaudio` out of the
+win32 expectation, because an alarm that is wrong on every run is one nobody reads.
+
+**And the claim underneath.** `decodebin` resolving says nothing about what it can autoplug:
+measured on the same win32 bundle, `decodebin3`, `playbin3`, `filesrc` and `souphttpsrc` all
+resolved while `mpg123audiodec` was null. So the registry is now asked for the DECODER of each
+format the audio path claims — `GST_AUDIO_DECODERS`, one row per format, read by
+`gst-elements.test.mjs` and by the same gap list, so a declared gap is not asked for and a
+retired one is caught from this side too.
+
+Writing that table down settled a claim this file had carried since it was written: the header
+listed AAC-in-M4A among the formats "a browser's decodeAudioData is expected to take", and no AAC
+decoder has ever been in the list. `isomp4` demuxes the container, `aacparse` parses the stream,
+and nothing decodes it. The two elements that would are `faad` (GPL) and `avdec_aac` (the libav
+closure § Decision drivers refuses), so it is a redistribution decision rather than an oversight —
+and it now sits in `GST_FORMAT_GAPS`, where it is a promise not made instead of a sentence that
+claims coverage.

--- a/docs/adr/0037-gtk-runtime-bundles-carry-the-uri-source.md
+++ b/docs/adr/0037-gtk-runtime-bundles-carry-the-uri-source.md
@@ -242,7 +242,20 @@ the answer three ways rather than two:
   outlive the archive that justified it.
 
 A platform's own sink is not the other's gap — `GST_PLATFORM_SINKS` keeps `osxaudio` out of the
-win32 expectation, because an alarm that is wrong on every run is one nobody reads.
+win32 expectation, because an alarm that is wrong on every run is one nobody reads. An os this
+does not bundle for is REFUSED rather than answered: an unrecognised string makes every sink
+foreign, so a typo in a target would have relaxed the expectation instead of failing it.
+
+**And one level up from all of it**, found by review of this change: the whole GStreamer section
+sits behind `existsSync(pluginDir)`, whose `else` was a warning. A `--windowing` bundle with no
+plugin directory at all shipped, advertised windowing and decoded nothing — the same defect as
+#1544 with the directory instead of four files. It is fatal now, in both builders.
+
+The registry questions are asked only where a BUNDLE resolves (`resolveGtkRuntimeBundle()`, the
+same answer node-gi acts on when it points `GST_PLUGIN_SYSTEM_PATH`). A host GStreamer answers a
+different question, and asking it this one is wrong in both directions: a thin container would
+fail a claim the bundle never made, and a Windows box with MSYS2's GStreamer would report a
+declared gap as retired while the bundle it is about still has it.
 
 **And the claim underneath.** `decodebin` resolving says nothing about what it can autoplug:
 measured on the same win32 bundle, `decodebin3`, `playbin3`, `filesrc` and `souphttpsrc` all

--- a/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
+++ b/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
@@ -644,10 +644,16 @@ if (WINDOWING) {
                 `${(bytes / 1024 / 1024).toFixed(1)} MiB`,
         );
     } else {
-        console.warn(
-            `build-gtk-runtime: WARNING — ${gstPluginDir} missing; no GStreamer plugins bundled ` +
-                '(Gst.init() would succeed and decode nothing)',
+        console.error(
+            `build-gtk-runtime: ${gstPluginDir} does not exist — a --windowing bundle with NO GStreamer ` +
+                'plugin directory at all. `Gst.init()` then succeeds against an empty registry and the ' +
+                'failure surfaces in the application as "no element decodebin".\n' +
+                '    This used to be a warning, which is the same defect the per-plugin gap check ' +
+                'below exists for, one level up: four missing files are caught and the whole directory ' +
+                'missing was not (#1544). Install GStreamer into the build prefix; do NOT drop the ' +
+                'windowing claim to get a green build.',
         );
+        process.exit(1);
     }
 
     // 4h. GIO modules — the TLS backend. `GTlsConnection` has no implementation in GIO

--- a/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
+++ b/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
@@ -67,7 +67,7 @@ import {
     formatMissingGlImplementation,
 } from '../../scripts/gl-implementation.mjs';
 import { decodeProbeProblems, spawnDecodeProbe } from '../../scripts/decode-probe.mjs';
-import { isBundledGstPlugin, missingRequiredGstPlugins } from '../../scripts/gst-plugins.mjs';
+import { isBundledGstPlugin, missingBundledGstPlugins, missingRequiredGstPlugins } from '../../scripts/gst-plugins.mjs';
 import { bundleRelativeLoaderCache, loaderCacheProblems } from '../../scripts/pixbuf-loader-cache.mjs';
 import {
     REQUIRED_NAMESPACES,
@@ -607,6 +607,35 @@ if (WINDOWING) {
                     'element for an http(s) URI). `soup` comes from gst-plugins-good and needs libsoup3 ' +
                     'built into the same gvsbuild prefix FIRST, else meson disables the plugin silently. ' +
                     'Do NOT drop the name from GST_REQUIRED_PLUGINS to get a green build.',
+            );
+            process.exit(1);
+        }
+        // AND THE SEED THAT MATCHED NOTHING. The block above asks for three plugins by
+        // name; this asks the whole DECLARATION against what was actually copied, which
+        // is the only direction that can see a plugin the source archive never
+        // contained. A builder logs what it SKIPPED out of what it WALKED, so four
+        // plugins left the published win32 bundle without a single line about any of
+        // them, and an application played nothing (#1544). A gap that is written down
+        // stays; one nobody has written down fails here.
+        const bundledGaps = missingBundledGstPlugins(shippedGstPlugins, 'win32-x64');
+        for (const gap of bundledGaps.declared) {
+            console.warn(`build-gtk-runtime: DECLARED GAP — no ${gap.plugin} plugin: ${gap.why}`);
+        }
+        if (bundledGaps.retired.length > 0) {
+            console.error(
+                `build-gtk-runtime: ${bundledGaps.retired.join(', ')} IS in this prefix, and ` +
+                    'gst-plugins.mjs still declares it as a gap. Delete the entry from ' +
+                    'GST_PLUGIN_GAPS — a gap that outlives its cause is a promise this bundle now ' +
+                    'keeps and still says it does not.',
+            );
+            process.exit(1);
+        }
+        if (bundledGaps.undeclared.length > 0) {
+            console.error(
+                `build-gtk-runtime: ${bundledGaps.undeclared.join(', ')} declared in GST_AUDIO_PLUGINS ` +
+                    'and absent from the payload, with no entry in GST_PLUGIN_GAPS saying so. Either ' +
+                    'the build prefix lost a formula, or the bundle is about to advertise a format it ' +
+                    'cannot decode — which is what a silent skip looked like before this check existed.',
             );
             process.exit(1);
         }

--- a/packages/node-gi/node-gi/test/gst-elements.test.mjs
+++ b/packages/node-gi/node-gi/test/gst-elements.test.mjs
@@ -22,6 +22,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { requireGi } from '../gi.js';
+import { GST_AUDIO_DECODERS, GST_PLUGIN_GAPS } from '../../scripts/gst-plugins.mjs';
 import { Gst, gstSkip as skip } from './gst-gate.mjs';
 
 // The pipeline @gjsify/webaudio is built from, element by element. Named
@@ -59,6 +60,60 @@ test('the GStreamer registry resolves the audio-path elements', { skip }, () => 
             "the bundle's lib/gstreamer-1.0. An EMPTY result here means either the bundle ships " +
             'no plugins or nothing told GStreamer where they are — both look like a healthy ' +
             'Gst.init() and fail in the application instead.',
+    );
+});
+
+/**
+ * The decoder gaps this platform has DECLARED, as element names.
+ *
+ * A gap is a promise not made, and it is written once — in `gst-plugins.mjs`, next to the
+ * plugin it is about. Reading it here rather than restating it is what makes the entry
+ * self-retiring in BOTH places: the builder fails when a declared gap's plugin arrives,
+ * and this test starts asking for the element the moment the same entry is deleted.
+ */
+const declaredGapElements = new Set(
+    (GST_PLUGIN_GAPS[`${process.platform}-${process.arch}`] ?? []).flatMap((gap) =>
+        GST_AUDIO_DECODERS.filter((row) => row.plugin === gap.plugin).map((row) => row.element),
+    ),
+);
+
+test('every format the audio path claims has a decoder in the registry', { skip }, () => {
+    // THE ELEMENTS ABOVE ARE THE SKELETON, and a skeleton decodes nothing. `decodebin`
+    // resolving says only that autoplugging exists — what it autoplugs is a decoder that
+    // has to be in the registry too, and asking for the skeleton alone is why a bundle
+    // advertising MP3 shipped without one. Measured on the published
+    // `@gjsify/gtk-runtime-win32-x64@0.47.0`: `decodebin3`, `playbin3`, `filesrc` and
+    // `souphttpsrc` all resolved, `mpg123audiodec` was null, and both a bundled mp3 and an
+    // mp3 stream failed — the second one as `Internal data stream error`, which reads like
+    // a missing TLS backend and was not (#1544).
+    const missing = [];
+    for (const { format, element, plugin } of GST_AUDIO_DECODERS) {
+        if (declaredGapElements.has(element)) continue;
+        if (Gst.ElementFactory.make(element, null) === null) missing.push(`${format}: ${element} (${plugin})`);
+    }
+    assert.deepEqual(
+        missing,
+        [],
+        `the registry has no decoder for:\n  ${missing.join('\n  ')}\n\n` +
+            'Each is a format gst-plugins.mjs says the audio path takes. A format with no decoder ' +
+            'fails in the application as "missing a plug-in" for a local file, and as "Internal ' +
+            'data stream error" for a stream — the second of which reads like something else ' +
+            'entirely. If the platform genuinely cannot carry it, declare it in GST_PLUGIN_GAPS ' +
+            'with what it costs; the builder and this test both read that list.',
+    );
+});
+
+test('a declared decoder gap is still a gap', { skip }, () => {
+    // The other direction, and the reason a gap list does not rot: if the element a gap
+    // says is absent resolves, the entry is stale and the platform silently regained a
+    // format nobody re-declared. Same shape as `it.failing` retiring itself.
+    const arrived = [...declaredGapElements].filter((element) => Gst.ElementFactory.make(element, null) !== null);
+    assert.deepEqual(
+        arrived,
+        [],
+        `GST_PLUGIN_GAPS declares no decoder for ${arrived.join(', ')} on this platform, and the ` +
+            'registry has one. Delete the entry — the bundle now keeps a promise its own ' +
+            'declaration still refuses.',
     );
 });
 

--- a/packages/node-gi/node-gi/test/gst-elements.test.mjs
+++ b/packages/node-gi/node-gi/test/gst-elements.test.mjs
@@ -23,6 +23,7 @@ import assert from 'node:assert/strict';
 
 import { requireGi } from '../gi.js';
 import { GST_AUDIO_DECODERS, GST_PLUGIN_GAPS } from '../../scripts/gst-plugins.mjs';
+import { resolveGtkRuntimeBundle } from '../gtk-runtime.js';
 import { Gst, gstSkip as skip } from './gst-gate.mjs';
 
 // The pipeline @gjsify/webaudio is built from, element by element. Named
@@ -64,6 +65,25 @@ test('the GStreamer registry resolves the audio-path elements', { skip }, () => 
 });
 
 /**
+ * Is the GStreamer this process talks to the BUNDLE's, or the host's?
+ *
+ * The whole format claim is about the bundle: `GST_AUDIO_PLUGINS` is what the builders
+ * copy, and `GST_PLUGIN_GAPS` says which of those a platform's archive did not have. A
+ * host GStreamer answers a different question, and asking it this one is wrong in both
+ * directions — a Fedora container with thin plugins would fail a claim it never made,
+ * and a Windows box with MSYS2's GStreamer would report a DECLARED gap as retired while
+ * the bundle it is about still has it (measured shape: #1544's own win11 VM has mpg123
+ * through MSYS2 and the published bundle does not).
+ *
+ * `resolveGtkRuntimeBundle()` is the same answer node-gi itself acts on when it points
+ * `GST_PLUGIN_SYSTEM_PATH` at the bundle, so the two cannot disagree about which
+ * registry is loaded.
+ */
+const bundle = resolveGtkRuntimeBundle();
+const bundleSkip =
+    skip || (bundle === null ? 'no @gjsify/gtk-runtime bundle resolves here — this asks about the BUNDLE' : false);
+
+/**
  * The decoder gaps this platform has DECLARED, as element names.
  *
  * A gap is a promise not made, and it is written once — in `gst-plugins.mjs`, next to the
@@ -77,7 +97,7 @@ const declaredGapElements = new Set(
     ),
 );
 
-test('every format the audio path claims has a decoder in the registry', { skip }, () => {
+test('every format the audio path claims has a decoder in the registry', { skip: bundleSkip }, () => {
     // THE ELEMENTS ABOVE ARE THE SKELETON, and a skeleton decodes nothing. `decodebin`
     // resolving says only that autoplugging exists — what it autoplugs is a decoder that
     // has to be in the registry too, and asking for the skeleton alone is why a bundle
@@ -103,7 +123,7 @@ test('every format the audio path claims has a decoder in the registry', { skip 
     );
 });
 
-test('a declared decoder gap is still a gap', { skip }, () => {
+test('a declared decoder gap is still a gap', { skip: bundleSkip }, () => {
     // The other direction, and the reason a gap list does not rot: if the element a gap
     // says is absent resolves, the entry is stale and the platform silently regained a
     // format nobody re-declared. Same shape as `it.failing` retiring itself.

--- a/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
@@ -1393,7 +1393,14 @@ test('every claimed format names a decoder, and every declared gap names a real 
     // and a gap must be about a plugin the list actually declares, or it silences nothing.
     for (const row of GST_AUDIO_DECODERS) {
         assert.match(row.element, /^[a-z0-9]+$/, `${row.format} names no decoder element`);
-        assert.ok(expectedGstPlugins('darwin-arm64').includes(row.plugin) || row.plugin === 'mpg123');
+        // The plugin behind a claimed format must be one the bundle actually carries.
+        // Written with an `|| row.plugin === 'mpg123'` escape at first, which decided
+        // nothing — `mpg123` IS in the list — so deleting it from GST_AUDIO_PLUGINS
+        // would have left this assertion green: the exact regression it guards.
+        assert.ok(
+            expectedGstPlugins('darwin-arm64').includes(row.plugin),
+            `${row.format} names the plugin ${row.plugin}, which GST_AUDIO_PLUGINS does not carry`,
+        );
     }
     for (const [target, gaps] of Object.entries(GST_PLUGIN_GAPS)) {
         for (const gap of gaps) {
@@ -1402,5 +1409,27 @@ test('every claimed format names a decoder, and every declared gap names a real 
                 `${target} declares a gap for ${gap.plugin}, which this platform never expected`,
             );
         }
+    }
+});
+
+test('a file name the archive spells differently is still read as its plugin', () => {
+    // Every spelling the two archives produce, plus the two that used to mis-parse: the
+    // extension strip carried `/i` and the prefix strip did not, so `LIBGSTAPP.DLL` kept
+    // its prefix, and a versioned `.so.0` kept its suffix. Both then read as an unknown
+    // plugin — which lands in `undeclared` and fails the build, so the direction was safe
+    // and the answer was still wrong.
+    const three = ['libgstplayback.dll', 'libgstsoup.dll'];
+    for (const spelling of ['libgstapp.dylib', 'gstapp.dll', 'libgstapp.so', 'LIBGSTAPP.DLL', 'libgstapp.so.0']) {
+        const gaps = missingBundledGstPlugins([spelling, ...three], 'win32-x64');
+        assert.ok(!gaps.undeclared.includes('app'), `${spelling} did not read as the app plugin`);
+    }
+});
+
+test('a target this does not bundle for is refused, not answered', () => {
+    // An unrecognised os makes every platform sink foreign, so the expectation quietly
+    // stops requiring an audio sink at all — a typo would RELAX the check instead of
+    // failing it.
+    for (const target of ['WIN32-X64', 'linux-x64', '', undefined]) {
+        assert.throws(() => expectedGstPlugins(target), /names no platform this bundles for/);
     }
 });

--- a/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
@@ -46,6 +46,12 @@ import {
     verifyBundleTypelibs,
 } from '../../scripts/typelib-backers.mjs';
 import {
+    GST_AUDIO_DECODERS,
+    GST_PLUGIN_GAPS,
+    expectedGstPlugins,
+    missingBundledGstPlugins,
+} from '../../scripts/gst-plugins.mjs';
+import {
     WINDOWING_DATA_SETS,
     copyTreeDereferenced,
     duplicatedModuleLeaves,
@@ -1305,4 +1311,96 @@ test('the operator message names the leaves and refuses the tempting repair', ()
     assert.match(message, /libgstsoup\.dylib/);
     // The repair is at the WALK. Deleting the flat copy afterwards hides the reference.
     assert.match(message, /Do NOT delete the flat copy as a post-step/);
+});
+
+// --- the seed that matched nothing -------------------------------------------
+//
+// A builder logs what it SKIPPED out of what it WALKED, so a plugin the source archive
+// never contained produces no line at all. That is how `mpg123`, `vorbis`, `flac` and
+// `wasapi2` left the published win32 bundle in silence, and why an application played
+// neither its bundled mp3 nor its mp3 stream (#1544). The comparison that CAN see it is
+// the declaration against what was copied, which is a set difference — and it is
+// unit-tested here for the reason every gate in this file is: it runs on a macOS or
+// Windows runner and on no machine a developer has.
+
+const winPlugins = (names) => names.map((n) => `libgst${n}.dll`);
+
+test('a plugin the archive never contained is a finding, not a silence', () => {
+    const complete = winPlugins([
+        'coreelements',
+        'app',
+        'typefindfunctions',
+        'playback',
+        'audioparsers',
+        'wavparse',
+        'isomp4',
+        'ogg',
+        'vorbis',
+        'opus',
+        'flac',
+        'mpg123',
+        'alaw',
+        'mulaw',
+        'auparse',
+        'audioconvert',
+        'audioresample',
+        'audiorate',
+        'audiomixer',
+        'volume',
+        'audiotestsrc',
+        'soup',
+        'autodetect',
+        'wasapi2',
+        'directsound',
+    ]);
+    // The payload as it actually shipped: the four that were never in the prefix.
+    const asShipped = complete.filter((f) => !/mpg123|vorbis|flac|wasapi2/.test(f));
+    const gaps = missingBundledGstPlugins(asShipped, 'win32-x64');
+    assert.deepEqual(gaps.undeclared, [], 'every absence on win32 is declared today');
+    assert.deepEqual(
+        gaps.declared.map((gap) => gap.plugin),
+        ['mpg123', 'vorbis', 'flac', 'wasapi2'],
+        'the four #1544 measured are reported, with their reason',
+    );
+    for (const gap of gaps.declared) assert.ok(gap.why.length > 20, `${gap.plugin} carries no reason`);
+});
+
+test('an UNdeclared absence fails, which is the whole point', () => {
+    const withoutOpus = winPlugins(['coreelements', 'app', 'playback', 'soup']);
+    const gaps = missingBundledGstPlugins(withoutOpus, 'win32-x64');
+    assert.ok(gaps.undeclared.includes('opus'), 'opus is declared in the list and absent from the payload');
+    assert.ok(!gaps.undeclared.includes('mpg123'), 'a DECLARED gap must not read as an undeclared one');
+});
+
+test('a declared gap whose plugin arrived is reported, so the entry cannot outlive its cause', () => {
+    const complete = winPlugins(['mpg123', 'vorbis', 'flac', 'wasapi2', 'app', 'playback', 'soup']);
+    const gaps = missingBundledGstPlugins(complete, 'win32-x64');
+    assert.deepEqual(gaps.retired.sort(), ['flac', 'mpg123', 'vorbis', 'wasapi2']);
+});
+
+test("the other platform's sink is not this platform's gap", () => {
+    // One list serves both bundles because every other plugin in it is portable. An
+    // alarm that fires on every Windows run for a missing `osxaudio` is one nobody reads.
+    assert.ok(!expectedGstPlugins('win32-x64').includes('osxaudio'));
+    assert.ok(expectedGstPlugins('win32-x64').includes('directsound'));
+    assert.ok(expectedGstPlugins('darwin-arm64').includes('osxaudio'));
+    assert.ok(!expectedGstPlugins('darwin-arm64').includes('wasapi2'));
+});
+
+test('every claimed format names a decoder, and every declared gap names a real plugin', () => {
+    // The two halves of the claim, held against each other: a format the audio path says
+    // it takes must name the element that decodes it — `decodebin` resolving is not that —
+    // and a gap must be about a plugin the list actually declares, or it silences nothing.
+    for (const row of GST_AUDIO_DECODERS) {
+        assert.match(row.element, /^[a-z0-9]+$/, `${row.format} names no decoder element`);
+        assert.ok(expectedGstPlugins('darwin-arm64').includes(row.plugin) || row.plugin === 'mpg123');
+    }
+    for (const [target, gaps] of Object.entries(GST_PLUGIN_GAPS)) {
+        for (const gap of gaps) {
+            assert.ok(
+                expectedGstPlugins(target).includes(gap.plugin),
+                `${target} declares a gap for ${gap.plugin}, which this platform never expected`,
+            );
+        }
+    }
 });

--- a/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
+++ b/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
@@ -728,10 +728,16 @@ if (WINDOWING) {
                 `${gstPluginSkips.dangling ? `, ${gstPluginSkips.dangling} dangling brew link(s)` : ''}`,
         );
     } else {
-        console.warn(
-            `build-gtk-runtime: WARNING — ${pluginsSrc} missing; no GStreamer plugins bundled ` +
-                '(Gst.init() would succeed and decode nothing)',
+        console.error(
+            `build-gtk-runtime: ${pluginsSrc} does not exist — a --windowing bundle with NO GStreamer ` +
+                'plugin directory at all. `Gst.init()` then succeeds against an empty registry and the ' +
+                'failure surfaces in the application as "no element decodebin".\n' +
+                '    This used to be a warning, which is the same defect the per-plugin gap check ' +
+                'below exists for, one level up: four missing files are caught and the whole directory ' +
+                'missing was not (#1544). Install GStreamer into the build prefix; do NOT drop the ' +
+                'windowing claim to get a green build.',
         );
+        process.exit(1);
     }
 }
 

--- a/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
+++ b/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
@@ -92,7 +92,7 @@ import {
     writeLicensePayload,
 } from './bundle-licenses.mjs';
 import { decodeProbeProblems, spawnDecodeProbe } from './decode-probe.mjs';
-import { isBundledGstPlugin, missingRequiredGstPlugins } from './gst-plugins.mjs';
+import { isBundledGstPlugin, missingBundledGstPlugins, missingRequiredGstPlugins } from './gst-plugins.mjs';
 import {
     REQUIRED_NAMESPACES,
     WINDOWING_REQUIRED_NAMESPACES,
@@ -686,6 +686,38 @@ if (WINDOWING) {
                     'Gst.init() and then fails in the application (no appsrc / no decodebin / no source ' +
                     'element for an http(s) URI). Install the formula that provides it into the build ' +
                     'prefix; do NOT drop the name from GST_REQUIRED_PLUGINS to get a green build.',
+            );
+            process.exit(1);
+        }
+        // AND THE SEED THAT MATCHED NOTHING. The block above asks for three plugins by
+        // name; this asks the whole DECLARATION against what was actually copied, which
+        // is the only direction that can see a plugin the source archive never
+        // contained. A builder logs what it SKIPPED out of what it WALKED, so four
+        // plugins left the published win32 bundle without a single line about any of
+        // them, and an application played nothing (#1544). A gap that is written down
+        // stays; one nobody has written down fails here.
+        const bundledGaps = missingBundledGstPlugins(
+            gstPluginImages.map((p) => basename(p)),
+            TARGET,
+        );
+        for (const gap of bundledGaps.declared) {
+            console.warn(`build-gtk-runtime: DECLARED GAP — no ${gap.plugin} plugin: ${gap.why}`);
+        }
+        if (bundledGaps.retired.length > 0) {
+            console.error(
+                `build-gtk-runtime: ${bundledGaps.retired.join(', ')} IS in this prefix, and ` +
+                    'gst-plugins.mjs still declares it as a gap. Delete the entry from ' +
+                    'GST_PLUGIN_GAPS — a gap that outlives its cause is a promise this bundle now ' +
+                    'keeps and still says it does not.',
+            );
+            process.exit(1);
+        }
+        if (bundledGaps.undeclared.length > 0) {
+            console.error(
+                `build-gtk-runtime: ${bundledGaps.undeclared.join(', ')} declared in GST_AUDIO_PLUGINS ` +
+                    'and absent from the payload, with no entry in GST_PLUGIN_GAPS saying so. Either ' +
+                    'the build prefix lost a formula, or the bundle is about to advertise a format it ' +
+                    'cannot decode — which is what a silent skip looked like before this check existed.',
             );
             process.exit(1);
         }

--- a/packages/node-gi/scripts/gst-plugins.mjs
+++ b/packages/node-gi/scripts/gst-plugins.mjs
@@ -124,11 +124,21 @@ export function isBundledGstPlugin(fileName) {
     return GST_AUDIO_PLUGINS.includes(base);
 }
 
-/** The list above's spelling of a plugin file: no `libgst`/`gst` prefix, no extension, lowercase. */
+/**
+ * The list above's spelling of a plugin file: no `libgst`/`gst` prefix, no extension, lowercase.
+ *
+ * CASE-INSENSITIVE THROUGHOUT, and it was not: the extension strip carried `/i` while the prefix
+ * strip did not, so `LIBGSTAPP.DLL` — the archive's spelling, not ours — kept its prefix and read
+ * as an unknown plugin. Same for a versioned `libgstapp.so.0`. No caller reaches either shape
+ * today, and both would now REPORT rather than mis-parse, which is the direction that ends in a
+ * red build instead of a silent one.
+ */
 function gstPluginBaseName(fileName) {
     return fileName
-        .replace(/^(lib)?gst/, '')
-        .replace(/\.(dylib|so|dll)$/i, '')
+        .replace(/^.*[\\/]/, '')
+        .replace(/^(lib)?gst/i, '')
+        .replace(/\.(dylib|dll)$/i, '')
+        .replace(/\.so(\.\d+)*$/i, '')
         .toLowerCase();
 }
 
@@ -238,9 +248,22 @@ export const GST_PLATFORM_SINKS = {
     win32: ['wasapi2', 'directsound'],
 };
 
-/** Every plugin `<os>-<arch>`'s bundle is expected to carry. */
+/**
+ * Every plugin `<os>-<arch>`'s bundle is expected to carry.
+ *
+ * REFUSES AN OS IT DOES NOT KNOW rather than answering. An unrecognised os makes every
+ * platform sink foreign, so the expectation quietly stops requiring an audio sink at all —
+ * a typo in a target string would have relaxed the check instead of failing it, which is
+ * this file's own subject one level up. Every caller passes a literal.
+ */
 export function expectedGstPlugins(target) {
     const os = String(target).split('-')[0];
+    if (!Object.hasOwn(GST_PLATFORM_SINKS, os)) {
+        throw new Error(
+            `gst-plugins: "${target}" names no platform this bundles for. Known: ` +
+                `${Object.keys(GST_PLATFORM_SINKS).join(', ')} — the \`process.platform\` spelling.`,
+        );
+    }
     const foreign = new Set(
         Object.entries(GST_PLATFORM_SINKS)
             .filter(([platform]) => platform !== os)

--- a/packages/node-gi/scripts/gst-plugins.mjs
+++ b/packages/node-gi/scripts/gst-plugins.mjs
@@ -28,9 +28,14 @@ export const GST_AUDIO_PLUGINS = [
     // decodebin/uridecodebin itself.
     'typefindfunctions',
     'playback',
-    // Parsers, then decoders, covering what a browser's decodeAudioData is expected to take:
-    // WAV, MP3, AAC-in-M4A, Ogg/Vorbis, Opus, FLAC. `audioparsers` supplies the mp3/aac/flac
-    // parsers decodebin autoplugs.
+    // Parsers, then decoders. What is COVERED is WAV, MP3, Ogg/Vorbis, Opus and FLAC, and the
+    // list of formats with the element that decodes each is `GST_AUDIO_DECODERS` below — the
+    // registry is asked for those, because `decodebin` resolving says nothing about what it can
+    // autoplug. `audioparsers` supplies the mp3/aac/flac parsers decodebin reaches for.
+    //
+    // AAC-in-M4A is NOT covered, and this sentence used to say it was: `isomp4` demuxes the
+    // container and `aacparse` parses the stream, after which nothing decodes it. The gap is
+    // stated in `GST_FORMAT_GAPS` with the licensing reason rather than left in a claim.
     'audioparsers',
     'wavparse',
     'isomp4',
@@ -130,14 +135,146 @@ function gstPluginBaseName(fileName) {
 /**
  * The plugins whose ABSENCE is a build failure rather than a counted skip.
  *
- * The rest of the list degrades honestly — a prefix without `mpg123` loses MP3 and says so in the
- * skip count. These do not: without `app` there is no JS boundary, without `playback` there is no
- * decodebin, and without `soup` a URI pipeline reports a healthy `Gst.init()` and then finds no
- * source element far away in the application. The builders already refuse a bundle with ZERO
- * plugins; this is that same rule made specific, because the zero check passed while the one
- * element an app actually asked for was missing.
+ * Without `app` there is no JS boundary, without `playback` there is no decodebin, and without
+ * `soup` a URI pipeline reports a healthy `Gst.init()` and then finds no source element far away
+ * in the application.
+ *
+ * THIS USED TO SAY the rest of the list "degrades honestly — a prefix without `mpg123` loses MP3
+ * and says so in the skip count". It does not, and #1544 is what that cost. The builders log what
+ * they SKIPPED out of what they WALKED; a plugin the source archive never contained is never
+ * walked, so it is never skipped, so it is never counted. Measured on the published
+ * `@gjsify/gtk-runtime-win32-x64@0.47.0`: `mpg123`, `vorbis`, `flac` and `wasapi2` were absent
+ * with no line about any of them, an application played nothing, and the mp3 stream failed as
+ * `Internal data stream error` — the string this file documents for a missing TLS backend, which
+ * it was not. {@link missingBundledGstPlugins} is the answer to the count's blind spot.
  */
 export const GST_REQUIRED_PLUGINS = ['app', 'playback', 'soup'];
+
+/**
+ * The DECODER behind each format the audio path claims to take, keyed by format.
+ *
+ * A plugin list is the payload; this is the CLAIM, and they are not the same question. `decodebin`
+ * resolving says nothing about whether anything can decode what it autoplugs — measured on win32,
+ * where `decodebin3`, `playbin3`, `filesrc` and `souphttpsrc` all resolved and `mpg123audiodec`
+ * was null. So the running registry is asked for the element that actually decodes, one per
+ * format, and `gst-elements.test.mjs` is where that question is put.
+ *
+ * The header of this file lists the formats "a browser's decodeAudioData is expected to take". AAC
+ * is in that sentence and has never been in the list: `isomp4` demuxes the container and
+ * `audioparsers` supplies `aacparse`, after which the stream reaches no decoder at all. The two
+ * elements that would decode it are `faad` (gst-plugins-bad, GPL) and `avdec_aac` (libav, whose
+ * whole closure this file refuses one screen up), so it is a licensing decision rather than an
+ * oversight — and it belongs in {@link GST_FORMAT_GAPS} where it is stated, not in a sentence that
+ * claims coverage.
+ */
+export const GST_AUDIO_DECODERS = [
+    { format: 'WAV / PCM', element: 'wavparse', plugin: 'wavparse' },
+    { format: 'MP3', element: 'mpg123audiodec', plugin: 'mpg123' },
+    { format: 'Ogg / Vorbis', element: 'vorbisdec', plugin: 'vorbis' },
+    { format: 'Opus', element: 'opusdec', plugin: 'opus' },
+    { format: 'FLAC', element: 'flacdec', plugin: 'flac' },
+    { format: 'A-law', element: 'alawdec', plugin: 'alaw' },
+    { format: 'µ-law', element: 'mulawdec', plugin: 'mulaw' },
+];
+
+/**
+ * Formats the audio path does NOT take, with the reason — declared so the claim is one place.
+ *
+ * An entry here is a promise NOT made. It is not an exemption from a check: nothing in
+ * `GST_AUDIO_DECODERS` names these, so no probe looks for them, and this list exists so the
+ * header's sentence about what a browser takes cannot quietly cover more than the payload does.
+ */
+export const GST_FORMAT_GAPS = [
+    {
+        format: 'AAC (in M4A)',
+        why:
+            '`isomp4` demuxes the container and `aacparse` parses the stream; nothing decodes it. ' +
+            '`faad` is GPL and `avdec_aac` brings the libav closure this file refuses — both are a ' +
+            "redistribution decision for whoever ships the product, not this script's.",
+    },
+];
+
+/**
+ * Plugins a platform's source archive does not contain, DECLARED, with what it costs.
+ *
+ * The `check-committed-musl` shape: a gap that is written down, printed on every build, and fails
+ * the day it stops applying. Without it the only two options are a silently incomplete bundle
+ * (what #1544 measured) or a red build for a payload decision nobody has taken yet — and the first
+ * is how a runtime advertises a format it cannot play.
+ *
+ * `retires` is not decoration: {@link missingBundledGstPlugins} reports a gap whose plugin DID
+ * arrive as a problem of its own, so an entry cannot outlive the archive that justified it.
+ */
+export const GST_PLUGIN_GAPS = {
+    'win32-x64': [
+        {
+            plugin: 'mpg123',
+            why: 'no MP3 decoding. gvsbuild carries the plugin only if libmpg123 was built, and it was not — measured on @gjsify/gtk-runtime-win32-x64@0.47.0, where a bundled mp3 asset and an mp3 stream both failed (#1544).',
+        },
+        {
+            plugin: 'vorbis',
+            why: 'no Ogg/Vorbis decoding: `ogg` demuxes the container and nothing decodes the stream inside it.',
+        },
+        {
+            plugin: 'flac',
+            why: 'no FLAC decoding. Same upstream cause as the two above: the gst-plugins-good element links libFLAC, and a gvsbuild prefix carries it only if that library was built.',
+        },
+        {
+            plugin: 'wasapi2',
+            why: 'the modern Windows sink. Costs nothing today: `directsound` ships and `autoaudiosink` resolves to it — listed because it is the same silent absence, not because it breaks anything.',
+        },
+    ],
+};
+
+/**
+ * The output sinks that belong to ONE platform, so the other's absence is not a gap.
+ *
+ * The list above is one list for both bundles because every other plugin in it is portable. These
+ * are not, and a checker that did not know it would report `osxaudio` missing from every Windows
+ * bundle — an alarm that is wrong on every run, which is the kind that gets switched off.
+ */
+export const GST_PLATFORM_SINKS = {
+    darwin: ['osxaudio'],
+    win32: ['wasapi2', 'directsound'],
+};
+
+/** Every plugin `<os>-<arch>`'s bundle is expected to carry. */
+export function expectedGstPlugins(target) {
+    const os = String(target).split('-')[0];
+    const foreign = new Set(
+        Object.entries(GST_PLATFORM_SINKS)
+            .filter(([platform]) => platform !== os)
+            .flatMap(([, sinks]) => sinks),
+    );
+    return GST_AUDIO_PLUGINS.filter((name) => !foreign.has(name));
+}
+
+/**
+ * Which expected plugins the bundle does not carry, split by whether anybody said so.
+ *
+ * THE COUNT'S BLIND SPOT, closed. A builder logs what it skipped out of what it walked, so a
+ * plugin the source archive never contained produces no line at all — and that is how four of
+ * them left the win32 bundle silently (#1544). This compares the DECLARATION against what was
+ * actually copied, which is a set difference and cannot be blind in that direction.
+ *
+ * `retired` is the half that keeps the gap list honest: a declared gap whose plugin DID arrive is
+ * reported too, so an entry cannot outlive the archive that justified it.
+ *
+ * @param {Iterable<string>} shippedFileNames plugin leaf names as they landed in the bundle
+ * @param {string} target `<os>-<arch>`, the key {@link GST_PLUGIN_GAPS} is written under
+ * @returns {{ undeclared: string[], declared: {plugin: string, why: string}[], retired: string[] }}
+ */
+export function missingBundledGstPlugins(shippedFileNames, target) {
+    const shipped = new Set();
+    for (const f of shippedFileNames) shipped.add(gstPluginBaseName(f));
+    const gaps = GST_PLUGIN_GAPS[target] ?? [];
+    const declaredNames = new Set(gaps.map((gap) => gap.plugin));
+    return {
+        undeclared: expectedGstPlugins(target).filter((name) => !shipped.has(name) && !declaredNames.has(name)),
+        declared: gaps.filter((gap) => !shipped.has(gap.plugin)),
+        retired: gaps.filter((gap) => shipped.has(gap.plugin)).map((gap) => gap.plugin),
+    };
+}
 
 /**
  * Which of {@link GST_REQUIRED_PLUGINS} the given plugin files do NOT cover. Both builders call

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -1119,6 +1119,30 @@ artifacts somewhere the project does not also use as scratch. Both are config su
 the ADR treatment rather than a filter someone adds in passing. Until then the fat is visible only
 to a reader of `--verbose`, which is how it stayed unnoticed in the first place.
 
+### `canPlayType` answers from a hardcoded list, and one of its answers is now known wrong
+
+`@gjsify/webaudio`'s `HTMLAudioElement` carries `SUPPORTED_TYPES`, a hardcoded set of MIME types
+commented as "GStreamer-supported (common on GNOME systems)". It includes `audio/aac` and
+`audio/mp4`.
+
+On a GNOME host that is usually true — `gst-libav` is installed and `avdec_aac` resolves. **In a
+`@gjsify/gtk-runtime-*` bundle it is false**, and now measurably so: the audio payload carries no
+AAC decoder at all, which #1544's amendment to ADR 0037 states as a declared gap
+(`GST_FORMAT_GAPS`). So a shipped application asks `canPlayType('audio/aac')`, is told the format
+is playable, and then fails at decode — the exact distance between a claim and a registry that the
+plugin-gap work closed one layer down.
+
+**Why it is not a one-line deletion.** Removing `audio/aac` makes the answer wrong in the other
+direction on every ordinary GNOME desktop, which is the platform that file was written for. The
+honest answer is to ask the registry — the same question `gst-elements.test.mjs` puts — rather than
+to guess in either direction.
+
+**What makes it awkward** is the direction of the dependency: the format table lives in
+`packages/node-gi/scripts/gst-plugins.mjs`, and `@gjsify/webaudio` is Tier 1 while `@gjsify/node-gi`
+is Tier 2, so it cannot import it. Either the table moves somewhere both may read, or webaudio asks
+GStreamer directly (`Gst.ElementFactory` is already in reach through `gst-init.ts`) and the table
+stays the BUILDER's declaration. The second is smaller and does not move a published contract.
+
 ### `gjsify ship --sign`: three things M6 did not prove, each with what WAS measured
 
 The signing interface landed whole (ADR 0024 § A12-§ A17) and its darwin half is


### PR DESCRIPTION
Closes #1544.

`@gjsify/gtk-runtime-win32-x64@0.47.0` shipped without `mpg123`, `vorbis`, `flac` and `wasapi2` — **with no line about any of them** — and a desktop application played neither its bundled mp3 nor its mp3 stream. The second failed as `Internal data stream error`, which is the string `gst-plugins.mjs` documents for a missing TLS backend, and was not.

## Why three checks looked and none could see it

Each answers a different question, and the third is the one that reads like coverage:

- the count refuses a bundle with **zero** plugins;
- `missingRequiredGstPlugins` asks for the three whose absence is silent (`app`, `playback`, `soup`);
- the builders **log every plugin they SKIPPED**.

A builder logs what it skipped out of what it **walked**. A plugin the source archive never contained is never walked, so it is never skipped, so it is never counted — **a seed that matches nothing is byte-identical to a seed that matched**. That is the same shape #1097 named for the win32 GL patterns.

## The comparison that can see it

`missingBundledGstPlugins(shipped, target)` — the declaration against what was actually copied, a set difference, split three ways rather than two:

| | meaning | outcome |
|---|---|---|
| **undeclared** | declared in `GST_AUDIO_PLUGINS`, absent, nobody said why | build fails |
| **declared** | an entry in `GST_PLUGIN_GAPS[target]` with what it costs | printed every build |
| **retired** | a declared gap whose plugin **arrived** | build fails |

The `check-committed-musl` shape: a gap that is written down, printed, and fails the day it stops applying. The four win32 names are seeded with their measurement, because where the three decoders come from on a gvsbuild prefix is a *decision* (#1544's own item 2) and a silently incomplete bundle is not the way to wait for one.

A platform's own sink is not the other's gap: `GST_PLATFORM_SINKS` keeps `osxaudio` out of the win32 expectation, because an alarm that is wrong on every run is one nobody reads.

## And the claim underneath

`decodebin` resolving says nothing about what it can autoplug. Measured on that bundle: `decodebin3`, `playbin3`, `filesrc` and `souphttpsrc` all resolved while `mpg123audiodec` was null. So `GST_AUDIO_DECODERS` names the decoder of each format the audio path claims, and `gst-elements.test.mjs` asks the running registry for those — the skeleton was never the question. A declared gap is not asked for, and a gap whose element resolves fails from this side too.

Writing that table down settled a claim the file has carried since it was written: the header listed **AAC-in-M4A** among the formats it takes, and no AAC decoder has ever been in the list. `isomp4` demuxes the container, `aacparse` parses the stream, nothing decodes it. `faad` is GPL and `avdec_aac` brings the libav closure § Decision drivers refuses — a redistribution decision, now a declared gap in `GST_FORMAT_GAPS` instead of a sentence claiming coverage.

## Measured here

- `gtk-runtime-bundle-gates.test.mjs`: **49 pass, 0 fail** — five new vectors drive the payload-as-shipped, an undeclared absence, a retired gap, the foreign sink, and the table-against-table consistency
- one of those vectors failed on my own data and stayed failed until fixed: the `flac` gap carried a reason too thin to be one
- every `audit-runtimes.yml` script, `gjsify format --check`, `gjsify lint`: clean
- `gst-elements.test.mjs` needs the native addon and runs on the OS legs, not here

`@gjsify/webaudio`'s `canPlayType` still answers `audio/aac` from a hardcoded list — true on an ordinary GNOME desktop, false in a bundle. That is in `open-todos` with why deleting the entry is wrong in the other direction, and why the fix is to ask the registry rather than to guess.

ADR 0037 carries the amendment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtCcG3LLsz9voXAG9DVjhD