### PR TITLE
feat(adwaita)!: a page is chosen, not counted

### DIFF
--- a/docs/adr/0048-page-selection-by-identity.md
+++ b/docs/adr/0048-page-selection-by-identity.md
@@ -1,0 +1,158 @@
+# 48. A selection takes the shape its counterpart gives it: a name, a page, or an ordinal
+
+- Status: **Proposed**
+- Date: 2026-09-05
+- Deciders: Pascal Garber
+- Related: [ADR 0004 (headless Adwaita core)](0004-headless-adwaita-core.md), [ADR 0027 (GTK host layer)](0027-gtk-host-layer.md), [ADR 0034 (widget vocabulary convergence)](0034-widget-vocabulary-convergence.md), [ADR 0042 (portable menu model)](0042-portable-menu-model.md), [ADR 0046 (portable list model)](0046-portable-list-model.md), [ADR 0047 (portable adjustment)](0047-portable-adjustment.md)
+
+## Context
+
+ADRs 0042, 0046 and 0047 each gave one thing a portable VALUE — a menu, a list, a range.
+This one is different in kind and it is worth saying so first, because the obvious reading
+of it is wrong: **there is no portable selection value to introduce.** The value already
+exists on every surface. What diverged is which of GTK's own shapes each port picked.
+
+GTK offers three, and it picks between them per widget. Measured against
+`packages/framework/gtk-host/src/generated/props.ts`, the in-repo GIR-derived surface:
+
+| the shape GTK gives the selection | the types that have it |
+|---|---|
+| identity, by NAME — `visible-child-name` | `AdwLeaflet`, `AdwViewStack`, `GtkStack` |
+| identity, by OBJECT — `selected-page` | `AdwTabView` |
+| ORDINAL — `selected: number` | `AdwComboRow`, `AdwSidebar`, `GtkDropDown` |
+
+The split is not an accident of history. A `GtkDropDown` selects a row of a `GListModel`,
+where a position IS the identity the model exposes; an `AdwViewStack` selects one of a set
+of NAMED pages, and a `GtkStack` page's name outlives an insertion before it. So an ordinal
+is right where the model is a list, and wrong where the pages have names of their own.
+
+**The port took the ordinal in the two places GTK names an identity**, and both renderers
+took it the same way:
+
+| widget | `@gjsify/adwaita-nativescript` | `@gjsify/adwaita-web` | `@gjsify/adwaita-react-native` | GIR |
+|---|---|---|---|---|
+| `AdwViewStack` | `visibleChildIndex` (settable) beside `visibleChildName` | the same pair | `visibleChildName` only | `visible-child-name` |
+| `AdwTabView` | `selected` (settable ordinal) | the same | — | `selected-page` |
+
+Two things follow from that table and both shaped this decision.
+
+**React Native is the control.** It carries a view stack and no ordinal door — its
+`visibleChildName` prop is the only way in, written that way from the start
+(`view-stack.native.tsx:65`). So the converged shape is not a proposal here; it is already
+shipping on a third renderer, and this ADR brings the older two to it rather than inventing
+anything.
+
+**The three ordinal widgets are already right and are deliberately untouched.**
+`adw-sidebar.selected`, `gtk-drop-down.selected` and `adw-combo-row.selected` name the same
+slot their counterpart names, in the same shape. A rule reading "identity always wins"
+would have broken all three, which is how a convergence programme starts producing
+divergence — the rule is *take the counterpart's shape*, and this ADR is one application
+of it.
+
+### What an ordinal DOOR costs, beyond disagreeing with the GIR
+
+The ordinal is derived, and `ViewStackState` already contains the code that proves it:
+inserting a page before the visible one increments the stored index
+(`view-stack.ts:296`), a reorder rewrites it (`:322`), a removal decrements it (`:348-349`).
+Every one of those lines exists so that a NUMBER a caller is holding does not silently come
+to mean another page. A name needs none of them — it survives all three operations
+unchanged. An ordinal is therefore safe to READ, at a moment, and unsafe to hold; a
+settable property invites exactly the holding.
+
+## Decision
+
+**An ordinal is a report. Identity is the door.**
+
+### 1. `AdwViewStack`: the settable ordinal becomes a call
+
+`visibleChildIndex` loses its setter on `@gjsify/adwaita-nativescript` and
+`@gjsify/adwaita-web`. The GETTER stays on both, unchanged: "which position is selected
+right now" is a legitimate question, it is what a switcher bar renders, and
+`notify::visible-child` already carries `index` in its payload for the same reason.
+
+Selecting is `visibleChildName`, which both renderers already have and which is
+`Adw.ViewStack`'s own property — **or `selectNthPage(n)`, which is new.** A method rather
+than a property because the difference is the holding: a call resolves against the page
+list as it is at that moment and keeps nothing, while a property invites a caller to hold
+a number that later means another page.
+
+**It is port-owned, and the reference says so**: `refs/libadwaita/src/adw-view-stack.h`
+declares no ordinal API at all, and neither does `adw-tab-view.h` — `select_previous_page`
+and `select_next_page` are the only relative moves there. So this is not GTK's shape being
+restored; it is the port's own, named for the `selectNthPage` the tab view has carried all
+along so that the two widgets ask the same question the same way.
+
+Without it the translation is `stack.pages[n]?.name`, and the first draft of this change
+wrote that line **three times** across the two switcher bars — the copied-arithmetic smell
+[ADR 0047](0047-portable-adjustment.md) found in `AdwSliderRow`, arriving in the same
+change that was supposed to reduce it. One method, three call sites, no copies.
+
+### 2. `AdwTabView`: `selected` becomes `selectedPage`, and it holds the page
+
+`selected` — a settable ordinal on both renderers — is replaced by `selectedPage`, which is
+`Adw.TabView`'s own property name and, as there, holds the PAGE rather than a number. The
+core already models exactly this (`TabViewState.selectedPage`), so the renderers expose a
+value that existed and was not reachable from the outside except through
+`setSelectedPage(id)`.
+
+`selectedIndex` and `selectedId` stay as the getters they already are. Neither is a door.
+
+### 3. On the web, the MARKUP door names the page too
+
+`<adw-tab-view selected="1">` becomes `<adw-tab-view selected-page="<page id>">`, reflected
+on every selection change as the ordinal was.
+
+Markup cannot hold an object, so the attribute holds the page's **id** — the one
+`<adw-tab-page page-id>` already declares, and the reason that attribute exists. A page
+that declares none gets a generated id, which an author cannot predict and therefore cannot
+select by; that is the same bargain `<adw-view-stack visible-child-name>` has always made
+for a page with no name, and it is why the parse rule is *ignore an id no page holds*
+rather than *fall back to the first page*.
+
+`@gjsify/adwaita-nativescript` needs no equivalent: its XML door is the property, and the
+property now holds a page.
+
+### 4. The core keeps its ordinal API, and that is the point of the split
+
+`ViewStackState.setVisibleIndex` and `TabViewState.selectNthPage` are unchanged, and the
+conformance vectors that drive them (`selectIndex` ops in
+`@gjsify/adwaita-core/conformance/view-stack`) are unchanged with them.
+
+A switcher bar IS ordinal: it renders button *n* and must select page *n*. That translation
+belongs where the ordinal is a fact about a rendered list, not on the widget's public
+surface where it is a promise about a page. So the two switcher bars translate through
+`pages[n].name`, which is one lookup and is what makes the promise true.
+
+## Consequences
+
+- **Breaking**, on two published packages. `stack.visibleChildIndex = 2` becomes
+  `stack.selectNthPage(2)` (or `stack.visibleChildName = '…'`), and `view.selected = 2`
+  becomes `view.selectNthPage(2)` — a method both tab views already had — or
+  `view.selectedPage = page`. Every migration is one line and mechanical, and none has a
+  silent failure mode: the removed setters were the only writable properties of their name,
+  so an unmigrated write is a TypeScript error and, at runtime, a no-op on a getter.
+- The vocabulary ledger loses two `should converge` property entries. That is the metric
+  moving because the thing it measures moved: `check-vocabulary-alignment.mjs` counts
+  SETTABLE properties, because a door is what a portable authored tree writes.
+- No XML door changes. `visibleChildIndex` and `selected` were reachable from NativeScript
+  XML as numbers; `visibleChildName` is a string, which is what an XML attribute is anyway,
+  and `selectedPage` holds an object, which XML cannot express and therefore never offered.
+- Nothing in `website/`, `showcases/`, `packages/framework/stories` or the generated
+  NativeScript templates writes either property — measured before writing this, which is
+  why this ADR proposes a removal rather than a deprecation.
+
+## What this does not decide
+
+- **`visible-child` (the widget) is not added.** `Adw.ViewStack` also selects by CHILD
+  WIDGET, and neither renderer offers that. It is a third door onto the same slot and
+  nothing has asked for it; the ADR that adds it should say what it is for.
+- **`AdwLeaflet` and `GtkStack` are out of scope** — neither renderer ports them today.
+  When one does, the table above is the rule it inherits.
+- **Ordinal REPORTS elsewhere are untouched**, including every `selected` on the three
+  widgets whose counterpart is ordinal.
+- **`setSelectedPage(id)` keeps its id parameter**, so the two renderers now offer the page
+  through a property and its id through a method. libadwaita's own
+  `adw_tab_view_set_selected_page()` takes the PAGE, so the method diverges from its
+  counterpart in shape — but a method is not what a portable authored tree writes, the
+  vocabulary ledger does not read one, and changing it is a second breaking change with no
+  measurement behind it yet. It is written down in `status/open-todos.md` instead.

--- a/docs/adr/0048-page-selection-by-identity.md
+++ b/docs/adr/0048-page-selection-by-identity.md
@@ -76,16 +76,43 @@ than a property because the difference is the holding: a call resolves against t
 list as it is at that moment and keeps nothing, while a property invites a caller to hold
 a number that later means another page.
 
-**It is port-owned, and the reference says so**: `refs/libadwaita/src/adw-view-stack.h`
-declares no ordinal API at all, and neither does `adw-tab-view.h` — `select_previous_page`
-and `select_next_page` are the only relative moves there. So this is not GTK's shape being
-restored; it is the port's own, named for the `selectNthPage` the tab view has carried all
-along so that the two widgets ask the same question the same way.
+**It is port-owned as a SETTER, and the reference is more precise than that**: neither
+`refs/libadwaita/src/adw-view-stack.h` nor `adw-tab-view.h` declares a function that
+SELECTS by position — `select_previous_page` / `select_next_page` are the only relative
+moves. An ordinal is not absent from either, though, and pretending it is would make the
+weaker argument:
+
+- `adw_tab_view_get_nth_page (AdwTabView *self, int position)`
+  (`refs/libadwaita/src/adw-tab-view.h:192#adw_tab_view_get_nth_page`) is a public ordinal
+  ACCESSOR.
+- `select_nth_page_cb` (`refs/libadwaita/src/adw-tab-view.c:2137#select_nth_page_cb`) is
+  libadwaita's OWN ordinal selection — the
+  Alt+1…Alt+9 / Alt+0 shortcut — and it is exactly this composition:
+  `adw_tab_view_get_nth_page()` then `adw_tab_view_set_selected_page()`. Private, because a
+  shortcut handler is not API.
+- both widgets hand out a `GtkSelectionModel`
+  (`refs/libadwaita/src/adw-view-stack.h:166#adw_view_stack_get_pages`;
+  `refs/libadwaita/src/adw-tab-view.h:268#adw_tab_view_get_pages`), and selection on one is
+  positional.
+
+So `selectNthPage` is not an ordinal libadwaita refuses; it is the ordinal libadwaita
+performs, promoted from a private shortcut handler to a method, and named for the
+`selectNthPage` the tab view has carried all along so that the two widgets ask the same
+question the same way. What stays port-owned is putting it in the public surface.
 
 Without it the translation is `stack.pages[n]?.name`, and the first draft of this change
 wrote that line **three times** across the two switcher bars — the copied-arithmetic smell
 [ADR 0047](0047-portable-adjustment.md) found in `AdwSliderRow`, arriving in the same
 change that was supposed to reduce it. One method, three call sites, no copies.
+
+And that is the weaker half of the case. `pages[n].name` is not a translation of
+`selectNthPage(n)` at all for two page shapes the specs already pin: a page whose name is
+`''` cannot be selected by name (`view-stack.spec.ts:226` — the reflection guard never
+fires for it), and where two pages share a name a lookup resolves to the FIRST
+(`:252`, written against exactly that bounce). A switcher bar renders button *n* over
+whatever pages the stack holds, duplicates and blanks included, so for those two it has no
+name to pass. The method is not a convenience over the name; it is the only door onto the
+pages the name cannot reach.
 
 ### 2. `AdwTabView`: `selected` becomes `selectedPage`, and it holds the page
 
@@ -109,8 +136,20 @@ select by; that is the same bargain `<adw-view-stack visible-child-name>` has al
 for a page with no name, and it is why the parse rule is *ignore an id no page holds*
 rather than *fall back to the first page*.
 
-`@gjsify/adwaita-nativescript` needs no equivalent: its XML door is the property, and the
-property now holds a page.
+Ignored, and RECORDED: the refusal goes through `setSelectedPage`, so an id no page holds
+appends C's `page_belongs_to_this_view` assertion to `view.diagnostics`, where the ordinal
+attribute refused an out-of-range index in silence. The selection is the same either way;
+what changes is that the typo is now visible to anyone reading the diagnostics.
+
+`@gjsify/adwaita-nativescript` gets no equivalent, and that is a LOSS, not a
+non-requirement. Its XML door IS the property, and a property holding an object is not one:
+measured, `check-nativescript-xml-doors` moves `selectedPage` into "typed as something no
+XML attribute can carry" (19 → 20) and `AdwTabView` is left with no string-typed selection
+setter at all, where `selected="1"` used to work through `xmlNumber`. So a NativeScript XML
+tree can no longer declare which tab starts selected — only code can. The web kept a markup
+door for exactly this reason and NativeScript should have the same one; it is written down
+in `status/open-todos.md` rather than added here, because the shape (`selectedPageId`, or
+the id-taking method question below) is one decision and should be made once.
 
 ### 4. The core keeps its ordinal API, and that is the point of the split
 
@@ -128,18 +167,40 @@ surface where it is a promise about a page. So the two switcher bars translate t
 - **Breaking**, on two published packages. `stack.visibleChildIndex = 2` becomes
   `stack.selectNthPage(2)` (or `stack.visibleChildName = '…'`), and `view.selected = 2`
   becomes `view.selectNthPage(2)` — a method both tab views already had — or
-  `view.selectedPage = page`. Every migration is one line and mechanical, and none has a
-  silent failure mode: the removed setters were the only writable properties of their name,
-  so an unmigrated write is a TypeScript error and, at runtime, a no-op on a getter.
+  `view.selectedPage = page`. Every migration is one line and mechanical.
+- **A PROPERTY write fails loudly; an ATTRIBUTE write does not.** The removed setters were
+  the only writable properties of their name, so an unmigrated `stack.visibleChildIndex = 2`
+  is a TypeScript error and, at runtime, a no-op on a getter. Three other doors have no such
+  backstop and each one was measured going silently dead:
+  - `view.setAttribute('selected', String(n))` on the web element. `website/` had TWO —
+    `CommandTabs.astro` (the npm/yarn/gjsify tabs, restored from `localStorage` and mirrored
+    across the page) and `AdwWidget.astro` (every gallery block's implementation tabs) —
+    which the first draft of this ADR recorded as none, because it grepped the PROPERTY
+    names. Both are migrated with this change, and `check-website-attr-samples.mjs` arm 4
+    now follows a binding taken from a custom-element selector to its `setAttribute` calls,
+    which is the reason this was ever findable by anything but a reader clicking a tab.
+  - `<AdwTabView selected="1" />` and `<AdwViewStack visibleChildIndex="2" />` in
+    NativeScript XML, which no type sees at all.
+- **XML doors DID change**, contrary to the first draft of this section. Measured with
+  `check-nativescript-xml-doors`: coercing non-string setters 66 → 64 (both numeric doors
+  gone), setters XML cannot carry 19 → 20 (`selectedPage` holds an object). What is true is
+  the narrower claim: nothing is left half-reachable — `visibleChildName` is a string, which
+  is what an XML attribute is anyway, and `selectedPage` is refused rather than coerced.
 - The vocabulary ledger loses two `should converge` property entries. That is the metric
   moving because the thing it measures moved: `check-vocabulary-alignment.mjs` counts
-  SETTABLE properties, because a door is what a portable authored tree writes.
-- No XML door changes. `visibleChildIndex` and `selected` were reachable from NativeScript
-  XML as numbers; `visibleChildName` is a string, which is what an XML attribute is anyway,
-  and `selectedPage` holds an object, which XML cannot express and therefore never offered.
-- Nothing in `website/`, `showcases/`, `packages/framework/stories` or the generated
-  NativeScript templates writes either property — measured before writing this, which is
-  why this ADR proposes a removal rather than a deprecation.
+  SETTABLE properties, because a door is what a portable authored tree writes. Measured:
+  143 → 142 settable, 107 → 108 agreeing, distance 7 → 5 property names.
+- **A refusal that was silent is now RECORDED**, on the web element and on both renderers'
+  tab views. `selected = 99` went through `selectNthPage`, which refuses an out-of-range
+  index and pushes nothing; an unknown `selected-page` id and `selectedPage = null` with
+  pages present both go through `setSelectedPage`, which is where C's
+  `page_belongs_to_this_view` and `ADW_IS_TAB_PAGE` assertions live. The selection outcome
+  is unchanged — both are refused — but `view.diagnostics` grows an entry where it did not.
+  That is the right answer (a typo'd id in markup is exactly what C would `g_critical`
+  about) and it is asserted in `tab-view.spec.ts`, not left to be discovered.
+- Nothing in `showcases/`, `packages/framework/stories` or the generated NativeScript
+  templates writes either property, which is why this ADR proposes a removal rather than a
+  deprecation. `website/` did — see the second bullet.
 
 ## What this does not decide
 

--- a/docs/adr/0048-page-selection-by-identity.md
+++ b/docs/adr/0048-page-selection-by-identity.md
@@ -114,13 +114,30 @@ whatever pages the stack holds, duplicates and blanks included, so for those two
 name to pass. The method is not a convenience over the name; it is the only door onto the
 pages the name cannot reach.
 
-### 2. `AdwTabView`: `selected` becomes `selectedPage`, and it holds the page
+### 2. `AdwTabView`: `selected` becomes `selectedPage`, and it holds an identity
 
 `selected` — a settable ordinal on both renderers — is replaced by `selectedPage`, which is
-`Adw.TabView`'s own property name and, as there, holds the PAGE rather than a number. The
-core already models exactly this (`TabViewState.selectedPage`), so the renderers expose a
-value that existed and was not reachable from the outside except through
-`setSelectedPage(id)`.
+`Adw.TabView`'s own property name and, as there, an IDENTITY rather than a number. The core
+already models exactly this (`TabViewState.selectedPage`), so the renderers expose a value
+that existed and was not reachable from the outside except through a method.
+
+**The two renderers write it in different shapes, and that is a decision** (ADR 0034 § 1
+clause 3: a divergence is declared, with its reason — the clause the phrase "converges in
+name, never in shape" belongs to is `composes`, which is about a widget assembled
+differently from its GIR counterpart, not about two renderers differing from each other;
+and the vocabulary ledger compares property NAMES, so nothing measures this either way):
+
+| | reads | writes | why |
+|---|---|---|---|
+| `@gjsify/adwaita-web` | the page | the page | its DOM has a page ELEMENT, and its markup door carries the id separately as `selected-page` |
+| `@gjsify/adwaita-nativescript` | the page | the page's **id** | an id already IS the page handle on that port (`isClosing`, `closePage`, `setPagePinned` all take one) and an XML attribute can carry nothing else — § 3 |
+
+The cost is on the NativeScript half and is deliberate: the two accessors have unrelated
+types, which TypeScript has allowed since 5.1, so `view.selectedPage = view.selectedPage`
+is a TYPE ERROR rather than a silent one. The alternative — `AdwTabPage | string | null` on
+the setter, which is what the core takes — makes the round-trip legal but is currently
+classified `json` by `check-nativescript-xml-doors` and turns the door red; that gate defect
+is in `status/open-todos.md`, and it is the thing to fix before revisiting this.
 
 `selectedIndex` and `selectedId` stay as the getters they already are. Neither is a door.
 
@@ -141,15 +158,27 @@ appends C's `page_belongs_to_this_view` assertion to `view.diagnostics`, where t
 attribute refused an out-of-range index in silence. The selection is the same either way;
 what changes is that the typo is now visible to anyone reading the diagnostics.
 
-`@gjsify/adwaita-nativescript` gets no equivalent, and that is a LOSS, not a
-non-requirement. Its XML door IS the property, and a property holding an object is not one:
-measured, `check-nativescript-xml-doors` moves `selectedPage` into "typed as something no
-XML attribute can carry" (19 → 20) and `AdwTabView` is left with no string-typed selection
-setter at all, where `selected="1"` used to work through `xmlNumber`. So a NativeScript XML
-tree can no longer declare which tab starts selected — only code can. The web kept a markup
-door for exactly this reason and NativeScript should have the same one; it is written down
-in `status/open-todos.md` rather than added here, because the shape (`selectedPageId`, or
-the id-taking method question below) is one decision and should be made once.
+`@gjsify/adwaita-nativescript` needs its own equivalent, because there the property IS the
+XML door and a property holding an object is not one. The first draft of this ADR gave it
+none and the loss was measurable: `selectedPage` landed in "typed as something no XML
+attribute can carry" and `AdwTabView` was left as the one XML-reachable class with a
+selection and no string-typed setter for it, where `<AdwTabView selected="1">` had worked
+through `xmlNumber`. So the setter there takes the ID — `<AdwTabView selectedPage="inbox">`
+— which is § 2's asymmetry and its reason.
+
+Measured with `check-nativescript-xml-doors`, whose string-door counter was added for this
+claim, because "classified `string`" and "the reader never saw it" printed identically
+before it:
+
+| | coercing non-string | string, carried as-is | XML cannot carry |
+|---|---|---|---|
+| before this ADR | 66 | 70 | 19 |
+| with an object-typed `selectedPage` | 64 | 70 | **20** |
+| as it stands | 64 | **71** | 19 |
+
+`selected` and `visibleChildIndex` left the numeric bucket and `selectedPage` joined the
+string one: two XML doors removed, one added, and no setter left in the bucket an attribute
+cannot reach.
 
 ### 4. The core keeps its ordinal API, and that is the point of the split
 
@@ -181,11 +210,11 @@ surface where it is a promise about a page. So the two switcher bars translate t
     which is the reason this was ever findable by anything but a reader clicking a tab.
   - `<AdwTabView selected="1" />` and `<AdwViewStack visibleChildIndex="2" />` in
     NativeScript XML, which no type sees at all.
-- **XML doors DID change**, contrary to the first draft of this section. Measured with
-  `check-nativescript-xml-doors`: coercing non-string setters 66 → 64 (both numeric doors
-  gone), setters XML cannot carry 19 → 20 (`selectedPage` holds an object). What is true is
-  the narrower claim: nothing is left half-reachable — `visibleChildName` is a string, which
-  is what an XML attribute is anyway, and `selectedPage` is refused rather than coerced.
+- **XML doors DID change**, contrary to the first draft of this section, and the final shape
+  is not the one that draft described either. Measured with `check-nativescript-xml-doors`:
+  coercing non-string setters 66 → 64 (both numeric doors gone), string doors 70 → 71
+  (`selectedPage` is one now), setters XML cannot carry 19 → 19 (it passed through 20 while
+  the setter took the object). Two doors removed, one added, none left half-reachable.
 - The vocabulary ledger loses two `should converge` property entries. That is the metric
   moving because the thing it measures moved: `check-vocabulary-alignment.mjs` counts
   SETTABLE properties, because a door is what a portable authored tree writes. Measured:

--- a/docs/adr/0048-page-selection-by-identity.md
+++ b/docs/adr/0048-page-selection-by-identity.md
@@ -211,9 +211,10 @@ surface where it is a promise about a page. So the two switcher bars translate t
   When one does, the table above is the rule it inherits.
 - **Ordinal REPORTS elsewhere are untouched**, including every `selected` on the three
   widgets whose counterpart is ordinal.
-- **`setSelectedPage(id)` keeps its id parameter**, so the two renderers now offer the page
-  through a property and its id through a method. libadwaita's own
-  `adw_tab_view_set_selected_page()` takes the PAGE, so the method diverges from its
-  counterpart in shape — but a method is not what a portable authored tree writes, the
-  vocabulary ledger does not read one, and changing it is a second breaking change with no
-  measurement behind it yet. It is written down in `status/open-todos.md` instead.
+- **`setSelectedPage` takes the PAGE now, and an id as well** — widened in the core rather
+  than guarded in each renderer, because the identity check `page_belongs_to_this_view` can
+  only be answered where the page list lives. A renderer-side guard was written first and
+  measured wrong twice over: it is two copies, and its refusal is silent where C raises a
+  diagnostic. The remaining id-taking methods — `isClosing`, `closePage`, `setPagePinned` —
+  are unchanged and stay in `status/open-todos.md`; libadwaita takes an `AdwTabPage *` in
+  every one, and settling them together is a decision this ADR does not need to make.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -68,6 +68,7 @@ the TODO records the *what's left*.
 | [0045](0045-portal-placement-in-the-gtk-host.md) | A node whose host node is not its parent node: a placement axis beside the child policy, so an `Adw.Dialog` is presented rather than appended | Accepted |
 | [0046](0046-portable-list-model.md) | A list is a value — but only for the widgets GTK gives a `model` | Proposed |
 | [0047](0047-portable-adjustment.md) | A numeric range is a value, and the value is `Gtk.Adjustment` | Proposed |
+| [0048](0048-page-selection-by-identity.md) | A selection takes the shape its counterpart gives it: a name, a page, or an ordinal | Proposed |
 
 Source review: [docs/reports/2026-07-01-architecture-review.md](../reports/2026-07-01-architecture-review.md)
 (condensed findings + prioritized backlog).

--- a/packages/nativescript-bridge/adwaita/src/index.spec.ts
+++ b/packages/nativescript-bridge/adwaita/src/index.spec.ts
@@ -198,19 +198,22 @@ class MockViewStack {
     get visibleChildIndex(): number {
         return this._visible;
     }
-    set visibleChildIndex(value: number) {
-        if (!Number.isFinite(value) || value < 0 || value >= this._pages.length) return;
-        if (value === this._visible) return;
+    // ADR 0048: a read-only ordinal on the widget, so the mock offers the same call the
+    // widget does rather than a setter the widget no longer has.
+    selectNthPage(value: number): boolean {
+        if (!Number.isFinite(value) || value < 0 || value >= this._pages.length) return false;
+        if (value === this._visible) return false;
         this._visible = value;
         this.notified.push({ index: value, name: this._pages[value].name });
         for (const fn of this._subs) fn();
+        return true;
     }
     get visibleChildName(): string {
         return this._pages[this._visible]?.name ?? '';
     }
     set visibleChildName(name: string) {
         const idx = this._pages.findIndex((p) => p.name === name);
-        if (idx >= 0) this.visibleChildIndex = idx;
+        if (idx >= 0) this.selectNthPage(idx);
     }
     pageVisibility(): string[] {
         return this._pages.map((_, i) => (i === this._visible ? 'visible' : 'collapse'));
@@ -227,7 +230,7 @@ class MockViewSwitcherBar {
         this._sync();
     }
     tap(index: number): void {
-        this._stack.visibleChildIndex = index;
+        this._stack.selectNthPage(index);
     }
     private _sync(): void {
         const sel = this._stack.visibleChildIndex;
@@ -733,8 +736,8 @@ export default async () => {
             stack.add('code', 'Code');
             stack.add('debug', 'Debug');
             stack.visibleChildName = 'debug';
-            stack.visibleChildIndex = 2; // no change
-            stack.visibleChildIndex = 9; // out of range
+            stack.selectNthPage(2); // no change
+            stack.selectNthPage(9); // out of range
             expect(stack.visibleChildIndex).toBe(2);
             expect(stack.notified).toStrictEqual([{ index: 2, name: 'debug' }]);
         });
@@ -750,7 +753,7 @@ export default async () => {
             expect(stack.visibleChildName).toBe('code');
             expect(bar.activeButtons).toStrictEqual([false, true]);
             // ...and a programmatic stack change syncs the bar back.
-            stack.visibleChildIndex = 0;
+            stack.selectNthPage(0);
             expect(bar.activeButtons).toStrictEqual([true, false]);
         });
 

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-tab-view.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-tab-view.ts
@@ -181,21 +181,22 @@ export class AdwTabView extends GridLayout {
         return this._state.selectedPage;
     }
 
-    set selectedPage(page: AdwTabPage | null) {
-        // `page_belongs_to_this_view` — see the web twin, which carries the measurement: an
-        // id is unique within ONE view, so passing another view's page would select this
-        // view's page of the same name instead of refusing. The object is what separates
-        // them.
-        if (page !== null && !this._state.pages.includes(page)) return;
-        this._state.setSelectedPage(page?.id ?? null);
+    set selectedPage(page: AdwTabPage | string | null) {
+        // The PAGE, or its id — and the id spelling is what an XML attribute can carry, so
+        // `<AdwTabView selectedPage="inbox">` declares the starting tab. Both go to the
+        // core, which owns the page list and therefore owns `page_belongs_to_this_view`:
+        // an id is unique within ONE view, so a foreign page read as an id would select
+        // this view's page of the same id instead of refusing.
+        this._state.setSelectedPage(page);
     }
 
     isClosing(id: string): boolean {
         return this._state.isClosing(id);
     }
 
-    setSelectedPage(id: string | null): boolean {
-        return this._state.setSelectedPage(id);
+    /** `adw_tab_view_set_selected_page`, which takes the PAGE; an id is accepted too. */
+    setSelectedPage(page: AdwTabPage | string | null): boolean {
+        return this._state.setSelectedPage(page);
     }
 
     selectNthPage(n: number): boolean {

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-tab-view.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-tab-view.ts
@@ -181,20 +181,25 @@ export class AdwTabView extends GridLayout {
         return this._state.selectedPage;
     }
 
-    set selectedPage(page: AdwTabPage | string | null) {
-        // The PAGE, or its id — and the id spelling is what an XML attribute can carry, so
-        // `<AdwTabView selectedPage="inbox">` declares the starting tab. Both go to the
-        // core, which owns the page list and therefore owns `page_belongs_to_this_view`:
-        // an id is unique within ONE view, so a foreign page read as an id would select
-        // this view's page of the same id instead of refusing.
-        this._state.setSelectedPage(page);
+    set selectedPage(id: string | null) {
+        // THE ID, BECAUSE ON THIS PORT AN ID IS WHAT A PAGE HANDLE IS. Every other page
+        // call here takes one — `isClosing`, `closePage`, `setPagePinned` — and a
+        // NativeScript XML attribute can carry nothing else, so `<AdwTabView
+        // selectedPage="inbox">` is the only way markup can declare a starting tab. The web
+        // twin takes the page OBJECT because its DOM has one and its attribute carries the
+        // id separately; ADR 0034 § 1 converges the NAME and never the shape.
+        //
+        // The core refuses an id this view does not hold, with the diagnostic C raises —
+        // and because a caller here cannot hand over another view's page object, the
+        // cross-view confusion the web twin has to guard against cannot arise.
+        this._state.setSelectedPage(id);
     }
 
     isClosing(id: string): boolean {
         return this._state.isClosing(id);
     }
 
-    /** `adw_tab_view_set_selected_page`, which takes the PAGE; an id is accepted too. */
+    /** `adw_tab_view_set_selected_page`. The page, or the id this port uses as its handle. */
     setSelectedPage(page: AdwTabPage | string | null): boolean {
         return this._state.setSelectedPage(page);
     }

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-tab-view.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-tab-view.ts
@@ -46,7 +46,7 @@ import {
     type TabViewNotifyPayload,
 } from './tab-view-state.js';
 import type { AdwViewPage } from './view-switcher-base.js';
-import { xmlBoolean, xmlNumber } from './xml-values.js';
+import { xmlBoolean } from './xml-values.js';
 
 // Re-exported so the widget module stays the one import site for the page type,
 // as `widgets/index.ts` and every consumer already expect.
@@ -169,14 +169,20 @@ export class AdwTabView extends GridLayout {
         return this._state.selectedIndex;
     }
 
-    /** The selected page index. Setting it IGNORES a non-integer or out-of-range value. */
-    get selected(): number {
-        return this._state.selectedIndex;
+    /**
+     * The selected page (`Adw.TabView:selected-page`), `null` when the view is empty.
+     *
+     * THE PAGE, NOT ITS POSITION (ADR 0048). `Adw.TabView` is the one widget in this port
+     * whose counterpart selects by OBJECT rather than by name or by ordinal, and the model
+     * has held that object all along — this property is the door onto it. Setting a page
+     * this view does not hold is ignored, as `setSelectedPage` already was.
+     */
+    get selectedPage(): AdwTabPage | null {
+        return this._state.selectedPage;
     }
 
-    set selected(raw: number | string) {
-        const value = xmlNumber(raw, this.selected);
-        this._state.selectNthPage(value);
+    set selectedPage(page: AdwTabPage | null) {
+        this._state.setSelectedPage(page?.id ?? null);
     }
 
     isClosing(id: string): boolean {

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-tab-view.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-tab-view.ts
@@ -182,6 +182,11 @@ export class AdwTabView extends GridLayout {
     }
 
     set selectedPage(page: AdwTabPage | null) {
+        // `page_belongs_to_this_view` — see the web twin, which carries the measurement: an
+        // id is unique within ONE view, so passing another view's page would select this
+        // view's page of the same name instead of refusing. The object is what separates
+        // them.
+        if (page !== null && !this._state.pages.includes(page)) return;
         this._state.setSelectedPage(page?.id ?? null);
     }
 

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-tab-view.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-tab-view.ts
@@ -174,8 +174,12 @@ export class AdwTabView extends GridLayout {
      *
      * THE PAGE, NOT ITS POSITION (ADR 0048). `Adw.TabView` is the one widget in this port
      * whose counterpart selects by OBJECT rather than by name or by ordinal, and the model
-     * has held that object all along — this property is the door onto it. Setting a page
-     * this view does not hold is ignored, as `setSelectedPage` already was.
+     * has held that object all along — this getter is the door onto it.
+     *
+     * READS THE PAGE, WRITES THE ID: the setter below takes the id this port uses as its
+     * page handle, because that is what an XML attribute can carry. TypeScript allows the
+     * two halves to differ, so `view.selectedPage = view.selectedPage` is a type error
+     * rather than a silent one — which is the intended reading, not an oversight.
      */
     get selectedPage(): AdwTabPage | null {
         return this._state.selectedPage;

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-view-stack.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-view-stack.ts
@@ -28,7 +28,6 @@ import {
     type AdwViewStackPage,
     type ViewStackNotifyPayload,
 } from './view-stack-state.js';
-import { xmlNumber } from './xml-values.js';
 
 // Re-exported so the widget module stays the one import site for the page type,
 // as `widgets/index.ts` and every consumer already expect.
@@ -116,14 +115,34 @@ export class AdwViewStack extends GridLayout {
         return this._state.pages;
     }
 
-    /** The visible page index, `-1` when nothing is selected. Swaps the visible page + emits. */
+    /**
+     * The visible page's position, `-1` when nothing is selected.
+     *
+     * A REPORT, NOT A DOOR (ADR 0048). `Adw.ViewStack` selects by NAME, and an ordinal
+     * is derived: an insertion before the visible page increments it, a reorder rewrites
+     * it and a removal decrements it — the three cases `ViewStackState` carries code for.
+     * So it is safe to read at a moment and unsafe to hold, and selecting is
+     * {@link visibleChildName}.
+     */
     get visibleChildIndex(): number {
         return this._state.visibleIndex;
     }
 
-    set visibleChildIndex(raw: number | string) {
-        const value = xmlNumber(raw, this.visibleChildIndex);
-        this._state.setVisibleIndex(value);
+    /**
+     * Show the page at position `n`. Returns whether the selection moved.
+     *
+     * THE ORDINAL IS A CALL, NOT A PROPERTY (ADR 0048). It resolves against the page list
+     * as it is at THIS moment and keeps nothing, which is the whole difference from the
+     * setter it replaces: a held index silently comes to mean another page after an
+     * insert, a reorder or a removal. Port-owned — measured, `refs/libadwaita` gives
+     * `AdwViewStack` no ordinal API at all — and named for the `selectNthPage` the tab
+     * view already has, so the two widgets ask the same question the same way.
+     *
+     * A non-integer or out-of-range `n` selects nothing; the guard is the core's
+     * ({@link ViewStackState.setVisibleIndex}) and is pinned by the shared vectors.
+     */
+    selectNthPage(n: number): boolean {
+        return this._state.setVisibleIndex(n);
     }
 
     /** The visible page name (`Adw.ViewStack.visible-child-name`), `''` for none. */

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-view-switcher-bar.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-view-switcher-bar.ts
@@ -219,7 +219,9 @@ export class AdwViewSwitcherBar extends GridLayout {
 
         attachRowPressFeedback(button);
         button.addEventListener('tap', () => {
-            if (this._stack) this._stack.visibleChildIndex = pageIndex;
+            // A bar IS ordinal — button n shows page n — and the stack resolves that to a
+            // page at the moment of the tap (ADR 0048). Nothing here holds an index.
+            this._stack?.selectNthPage(pageIndex);
         });
 
         GridLayout.setColumn(button, column);

--- a/packages/web/adwaita-core/src/tab-view.spec.ts
+++ b/packages/web/adwaita-core/src/tab-view.spec.ts
@@ -403,16 +403,38 @@ export default async () => {
                 state.appendPage({ id: 'two' });
             }
             a.setSelectedPage('one');
+            expect(a.diagnostics).toStrictEqual([]);
 
             expect(a.setSelectedPage(b.pages[1]!)).toBe(false);
             expect(a.selectedId).toBe('one');
-            const last = a.diagnostics[a.diagnostics.length - 1];
-            expect(last?.includes('page_belongs_to_this_view')).toBe(true);
+            // EXACTLY one, and the text C raises. The page overload refuses and returns
+            // before it recurses, so the id arm never runs for a foreign page — a `toBe(2)`
+            // here is the double-push that a substring check on the LAST entry cannot see.
+            expect(a.diagnostics).toStrictEqual([
+                "adw_tab_view_set_selected_page: assertion 'page_belongs_to_this_view (self, selected_page)' failed",
+            ]);
 
             // ...and its OWN page of the same id is accepted, so the refusal is identity
-            // and not the id.
+            // and not the id — and the accepted path records nothing.
             expect(a.setSelectedPage(a.pages[1]!)).toBe(true);
             expect(a.selectedId).toBe('two');
+            expect(a.diagnostics).toHaveLength(1);
+        });
+
+        await it('carries `interactive` through the page overload', () => {
+            // The overload RECURSES with `page.id`. A recursion that dropped the flag would
+            // notify `interactive: true` for a model-driven selection and every listener
+            // that distinguishes a user's click from the model's own move would be wrong —
+            // and `setSelectedPage(page)` reads identically at the call site either way.
+            const state = new TabViewState();
+            state.appendPage({ id: 'one' });
+            state.appendPage({ id: 'two' });
+            const seen: boolean[] = [];
+            state.subscribe((change) => seen.push(change.interactive));
+
+            state.setSelectedPage(state.pages[1]!, false);
+            state.setSelectedPage(state.pages[0]!);
+            expect(seen).toStrictEqual([false, true]);
         });
     });
 };

--- a/packages/web/adwaita-core/src/tab-view.spec.ts
+++ b/packages/web/adwaita-core/src/tab-view.spec.ts
@@ -391,5 +391,28 @@ export default async () => {
             expect(state.setSelectedPage(null)).toBe(false);
             expect(state.diagnostics).toStrictEqual([]);
         });
+
+        await it('refuses a page belonging to ANOTHER view, which its id cannot say', () => {
+            // `_nextId` counts per view, so two views both hold `page-0` — reading only the
+            // id would select THIS view's page of that id. Measured before the core took
+            // the page: `a.setSelectedPage(b.pages[1])` moved `a` to index 1.
+            const a = new TabViewState();
+            const b = new TabViewState();
+            for (const state of [a, b]) {
+                state.appendPage({ id: 'one' });
+                state.appendPage({ id: 'two' });
+            }
+            a.setSelectedPage('one');
+
+            expect(a.setSelectedPage(b.pages[1]!)).toBe(false);
+            expect(a.selectedId).toBe('one');
+            const last = a.diagnostics[a.diagnostics.length - 1];
+            expect(last?.includes('page_belongs_to_this_view')).toBe(true);
+
+            // ...and its OWN page of the same id is accepted, so the refusal is identity
+            // and not the id.
+            expect(a.setSelectedPage(a.pages[1]!)).toBe(true);
+            expect(a.selectedId).toBe('two');
+        });
     });
 };

--- a/packages/web/adwaita-core/src/tab-view.ts
+++ b/packages/web/adwaita-core/src/tab-view.ts
@@ -563,15 +563,37 @@ export class TabViewState<T = unknown> {
     }
 
     /**
-     * Select a page by id. Returns whether the selection changed.
+     * Select a page — by the PAGE, or by its id. Returns whether the selection changed.
      *
      * An unknown id is refused, and `null` is accepted only while the view is empty —
      * `adw_tab_view_set_selected_page` asserts `ADW_IS_TAB_PAGE` +
      * `page_belongs_to_this_view` when `n_pages > 0`, and `selected_page == NULL`
      * otherwise. `interactive` defaults to `true` because this IS the explicit call;
      * the model-driven paths (first-page auto-select, close successor) pass `false`.
+     *
+     * THE PAGE OVERLOAD IS WHAT MAKES `page_belongs_to_this_view` TRUE HERE. An id is
+     * unique within ONE view (`_nextId` counts per view), so handing this view another
+     * view's page and reading only its id selects the page of the same id HERE — measured
+     * on the renderers' `selectedPage` setters, where `viewA.selectedPage = viewB.pages[2]`
+     * moved viewA to index 2 rather than refusing. The object is what separates them, so
+     * the identity check belongs at the one place that owns the page list, and the refusal
+     * carries the same diagnostic C raises rather than being a silent no-op in two
+     * renderers.
      */
-    setSelectedPage(id: string | null, interactive = true): boolean {
+    setSelectedPage(page: AdwTabPageState<T> | string | null, interactive = true): boolean {
+        if (page !== null && typeof page !== 'string') {
+            if (!this.pages.includes(page)) {
+                this._diagnostics.push(
+                    assertionDiagnostic(
+                        'adw_tab_view_set_selected_page',
+                        'page_belongs_to_this_view (self, selected_page)',
+                    ),
+                );
+                return false;
+            }
+            return this.setSelectedPage(page.id, interactive);
+        }
+        const id = page;
         if (id === null) {
             if (this.nPages > 0) {
                 this._diagnostics.push(

--- a/packages/web/adwaita-web/src/adw-tab-view.spec.ts
+++ b/packages/web/adwaita-web/src/adw-tab-view.spec.ts
@@ -28,7 +28,7 @@ export const AdwTabViewTest = async () => {
         await it('builds one tab per page and shows the first page', async () => {
             const view = makeTabView();
             expect(view.querySelectorAll('.adw-tab').length).toBe(3);
-            expect(view.selected).toBe(0);
+            expect(view.selectedIndex).toBe(0);
             const pages = view.querySelectorAll('.adw-tab-page');
             expect((pages[0] as HTMLElement).hidden).toBe(false);
             expect((pages[1] as HTMLElement).hidden).toBe(true);
@@ -42,15 +42,18 @@ export const AdwTabViewTest = async () => {
                 notified = (event as CustomEvent).detail.selected;
             });
             (view.querySelectorAll('.adw-tab')[2] as HTMLButtonElement).click();
-            expect(view.selected).toBe(2);
+            expect(view.selectedIndex).toBe(2);
             expect(notified).toBe(2);
             expect((view.querySelectorAll('.adw-tab-page')[2] as HTMLElement).hidden).toBe(false);
             view.parentElement?.remove();
         });
 
-        await it('setting the selected attribute switches pages', async () => {
+        await it('setting the selected-page attribute switches pages', async () => {
             const view = makeTabView();
-            view.setAttribute('selected', '1');
+            // ADR 0048: the markup door names the PAGE. `makeTabView` declares no
+            // `page-id`, so the ids are the generated ones the element reflects back.
+            const second = view.pages[1]!.id;
+            view.setAttribute('selected-page', second);
             expect((view.querySelectorAll('.adw-tab-page')[1] as HTMLElement).hidden).toBe(false);
             expect((view.querySelectorAll('.adw-tab-page')[0] as HTMLElement).hidden).toBe(true);
             view.parentElement?.remove();
@@ -70,7 +73,7 @@ export const AdwTabViewTest = async () => {
             expect(view.querySelectorAll('.adw-tab').length).toBe(2);
             // Closing a page BEFORE the selection must not also select the tab,
             // and must leave the selected PAGE selected.
-            expect(view.selected).toBe(0);
+            expect(view.selectedIndex).toBe(0);
             view.parentElement?.remove();
         });
     });

--- a/packages/web/adwaita-web/src/elements/adw-tab-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-tab-view.ts
@@ -143,14 +143,14 @@ export class AdwTabView extends HTMLElement {
     }
 
     set selectedPage(page: AdwTabViewPage | null) {
-        // `page_belongs_to_this_view`, which the ID cannot answer: an id is unique WITHIN a
-        // view, never across two — a declared `page-id` is the author's to repeat and
-        // `_nextId` counts per element, so two views both hold a `tab-1`. Measured before
-        // this line existed: `viewA.selectedPage = viewB.pages[2]` moved viewA to index 2.
-        // The OBJECT is what tells them apart, and it is the whole reason this property
-        // takes one rather than the id `setSelectedPage` takes.
-        if (page !== null && !this._state.pages.includes(page)) return;
-        this._state.setSelectedPage(page?.id ?? null);
+        // Straight to the core, which owns the page list and therefore owns
+        // `page_belongs_to_this_view` — the check an ID cannot answer: an id is unique
+        // WITHIN a view, never across two (a declared `page-id` is the author's to repeat
+        // and `_nextId` counts per element, so two views both hold a `tab-1`). Measured
+        // before the core took the page: `viewA.selectedPage = viewB.pages[2]` moved viewA
+        // to index 2 instead of refusing. The refusal carries C's own diagnostic now,
+        // where a renderer-side guard could only return in silence.
+        this._state.setSelectedPage(page);
     }
 
     /**
@@ -285,8 +285,9 @@ export class AdwTabView extends HTMLElement {
         return this._state.isClosing(id);
     }
 
-    setSelectedPage(id: string | null): boolean {
-        return this._state.setSelectedPage(id);
+    /** `adw_tab_view_set_selected_page`, which takes the PAGE; an id is accepted too. */
+    setSelectedPage(page: AdwTabViewPage | string | null): boolean {
+        return this._state.setSelectedPage(page);
     }
 
     selectNthPage(n: number): boolean {

--- a/packages/web/adwaita-web/src/elements/adw-tab-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-tab-view.ts
@@ -106,11 +106,11 @@ export class AdwTabView extends HTMLElement {
     private readonly _hovered = new Set<string>();
     private _initialized = false;
     private _generatedIds = 0;
-    /** Guards the `selected` attribute reflection against re-entering the model. */
+    /** Guards the `selected-page` attribute reflection against re-entering the model. */
     private _reflecting = false;
 
     static get observedAttributes() {
-        return ['selected', 'autohide', 'expand-tabs', 'no-close'];
+        return ['selected-page', 'autohide', 'expand-tabs', 'no-close'];
     }
 
     constructor() {
@@ -131,13 +131,19 @@ export class AdwTabView extends HTMLElement {
         this._state.subscribe((change) => this._onSelectionChange(change));
     }
 
-    /** Zero-based index of the visible page, `-1` when the view is empty. */
-    get selected(): number {
-        return this._state.selectedIndex;
+    /**
+     * The selected page (`Adw.TabView:selected-page`), `null` when the view is empty.
+     *
+     * THE PAGE, NOT ITS POSITION (ADR 0048). Its position is {@link selectedIndex}, which
+     * stays a read-only report; `Adw.TabView` selects by object, and the model has held
+     * that object all along.
+     */
+    get selectedPage(): AdwTabViewPage | null {
+        return this._state.selectedPage;
     }
 
-    set selected(value: number) {
-        this._state.selectNthPage(value);
+    set selectedPage(page: AdwTabViewPage | null) {
+        this._state.setSelectedPage(page?.id ?? null);
     }
 
     /**
@@ -177,8 +183,8 @@ export class AdwTabView extends HTMLElement {
         this._initialized = true;
 
         // Read the declared selection BEFORE adopting anything: the auto-select
-        // of the first page reflects its own index into this very attribute.
-        const declaredSelection = this.getAttribute('selected');
+        // of the first page reflects its own id into this very attribute.
+        const declaredSelection = this.getAttribute('selected-page');
 
         // Snapshot the declared pages, then take over the subtree. The elements
         // themselves become the panels, so they must survive replaceChildren.
@@ -195,12 +201,12 @@ export class AdwTabView extends HTMLElement {
 
     attributeChangedCallback(name: string, _old: string | null, _value: string | null) {
         if (!this._initialized) return;
-        if (name === 'selected') {
+        if (name === 'selected-page') {
             // The LIVE attribute, not the value captured when the reaction was
             // queued: reflection writes this attribute, and a custom-element
             // reaction can run after a later write has already superseded it.
             if (this._reflecting) return;
-            const current = this.getAttribute('selected');
+            const current = this.getAttribute('selected-page');
             if (current !== null) this._applySelectedAttribute(current);
             return;
         }
@@ -724,19 +730,25 @@ export class AdwTabView extends HTMLElement {
 
     private _reflectSelected(): void {
         this._reflecting = true;
-        const index = this._state.selectedIndex;
-        if (index < 0) this.removeAttribute('selected');
-        else if (this.getAttribute('selected') !== String(index)) this.setAttribute('selected', String(index));
+        const id = this._state.selectedId;
+        if (id === null) this.removeAttribute('selected-page');
+        else if (this.getAttribute('selected-page') !== id) this.setAttribute('selected-page', id);
         this._reflecting = false;
     }
 
+    /**
+     * `selected-page="<page id>"` — the markup half of {@link selectedPage} (ADR 0048).
+     *
+     * The id is the one `<adw-tab-page page-id>` declares; a page that declares none gets
+     * a generated one, which an author cannot predict and therefore cannot select by. That
+     * is the same bargain `<adw-view-stack visible-child-name>` already makes for a page
+     * with no name, and it is why `page-id` exists.
+     *
+     * An id no page holds is IGNORED rather than treated as the first page — libadwaita
+     * refuses a foreign `AdwTabPage` outright, and `setSelectedPage` is the refusal here.
+     */
     private _applySelectedAttribute(value: string): void {
-        const index = Number.parseInt(value, 10);
-        // An unparseable value is IGNORED rather than treated as 0, and an out-of-range
-        // one is refused rather than clamped: libadwaita refuses both, so
-        // `selected="oops"` must not select the first page nor `selected="99"` the last.
-        if (Number.isNaN(index)) return;
-        this._state.selectNthPage(index);
+        this._state.setSelectedPage(value);
     }
 
     /**

--- a/packages/web/adwaita-web/src/elements/adw-tab-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-tab-view.ts
@@ -143,6 +143,13 @@ export class AdwTabView extends HTMLElement {
     }
 
     set selectedPage(page: AdwTabViewPage | null) {
+        // `page_belongs_to_this_view`, which the ID cannot answer: an id is unique WITHIN a
+        // view, never across two — a declared `page-id` is the author's to repeat and
+        // `_nextId` counts per element, so two views both hold a `tab-1`. Measured before
+        // this line existed: `viewA.selectedPage = viewB.pages[2]` moved viewA to index 2.
+        // The OBJECT is what tells them apart, and it is the whole reason this property
+        // takes one rather than the id `setSelectedPage` takes.
+        if (page !== null && !this._state.pages.includes(page)) return;
         this._state.setSelectedPage(page?.id ?? null);
     }
 

--- a/packages/web/adwaita-web/src/elements/adw-view-stack.ts
+++ b/packages/web/adwaita-web/src/elements/adw-view-stack.ts
@@ -26,7 +26,8 @@
 // Properties (mirroring Adw.ViewStack):
 //   pages               — readonly page descriptors ({ name, title, icon, content, visible }).
 //   visibleChildName    — name of the visible page ('' when nothing is selected).
-//   visibleChildIndex   — zero-based index of the visible page, -1 for none (guarded).
+//   visibleChildIndex   — READ-ONLY report: position of the visible page, -1 for none.
+//                         Selecting is `visibleChildName` (ADR 0048).
 //   visibleChild        — the visible page's content element (or null).
 // Methods:
 //   add(content, name, title?, icon?) — append a page; returns its descriptor.
@@ -70,13 +71,28 @@ export class AdwViewStack extends HTMLElement {
         return this._state.pages;
     }
 
-    /** Zero-based index of the visible page, `-1` when nothing is selected. */
+    /**
+     * Zero-based position of the visible page, `-1` when nothing is selected.
+     *
+     * A REPORT, NOT A DOOR (ADR 0048). `Adw.ViewStack` selects by NAME, and an ordinal is
+     * derived — an insertion before the visible page increments it, a reorder rewrites it,
+     * a removal decrements it. Selecting is {@link visibleChildName}.
+     */
     get visibleChildIndex(): number {
         return this._state.visibleIndex;
     }
 
-    set visibleChildIndex(value: number) {
-        this._state.setVisibleIndex(value);
+    /**
+     * Show the page at position `n`. Returns whether the selection moved.
+     *
+     * THE ORDINAL IS A CALL, NOT A PROPERTY (ADR 0048): it resolves against the page list
+     * as it is now and keeps nothing, where a held index comes to mean another page after
+     * an insert, a reorder or a removal. Port-owned — `refs/libadwaita` gives
+     * `AdwViewStack` no ordinal API — and named for the tab view's existing
+     * `selectNthPage`. The guard on `n` is the core's and is pinned by the shared vectors.
+     */
+    selectNthPage(n: number): boolean {
+        return this._state.setVisibleIndex(n);
     }
 
     get visibleChildName(): string {

--- a/packages/web/adwaita-web/src/elements/adw-view-switcher-bar.ts
+++ b/packages/web/adwaita-web/src/elements/adw-view-switcher-bar.ts
@@ -99,8 +99,10 @@ export class AdwViewSwitcherBar extends HTMLElement {
                     const stack = this._stack;
                     if (!stack) return;
                     const index = Number(item.dataset.pageIndex);
-                    // Re-assigning the current index would re-run the stack's transition.
-                    if (stack.visibleChildIndex !== index) stack.visibleChildIndex = index;
+                    // The roving-focus list is ordinal and the stack resolves it (ADR 0048).
+                    // Re-selecting the current page would re-run the stack's transition, which
+                    // is why the position is compared before the call.
+                    if (stack.visibleChildIndex !== index) stack.selectNthPage(index);
                 },
             });
         }
@@ -238,7 +240,8 @@ export class AdwViewSwitcherBar extends HTMLElement {
 
         button.append(icon, label, indicator);
         button.addEventListener('click', () => {
-            if (this._stack) this._stack.visibleChildIndex = pageIndex;
+            // Ordinal here, resolved by the stack (ADR 0048) — as in `select` above.
+            this._stack?.selectNthPage(pageIndex);
         });
 
         return { button, icon, label, indicator };

--- a/packages/web/adwaita-web/src/tab-view.spec.ts
+++ b/packages/web/adwaita-web/src/tab-view.spec.ts
@@ -207,7 +207,7 @@ export const AdwTabViewConformanceTest = async () => {
         });
     });
 
-    await describe('adw-tab-view selected attribute', async () => {
+    await describe('adw-tab-view selected-page attribute', async () => {
         function mountThree(attrs = ''): { view: AdwTabView; host: HTMLElement } {
             const host = document.createElement('div');
             host.innerHTML = `<adw-tab-view ${attrs}>
@@ -219,26 +219,52 @@ export const AdwTabViewConformanceTest = async () => {
             return { view: host.querySelector('adw-tab-view') as AdwTabView, host };
         }
 
-        await it('selects the declared index instead of the auto-pick', () => {
-            const { view, host } = mountThree('selected="2"');
+        await it('selects the declared PAGE instead of the auto-pick', () => {
+            const { view, host } = mountThree('selected-page="c"');
             expect(view.selectedIndex).toBe(2);
+            expect(view.selectedId).toBe('c');
             expect(shownPanels(view)).toStrictEqual([false, false, true]);
             host.remove();
         });
 
-        await it('IGNORES an out-of-range or unparseable index instead of clamping it', () => {
-            // A clamping `Number.isNaN(raw) ? 0 : Math.min(Math.max(raw, 0), max)` selects
-            // the last page for `99` and the first for `-1`/`oops`; libadwaita refuses all
-            // three.
+        await it('IGNORES an id no page holds instead of falling back to the first', () => {
+            // The ordinal spellings are just unknown ids now (ADR 0048), and a fallback to
+            // page 0 would be the same wrong answer clamping used to give: libadwaita
+            // refuses a foreign `AdwTabPage` outright.
             const { view, host } = mountThree();
             for (const value of ['99', '-1', 'oops']) {
-                view.setAttribute('selected', value);
+                view.setAttribute('selected-page', value);
                 expect(view.selectedIndex).toBe(0);
             }
             //...and the attribute is put back in sync rather than left lying.
-            view.setAttribute('selected', '1');
+            view.setAttribute('selected-page', 'b');
             expect(view.selectedIndex).toBe(1);
             expect(view.getAttribute('selected-page')).toBe(view.pages[1]!.id);
+            host.remove();
+        });
+
+        await it('RECORDS the refusal, where the ordinal door recorded nothing', () => {
+            // The behaviour change ADR 0048 does not name: `selected="99"` went through
+            // `selectNthPage`, which refuses an out-of-range index SILENTLY, while an
+            // unknown id goes through `setSelectedPage`, which is where C's
+            // `page_belongs_to_this_view` assertion lives. Three refusals, three records —
+            // if this list stays empty the element is swallowing the typo the reader made.
+            const { view, host } = mountThree();
+            expect(view.diagnostics).toStrictEqual([]);
+            for (const value of ['99', 'oops']) view.setAttribute('selected-page', value);
+            expect(view.diagnostics).toStrictEqual([
+                "adw_tab_view_set_selected_page: assertion 'page_belongs_to_this_view (self, selected_page)' failed",
+                "adw_tab_view_set_selected_page: assertion 'page_belongs_to_this_view (self, selected_page)' failed",
+            ]);
+
+            // ...and `null` while pages exist is the OTHER half of the same C assertion,
+            // which `view.selected = -1` also used to reach in silence.
+            view.selectedPage = null;
+            expect(view.selectedIndex).toBe(0);
+            expect(view.diagnostics).toHaveLength(3);
+            expect(view.diagnostics[2]).toBe(
+                "adw_tab_view_set_selected_page: assertion 'ADW_IS_TAB_PAGE (selected_page)' failed",
+            );
             host.remove();
         });
 
@@ -263,7 +289,7 @@ export const AdwTabViewConformanceTest = async () => {
 
             for (const id of ['a', 'b', 'c']) view.closePage(id);
             expect(view.nPages).toBe(0);
-            expect(view.hasAttribute('selected')).toBe(false);
+            expect(view.hasAttribute('selected-page')).toBe(false);
             expect(view.selectedIndex).toBe(-1);
             host.remove();
         });

--- a/packages/web/adwaita-web/src/tab-view.spec.ts
+++ b/packages/web/adwaita-web/src/tab-view.spec.ts
@@ -243,6 +243,21 @@ export const AdwTabViewConformanceTest = async () => {
             host.remove();
         });
 
+        await it('REFUSES a page belonging to ANOTHER view', () => {
+            // `page_belongs_to_this_view`. The property holds the PAGE but the setter passes
+            // its ID, and an id is only unique WITHIN a view — declared ones are the author's
+            // and `_nextId` counts per element, so two views both hold a `tab-1`. Passing
+            // another view's page must not select this view's page of the same name.
+            const first = mountThree();
+            const second = mountThree();
+            second.view.selectedPage = second.view.pages[2]!;
+            first.view.selectedPage = second.view.pages[2]!;
+            expect(first.view.selectedIndex).toBe(0);
+            expect(second.view.selectedIndex).toBe(2);
+            first.host.remove();
+            second.host.remove();
+        });
+
         await it('RECORDS the refusal, where the ordinal door recorded nothing', () => {
             // The behaviour change ADR 0048 does not name: `selected="99"` went through
             // `selectNthPage`, which refuses an out-of-range index SILENTLY, while an

--- a/packages/web/adwaita-web/src/tab-view.spec.ts
+++ b/packages/web/adwaita-web/src/tab-view.spec.ts
@@ -243,17 +243,30 @@ export const AdwTabViewConformanceTest = async () => {
             host.remove();
         });
 
-        await it('REFUSES a page belonging to ANOTHER view', () => {
-            // `page_belongs_to_this_view`. The property holds the PAGE but the setter passes
-            // its ID, and an id is only unique WITHIN a view — declared ones are the author's
-            // and `_nextId` counts per element, so two views both hold a `tab-1`. Passing
-            // another view's page must not select this view's page of the same name.
+        await it('REFUSES a page belonging to ANOTHER view, and RECORDS it', () => {
+            // `page_belongs_to_this_view`. An id is only unique WITHIN a view — declared ones
+            // are the author's to repeat and `_nextId` counts per element, so two views both
+            // hold a `tab-1`. Both views here hold 'a'/'b'/'c', which is the collision.
             const first = mountThree();
             const second = mountThree();
             second.view.selectedPage = second.view.pages[2]!;
+            expect(second.view.selectedIndex).toBe(2);
+
             first.view.selectedPage = second.view.pages[2]!;
             expect(first.view.selectedIndex).toBe(0);
             expect(second.view.selectedIndex).toBe(2);
+            // The refusal carries C's own assertion. It did NOT while the check was a
+            // renderer-side guard returning in silence, which is why the check moved into
+            // `TabViewState` — the one place that owns the page list.
+            expect(first.view.diagnostics).toStrictEqual([
+                "adw_tab_view_set_selected_page: assertion 'page_belongs_to_this_view (self, selected_page)' failed",
+            ]);
+            expect(second.view.diagnostics).toStrictEqual([]);
+
+            // ...and this view's OWN page of that same id is accepted, so what was refused
+            // is the IDENTITY and not the id.
+            first.view.selectedPage = first.view.pages[2]!;
+            expect(first.view.selectedIndex).toBe(2);
             first.host.remove();
             second.host.remove();
         });

--- a/packages/web/adwaita-web/src/tab-view.spec.ts
+++ b/packages/web/adwaita-web/src/tab-view.spec.ts
@@ -238,19 +238,19 @@ export const AdwTabViewConformanceTest = async () => {
             //...and the attribute is put back in sync rather than left lying.
             view.setAttribute('selected', '1');
             expect(view.selectedIndex).toBe(1);
-            expect(view.getAttribute('selected')).toBe('1');
+            expect(view.getAttribute('selected-page')).toBe(view.pages[1]!.id);
             host.remove();
         });
 
         await it('notifies on a PROGRAMMATIC selection, not only on a click', () => {
-            // C notifies on EVERY path: a programmatic `view.selected = 2` must notify as
-            // a tab click does.
+            // C notifies on EVERY path: a programmatic `view.selectedPage = …` must notify
+            // as a tab click does.
             const { view, host } = mountThree();
             const seen: number[] = [];
             view.addEventListener('notify::selected-page', (event) =>
                 seen.push((event as CustomEvent).detail.selected),
             );
-            view.selected = 2;
+            view.selectedPage = view.pages[2]!;
             expect(seen).toStrictEqual([2]);
             host.remove();
         });
@@ -259,7 +259,7 @@ export const AdwTabViewConformanceTest = async () => {
             const { view, host } = mountThree();
             const chips = tabChips(view);
             chips[1]!.click();
-            expect(view.getAttribute('selected')).toBe('1');
+            expect(view.getAttribute('selected-page')).toBe(view.pages[1]!.id);
 
             for (const id of ['a', 'b', 'c']) view.closePage(id);
             expect(view.nPages).toBe(0);

--- a/packages/web/adwaita-web/src/view-stack.spec.ts
+++ b/packages/web/adwaita-web/src/view-stack.spec.ts
@@ -66,7 +66,9 @@ function mountStack(pages: readonly ViewStackVectorPage[], visibleChildName?: st
 function applyOp(stack: AdwViewStack, op: ViewStackVectorOp): void {
     switch (op.kind) {
         case 'selectIndex':
-            stack.visibleChildIndex = op.index;
+            // ADR 0048: the element has no ordinal SETTER any more; the ordinal is this
+            // call, and it forwards to the same core guard the vector pins.
+            stack.selectNthPage(op.index);
             break;
         case 'selectName':
             stack.visibleChildName = op.name;
@@ -224,7 +226,7 @@ export const AdwViewStackTest = async () => {
         await it('reflects the selection back, including an empty name', () => {
             const { stack, host } = mountStack([{ name: 'a' }, { name: '' }]);
             expect(stack.getAttribute('visible-child-name')).toBe('a');
-            stack.visibleChildIndex = 1;
+            stack.selectNthPage(1);
             // Reflection guarded by `if (current && …)` never fires for nameless pages.
             expect(stack.getAttribute('visible-child-name')).toBe('');
             host.remove();
@@ -252,7 +254,7 @@ export const AdwViewStackTest = async () => {
             // with duplicate names a naive re-lookup resolves to the FIRST match and
             // undoes the selection.
             const { stack, host } = mountStack([{ name: 'dup' }, { name: 'dup' }]);
-            stack.visibleChildIndex = 1;
+            stack.selectNthPage(1);
             expect(stack.visibleChildIndex).toBe(1);
             expect(stack.getAttribute('visible-child-name')).toBe('dup');
             host.remove();

--- a/scripts/check-nativescript-xml-doors.mjs
+++ b/scripts/check-nativescript-xml-doors.mjs
@@ -31,7 +31,10 @@
 //      Three of the four did not even move the counter. So the reader parses every
 //      declaration, an unreadable one is a FAILURE rather than a skip, and a type an
 //      attribute genuinely cannot carry is COUNTED — the totals have to add up to the
-//      setters that exist, or "all of them coerce" is a claim about the parser.
+//      setters that exist, or "all of them coerce" is a claim about the parser. STRING
+//      doors are counted for the same reason and were the last bucket that was not:
+//      they need no coercion, so the loop skipped them, so a reader that stopped
+//      resolving `string` at all printed the same summary as one that resolved every one.
 //   2. No accessor in the package is a GETTER named after one of NativeScript's
 //      setter-only accessors. `GridLayoutBase.rows` and `.columns` have setters and no
 //      getters, so a same-named getter on a subclass shadows the setter and assignment
@@ -104,6 +107,7 @@ for (const tag of elements) {
 
 let checked = 0;
 let uncarryable = 0;
+let strings = 0;
 for (const tag of [...reachable].sort()) {
     const { file, text } = sources.get(tag);
     // Only the setters this class DECLARES; an inherited one is checked on its owner.
@@ -124,7 +128,17 @@ for (const tag of [...reachable].sort()) {
         }
         const annotation = setter.annotation;
         const kind = attributeKind(types, annotation);
-        if (kind === 'string') continue;
+        // A string door needs no coercion — NativeScript hands the setter the raw string
+        // and a string is what it wanted. COUNTED anyway, for the reason arm 1's header
+        // gives about every other bucket: this was the one skip that moved no counter, so
+        // "classified `string`" and "the reader never saw it" printed identically. Measured
+        // on ADR 0048: `AdwTabView.selectedPage` went from an object type (uncarryable, 20)
+        // to `string | null`, which is the whole claim that NativeScript XML got its tab
+        // selection back — and the summary could not say it had.
+        if (kind === 'string') {
+            strings += 1;
+            continue;
+        }
         // `null` is "an XML attribute cannot carry this" — an array of options, another
         // View. COUNTED rather than passed over, so the arm's totals add up to the
         // setters it read: a skip nobody counts is how a resolver that stopped
@@ -159,8 +173,10 @@ for (const tag of [...reachable].sort()) {
     }
 }
 notes.push(`${checked} non-string setter(s) on ${reachable.size} XML-reachable class(es), all coercing`);
+notes.push(`${strings} setter(s) an attribute carries as-is, needing no coercion`);
 notes.push(`${uncarryable} setter(s) typed as something no XML attribute can carry, held by no rule and counted`);
 if (checked === 0) failures.push('no non-string setter was found at all — arm 1 proved nothing');
+if (strings === 0) failures.push('no string setter was found at all — the reader stopped resolving `string`');
 
 // ---------------------------------------------------------------------------
 // 2. no getter shadows a NativeScript setter-only accessor

--- a/scripts/check-vocabulary-alignment.mjs
+++ b/scripts/check-vocabulary-alignment.mjs
@@ -482,14 +482,6 @@ const NS_PROPERTY_ALIGNMENT = {
     'adw-split-button.actions': {
         own: 'The same map as `GtkMenuButton.actions` above, on the widget whose dropdown half IS a `GtkMenuButton` — `adw_split_button_set_menu_model` passes straight through to one (adw-split-button.c:376-378). `Adw.SplitButton` declares no action-group property either, for the same reason: on GTK the group is INHERITED through the hierarchy, never assigned per widget (ADR 0042 § 2). Declared and left.',
     },
-    'adw-tab-view.selected': {
-        gir: 'selectedPage',
-        why: "`Adw.TabView:selected-page` is the same slot, holding an `Adw.TabPage` where the port holds its index (adw-tab-view.ts:173-177). NativeScript has no tab-page object to hand back, so the index is the port's shape of the same selection.",
-    },
-    'adw-view-stack.visibleChildIndex': {
-        gir: 'visibleChildName',
-        why: 'GTK selects the page by widget (`visible-child`) or by name (`visible-child-name`); the port selects it by index (adw-view-stack.ts:119-123). The convergent spelling is the NAME one, because a name is a string and a string is what survives an XML attribute — the same argument ADR 0034 § 4 makes for enum nicks.',
-    },
 
     // ── The counterpart's writable surface has no key for it. Declared and left. ──────
     'adw-about-dialog.open': {

--- a/scripts/check-website-attr-samples.mjs
+++ b/scripts/check-website-attr-samples.mjs
@@ -45,6 +45,16 @@
 //      Platform-global names (`slot`, `class`, `aria-*`, …) are excepted, and an element
 //      that observes NOTHING is skipped: its attributes are its parent's to read, which is
 //      what `<adw-view-switcher-page>` is.
+//   4. the same rule on the website's own SCRIPTS, which arm 3 cannot see: it reads
+//      markup, and `el.setAttribute('x', …)` is a call. ADR 0048 renamed
+//      `<adw-tab-view selected="n">` to `selected-page="<page id>"` and recorded that
+//      nothing in `website/` wrote it — measured wrong twice over, because both writers
+//      spelled it as a call: `CommandTabs.astro` (the npm/yarn/gjsify tabs, restored from
+//      localStorage and mirrored across the page) and `AdwWidget.astro` (every gallery
+//      block's implementation tabs). Both became silent no-ops, and neither a type nor
+//      arm 3 nor `astro build` could say so. So a binding taken from a custom-element
+//      selector is followed to its `set/get/has/removeAttribute` calls, and the name each
+//      one passes is held against the same `observedAttributes` list arm 3 uses.
 //
 // Plain Node over the repo's own files: no install, no build, no astro render.
 //
@@ -78,14 +88,40 @@ const fail = (what, expected, actual) => failures.push(`${what}\n      expected 
  * whose attributes belong to whichever parent reads them (`<adw-view-switcher-page>`).
  */
 const PLATFORM_GLOBAL = new Set(['slot', 'class', 'id', 'style', 'hidden', 'role', 'tabindex', 'part', 'lang', 'dir']);
+/** Whether a name belongs to the WIDGET's vocabulary at all. Shared by arms 3 and 4. */
+const isVocabulary = (name) => !PLATFORM_GLOBAL.has(name) && !name.startsWith('data-') && !name.startsWith('aria-');
 const unobservedIn = (markup, tag, observed) =>
-    [...sampleAttributes(markup, tag).keys()].filter(
-        (name) =>
-            !observed.includes(name) &&
-            !PLATFORM_GLOBAL.has(name) &&
-            !name.startsWith('data-') &&
-            !name.startsWith('aria-'),
-    );
+    [...sampleAttributes(markup, tag).keys()].filter((name) => !observed.includes(name) && isVocabulary(name));
+
+/**
+ * `<name>.setAttribute('x', …)` where `<name>` was bound from a custom-element selector,
+ * paired with the tag that selector named — the arm-4 finding.
+ *
+ * Deliberately shallow: one file, one binding statement, direct calls on that binding.
+ * A binding that travels through a helper or a field is out of reach and stays so, which
+ * is why arm 4 reports how many receivers it RESOLVED — a rule that silently resolves
+ * none is the shape this file exists to refuse.
+ */
+const ELEMENT_BINDING =
+    /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::[^=;]+)?(?:=|\sof\s)[^;]*?\b(?:querySelector(?:All)?|createElement)\s*(?:<[^;()]*>)?\s*\(\s*['"`]\s*([a-z][\w-]*)/g;
+
+function scriptedAttributeWrites(text) {
+    const bindings = new Map();
+    for (const [, name, tag] of text.matchAll(ELEMENT_BINDING)) {
+        // A custom element, i.e. a tag with a hyphen — `div`, `button` and the rest carry
+        // no widget vocabulary and are not this rule's business.
+        if (tag.includes('-')) bindings.set(name, tag);
+    }
+    const writes = [];
+    for (const [name, tag] of bindings) {
+        const call = new RegExp(
+            `(?<![\\w$.])${name.replaceAll('$', '\\$')}\\s*[?!]?\\.\\s*(?:set|get|has|remove)Attribute\\s*\\(\\s*(['"\`])([^'"\`]+)\\1`,
+            'g',
+        );
+        for (const [, , attr] of text.matchAll(call)) writes.push({ name, tag, attr });
+    }
+    return { receivers: bindings, writes };
+}
 
 // ---------------------------------------------------------------- 1. fixtures
 
@@ -195,6 +231,48 @@ for (const [what, markup, tag, observed, expected] of UNOBSERVED_FIXTURES) {
     }
 }
 
+// The arm-4 reader on the shapes a regex over source can get wrong. It has to SEE the
+// incident's own line, and it has to stay silent on a receiver that is not a widget.
+/** @type {[string, string, string[]][]} name, source, expected `<tag> <attr>` pairs */
+const SCRIPTED_FIXTURES = [
+    [
+        "the incident's own line — a renamed attribute written as a call",
+        "const view = el.querySelector<Adw.TabView>('adw-tab-view[data-cmd-view]');\n" +
+            "if (index >= 0) view.setAttribute('selected', String(index));",
+        ['adw-tab-view selected'],
+    ],
+    [
+        'a `for … of` binding, an optional call, and a getter',
+        "for (const row of host.querySelectorAll('adw-combo-row')) {\n" +
+            "  row?.setAttribute('items', '[]');\n" +
+            "  row.getAttribute('model');\n}",
+        ['adw-combo-row items', 'adw-combo-row model'],
+    ],
+    [
+        'a receiver that names no custom element carries no widget vocabulary',
+        "const frame = btn.querySelector('.frame');\nframe.setAttribute('data-copied', '1');\n" +
+            "const div = document.createElement('div');\ndiv.setAttribute('selected', '2');",
+        [],
+    ],
+    [
+        'a binding whose name is a PREFIX of another binding',
+        "const view = el.querySelector('adw-tab-view');\nconst viewBar = el.querySelector('adw-view-switcher-bar');\n" +
+            "viewBar.setAttribute('reveal', '');",
+        ['adw-view-switcher-bar reveal'],
+    ],
+    [
+        'a member access that merely ENDS in the binding name',
+        "const view = el.querySelector('adw-tab-view');\nthis.view.setAttribute('selected', '1');",
+        [],
+    ],
+];
+for (const [what, source, expected] of SCRIPTED_FIXTURES) {
+    const got = scriptedAttributeWrites(source).writes.map((w) => `${w.tag} ${w.attr}`);
+    if (got.join(',') !== expected.join(',')) {
+        fail(`fixture — scripted: ${what}`, JSON.stringify(expected), JSON.stringify(got));
+    }
+}
+
 // ------------------------------------------------- 2. every shipped preview fence
 
 const { byTag } = observedAttributes(ROOT);
@@ -251,6 +329,47 @@ for (const { page, file } of DOCS_SECTIONS.flatMap((section) =>
     }
 }
 
+// ------------------------------------------- 4. the website's own scripted writes
+
+/** Every source file the site SHIPS behaviour from, `website/src` down. */
+function* sourceFiles(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) yield* sourceFiles(full);
+        else if (/\.(astro|mdx|ts|mts|mjs)$/.test(entry.name)) yield full;
+    }
+}
+
+let receiversSeen = 0;
+let scriptedSeen = 0;
+for (const file of sourceFiles(join(ROOT, 'website/src'))) {
+    const { receivers, writes } = scriptedAttributeWrites(readFileSync(file, 'utf8'));
+    const rel = file.slice(ROOT.length + 1);
+    for (const tag of receivers.values()) if ((byTag.get(tag)?.length ?? 0) > 0) receiversSeen++;
+    for (const { name, tag, attr } of writes) {
+        const names = byTag.get(tag);
+        // An element that observes NOTHING is its parent's to read — the arm-3 exception.
+        if (names === undefined || names.length === 0 || !isVocabulary(attr)) continue;
+        scriptedSeen++;
+        if (names.includes(attr)) continue;
+        fail(
+            `${rel} — \`${name}\` is an <${tag}> and writes \`${attr}\``,
+            `an attribute <${tag}> observes (${names.join(', ')})`,
+            'a name it never reads, so the call compiles, runs, and does nothing at all',
+        );
+    }
+}
+
+if (receiversSeen === 0) {
+    // The same refusal the fence floor below makes: a reader that resolves no receiver
+    // satisfies the loop above by never entering it, and reports a clean site.
+    failures.push(
+        'resolved 0 custom-element bindings in website/src — the arm-4 reader found no ' +
+            'receiver to follow, so it checked nothing',
+    );
+}
+
 if (blocks === 0 || cellsSeen === 0) {
     // A scanner that finds nothing passes every assertion above it. That is the failure
     // this repo keeps paying for, so it is an error rather than a quiet exit 0.
@@ -263,6 +382,8 @@ if (failures.length > 0) {
     process.exit(1);
 }
 console.log(
-    `check-website-attr-samples: ${FIXTURES.length + UNOBSERVED_FIXTURES.length} fixtures and ${cellsSeen} cells ` +
-        `across ${blocks} gallery blocks, ${unobservedSeen} unobserved attribute(s) written — ok`,
+    `check-website-attr-samples: ${FIXTURES.length + UNOBSERVED_FIXTURES.length + SCRIPTED_FIXTURES.length} ` +
+        `fixtures and ${cellsSeen} cells across ${blocks} gallery blocks, ${unobservedSeen} unobserved ` +
+        `attribute(s) written; ${scriptedSeen} scripted attribute name(s) on ${receiversSeen} resolved ` +
+        'element binding(s) — ok',
 );

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -4913,40 +4913,24 @@ returns (measured: `g_application_run: assertion '!application->priv->must_quit_
 the case timed out at 5 s). So these need the LOOP, which is what the e2e host now provides —
 the work is writing the vectors, not finding somewhere to run them.
 
-### `AdwTabView` offers the page as a property and its id as a method, and libadwaita does neither
+### `AdwTabView`'s id-taking methods, where libadwaita takes the page
 
 [ADR 0048](../docs/adr/0048-page-selection-by-identity.md) made `selectedPage` the door on
-both renderers, holding the page — `Adw.TabView:selected-page`'s own shape. What it did not
-touch is the method beside it: `setSelectedPage(id: string | null)` takes an ID, where
-`adw_tab_view_set_selected_page()` takes the PAGE (`refs/libadwaita/src/adw-tab-view.h:150#adw_tab_view_set_selected_page`).
+both renderers and widened `TabViewState.setSelectedPage` to take the PAGE as well as an id
+— that one had to move, because `page_belongs_to_this_view` cannot be answered from an id:
+ids are unique within ONE view (`_nextId` counts per view), so `a.setSelectedPage(b.pages[1])`
+read as an id selected `a`'s own page of that id. The core refuses it now, with the
+diagnostic C raises.
 
-So one widget now answers the same question in two shapes, one line apart. Deliberately left
-for now, with the reason: a method is not what a portable authored tree writes and the
-vocabulary ledger does not read one, so this costs a second breaking change with no
-measurement behind it.
+What is left is the rest of the family: `isClosing(id)`, `closePage(id)`,
+`closePageFinish(id, …)` and `setPagePinned(id, …)` all take an ID where libadwaita takes an
+`AdwTabPage *` (`refs/libadwaita/src/adw-tab-view.h:150#adw_tab_view_set_selected_page` is
+the shape for all of them). Each carries the same latent confusion the selection one did,
+and none has produced a measured defect yet — which is exactly why they are here rather than
+in that ADR. Settle them together or not at all: an id-taking `closePage` beside a
+page-taking `setSelectedPage` is already the asymmetry, and fixing half of it twice is worse
+than either consistent answer.
 
-**There is a measurement now, and it is the seam itself.** The property holds the page and
-the setter passes its ID, and an id is unique WITHIN a view, never across two: a declared
-`page-id` is the author's to repeat and `_nextId` counts per element, so two views both hold
-a `tab-1`. Measured on the first draft of ADR 0048, in firefox:
-`viewA.selectedPage = viewB.pages[2]` moved viewA to index 2 instead of refusing, where
-`adw_tab_view_set_selected_page` asserts `page_belongs_to_this_view`. Both renderers now
-refuse by object identity in the setter — the defect is gone — but the refusal is SILENT
-where C `g_critical`s, because the assertion lives in `TabViewState.setSelectedPage` and an
-id that collides never reaches it.
-
-The core is where this belongs: `setSelectedPage` accepting the PAGE beside the id would put
-the identity check and its diagnostic in the one place both renderers share, and would not
-break a caller (every existing one passes a string). Two copies of a one-line guard is what
-the split costs meanwhile, and on NativeScript the guard is untested — no spec in that
-package imports a widget module, because `extends GridLayout` evaluates the bare
-`@nativescript/core` specifier at module-eval (`tab-view.spec.ts` header). The web twin
-carries the vector for both.
-
-The same question is open one call further: `isClosing(id)`, `closePage(id)`,
-`setPagePinned(id, …)` are the same shape, and libadwaita takes an `AdwTabPage *` in every
-one. Settle them together or not at all — an id-taking `closePage` beside a page-taking
-`setSelectedPage` would be worse than either consistent answer.
 
 ### A tab page with no `page-id` cannot be named from markup, and the reflection then leaks a generated id
 

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -4912,3 +4912,35 @@ reached from a spec: a nested `g_application_run` inside the runner's own main l
 returns (measured: `g_application_run: assertion '!application->priv->must_quit_now' failed`,
 the case timed out at 5 s). So these need the LOOP, which is what the e2e host now provides —
 the work is writing the vectors, not finding somewhere to run them.
+
+### `AdwTabView` offers the page as a property and its id as a method, and libadwaita does neither
+
+[ADR 0048](../docs/adr/0048-page-selection-by-identity.md) made `selectedPage` the door on
+both renderers, holding the page — `Adw.TabView:selected-page`'s own shape. What it did not
+touch is the method beside it: `setSelectedPage(id: string | null)` takes an ID, where
+`adw_tab_view_set_selected_page()` takes the PAGE (`refs/libadwaita/src/adw-tab-view.h:150#adw_tab_view_set_selected_page`).
+
+So one widget now answers the same question in two shapes, one line apart. Deliberately left
+for now, with the reason: a method is not what a portable authored tree writes and the
+vocabulary ledger does not read one, so this costs a second breaking change with no
+measurement behind it. The measurement that would settle it is who CALLS it — the port's own
+internals pass an id they have (`_state.selectedId`), and a consumer holding a page would
+prefer the property that now exists.
+
+The same question is open one call further: `isClosing(id)`, `closePage(id)`,
+`setPagePinned(id, …)` are the same shape, and libadwaita takes an `AdwTabPage *` in every
+one. Settle them together or not at all — an id-taking `closePage` beside a page-taking
+`setSelectedPage` would be worse than either consistent answer.
+
+### A tab page with no `page-id` cannot be named from markup, and the reflection then leaks a generated id
+
+`<adw-tab-view selected-page="…">` (ADR 0048 § 3) names the page by the id
+`<adw-tab-page page-id>` declares. A page that declares none gets `_nextId()`'s value, which
+an author cannot predict — so for those pages the markup door is write-never, and the
+reflection writes that generated id back into the DOM where it reads like an API.
+
+`<adw-view-stack visible-child-name>` has the same shape for a page with no name and it has
+never been a problem in practice, which is the only reason this is an entry rather than a
+blocker. The candidate fixes both have costs worth measuring before picking: making
+`page-id` required is a breaking change to every declared page, and deriving the id from the
+title makes it move when the title does.

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -4923,9 +4923,25 @@ touch is the method beside it: `setSelectedPage(id: string | null)` takes an ID,
 So one widget now answers the same question in two shapes, one line apart. Deliberately left
 for now, with the reason: a method is not what a portable authored tree writes and the
 vocabulary ledger does not read one, so this costs a second breaking change with no
-measurement behind it. The measurement that would settle it is who CALLS it — the port's own
-internals pass an id they have (`_state.selectedId`), and a consumer holding a page would
-prefer the property that now exists.
+measurement behind it.
+
+**There is a measurement now, and it is the seam itself.** The property holds the page and
+the setter passes its ID, and an id is unique WITHIN a view, never across two: a declared
+`page-id` is the author's to repeat and `_nextId` counts per element, so two views both hold
+a `tab-1`. Measured on the first draft of ADR 0048, in firefox:
+`viewA.selectedPage = viewB.pages[2]` moved viewA to index 2 instead of refusing, where
+`adw_tab_view_set_selected_page` asserts `page_belongs_to_this_view`. Both renderers now
+refuse by object identity in the setter — the defect is gone — but the refusal is SILENT
+where C `g_critical`s, because the assertion lives in `TabViewState.setSelectedPage` and an
+id that collides never reaches it.
+
+The core is where this belongs: `setSelectedPage` accepting the PAGE beside the id would put
+the identity check and its diagnostic in the one place both renderers share, and would not
+break a caller (every existing one passes a string). Two copies of a one-line guard is what
+the split costs meanwhile, and on NativeScript the guard is untested — no spec in that
+package imports a widget module, because `extends GridLayout` evaluates the bare
+`@nativescript/core` specifier at module-eval (`tab-view.spec.ts` header). The web twin
+carries the vector for both.
 
 The same question is open one call further: `isClosing(id)`, `closePage(id)`,
 `setPagePinned(id, …)` are the same shape, and libadwaita takes an `AdwTabPage *` in every

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -4944,3 +4944,21 @@ never been a problem in practice, which is the only reason this is an entry rath
 blocker. The candidate fixes both have costs worth measuring before picking: making
 `page-id` required is a breaking change to every declared page, and deriving the id from the
 title makes it move when the title does.
+
+### NativeScript XML can no longer say which tab starts selected
+
+[ADR 0048](../docs/adr/0048-page-selection-by-identity.md) § 3 gave the web a markup door
+(`<adw-tab-view selected-page="<page id>">`) and gave NativeScript none, on the reading that
+its XML door IS the property. A property holding an `AdwTabPage` is not an XML door:
+measured with `check-nativescript-xml-doors`, `selectedPage` lands in "typed as something no
+XML attribute can carry" (19 → 20 setters) while the two numeric doors left the coercing set
+(66 → 64), and `AdwTabView` is now the one XML-reachable class with a selection and no
+string-typed setter for it. `<AdwTabView selected="1">` worked through `xmlNumber` and is
+silently dead; nothing replaced it, and an XML attribute is not typechecked, so nothing says
+so.
+
+`AdwViewStack` is unaffected — `visibleChildName` is a string and stays the door there.
+
+The candidate is a `selectedPageId` string setter mirroring the web's attribute, which is
+the same question as the id-taking `setSelectedPage` above: settle the id-vs-page shape once
+across `setSelectedPage`, `isClosing`, `closePage`, `setPagePinned` and this, or not at all.

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -4945,20 +4945,29 @@ blocker. The candidate fixes both have costs worth measuring before picking: mak
 `page-id` required is a breaking change to every declared page, and deriving the id from the
 title makes it move when the title does.
 
-### NativeScript XML can no longer say which tab starts selected
 
-[ADR 0048](../docs/adr/0048-page-selection-by-identity.md) § 3 gave the web a markup door
-(`<adw-tab-view selected-page="<page id>">`) and gave NativeScript none, on the reading that
-its XML door IS the property. A property holding an `AdwTabPage` is not an XML door:
-measured with `check-nativescript-xml-doors`, `selectedPage` lands in "typed as something no
-XML attribute can carry" (19 → 20 setters) while the two numeric doors left the coercing set
-(66 → 64), and `AdwTabView` is now the one XML-reachable class with a selection and no
-string-typed setter for it. `<AdwTabView selected="1">` worked through `xmlNumber` and is
-silently dead; nothing replaced it, and an XML attribute is not typechecked, so nothing says
-so.
+### The XML-door gate has no kind for "an object, or the key that names it"
 
-`AdwViewStack` is unaffected — `visibleChildName` is a string and stays the door there.
+`check-nativescript-xml-doors` classifies a setter's declared type into `number`, `boolean`,
+`string` and `json` — the last added by [ADR 0047](../docs/adr/0047-portable-adjustment.md)
+for `AdwSpinRow.adjustment`, where the string spelling is JSON text a parser reads.
 
-The candidate is a `selectedPageId` string setter mirroring the web's attribute, which is
-the same question as the id-taking `setSelectedPage` above: settle the id-vs-page shape once
-across `setSelectedPage`, `isClosing`, `closePage`, `setPagePinned` and this, or not at all.
+[ADR 0048](../docs/adr/0048-page-selection-by-identity.md) met the shape that is neither.
+`AdwTabView.selectedPage` wants to take `AdwTabPage | string | null` — the page, or the id
+that names it — and `attributeKind` files any `<object> | string` union as `json`, so the
+gate then demands the setter run a JSON parser it has no business running. Measured while
+writing that change: the annotation alone turns the door red with *"does not go through
+parseAdjustment()"*.
+
+The NativeScript setter takes the ID for now, which is honest there — every other page call
+on that port takes one, and an XML attribute can carry nothing else. What is unresolved is
+the gate: `jsonDoors()` verifies an exported FUNCTION whose body has a `catch`, and a
+key-taking door has neither (it is a method, and it refuses by recording a diagnostic rather
+than by throwing). A fourth kind wants its own verifier — *the string half names something
+the receiver owns, the lookup refuses without throwing* — and the two registries should
+probably become one table keyed by kind rather than a third constant beside
+`STRING_TOLERANT` and `JSON_DOORS`.
+
+Not built now because one door does not establish a rule, and a kind invented for a single
+member is the "second way to say what the table can already say" that gate's own header
+refuses. The second member is what should trigger this.

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -558,6 +558,10 @@ for (const spec of WINDOWS) {
     // runs before the code below, so every element is defined by the time the
     // previews mount.
     import '@gjsify/adwaita-web';
+    // The element CLASS, for the ordinal door below. `<adw-tab-view>` has no settable
+    // ordinal any more (ADR 0048) and an attribute is a string no type sees, so the
+    // selection has to go through a method a type can miss.
+    import type { Adw } from '@gjsify/adwaita-web';
 
     // Mount each preview: clone its inert <template> into the stage now that the
     // custom elements are defined. Building the subtree and attaching it in one go
@@ -586,14 +590,19 @@ for (const spec of WINDOWS) {
             // happen to answer right today. The marker stays, because what makes it
             // right is that it names the window's OWN view rather than where the
             // preview currently sits.
-            const view = el.querySelector('adw-tab-view[data-impl-view]');
+            const view = el.querySelector<Adw.TabView>('adw-tab-view[data-impl-view]');
             if (!view || view === skip) continue;
             const impls = (el.dataset.impls ?? '').split(',');
             const index = impls.indexOf(impl);
             // The windows hold disjoint tab sets, so a stored choice simply does not
             // apply to most of them: picking "Blueprint" moves every Native
             // TypeScript window and leaves the others where the reader left them.
-            if (index >= 0) view.setAttribute('selected', String(index));
+            // A CALL, not an attribute: `selected="n"` was the door until ADR 0048 renamed
+            // the markup half to `selected-page="<page id>"`, and these panes declare no
+            // `page-id`. The stored preference is a NAME resolved to a position against the
+            // list as it is now — nothing here holds the number, which is the whole
+            // difference the ADR draws.
+            if (index >= 0) view.selectNthPage(index);
         }
     };
 

--- a/website/src/components/CommandTabs.astro
+++ b/website/src/components/CommandTabs.astro
@@ -148,6 +148,9 @@ const runtimesAttr = present.map((r) => r.slot).join(',');
 
 <script>
     import '@gjsify/adwaita-web';
+    // The element CLASS, for the ordinal door below — see AdwWidget.astro, which selects
+    // the same way for the same reason (ADR 0048).
+    import type { Adw } from '@gjsify/adwaita-web';
 
     // One key per tab GROUP. `runtime` keeps the original key so an existing
     // visitor's stored choice survives; other groups get their own namespace.
@@ -162,11 +165,13 @@ const runtimesAttr = present.map((r) => r.slot).join(',');
         if (!runtime) return;
         for (const el of document.querySelectorAll<HTMLElement>('[data-command-tabs]')) {
             if (groupOf(el) !== group) continue;
-            const view = el.querySelector('adw-tab-view[data-cmd-view]');
+            const view = el.querySelector<Adw.TabView>('adw-tab-view[data-cmd-view]');
             if (!view || view === skip) continue;
             const runtimes = (el.dataset.runtimes ?? '').split(',');
             const index = runtimes.indexOf(runtime);
-            if (index >= 0) view.setAttribute('selected', String(index));
+            // A CALL, not an attribute (ADR 0048): `selected="n"` is no longer read, and the
+            // markup half is `selected-page="<page id>"`, which these pages do not declare.
+            if (index >= 0) view.selectNthPage(index);
         }
     };
 

--- a/website/src/data/adwaita-attributes.ts
+++ b/website/src/data/adwaita-attributes.ts
@@ -130,7 +130,7 @@ export const ADWAITA_ATTRIBUTES: Readonly<Record<string, readonly string[]>> = {
     'adw-status-page': ['icon', 'title', 'description'],
     'adw-switch-row': ['title', 'subtitle', 'active'],
     'adw-tab-page': ['title', 'tooltip', 'icon', 'indicator-icon', 'loading', 'needs-attention', 'pinned'],
-    'adw-tab-view': ['selected', 'autohide', 'expand-tabs', 'no-close'],
+    'adw-tab-view': ['selected-page', 'autohide', 'expand-tabs', 'no-close'],
     'adw-toast-overlay': [],
     'adw-toggle': ['label', 'icon-name'],
     'adw-toggle-group': ['active', 'flat', 'round'],


### PR DESCRIPTION
## What

[ADR 0048](https://github.com/gjsify/gjsify/blob/feat/portable-page-selection/docs/adr/0048-page-selection-by-identity.md). The three sibling ADRs each gave one thing a portable VALUE — a menu (0042), a list (0046), a range (0047). This one is different in kind: **there is no portable selection value to introduce.** The value already exists on every surface. What diverged is which of GTK's own shapes each port picked.

GTK offers three and chooses per widget. Measured against the in-repo GIR surface `packages/framework/gtk-host/src/generated/props.ts`:

| the shape GTK gives the selection | the types that have it |
|---|---|
| identity, by NAME — `visible-child-name` | `AdwLeaflet`, `AdwViewStack`, `GtkStack` |
| identity, by OBJECT — `selected-page` | `AdwTabView` |
| ORDINAL — `selected: number` | `AdwComboRow`, `AdwSidebar`, `GtkDropDown` |

A `GtkDropDown` selects a row of a `GListModel`, where a position IS the identity the model exposes; a view stack selects one of a set of NAMED pages. **The port took the ordinal in the two places GTK names an identity**, on both renderers. React Native — which has a view stack and no ordinal door — is the control: the converged shape was already shipping there.

The three ordinal widgets (`adw-sidebar`, `gtk-drop-down`, `adw-combo-row`) are deliberately untouched. The rule is *take the counterpart's shape*, not "identity always wins".

## Breaking

| published as | becomes |
|---|---|
| `visibleChildIndex` (setter) | `selectNthPage(n)`, or `visibleChildName` |
| `AdwTabView.selected` (settable ordinal) | `selectedPage` — the page on the web, the page **id** on NativeScript |
| `<adw-tab-view selected="1">` | `<adw-tab-view selected-page="<page id>">` |

The `visibleChildIndex` / `selectedIndex` getters stay. A position is what a switcher bar renders, and `notify::visible-child` already carries `index`.

**One migration does fail silently, and the first version of this body denied it.** A TypeScript error catches an unmigrated PROPERTY write. It does not catch `setAttribute('selected', …)`, and it does not catch NativeScript XML. Both bit this branch — see below.

## Why an ordinal is safe to read and unsafe to hold

`ViewStackState` carries the code that proves it: an insertion before the visible page increments the stored index (`view-stack.ts:296`), a reorder rewrites it (`:322`), a removal decrements it (`:348-349`). Every one of those lines exists so a number a caller HOLDS does not come to mean another page.

`selectNthPage(n)` is new on both view stacks: a call resolves against the page list as it is at that moment and keeps nothing. It is **not** an ordinal libadwaita refuses — `adw_tab_view_get_nth_page` (`adw-tab-view.h:192`) is public and `select_nth_page_cb` (`adw-tab-view.c:2137`) is exactly `get_nth_page` + `set_selected_page`, private only because a shortcut handler is not API. What is port-owned is putting it in the public surface.

It is also the only door onto two page shapes the specs already pin: a page whose name is `''` cannot be selected by name (`view-stack.spec.ts:226`), and where two pages share a name the lookup resolves to the FIRST (`:252`). A switcher bar renders button *n* over whatever the stack holds, blanks and duplicates included.

## What the independent review found (all fixed on the branch)

1. **The branch was red.** 2 of 1647 `@gjsify/adwaita-web` specs, plus a third passing vacuously — a `describe` block left on the retired attribute.
2. **The website wrote the attribute.** `CommandTabs.astro` and `AdwWidget.astro` both did `view.setAttribute('selected', …)`; the docs' command tabs and every gallery block's implementation tabs had gone dead. A grep for the property names cannot see it. The mechanism now lives in `check-website-attr-samples.mjs` — which already owned this rule and its incident (ADR 0046's `items` → `model`) and whose arms only read markup, so a scripted `setAttribute` was outside all of them. Arm 4 follows element-selector bindings to their attribute calls.
3. **`selectedPage` selected the wrong page** — a defect this branch introduced. Ids are unique within ONE view (`_nextId` counts per view), so `viewA.selectedPage = viewB.pages[2]` moved viewA to index 2 where C asserts `page_belongs_to_this_view`. **Fixed in the core, not in the renderers**: `TabViewState.setSelectedPage` takes the page or an id, checks identity against its own page list, and records the assertion C raises — a renderer-side guard was two copies with a silent refusal.
4. **NativeScript XML lost its only tab selection**, because a property holding an object is not an XML door. The setter takes the ID there, which is what a page handle already is on that port (`isClosing`, `closePage`, `setPagePinned` all take one). The gate's missing kind — a door whose string half NAMES something rather than serialising it — is written down in `status/open-todos.md` rather than worked around.
5. **Four ADR claims re-measured**, including the two corrected above.

## Measured

| | |
|---|---|
| `@gjsify/adwaita-core` | **2099 tests, 13049 assertions**, including the new vectors: a foreign page is refused with C's own assertion, this view's OWN page of the same id is accepted, and `interactive` survives both arms of the core's overload |
| `@gjsify/adwaita-web` | **1649 tests, 4980 assertions** — 1647 was the pre-fix total, two of them failing |
| `@gjsify/adwaita-nativescript` | 1244 tests, 3587 assertions |
| `check-vocabulary-alignment` | distance **7 → 5** property names; settable 143 → 142, agreeing 107 → 108 |
| `check-nativescript-xml-doors` | coercing / typed / un-XML-able: **64 / 71 / 19**. That triple IS the proof for finding 4 — an object-typed setter moved it to 64/70/20, and arm 1 used to `continue` past a `string`-classified door without counting it, so "classified" and "not read" printed identically |
| `check-adwaita-element-properties`, `check-generated-website-data`, `check-refs-citations` | green |
| `tsc` | `adwaita-core` emits, `adwaita-web` and `adwaita-nativescript` clean |
| `oxfmt` / `oxlint` | clean |

## Left open, in `status/open-todos.md`

- `isClosing` / `closePage` / `setPagePinned` still take an id where libadwaita takes an `AdwTabPage *`. Settle them together or not at all.
- A tab page with no `page-id` cannot be named from markup, and the reflection then writes a generated id into the DOM.
- The XML-door gate has no kind for "an object, or the key that names it". **`selectedPage` takes the page on the web and the id on NativeScript because of that gap** — the reasons given for the NativeScript shape stand on their own (an id already is the page handle there, and markup can carry nothing else), but the narrowing was triggered by a classifier this repo agrees is wrong, and should be re-taken on its own merits when the fourth kind lands.
- The property's getter returns the page on both surfaces while the NativeScript setter takes an id, so it does not round-trip there. Deliberate, and the first thing a consumer meets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQ87zT8bbwAhB1Hn264Krx

