### PR TITLE
docs(status): free an entry from the header comment

### DIFF
--- a/scripts/generate-status.mjs
+++ b/scripts/generate-status.mjs
@@ -562,6 +562,22 @@ export function loadStatusData(root, facts) {
             );
         }
     }
+    // A heading inside an HTML comment is silently dropped by the generator (regex /^### /gm
+    // matches line-start only, and comment-wrapped text does not export to STATUS.md). The error
+    // is completely silent — the entry vanishes with no warning. Catch it here.
+    const commentMatch = todosMd.match(/<!--[\s\S]*?-->/);
+    if (commentMatch) {
+        const commentText = commentMatch[0];
+        const inCommentHeadings = [...commentText.matchAll(/###\s+([^\n`<>]+)/g)];
+        for (const match of inCommentHeadings) {
+            const headingText = match[1].trim();
+            failures.push(
+                `status/open-todos.md has a \`### ${headingText}\` heading inside an HTML comment. ` +
+                    'The generator silently drops headings in comments — they do not render in STATUS.md. ' +
+                    'Move the heading and its section outside the comment block.',
+            );
+        }
+    }
 
     // The OTHER direction, and it is the same class as the corpse check above.
     //

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -1,5 +1,10 @@
 <!-- Authored Open-TODO sections — THIS FILE is the tracked source of truth (the
-     rendered STATUS.md view is generated and gitignored). One `### Two XMLHttpRequest implementations, and the docs name the wrong one as the only one
+     rendered STATUS.md view is generated and gitignored). One `### <title>` per open item.
+     A RESOLVED item is DELETED (its record is the commit + CHANGELOG that closed
+     it) — the status-data check rejects struck-through / ✓ / "Completed"
+     headings, so the done-log cannot regrow. -->
+
+### Two XMLHttpRequest implementations, and the docs name the wrong one as the only one
 
 `@gjsify/xmlhttprequest` ships a class in `src/index.ts`. `@gjsify/fetch` ships another in
 `src/xhr.ts` (11 269 bytes). `packages/infra/resolve-npm/lib/index.mjs` routes the SCOPED
@@ -25,10 +30,6 @@ constants as module-level `export const`s and may or may not carry the same defe
 either class is a published-contract change (`@gjsify/xmlhttprequest` is tier 1), and merging
 them is a decision about which package OWNS the API, not a refactor. Establish that first.
 
-### <title>` per open item.
-     A RESOLVED item is DELETED (its record is the commit + CHANGELOG that closed
-     it) — the status-data check rejects struck-through / ✓ / "Completed"
-     headings, so the done-log cannot regrow. -->
 
 ### A `Gtk.Window` in a child list is accepted silently, where an `Adw.Dialog` aborts
 


### PR DESCRIPTION
## What

`### Two XMLHttpRequest implementations, and the docs name the wrong one as the only one` has been sitting **inside `status/open-todos.md`'s own HTML comment**.

The splice is visible once you know where to look. The header opens:

```
<!-- Authored Open-TODO sections — THIS FILE is the tracked source of truth (the
     rendered STATUS.md view is generated and gitignored). One `### <title>` per open item.
```

Someone appended the entry directly after that backtick, so `` `### <title>` `` was cut in half: the first half became the entry's own heading, the second half surfaced 24 lines later as

```
### <title>` per open item.
     A RESOLVED item is DELETED …
```

and everything between them — the entire entry — is inside `<!-- -->`.

## Why it matters more than a typo

- The ledger's **most-read line** — the one that tells every agent and every reader what the file's convention is — reads as garbage.
- The entry documents a **tier-1 published-contract question** (`@gjsify/xmlhttprequest` ships one XHR class, `@gjsify/fetch` ships another, and the routing table sends the scoped name to the second). It renders nowhere: the generated `STATUS.md` view comes from this file, so the entry is missing there too.
- It is reachable by `grep`, which is exactly why nobody noticed. Anyone opening the file at the top cannot see it.

## The fix

The header is back to its one sentence; the entry is the first `###` section after it, **unchanged in wording**. 6 insertions, 5 deletions, and 177 `###` sections where a reader could previously see 176.

## What now catches it (added after review)

A reviewer pointed out the error was completely silent — the entry vanished from the rendered `STATUS.md` with no gate firing. The existing conformance check (reading headings via `/^### /gm`) does not validate extraction completeness, so a heading inside a comment would pass undetected.

Added: `status-data` rule now checks that no `###` heading appears inside the HTML comment block of `status/open-todos.md`. The check fails with the heading text and a message naming where to move it. The generator's regex matches line-start only, and comments are never rendered to STATUS.md, so any heading found inside a comment is certain to be lost — the check fires exactly when the error would occur.

- **Cost**: 16 lines in `scripts/generate-status.mjs`
- **False positives**: zero (no legitimate heading should live in a comment)
- **Caught by negative-test**: yes (breaking the file by moving the entry back into the comment makes the check go red; restoring makes it green)

Found while another branch appended to the tail of the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQ87zT8bbwAhB1Hn264Krx
