### PR TITLE
feat(scripts): measure the gap the vocabulary gate cannot see

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -489,6 +489,18 @@ jobs:
       - name: Check adw-* elements hold their widget's GIR properties (self-testing)
         run: node scripts/check-adwaita-element-properties.mjs
 
+      # The SAME question, one renderer over, and it had no gate at all. The vocabulary
+      # step above measures ONE direction: it holds the port's settable properties
+      # against the counterpart's ConstructorProps and asks whether the NAME agrees, so a
+      # GIR property the port simply does not HAVE is invisible to it and to everything
+      # else. Measured when this landed: AdwAvatar set `text` and `size` against
+      # AdwAvatar's four scalar properties, every check green, for as long as the widget
+      # existed — while <adw-avatar> had been held against the same four since
+      # 2026-08-26. Same denominator, same reader (`gir-scalar-properties.mjs`), same
+      # ratchet: a new gap fails, and closing one fails too until it leaves the ledger.
+      - name: Check NativeScript widgets hold their widget's GIR properties (self-testing)
+        run: node scripts/check-nativescript-widget-coverage.mjs
+
       # `$adw-components` in adwaita-web's `_reset.scss` is a hand-written copy of every
       # `customElements.define('adw-…')` call, and it is what applies the ADR 0010
       # style-isolation floor. A tag missing from it renders in the host page's font and

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
         "check:examples": "gjsify foreach check -ptv --include \"@gjsify/example-*\"",
         "check:type-surfaces": "node scripts/check-type-surfaces.mjs",
         "check:adwaita-element-properties": "node scripts/check-adwaita-element-properties.mjs",
+        "check:nativescript-widget-coverage": "node scripts/check-nativescript-widget-coverage.mjs",
         "check:vocabulary-alignment": "node scripts/check-vocabulary-alignment.mjs",
         "clear": "gjsify foreach clear -v --no-private -p --exclude \"@gjsify/example-*\" --exclude \"@gjsify/website\"",
         "clear:examples": "gjsify foreach clear -v -p --include \"@gjsify/example-*\"",

--- a/scripts/check-adwaita-element-properties.mjs
+++ b/scripts/check-adwaita-element-properties.mjs
@@ -47,6 +47,17 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { observedAttributes } from './adwaita-elements.mjs';
+// The GIR side is SHARED with `check-nativescript-widget-coverage.mjs`, which asks the
+// same question of the same file for the NativeScript surface. Two copies of "what is a
+// scalar property" is two backlogs that can disagree while both stay green.
+import {
+    GIR_FIXTURE_PROPS,
+    GIR_FIXTURE_SCALARS,
+    girReaderSelfTest,
+    propsBodies,
+    scalarProps,
+    tagGTypes,
+} from './gir-scalar-properties.mjs';
 
 const ROOT = process.cwd();
 
@@ -180,86 +191,6 @@ const KNOWN_GAPS = {
     'gtk-switch': ['state'],
 };
 
-/** A GIR type that holds an object — a slot on this renderer, never an attribute. */
-const OBJECT_TYPE = /\b(?:Gtk|Adw|Gio|Gdk|Pango|GObject)\.\w+/;
-
-/**
- * An ENUM, which {@link OBJECT_TYPE} also matches and must not exclude.
- *
- * The generator spells an enum property `AdwToolbarStyleNick | Adw.ToolbarStyle`, so the
- * namespaced half makes it look object-typed. It is not: a nick is a STRING, exactly what
- * an attribute carries. The proof that these belong to the checked surface is that 17 of
- * them are already observed as attributes today (`adw-banner/button-style`,
- * `adw-dialog/presentation-mode`, `adw-toolbar-view/top-bar-style`, …). Excluding them
- * would have hidden 14 real gaps behind a justification — "an attribute cannot carry a
- * widget" — that does not apply to them.
- */
-const ENUM_TYPE = /\b\w+Nick\b/;
-
-const kebab = (name) => name.replace(/([A-Z])/g, (c) => `-${c.toLowerCase()}`);
-
-/** `tag -> GType`, from the runtime widget table. */
-export function tagGTypes(widgetsSource) {
-    const map = new Map();
-    for (const m of widgetsSource.matchAll(/gtype: '([^']+)', tag: '([^']+)'/g)) map.set(m[2], m[1]);
-    return map;
-}
-
-/**
- * `<GType> -> interface body`, brace-MATCHED rather than regex-bounded.
- *
- * A lazy `[\s\S]*?\n\}` reads an EMPTY interface as the next one's body, which silently
- * credited `adw-spinner` with `AdwSplitButton`'s properties while this was being built.
- */
-export function propsBodies(propsSource) {
-    const bodies = new Map();
-    // `extends\s`, NOT `extends ` — the generator wraps long heritage lists onto the
-    // next line, and a literal space missed 65 of 190 interfaces. Each one then had no
-    // body, and `propertyProblems` skipped its element as unmapped: eight `adw-*`
-    // elements passed by being invisible. A vector pins it.
-    //
-    // `\s*` before the brace is the SAME defect one clause over, and it was live here
-    // after the first one was fixed: `[^{]*` swallows the space only when `extends` is
-    // present, so an interface declared WITHOUT one — `export interface AdwToggleProps
-    // {` — never matched. 13 interfaces were invisible that way, and the @girs 4.5.0
-    // vocabulary took it to 25 by dropping the empty `GObject` base: `<adw-toggle>`
-    // left this check silently, and surfaced only as five KNOWN_GAPS entries reported
-    // as stale. `girs-vocabulary.mts` carries the identical rule and its own vector.
-    const head = /export interface (\w+)Props(?:\s+extends\s[^{]*)?\s*\{/g;
-    let m;
-    while ((m = head.exec(propsSource))) {
-        let depth = 1;
-        let i = head.lastIndex;
-        while (i < propsSource.length && depth > 0) {
-            const c = propsSource[i];
-            if (c === '{') depth++;
-            else if (c === '}') depth--;
-            i++;
-        }
-        bodies.set(m[1], propsSource.slice(head.lastIndex, i - 1));
-    }
-    return bodies;
-}
-
-/**
- * The scalar property names of one interface body, kebab-spelled and deduplicated.
- *
- * The generator emits multiword properties TWICE — `canOpen?: boolean;` and
- * `'can-open'?: boolean;` — so without the dedupe every multiword gap counts double.
- */
-export function scalarProps(body) {
-    const names = new Set();
-    for (const line of body.split('\n')) {
-        const m = /^\s*(?:'([a-z0-9-]+)'|([a-zA-Z][a-zA-Z0-9]*))\?:\s*(.+?);\s*$/.exec(line);
-        if (!m) continue;
-        const name = m[1] ?? kebab(m[2]);
-        if (name.startsWith('on-')) continue;
-        if (OBJECT_TYPE.test(m[3]) && !ENUM_TYPE.test(m[3])) continue;
-        names.add(name);
-    }
-    return names;
-}
-
 /** @returns {string[]} one line per problem; empty means aligned. */
 export function propertyProblems({ byTag, tagToGtype, bodies, knownGaps }) {
     const problems = [];
@@ -308,38 +239,6 @@ export function propertyProblems({ byTag, tagToGtype, bodies, knownGaps }) {
 // SELF-TEST FIRST — a check that cannot go red is worse than no check.
 // ---------------------------------------------------------------------------
 
-const FIXTURE_PROPS = `
-export interface DemoWidgetProps extends GtkWidgetProps {
-    /** A scalar. */
-    label?: string;
-    /** Multiword, emitted twice by the generator. */
-    canShrink?: boolean;
-    'can-shrink'?: boolean;
-    /** An ENUM — namespaced, but a nick is a string an attribute carries. */
-    barStyle?: AdwBarStyleNick | Adw.BarStyle;
-    'bar-style'?: AdwBarStyleNick | Adw.BarStyle;
-    /** A slot, not an attribute. */
-    child?: Gtk.Widget | null;
-    /** A signal, not a property. */
-    'on-clicked'?: () => void;
-}
-export interface RootWidgetProps {
-    /** Reachable ONLY if the head reader tolerates a space before the brace. */
-    rooted?: string;
-}
-export interface EmptyWidgetProps extends GtkWidgetProps {}
-export interface AfterEmptyProps extends GtkWidgetProps {
-    trap?: string;
-}
-export interface WrappedWidgetProps
-    extends GtkWidgetProps,
-        GtkAccessibleProps,
-        GtkBuildableProps {
-    /** Reachable ONLY if the head reader tolerates a newline after \`extends\`. */
-    wrapped?: string;
-}
-`;
-
 const FIXTURE_WIDGETS = `
     { gtype: 'DemoWidget', tag: 'adw-demo', ctor: () => Adw.Demo },
     { gtype: 'EmptyWidget', tag: 'adw-empty', ctor: () => Adw.Empty },
@@ -350,22 +249,27 @@ const FIXTURE_WIDGETS = `
 const world = (attributes, knownGaps = {}, tag = 'adw-demo') => ({
     byTag: new Map([[tag, attributes]]),
     tagToGtype: tagGTypes(FIXTURE_WIDGETS),
-    bodies: propsBodies(FIXTURE_PROPS),
+    bodies: propsBodies(GIR_FIXTURE_PROPS),
     knownGaps,
 });
 
-/** Every scalar `DemoWidget` offers — an enum among them, on purpose. */
-const DEMO_SCALARS = ['label', 'can-shrink', 'bar-style'];
-
 const VECTORS = [
-    ['every scalar observed is not a problem', () => world(DEMO_SCALARS), 0],
+    ['every scalar observed is not a problem', () => world(GIR_FIXTURE_SCALARS), 0],
     ['one unobserved scalar IS a problem', () => world(['label', 'can-shrink']), 1],
     ['all unobserved is one problem each', () => world([]), 3],
     ['a declared gap is accepted', () => world(['label', 'bar-style'], { 'adw-demo': ['can-shrink'] }), 0],
-    ['a declaration the element now honours fails', () => world(DEMO_SCALARS, { 'adw-demo': ['can-shrink'] }), 1],
-    ['a declaration for a property that does not exist fails', () => world(DEMO_SCALARS, { 'adw-demo': ['ghost'] }), 1],
-    ['a missing SLOT property is not a problem', () => world(DEMO_SCALARS), 0],
-    ['a missing SIGNAL property is not a problem', () => world(DEMO_SCALARS), 0],
+    [
+        'a declaration the element now honours fails',
+        () => world(GIR_FIXTURE_SCALARS, { 'adw-demo': ['can-shrink'] }),
+        1,
+    ],
+    [
+        'a declaration for a property that does not exist fails',
+        () => world(GIR_FIXTURE_SCALARS, { 'adw-demo': ['ghost'] }),
+        1,
+    ],
+    ['a missing SLOT property is not a problem', () => world(GIR_FIXTURE_SCALARS), 0],
+    ['a missing SIGNAL property is not a problem', () => world(GIR_FIXTURE_SCALARS), 0],
 
     // BLOCKER-1 REGRESSION. `WrappedWidget` declares its heritage across three lines,
     // which is how the generator emits a long `extends` list. With the old `extends `
@@ -440,30 +344,11 @@ function alertDialogRegression() {
 }
 
 function selfTest() {
-    const failures = [];
-
-    // The brace matcher, pinned directly: the lazy-regex bug it replaces was silent.
-    const bodies = propsBodies(FIXTURE_PROPS);
-    if (scalarProps(bodies.get('EmptyWidget') ?? '').size !== 0) {
-        failures.push('an empty interface must have no properties — the body reader ran past its closing brace');
-    }
-    if (!scalarProps(bodies.get('AfterEmpty') ?? '').has('trap')) {
-        failures.push('the interface after an empty one must still be read');
-    }
-    if (!bodies.has('WrappedWidget')) {
-        failures.push('an interface whose `extends` list wraps must be found — the head reader needs `\\s`');
-    }
-    if (!bodies.has('RootWidget')) {
-        failures.push('an interface with no `extends` must be found — the head reader needs `\\s*` before `{`');
-    }
-    const demo = scalarProps(bodies.get('DemoWidget') ?? '');
-    for (const property of DEMO_SCALARS) {
-        if (!demo.has(property)) failures.push(`DemoWidget must expose '${property}' as a scalar`);
-    }
-    if (demo.has('child')) failures.push('a widget-valued property must not count as a scalar');
-    if (demo.size !== DEMO_SCALARS.length) {
-        failures.push(`DemoWidget must expose ${DEMO_SCALARS.length} scalars, got ${[...demo].join(', ')}`);
-    }
+    // The brace matcher and the scalar rule are pinned in the module that OWNS them,
+    // and run from here as well as from the NativeScript ratchet: a shared reader only
+    // one of its two callers proves is a reader half the repository trusts on somebody
+    // else's word. The lazy-regex bug it replaces was silent.
+    const failures = girReaderSelfTest();
 
     for (const [label, build, expected] of VECTORS) {
         const got = propertyProblems(build()).length;

--- a/scripts/check-nativescript-widget-coverage.mjs
+++ b/scripts/check-nativescript-widget-coverage.mjs
@@ -1,0 +1,786 @@
+#!/usr/bin/env node
+// Every NativeScript widget against the scalar GIR properties of the widget it NAMES —
+// the direction `check-vocabulary-alignment.mjs` does not measure — and the check proves
+// itself on broken input before it looks at the repository.
+//
+// WHY THIS EXISTS, AND WHAT WAS INVISIBLE
+//
+// `NS_PROPERTY_ALIGNMENT` holds the port's SETTABLE properties against the counterpart's
+// `ConstructorProps` and asks "does this name agree?". A GIR property the port simply
+// does not HAVE is invisible to it, and to every other gate: nothing iterates the
+// counterpart's side. So the printed line "Distance to one vocabulary: N property
+// name(s)" measures disagreement among the properties that EXIST and says nothing about
+// the ones that do not.
+//
+// Measured instance, on the commit this check landed against: `AdwAvatar` set `text` and
+// `size` while `AdwAvatar` declares four scalar properties — `icon-name`,
+// `show-initials`, `size`, `text`. Two of four, with every check green, for as long as
+// the widget existed. `<adw-avatar>` on the web surface has been held against the same
+// four since 2026-08-26 by `check-adwaita-element-properties.mjs`; this is that ratchet,
+// one renderer over, and the ONE fact it adds is that the two surfaces are now measured
+// against the same denominator by the same reader (`gir-scalar-properties.mjs`).
+//
+// THE DENOMINATOR, SAID EXACTLY, BECAUSE THE HONESTY OF IT IS THE WHOLE DELIVERABLE
+//
+// For each widget: the properties its counterpart GTYPE DECLARES ITSELF, in
+// `packages/framework/gtk-host/src/generated/props.ts` — the own interface body, not the
+// `extends` chain — minus signal handlers and minus widget-valued slots. Every one of
+// those four choices removes a number nobody could act on:
+//
+//   · the CHAIN would put `GtkWidget`'s ~59 keys, plus `GtkAccessible`/`GtkBuildable`/
+//     `GtkConstraintTarget`, behind every widget: 1835 keys against 231, and 1699 of
+//     them "missing" on a port whose views are `GridLayout`s. A property a GIR type
+//     inherits from a GIR ancestor is measured on THAT ancestor's row when the port
+//     ships it as a widget too — `AdwSwitchRow`'s `title` is counted on `adw-action-row`
+//     — and is not counted at all when it does not, which is this denominator's one
+//     under-count and is stated rather than hidden.
+//   · `onNotify*`/`on<Signal>` are a JSX convention. A NativeScript view takes
+//     `addEventListener`, so there is no property to be missing.
+//   · a widget-valued key (`child`, `content`, `sidebar`, `title-widget`) is a SLOT.
+//     `component-builder` assigns `instance[name] = "<raw string>"` from an XML
+//     attribute; a view cannot arrive that way on either renderer.
+//   · the generator emits multiword properties twice (`canOpen` beside `'can-open'`), so
+//     without the dedupe every multiword gap would count double.
+//
+// Those exclusions are COUNTED and printed, so the rule cannot drown its findings in
+// false ones and cannot quietly grow a fifth exclusion either.
+//
+// THE PORT SIDE RESOLVES THE PORT'S OWN `extends` CHAIN, AND THAT IS NOT A DETAIL
+//
+// `settablePropertiesOfClass` reads ONE class body. `AdwOverlaySplitView` declares one
+// setter and inherits seven from `AdwSplitViewBase`, which lives in `split-view-base.ts`
+// — not a `<library>-<name>.ts` widget file. Reading the class body alone reports
+// `collapsed`, `showSidebar`, `minSidebarWidth`, `maxSidebarWidth`,
+// `sidebarWidthFraction` and `sidebarPosition` as six properties the port does not have,
+// on a widget that has all six. A false red is the expensive kind: the fix that makes it
+// green is deleting the rule. So the chain is walked across the whole package, and where
+// it LEAVES the package it must land on a class `ns-core.d.ts` declares — a base this
+// reader cannot follow is a failure with its own message, never a silently shorter
+// setter set.
+//
+// WHICH HALF CAN GO RED
+//
+//   CAN. The two sides are independent and neither reads the other: the port's setters
+//   are hand-typed accessors, and `generated/props.ts` is emitted from the GIR by a
+//   generator that reads none of them. A gap that is not declared fails. A declared gap
+//   the widget now sets fails, so the backlog can only shrink. A declared gap that is no
+//   longer a scalar property of that GType fails, so a @girs bump that drops a property
+//   cannot leave a ledger row describing something that does not exist.
+//
+//   CANNOT. The `why` floor holds a table in this file against a constant in this file:
+//   it refuses a blank, it judges nothing. And the comparison target is a file this
+//   repository generates from the same `.gir` ts-for-gir reads — agreement is evidence
+//   about two hand-typed vocabularies, never proof about GTK.
+//
+//   WHAT NO HALF PROVES: that a property the port DOES have carries the same kind of
+//   value. `Gtk.Image:icon-size` is a `GtkIconSize` enum and the port's `iconSize` is a
+//   size in DIPs; both gates read that as agreement, because both compare names. The
+//   census behind that is in `status/open-todos.md`.
+//
+// SCOPE: the widgets whose file spelling IS a GTK tag. The three that are not
+// (`adw-image-button`, `adw-slider-row`, `adw-data-grid`) are declared divergences that
+// `NS_WIDGET_ALIGNMENT` owns, and reading their ledger from here would be a second copy
+// of it. The count of them is printed, so "not measured" cannot be mistaken for "none".
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { adwaitaNativeScriptWidgets, settablePropertiesOfClass, tagClass } from './adwaita-elements.mjs';
+// The GIR side is the SAME reader `check-adwaita-element-properties.mjs` uses for the
+// web surface. Two definitions of "a scalar property" is two backlogs that can disagree
+// about what they are counting while both stay green.
+import { girReaderSelfTest, propsBodies, scalarPropertyNames, tagGTypes } from './gir-scalar-properties.mjs';
+import { stripComments } from '../packages/infra/manifest-conformance/lib/strip-comments.mjs';
+
+const ROOT = process.cwd();
+const NS_SRC = 'packages/nativescript-bridge/adwaita/src';
+const NS_CORE_TYPES = `${NS_SRC}/ns-core.d.ts`;
+const PROPS = 'packages/framework/gtk-host/src/generated/props.ts';
+const WIDGETS = 'packages/framework/gtk-host/src/generated/widgets.ts';
+
+/** Named in every failure that asks for an edit to the ledger below. */
+const LEDGER_SOURCE = 'KNOWN_GAPS in scripts/check-nativescript-widget-coverage.mjs';
+
+/**
+ * The floor a declared gap has to clear, borrowed rather than invented:
+ * `check-vocabulary-alignment.mjs`, `check-storybook-widget-coverage.mjs` and
+ * `check-nativescript-theme-classes.mjs` all buy an exemption with a sentence and all
+ * set it here. It refuses a blank; it judges nothing.
+ */
+const MIN_REASON = 40;
+
+/**
+ * Scalar GIR properties the NativeScript port does not set, per widget, with the reason.
+ *
+ * ONE ENTRY PER WIDGET, NOT PER PROPERTY, and that is a decision rather than a shortcut.
+ * `check-adwaita-element-properties.mjs` carries the same backlog for the web surface as
+ * a bare list and argues for it in place: "inventing a rationale per entry would be
+ * worse than naming none". A per-WIDGET reason is a different object — it says what this
+ * port BUILDS and therefore which part of the GTK widget it does not reach, which is a
+ * statement about the file it names and can be checked by reading it. A per-property one
+ * would be 131 sentences of which most would be that same sentence restated.
+ *
+ * THE RATCHET, in both directions. A gap not listed here fails. A listed gap the widget
+ * now sets fails, so closing one is an edit here and the number can only go down. A
+ * listed name that is no longer a scalar property of that GType fails, so a @girs bump
+ * cannot leave a row describing a property that does not exist.
+ *
+ * NO COUNT IS WRITTEN IN THIS COMMENT. The summary at the bottom derives every number it
+ * prints, for the reason ADR 0034 § *Why the distance has to be PRINTED by a gate* gives
+ * — a hand-kept count beside a printed one is the copy that drifts, and in this area it
+ * has drifted twice.
+ */
+const KNOWN_GAPS = {
+    'adw-about-dialog': {
+        gaps: [
+            'appdataResourcePath',
+            'artists',
+            'debugInfo',
+            'debugInfoFilename',
+            'designers',
+            'developers',
+            'documenters',
+            'issueUrl',
+            'license',
+            'licenseType',
+            'otherAppsTitle',
+            'releaseNotes',
+            'releaseNotesVersion',
+            'supportUrl',
+            'translatorCredits',
+        ],
+        why: 'The port builds the identity CARD and none of the pages behind it: "the app icon glyph, name, version, developer, comments, and a close button" (adw-about-dialog.ts:3-4), which is exactly the seven properties it sets. Credits (artists, designers, developers, documenters, translator-credits), the legal text (license, license-type), the release notes, the debug-info tab, the other-apps list and the two extra link rows are sections it does not render, so there is nothing for the value to reach. `<adw-about-dialog>` declares twelve of the same names on the web surface, which is the same absence measured by the sibling ratchet.',
+    },
+    'adw-action-row': {
+        gaps: ['iconName', 'subtitleLines', 'subtitleSelectable', 'titleLines'],
+        why: 'The prefix is a SLOT here, not a property: the port takes a prefix VIEW and the consumer puts a `GtkImage` in it (adw-action-row.ts:3-6), where `Adw.ActionRow:icon-name` is a shortcut GTK resolves against the icon theme this port has no lookup for. The three label knobs are Pango properties of the GTK label — line counts and selectable text — and a NativeScript `Label` exposes neither. Same four names as `<adw-action-row>` on the web surface.',
+    },
+    'adw-alert-dialog': {
+        gaps: ['bodyUseMarkup', 'headingUseMarkup', 'preferWideLayout'],
+        why: "There is no in-app dialog to carry them: this class maps onto the platform `confirm()` / `action()` sheet so the dialog looks like the user's OS rather than a libadwaita card (adw-alert-dialog.ts:12-16). A native sheet takes PLAIN strings — no Pango markup to enable — and picks its own width, so the wide-layout hint has nothing to hint to.",
+    },
+    'adw-avatar': {
+        gaps: ['iconName', 'showInitials'],
+        why: 'The port renders one thing: "a circular accent-tinted background and a centered initials `Label`" (adw-avatar.ts:3-5). `Adw.Avatar` falls back to an icon when the text is empty or `show-initials` is FALSE, and neither the fallback nor the switch exists here — the initials are the only content path. This is the measured instance that motivated this check, and `<adw-avatar>` carries `icon-name` on the web surface for the same reason.',
+    },
+    'adw-bottom-sheet': {
+        gaps: ['align', 'canOpen', 'fullWidth', 'modal', 'revealBottomBar', 'showDragHandle'],
+        why: 'The sheet is bottom-aligned in a `GridLayout` and toggled by `visibility` — "no upward slide, no dimming scrim/backdrop-blur" (adw-bottom-sheet.ts, FIDELITY). Alignment, full-width and modality are properties of a presentation this port does not perform; the bottom bar and the drag handle are the two sub-widgets it does not build, and `can-open` gates an interaction that is a plain `open` write here.',
+    },
+    'adw-carousel': {
+        gaps: ['allowLongSwipes', 'allowMouseDrag', 'allowScrollWheel', 'revealDuration', 'spacing'],
+        why: 'The file states two of these itself: "No scroll wheel and no reveal animation, so `allow-scroll-wheel` and `reveal-duration` are absent rather than present and inert" (adw-carousel.ts, FIDELITY 4). The swipe knobs go with it — an NS `ScrollView` has no snap-to-page and no long-swipe concept, so there is no behaviour for them to switch. Page spacing is not settable because the pages are fixed-width children whose offsets `pageWidth` computes.',
+    },
+    'adw-clamp': {
+        gaps: ['unit'],
+        why: "Every size in this port is a DIP: `clampAllocationFor` is evaluated against the container's real width in DIPs on `layoutChanged` (adw-clamp.ts, FIDELITY). `Adw.LengthUnit` chooses between px, pt and sp, and a port with one unit has no second one to name. `<adw-clamp>` declares the same gap on the web surface.",
+    },
+    'adw-combo-row': {
+        gaps: ['enableSearch', 'searchMatchMode', 'useSubtitle'],
+        why: 'The chooser is the platform `action()` sheet (adw-combo-row.ts:4-6), which has no search field to enable and no match mode to set. `use-subtitle` puts the selected item into the row\'s subtitle instead of the suffix, and this port renders the value inline in the suffix — "the suffix shows the SELECTED value inline plus a small down-chevron" — so the alternative it switches to does not exist.',
+    },
+    'adw-entry-row': {
+        gaps: ['enableEmojiCompletion', 'inputHints', 'inputPurpose'],
+        why: 'All three are GTK INPUT-METHOD properties on the inner text widget. A NativeScript `TextField` exposes its keyboard through a different vocabulary (`keyboardType`, `autocorrect`, `secure`), so there is no key to write these onto and mapping them would be inventing a translation table rather than a property. `<adw-entry-row>` declares the same three on the web surface.',
+    },
+    'adw-expander-row': {
+        gaps: ['enableExpansion', 'iconName', 'showEnableSwitch', 'subtitleLines', 'titleLines'],
+        why: "The disclosure is a `visibility` toggle over a second grid row (adw-expander-row.ts:2-8) and carries no ENABLE switch: `enable-expansion` and `show-enable-switch` are the pair that puts a `GtkSwitch` in the header and gates the row on it, which this port does not build. `icon-name` and the two label line-counts inherit `AdwActionRow`'s answer above — a slot and two Pango properties.",
+    },
+    'adw-header-bar': {
+        gaps: [
+            'centeringPolicy',
+            'decorationLayout',
+            'showBackButton',
+            'showEndTitleButtons',
+            'showStartTitleButtons',
+            'showTitle',
+        ],
+        why: "Five of the six are WINDOW CHROME, and a NativeScript app has none: there is no window to decorate, no close/minimise/maximise triple to lay out and no navigation stack owning a back button at this level (the port's navigation views own theirs). `show-title` and `centering-policy` belong to the title-centring machinery `Adw.HeaderBar` runs against those buttons; this bar centres its title widget in a three-column grid unconditionally. Same six names as `<adw-header-bar>` on the web surface.",
+    },
+    'adw-inline-view-switcher': {
+        gaps: ['canShrink', 'homogeneous'],
+        why: "Both are GTK SIZE-NEGOTIATION properties — whether the switcher may go below its natural width, and whether every button gets the widest button's width. NativeScript has no minimum/natural size protocol: a `StackLayout` of buttons is laid out by the layout pass, so neither switch has an allocation decision to change. `<adw-inline-view-switcher>` declares the same two.",
+    },
+    'adw-navigation-split-view': {
+        gaps: ['sidebarWidthUnit'],
+        why: "The same one-unit answer as `adw-clamp`: `sidebarWidth`, `minSidebarWidth` and `maxSidebarWidth` are DIP numbers here, so `Adw.LengthUnit`'s px/pt/sp choice has nothing to choose between. Declared rather than mapped, because a unit property that only ever accepts one value is worse than none.",
+    },
+    'adw-navigation-view': {
+        gaps: ['hhomogeneous', 'vhomogeneous'],
+        why: 'Two size-negotiation properties again: they make the stack request the widest and tallest page rather than the visible one. The port overlays its pages in one `GridLayout` and shows the top by `visibility` (adw-navigation-view.ts:3-4), which means the grid already measures every child — the behaviour is fixed, not settable.',
+    },
+    'adw-overlay-split-view': {
+        gaps: ['enableHideGesture', 'enableShowGesture', 'sidebarWidthUnit'],
+        why: 'The two gestures are GTK swipe-tracker switches; this port dismisses the collapsed sidebar by a tap on the scrim and has no swipe tracker to enable or disable (adw-overlay-split-view.ts:3-5). `sidebar-width-unit` gets the same answer its sibling above gets: every width here is a DIP number.',
+    },
+    'adw-preferences-dialog': {
+        gaps: ['searchEnabled', 'visiblePageName'],
+        why: 'The search MODEL is implemented and the UI is not — "a search UI (the toggle button, the entry, the results list) is not built yet; the model is" (adw-preferences-dialog.ts) — so `search-enabled` would switch a control that does not exist. The dialog hosts its pages in a plain scroller rather than a view stack, so there is no visible-page name to write. `<adw-preferences-dialog>` declares the same two.',
+    },
+    'adw-preferences-group': {
+        gaps: ['separateRows'],
+        why: 'It selects between one boxed list and one card per row. The port renders the `.boxed-list` container only (adw-preferences-group.ts:3-7), so the alternative arrangement the property switches to is not built. `<adw-preferences-group>` declares the same gap on the web surface.',
+    },
+    'adw-preferences-page': {
+        gaps: ['description', 'descriptionCentered'],
+        why: 'The page carries its IDENTITY — title, name, icon-name, use-underline — because the dialog binds those onto the view-stack page and the search results need them back (adw-preferences-page.ts). The description is the one field that is PAINTED by the page rather than read off it, and this port paints the groups only. `<adw-preferences-page>` declares the same pair.',
+    },
+    'adw-sidebar': {
+        gaps: ['dropPreload'],
+        why: "A drag-and-drop hover behaviour: whether hovering a drag over an item selects it. The port's rows are tappable labels with no drop target and no drag protocol (adw-sidebar.ts, FIDELITY), so there is no hover-during-drag to gate. `<adw-sidebar>` declares the same gap.",
+    },
+    'adw-spin-row': {
+        gaps: ['climbRate', 'digits', 'numeric', 'snapToTicks', 'updatePolicy', 'wrap'],
+        why: "All six are `GtkSpinButton` knobs that `Adw.SpinRow` re-exposes, and this row has no spin button: it installs a `[−] value [+]` triplet of two Buttons and a Label in the suffix slot (adw-spin-row.ts:3-8). There is no press-and-hold acceleration, no editable text field to parse or restrict, and no tick snapping — the buttons step by the adjustment's increment and clamp. `<adw-spin-row>` declares the same six.",
+    },
+    'adw-split-button': {
+        gaps: ['canShrink'],
+        why: 'The size-negotiation property once more: it lets the button ellipsize below its natural width. NativeScript has no minimum/natural protocol for a `GridLayout` of two tappable parts, so there is no allocation the switch could change. `<adw-split-button>` declares the same gap.',
+    },
+    'adw-tab-view': {
+        gaps: ['shortcuts'],
+        why: 'A `Adw.TabViewShortcuts` flag set naming the keyboard accelerators the tab view handles itself (Ctrl+Tab, Alt+digit, …). This port is a touch tab bar on a phone with no key events reaching it, so there is no shortcut to enable or suppress. `<adw-tab-view>` declares the same gap.',
+    },
+    'adw-toggle-group': {
+        gaps: ['activeName', 'canShrink', 'homogeneous'],
+        why: '`active-name` addresses a toggle by the `Adw.Toggle:name` its objects carry; this port builds its segments from a label array and per-toggle icons (adw-toggle-group.ts:5-8), so a toggle has no name to be addressed by — the index is its identity. The other two are the size-negotiation pair, with no minimum/natural protocol behind them. `<adw-toggle-group>` declares the same three.',
+    },
+    'adw-toolbar-view': {
+        gaps: ['revealBottomBars', 'revealTopBars'],
+        why: 'They animate the bars in and out of the view. This port arranges the bars as `GridLayout` rows and does not reproduce the size allocation libadwaita runs over them (adw-toolbar-view.ts, "NOT reproduced: the two chained CLAMPs"), so there is no reveal to drive; a consumer hides a bar by removing it. `<adw-toolbar-view>` declares the same pair.',
+    },
+    'adw-view-stack': {
+        gaps: ['enableTransitions', 'hhomogeneous', 'transitionDuration', 'vhomogeneous'],
+        why: 'Pages swap by toggling `visibility` — "instant, no cross-fade (the CSS subset has" no transition) (adw-view-stack.ts, FIDELITY) — so the two transition properties would switch and time an animation that is not there. The two homogeneity flags are the same size-negotiation pair `adw-navigation-view` answers above. `<adw-view-stack>` declares the same four.',
+    },
+    'adw-view-switcher': {
+        gaps: ['policy'],
+        why: 'The port HAS this control and not under this name: `AdwViewSwitcherBase` declares a PROTECTED `policy` getter for the button orientation and exposes the settable door as `switcherPolicy` beside it (view-switcher-base.ts:89-99). So the GIR name is taken by a port-owned member, which ADR 0034 § Amendment 11 records as a question about that member rather than a reason the name cannot converge — the getter is internal and could be renamed. Listed here because until it is, the widget does not answer to `policy`.',
+    },
+    'gtk-button': {
+        gaps: ['canShrink', 'hasFrame', 'iconName', 'label', 'useUnderline'],
+        why: "This class extends the REAL NativeScript `Button` (gtk-button.ts:9) and adds exactly one property, `variant`. The label is NS `Button.text` — the same control under the platform's name, which is a divergence no gate sees because `text` is inherited rather than declared here. `has-frame` and the mnemonic underline are GTK chrome with no NS counterpart, `icon-name` is what `AdwImageButton` is for, and `can-shrink` is the size-negotiation property. `<gtk-button>` declares four of the five on the web surface.",
+    },
+    'gtk-drop-down': {
+        gaps: ['enableSearch', 'searchMatchMode', 'showArrow'],
+        why: 'The chooser is the platform `action()` sheet, exactly as in `adw-combo-row`, so there is no search field to enable and no match mode. The chevron is drawn unconditionally by the render half (gtk-drop-down.ts:8-10) rather than gated by a property. `<gtk-drop-down>` declares two of the three.',
+    },
+    'gtk-entry': {
+        gaps: [
+            'activatesDefault',
+            'enableEmojiCompletion',
+            'hasFrame',
+            'imModule',
+            'inputHints',
+            'inputPurpose',
+            'invisibleChar',
+            'invisibleCharSet',
+            'menuEntryIconPrimaryText',
+            'menuEntryIconSecondaryText',
+            'overwriteMode',
+            'primaryIconActivatable',
+            'primaryIconName',
+            'primaryIconSensitive',
+            'primaryIconTooltipMarkup',
+            'primaryIconTooltipText',
+            'progressFraction',
+            'progressPulseStep',
+            'secondaryIconActivatable',
+            'secondaryIconName',
+            'secondaryIconSensitive',
+            'secondaryIconTooltipMarkup',
+            'secondaryIconTooltipText',
+            'showEmojiIcon',
+            'truncateMultiline',
+            'visibility',
+        ],
+        why: 'The port is "the bare input" (gtk-entry.ts:8-10) — a `TextField` in a `GridLayout` with four properties. Three whole families of `Gtk.Entry` are absent: the two ICON packs (activatable, name, sensitive and two tooltip spellings each), the PROGRESS bar drawn inside the entry, and the INPUT-METHOD group (`im-module`, hints, purpose, emoji, overwrite, the invisible-char pair) that a NativeScript `TextField` spells with `keyboardType`/`secure`/`autocorrect` instead. `visibility` is the sharpest of them: `Gtk.Entry:visibility` is password masking, and the port already answers to `visibility` from NativeScript `View` meaning show-or-hide — the same name for two controls, which is why it is listed rather than mapped. `<gtk-entry>` declares 28 names on the web surface, this one 26; the two the web still lists are `max-length` and `placeholder-text`, which converged here.',
+    },
+    'gtk-image': {
+        gaps: ['file', 'pixelSize', 'resource', 'useFallback'],
+        why: "The port renders ONE source: an Adwaita symbolic SVG resolved by name through `renderSymbolicIcon` (gtk-image.ts:14-17), so `file`, `resource` and the icon-theme `use-fallback` name loading paths it does not have. `pixel-size` is the one to read twice: it is GTK's NUMBER for the rendered size, and this widget already answers to `iconSize` as \"the icon size in DIPs\" (gtk-image.ts:109) where `Gtk.Image:icon-size` is a `GtkIconSize` ENUM. So the port carries GTK's `pixel-size` under GTK's `icon-size` name, which is a false friend a name comparison cannot see. `<gtk-image>` declares five on the web surface, `icon-size` among them.",
+    },
+    'gtk-menu-button': {
+        gaps: ['active', 'alwaysShowArrow', 'canShrink', 'direction', 'hasFrame', 'label', 'primary', 'useUnderline'],
+        why: 'The menu is the platform `action()` sheet, not a popover (gtk-menu-button.ts, FIDELITY), so `active` — whether the popover is shown — has no state to hold, and the arrow that `always-show-arrow` and `direction` position is not drawn. The button itself extends `AdwImageButton`: it is an ICON button, so `label` and the mnemonic underline have nothing to label, and `has-frame`/`can-shrink` are the GTK chrome and size-negotiation properties this port does not model. `primary` marks the app menu for the F10 accelerator, and there are no key events on a phone. `<gtk-menu-button>` declares seven of the eight.',
+    },
+};
+
+// ------------------------------------------------------------------ readers
+
+/** Every `.ts` source in the port, `.d.ts` and specs excluded. */
+function packageSources(dir) {
+    const out = [];
+    for (const entry of readdirSync(dir)) {
+        const path = join(dir, entry);
+        if (statSync(path).isDirectory()) out.push(...packageSources(path));
+        else if (entry.endsWith('.ts') && !entry.includes('.spec.') && !entry.endsWith('.d.ts')) out.push(path);
+    }
+    return out;
+}
+
+/**
+ * `class <Name>[<T>] [extends <Base>]` over one source, comments stripped.
+ *
+ * The type arguments are what makes this a reader rather than a one-liner:
+ * `AdwOverlaySplitView extends AdwSplitViewBase<NsOverlaySplitViewState>` names its base
+ * with a generic, and a pattern that stops at the identifier before `<` reads the base as
+ * missing — which ends the chain walk and hands the widget a setter set seven short.
+ *
+ * @param {string} source
+ * @returns {Map<string, string | null>} class -> base class name, or null
+ */
+export function classBases(source) {
+    const bases = new Map();
+    for (const [, name, base] of stripComments(source).matchAll(
+        /\bclass\s+([A-Za-z0-9_$]+)(?:<[^>]*>)?(?:\s+extends\s+([A-Za-z0-9_$]+))?/g,
+    )) {
+        bases.set(name, base ?? null);
+    }
+    return bases;
+}
+
+/** Every class `ns-core.d.ts` declares — where the port's chains are allowed to end. */
+export function ambientCoreClasses(source) {
+    return new Set(classBases(source).keys());
+}
+
+// ------------------------------------------------------------------ rules
+
+/**
+ * A declared gap has to say WHY, in a sentence rather than a word.
+ *
+ * @param {string} subject already-phrased subject of the failure
+ * @param {string | undefined} reason the field as written
+ * @returns {string[]}
+ */
+function reasonProblems(subject, reason) {
+    const written = typeof reason === 'string' ? reason.trim() : '';
+    if (written === '') {
+        return [
+            `${subject} with no reason. Add a 'why' to ${LEDGER_SOURCE} saying what the port BUILDS and ` +
+                'therefore which part of the GTK widget it does not reach — a gap with no reason is ' +
+                'indistinguishable from an oversight.',
+        ];
+    }
+    if (written.length < MIN_REASON) {
+        return [
+            `${subject} with a ${written.length}-character reason, under the ${MIN_REASON}-character floor ` +
+                `the sibling ledgers set: "${written}". Say what the port builds, and cite it, in ${LEDGER_SOURCE}.`,
+        ];
+    }
+    return [];
+}
+
+/**
+ * Every rule, as one pure function over plain data.
+ *
+ * Pure so the self-test can hand it a broken world without materialising files, and so a
+ * rule with no failing vector is visible as one.
+ *
+ * @param {{
+ *   measured: {tag: string, klass: string, gtype: string,
+ *              scalars: Map<string, string> | null, setters: Set<string> | null,
+ *              chainEnd: string | null}[],
+ *   unmeasured: string[],
+ *   coreClasses: Set<string>,
+ *   ledger: Record<string, {gaps?: string[], why?: string}>,
+ * }} world
+ * @returns {string[]} problems, empty when every gap is declared
+ */
+export function coverageProblems(world) {
+    const { measured, coreClasses, ledger } = world;
+    const problems = [];
+
+    // The controls. Each of these would make the whole check pass while measuring
+    // nothing, which is the one failure a ratchet cannot be allowed to have.
+    if (measured.length === 0) {
+        problems.push(
+            'no NativeScript widget could be measured against a GIR counterpart — the widget reader, the ' +
+                'tag table or the props file moved, and an empty comparison agrees with everything',
+        );
+        return problems;
+    }
+    const unreadable = measured.filter((widget) => widget.scalars === null);
+    if (unreadable.length > 0) {
+        problems.push(
+            `no props interface found for ${unreadable.map((w) => `${w.klass} (${w.gtype})`).join(', ')} — a ` +
+                'widget with no comparison target drops out of the census as a fully covered one',
+        );
+    }
+    const classless = measured.filter((widget) => widget.setters === null);
+    if (classless.length > 0) {
+        problems.push(
+            `the settable-property reader found no class for ${classless.map((w) => w.klass).join(', ')} — a ` +
+                'widget whose accessors cannot be read reads as one that sets nothing, i.e. maximally short',
+        );
+    }
+    if (problems.length > 0) return problems;
+
+    // …and the one that keeps a SHORT read from looking like a real gap. A port class
+    // whose base is neither another class in the package nor a class `ns-core.d.ts`
+    // declares means the chain walk stopped early, and every setter above that point is
+    // reported as a property the widget does not have.
+    for (const widget of measured) {
+        if (widget.chainEnd === null || coreClasses.has(widget.chainEnd)) continue;
+        problems.push(
+            `${widget.klass}'s inheritance chain leaves the package at '${widget.chainEnd}', which ` +
+                `${NS_CORE_TYPES} does not declare. The setter reader cannot follow it, so every property ` +
+                'declared above that point would be reported as missing. Teach the reader, or declare the base.',
+        );
+    }
+    const scalarTotal = measured.reduce((sum, widget) => sum + widget.scalars.size, 0);
+    if (scalarTotal === 0) {
+        problems.push(
+            'no scalar GIR property found on any counterpart — the props reader or the generated shape ' +
+                'moved, and an empty denominator makes every widget complete',
+        );
+    }
+    if (measured.every((widget) => widget.setters.size === 0)) {
+        problems.push(
+            'no settable property found on any NativeScript widget — the accessor convention or the chain ' +
+                'walk moved, and a surface that sets nothing makes every gap look declared-or-new at once',
+        );
+    }
+    if (problems.length > 0) return problems;
+
+    const declaredTags = new Set(Object.keys(ledger));
+    for (const widget of measured) {
+        const entry = ledger[widget.tag];
+        const gaps = Array.isArray(entry?.gaps) ? entry.gaps : null;
+        if (entry !== undefined && gaps === null) {
+            problems.push(
+                `${widget.klass} has a ledger entry with no 'gaps' array — an entry names the properties it ` +
+                    `covers, or it covers nothing. Fix it in ${LEDGER_SOURCE}.`,
+            );
+            continue;
+        }
+        const declared = new Set(gaps ?? []);
+        if (gaps !== null && declared.size !== gaps.length) {
+            problems.push(
+                `${widget.klass} lists a property twice in ${LEDGER_SOURCE} — a repeated name counts one gap ` +
+                    'as two and makes the printed backlog larger than the tree',
+            );
+        }
+        for (const [property] of widget.scalars) {
+            const set = widget.setters.has(property);
+            if (set && declared.has(property)) {
+                problems.push(
+                    `${widget.klass} now sets '${property}' — delete it from ${LEDGER_SOURCE} so the backlog ` +
+                        'can only shrink. A declaration whose gap is closed is a stale reason left standing.',
+                );
+                continue;
+            }
+            if (set || declared.has(property)) continue;
+            problems.push(
+                `${widget.klass} does not set '${property}', a scalar property of ${widget.gtype}. Implement ` +
+                    `it, or add it to that widget's 'gaps' in ${LEDGER_SOURCE} with the reason the port does ` +
+                    'not reach it. An undeclared gap is an undecided one, and undecided is what fails here.',
+            );
+        }
+        for (const property of declared) {
+            if (widget.scalars.has(property)) continue;
+            problems.push(
+                `${LEDGER_SOURCE} lists ${widget.klass}.${property}, which is not a scalar property of ` +
+                    `${widget.gtype} any more — drop the entry. A ledger describing a property that does not ` +
+                    'exist tells the next reader something false.',
+            );
+        }
+        if (gaps === null) continue;
+        if (gaps.length === 0) {
+            problems.push(
+                `${widget.klass} has a ledger entry declaring no gap at all — a widget that holds every ` +
+                    `scalar property of its counterpart has no entry. Delete it from ${LEDGER_SOURCE}.`,
+            );
+            continue;
+        }
+        problems.push(...reasonProblems(`${widget.klass} declares ${gaps.length} property gap(s)`, entry.why));
+    }
+    const present = new Set(measured.map((widget) => widget.tag));
+    for (const tag of declaredTags) {
+        if (present.has(tag)) continue;
+        problems.push(
+            `${LEDGER_SOURCE} declares '${tag}', which is not a NativeScript widget with a GIR counterpart ` +
+                'any more — drop the entry, or say where the widget went',
+        );
+    }
+    return problems;
+}
+
+// ------------------------------------------------------------------ self-test
+
+const FIXTURE_REASON = 'a fixture reason, written long enough to clear the floor this file sets';
+
+/**
+ * `adw-demo` sets one of its two scalars and declares the other; `adw-plain` sets both.
+ * Without a widget that has NO gap the "an entry declaring no gap" rule is vectorless.
+ */
+const WORLD = () => ({
+    measured: [
+        {
+            tag: 'adw-demo',
+            klass: 'AdwDemo',
+            gtype: 'AdwDemo',
+            scalars: new Map([
+                ['label', 'label'],
+                ['canShrink', 'can-shrink'],
+            ]),
+            setters: new Set(['label']),
+            chainEnd: 'GridLayout',
+        },
+        {
+            tag: 'adw-plain',
+            klass: 'AdwPlain',
+            gtype: 'AdwPlain',
+            scalars: new Map([['title', 'title']]),
+            setters: new Set(['title']),
+            chainEnd: 'StackLayout',
+        },
+    ],
+    unmeasured: ['adw-own'],
+    coreClasses: new Set(['GridLayout', 'StackLayout']),
+    ledger: { 'adw-demo': { gaps: ['canShrink'], why: FIXTURE_REASON } },
+});
+
+/** Each vector breaks exactly one rule and names the substring its failure must contain. */
+const VECTORS = [
+    ['the declared baseline', (w) => w, null],
+    ['nothing measured at all', (w) => ({ ...w, measured: [] }), 'no NativeScript widget could be measured'],
+    [
+        'a counterpart with no props interface',
+        (w) => ({ ...w, measured: [{ ...w.measured[0], scalars: null }, w.measured[1]] }),
+        'no props interface found for AdwDemo',
+    ],
+    [
+        'a widget class the setter reader could not find',
+        (w) => ({ ...w, measured: [{ ...w.measured[0], setters: null }, w.measured[1]] }),
+        'the settable-property reader found no class for AdwDemo',
+    ],
+    [
+        'an inheritance chain that leaves the package at an unknown base',
+        (w) => ({ ...w, measured: [{ ...w.measured[0], chainEnd: 'MysteryBase' }, w.measured[1]] }),
+        "AdwDemo's inheritance chain leaves the package at 'MysteryBase'",
+    ],
+    [
+        'a denominator that read nothing',
+        (w) => ({ ...w, measured: w.measured.map((m) => ({ ...m, scalars: new Map() })) }),
+        'no scalar GIR property found on any counterpart',
+    ],
+    [
+        'a surface that sets nothing',
+        (w) => ({ ...w, measured: w.measured.map((m) => ({ ...m, setters: new Set() })), ledger: {} }),
+        'no settable property found on any NativeScript widget',
+    ],
+    ['an undeclared gap', (w) => ({ ...w, ledger: {} }), "AdwDemo does not set 'canShrink'"],
+    [
+        'a declared gap the widget now sets',
+        (w) => ({
+            ...w,
+            measured: [{ ...w.measured[0], setters: new Set(['label', 'canShrink']) }, w.measured[1]],
+        }),
+        "AdwDemo now sets 'canShrink'",
+    ],
+    [
+        'a declared gap that is not a property of the widget',
+        (w) => ({ ...w, ledger: { 'adw-demo': { gaps: ['canShrink', 'ghost'], why: FIXTURE_REASON } } }),
+        'lists AdwDemo.ghost, which is not a scalar property of AdwDemo',
+    ],
+    [
+        'a declaration for a widget that is not measured',
+        (w) => ({ ...w, ledger: { ...w.ledger, 'adw-vanished': { gaps: ['x'], why: FIXTURE_REASON } } }),
+        "declares 'adw-vanished', which is not a NativeScript widget",
+    ],
+    [
+        'an entry with no gaps array',
+        (w) => ({ ...w, ledger: { 'adw-demo': { why: FIXTURE_REASON } } }),
+        "AdwDemo has a ledger entry with no 'gaps' array",
+    ],
+    [
+        'an entry declaring no gap at all',
+        (w) => ({ ...w, ledger: { ...w.ledger, 'adw-plain': { gaps: [], why: FIXTURE_REASON } } }),
+        'AdwPlain has a ledger entry declaring no gap at all',
+    ],
+    [
+        'the same property listed twice',
+        (w) => ({ ...w, ledger: { 'adw-demo': { gaps: ['canShrink', 'canShrink'], why: FIXTURE_REASON } } }),
+        'lists a property twice',
+    ],
+    [
+        'a gap declared with no reason',
+        (w) => ({ ...w, ledger: { 'adw-demo': { gaps: ['canShrink'] } } }),
+        'AdwDemo declares 1 property gap(s) with no reason',
+    ],
+    [
+        'a reason under the floor',
+        (w) => ({ ...w, ledger: { 'adw-demo': { gaps: ['canShrink'], why: 'later' } } }),
+        'AdwDemo declares 1 property gap(s) with a 5-character reason',
+    ],
+];
+
+/**
+ * The READERS get their own vectors, because the rules above cannot cover them.
+ *
+ * `coverageProblems` takes plain data, so every vector proves a rule and none of them
+ * proves that the thing which BUILT the data read the source correctly. That gap is not
+ * hypothetical here: a base pattern that stops at the identifier before `<` reads
+ * `extends AdwSplitViewBase<NsOverlaySplitViewState>` as no base at all, ends the chain
+ * walk, and reports seven properties the widget has as seven it does not.
+ */
+const BASE_VECTORS = [
+    ['export class AdwDemo extends GridLayout {}', 'AdwDemo', 'GridLayout'],
+    ['export abstract class AdwBase<T> extends GridLayout {}', 'AdwBase', 'GridLayout'],
+    ['class AdwDemo extends AdwBase<NsState> {}', 'AdwDemo', 'AdwBase'],
+    ['class AdwDemo extends AdwBase<NsState<Deep>> {}', 'AdwDemo', 'AdwBase'],
+    ['export class AdwGroup extends StackLayout implements NsSearchableGroup {}', 'AdwGroup', 'StackLayout'],
+    ['export class AdwRoot {}', 'AdwRoot', null],
+    // A class named inside a comment is prose, and these files explain their own
+    // hierarchies in prose — `adw-combo-row.ts` opens with "Extends {@link AdwActionRow}".
+    ['// class AdwGhost extends GridLayout\nexport class AdwDemo extends Image {}', 'AdwGhost', undefined],
+];
+
+function readerSelfTest() {
+    const failures = [];
+    for (const [source, klass, want] of BASE_VECTORS) {
+        const bases = classBases(source);
+        const got = bases.has(klass) ? bases.get(klass) : undefined;
+        if (got !== want) {
+            failures.push(`classBases(${JSON.stringify(source)}).get('${klass}') is ${got}, wanted ${want}`);
+        }
+    }
+    return failures;
+}
+
+function selfTest() {
+    const failures = [...girReaderSelfTest(), ...readerSelfTest()];
+    for (const [label, mutate, expected] of VECTORS) {
+        let problems;
+        try {
+            problems = coverageProblems(mutate(WORLD()));
+        } catch (error) {
+            // A REAL throw path, and the reason to catch it is attribution rather than
+            // tolerance: the two vectors that hand this rule a `null` side exist because
+            // the CONTROL in front of them must return early. Delete that control and the
+            // rules behind it dereference the null — the check still exits 1, but as a
+            // stack trace naming a line instead of as "that rule is not holding", which
+            // is the difference between a suite that reports a broken rule and one that
+            // looks broken itself. Measured by disabling each control in turn.
+            failures.push(
+                `${label} THREW instead of reporting: ${error.message} — a control in front of a ` +
+                    'rule was removed, or a rule reads a side the control was there to reject',
+            );
+            continue;
+        }
+        if (expected === null) {
+            if (problems.length > 0) failures.push(`${label} should be clean, got: ${problems.join(' | ')}`);
+            continue;
+        }
+        if (problems.length === 0) failures.push(`${label} produced NO problem — that rule is not holding`);
+        else if (!problems.some((problem) => problem.includes(expected))) {
+            failures.push(`${label} failed for the wrong reason (wanted "${expected}"): ${problems.join(' | ')}`);
+        }
+    }
+    return failures;
+}
+
+// ------------------------------------------------------------------ run
+
+const selfTestFailures = selfTest();
+if (selfTestFailures.length > 0) {
+    console.error('check-nativescript-widget-coverage: SELF-TEST failed — the check itself is broken:');
+    for (const failure of selfTestFailures) console.error(`  - ${failure}`);
+    process.exit(1);
+}
+
+let world;
+try {
+    const read = (relativePath) => readFileSync(join(ROOT, relativePath), 'utf8');
+    const bodies = propsBodies(read(PROPS));
+    const tagToGType = new Map([...tagGTypes(read(WIDGETS))].map(([tag, gtype]) => [tag, gtype]));
+    const coreClasses = ambientCoreClasses(read(NS_CORE_TYPES));
+
+    // Every class in the package and where it lives, so the chain walk can cross files:
+    // a widget's base is often a shared abstract class that is not a widget file itself.
+    const declaredIn = new Map();
+    const baseOf = new Map();
+    for (const file of packageSources(join(ROOT, NS_SRC))) {
+        const source = readFileSync(file, 'utf8');
+        for (const [name, base] of classBases(source)) {
+            declaredIn.set(name, file);
+            baseOf.set(name, base);
+        }
+    }
+    /** Every setter reachable on a class, plus where the chain left the package. */
+    const surfaceOf = (klass) => {
+        const setters = new Set();
+        const seen = new Set();
+        let name = klass;
+        while (name !== null && declaredIn.has(name) && !seen.has(name)) {
+            seen.add(name);
+            const own = settablePropertiesOfClass(readFileSync(declaredIn.get(name), 'utf8'), name);
+            if (own === null) return { setters: null, chainEnd: name };
+            for (const property of own) setters.add(property);
+            name = baseOf.get(name) ?? null;
+        }
+        return { setters, chainEnd: name };
+    };
+
+    const widgetFiles = adwaitaNativeScriptWidgets(ROOT);
+    const measured = [];
+    const unmeasured = [];
+    for (const tag of [...widgetFiles.keys()].sort()) {
+        const gtype = tagToGType.get(tag);
+        // A widget whose file spelling is not a GTK tag is a declared divergence
+        // `NS_WIDGET_ALIGNMENT` owns; reading that ledger from here would be a second
+        // copy of it. Counted and printed, never silently dropped.
+        if (gtype === undefined) {
+            unmeasured.push(tag);
+            continue;
+        }
+        const body = bodies.get(gtype);
+        const { setters, chainEnd } = surfaceOf(tagClass(tag));
+        measured.push({
+            tag,
+            klass: tagClass(tag),
+            gtype,
+            // KEYED ON THE CAMEL SPELLING, because that is what a NativeScript setter and
+            // therefore the ledger is written in; the kebab one rides along so a failure
+            // could name it. The generator emits both, so neither is derived here.
+            scalars:
+                body === undefined
+                    ? null
+                    : new Map([...scalarPropertyNames(body)].map(([kebab, camel]) => [camel, kebab])),
+            setters,
+            chainEnd,
+        });
+    }
+    world = { measured, unmeasured, coreClasses, ledger: KNOWN_GAPS };
+} catch (error) {
+    console.error(`check-nativescript-widget-coverage: cannot read an input — ${error.message}`);
+    console.error('If a file moved, teach this check where it went. Do not delete it.');
+    process.exit(1);
+}
+
+const problems = coverageProblems(world);
+if (problems.length > 0) {
+    console.error('check-nativescript-widget-coverage: a widget and its GIR counterpart disagree:');
+    for (const problem of problems) console.error(`  - ${problem}`);
+    process.exit(1);
+}
+
+// EVERY NUMBER HERE IS DERIVED, for the reason ADR 0034 gives about this exact area: a
+// count written into prose beside a count a run computes is the copy that drifts, and it
+// has drifted twice here already.
+const scalarTotal = world.measured.reduce((sum, widget) => sum + widget.scalars.size, 0);
+const backlog = Object.values(KNOWN_GAPS).reduce((sum, entry) => sum + entry.gaps.length, 0);
+const withGaps = Object.keys(KNOWN_GAPS).length;
+const complete = world.measured.filter((widget) => KNOWN_GAPS[widget.tag] === undefined).length;
+console.log(
+    `check-nativescript-widget-coverage: self-test green — ${VECTORS.length - 1} failing vector(s), ` +
+        `${BASE_VECTORS.length} reader vector(s). ${world.measured.length} NativeScript widgets share a ` +
+        `spelling with a GTK tag and are held against ${scalarTotal} scalar GIR propert(y|ies) their ` +
+        `counterparts declare — ${scalarTotal - backlog} are set, ${backlog} across ${withGaps} widgets remain ` +
+        `a declared backlog, and ${complete} widgets hold every one. ${world.unmeasured.length} widget(s) have ` +
+        `no GTK tag of their own and are NOT measured here (${world.unmeasured.join(', ')}) — ` +
+        'check-vocabulary-alignment.mjs is what declares what they are.',
+);

--- a/scripts/check-nativescript-widget-coverage.mjs
+++ b/scripts/check-nativescript-widget-coverage.mjs
@@ -29,11 +29,11 @@
 //
 //   · the CHAIN would put `GtkWidget` plus `GtkAccessible`/`GtkBuildable`/
 //     `GtkConstraintTarget` behind every widget, nearly all of it reading as "missing"
-//     on a port whose views are `GridLayout`s — a number nobody can act on. The ladder's
-//     three rungs are MEASURED in `status/open-todos.md`, not written here: a count in a
-//     comment is the copy that drifts, and the one that stood here contradicted that
-//     ladder in the same change. A property a GIR type inherits from a GIR ancestor is
-//     measured on THAT ancestor's row when the port ships the ancestor as a widget too
+//     on a port whose views are `GridLayout`s. The ladder's three rungs are MEASURED in
+//     `status/open-todos.md`, not written here: a count in a comment is the copy that
+//     drifts, and the one that stood here contradicted that ladder in the same change. A
+//     property a GIR type inherits from a GIR ancestor is measured on THAT ancestor's row
+//     when the port ships the ancestor as a widget too
 //     (`AdwSwitchRow`'s `subtitle` is `AdwActionRow`'s, counted on `adw-action-row`) and
 //     not at all when it does not (`AdwSwitchRow`'s `title` is `AdwPreferencesRow`'s and
 //     the port ships no `adw-preferences-row`) — the one under-count, stated not hidden.
@@ -45,8 +45,11 @@
 //   · the generator emits multiword properties twice (`canOpen` beside `'can-open'`), so
 //     without the dedupe every multiword gap would count double.
 //
-// Those exclusions are COUNTED and printed, so the rule cannot drown its findings in
-// false ones and cannot quietly grow a fifth exclusion either.
+// Each exclusion is STATED with what it removes and pinned by its own vector in the
+// shared reader's self-test, and a fifth would have to be added in
+// `gir-scalar-properties.mjs`, where BOTH ratchets would carry it. What no run prints is
+// how many keys each one removes: the ladder in `status/open-todos.md` measures that, and
+// its 293 → 231 rung IS the slot exclusion.
 //
 // THE PORT SIDE RESOLVES THE PORT'S OWN `extends` CHAIN, AND THAT IS NOT A DETAIL
 //

--- a/scripts/check-nativescript-widget-coverage.mjs
+++ b/scripts/check-nativescript-widget-coverage.mjs
@@ -475,8 +475,8 @@ export function coverageProblems(world) {
             const set = widget.setters.has(property);
             if (set && declared.has(property)) {
                 problems.push(
-                    `${widget.klass} now sets '${property}' — delete it from ${LEDGER_SOURCE} so the backlog ` +
-                        'can only shrink. A declaration whose gap is closed is a stale reason left standing.',
+                    `${widget.klass} now sets '${property}' — delete it from ${LEDGER_SOURCE}. A declaration ` +
+                        'whose gap is closed is a stale reason left standing, and the next reader believes it.',
                 );
                 continue;
             }

--- a/scripts/check-nativescript-widget-coverage.mjs
+++ b/scripts/check-nativescript-widget-coverage.mjs
@@ -27,13 +27,16 @@
 // `extends` chain — minus signal handlers and minus widget-valued slots. Every one of
 // those four choices removes a number nobody could act on:
 //
-//   · the CHAIN would put `GtkWidget`'s ~59 keys, plus `GtkAccessible`/`GtkBuildable`/
-//     `GtkConstraintTarget`, behind every widget: 1835 keys against 231, and 1699 of
-//     them "missing" on a port whose views are `GridLayout`s. A property a GIR type
-//     inherits from a GIR ancestor is measured on THAT ancestor's row when the port
-//     ships it as a widget too — `AdwSwitchRow`'s `title` is counted on `adw-action-row`
-//     — and is not counted at all when it does not, which is this denominator's one
-//     under-count and is stated rather than hidden.
+//   · the CHAIN would put `GtkWidget` plus `GtkAccessible`/`GtkBuildable`/
+//     `GtkConstraintTarget` behind every widget, nearly all of it reading as "missing"
+//     on a port whose views are `GridLayout`s — a number nobody can act on. The ladder's
+//     three rungs are MEASURED in `status/open-todos.md`, not written here: a count in a
+//     comment is the copy that drifts, and the one that stood here contradicted that
+//     ladder in the same change. A property a GIR type inherits from a GIR ancestor is
+//     measured on THAT ancestor's row when the port ships the ancestor as a widget too
+//     (`AdwSwitchRow`'s `subtitle` is `AdwActionRow`'s, counted on `adw-action-row`) and
+//     not at all when it does not (`AdwSwitchRow`'s `title` is `AdwPreferencesRow`'s and
+//     the port ships no `adw-preferences-row`) — the one under-count, stated not hidden.
 //   · `onNotify*`/`on<Signal>` are a JSX convention. A NativeScript view takes
 //     `addEventListener`, so there is no property to be missing.
 //   · a widget-valued key (`child`, `content`, `sidebar`, `title-widget`) is a SLOT.
@@ -63,9 +66,12 @@
 //   CAN. The two sides are independent and neither reads the other: the port's setters
 //   are hand-typed accessors, and `generated/props.ts` is emitted from the GIR by a
 //   generator that reads none of them. A gap that is not declared fails. A declared gap
-//   the widget now sets fails, so the backlog can only shrink. A declared gap that is no
-//   longer a scalar property of that GType fails, so a @girs bump that drops a property
-//   cannot leave a ledger row describing something that does not exist.
+//   the widget now sets fails, so a gap that closes cannot leave its reason standing. A
+//   declared gap that is no longer a scalar property of that GType fails, so a @girs
+//   bump that drops a property cannot leave a ledger row describing something that does
+//   not exist. The TOTAL is not the invariant and does not only fall — a new widget, or
+//   a @girs bump that ADDS a property, raises it. What holds is that neither direction
+//   is silent: a new gap costs a written reason here, a closed one costs deleting it.
 //
 //   CANNOT. The `why` floor holds a table in this file against a constant in this file:
 //   it refuses a blank, it judges nothing. And the comparison target is a file this
@@ -118,12 +124,14 @@ const MIN_REASON = 40;
  * worse than naming none". A per-WIDGET reason is a different object — it says what this
  * port BUILDS and therefore which part of the GTK widget it does not reach, which is a
  * statement about the file it names and can be checked by reading it. A per-property one
- * would be 131 sentences of which most would be that same sentence restated.
+ * would be one sentence per gap below, most of them that same sentence restated.
  *
  * THE RATCHET, in both directions. A gap not listed here fails. A listed gap the widget
- * now sets fails, so closing one is an edit here and the number can only go down. A
- * listed name that is no longer a scalar property of that GType fails, so a @girs bump
- * cannot leave a row describing a property that does not exist.
+ * now sets fails, so closing one is an edit here. A listed name that is no longer a
+ * scalar property of that GType fails, so a @girs bump cannot leave a row describing a
+ * property that does not exist. The total is not the invariant and does not only fall —
+ * a new widget, or a @girs bump that ADDS a property, raises it. What holds is that
+ * neither direction happens without this edit.
  *
  * NO COUNT IS WRITTEN IN THIS COMMENT. The summary at the bottom derives every number it
  * prints, for the reason ADR 0034 § *Why the distance has to be PRINTED by a gate* gives
@@ -774,13 +782,22 @@ if (problems.length > 0) {
 const scalarTotal = world.measured.reduce((sum, widget) => sum + widget.scalars.size, 0);
 const backlog = Object.values(KNOWN_GAPS).reduce((sum, entry) => sum + entry.gaps.length, 0);
 const withGaps = Object.keys(KNOWN_GAPS).length;
-const complete = world.measured.filter((widget) => KNOWN_GAPS[widget.tag] === undefined).length;
+// A counterpart declaring NO scalar property of its OWN gives its widget an empty
+// denominator — `AdwPasswordEntryRow` introduces nothing over `AdwEntryRow` — and "holds
+// every one" is then true of it vacuously. Counted with the real ones it would be this
+// gate reporting a pass it did not measure, so they are named apart; the control above
+// is what catches the day ALL of them read that way.
+const held = world.measured.filter((widget) => widget.scalars.size > 0);
+const vacuous = world.measured.filter((widget) => widget.scalars.size === 0).map((widget) => widget.tag);
+const complete = held.filter((widget) => KNOWN_GAPS[widget.tag] === undefined).length;
 console.log(
     `check-nativescript-widget-coverage: self-test green — ${VECTORS.length - 1} failing vector(s), ` +
         `${BASE_VECTORS.length} reader vector(s). ${world.measured.length} NativeScript widgets share a ` +
         `spelling with a GTK tag and are held against ${scalarTotal} scalar GIR propert(y|ies) their ` +
         `counterparts declare — ${scalarTotal - backlog} are set, ${backlog} across ${withGaps} widgets remain ` +
-        `a declared backlog, and ${complete} widgets hold every one. ${world.unmeasured.length} widget(s) have ` +
-        `no GTK tag of their own and are NOT measured here (${world.unmeasured.join(', ')}) — ` +
-        'check-vocabulary-alignment.mjs is what declares what they are.',
+        `a declared backlog, and ${complete} widgets hold every one their counterpart declares. ` +
+        `${vacuous.length} counterpart(s) declare no scalar property of their own, so those widgets have ` +
+        `nothing to hold and are not evidence of anything${vacuous.length > 0 ? ` (${vacuous.join(', ')})` : ''}. ` +
+        `${world.unmeasured.length} widget(s) have no GTK tag of their own and are NOT measured here ` +
+        `(${world.unmeasured.join(', ')}) — check-vocabulary-alignment.mjs is what declares what they are.`,
 );

--- a/scripts/gir-scalar-properties.mjs
+++ b/scripts/gir-scalar-properties.mjs
@@ -25,10 +25,12 @@
 // exactly what ADR 0034 § 4 names as the convergent spelling for both surfaces.
 //
 // THE OWN BODY, NOT THE `extends` CHAIN. Both ratchets ask what the GType ITSELF
-// declares. Resolving the chain would put `GtkWidget`'s 59 keys behind every widget and
-// produce a number nobody can act on; the chain-resolved set is the right one for the
-// opposite question (is a property a surface HAS a key of its counterpart), which is
-// what `check-vocabulary-alignment.mjs` uses it for.
+// declares. Resolving the chain would put the whole of `GtkWidget` behind every widget
+// and produce a number nobody can act on — the three rungs of that ladder are measured in
+// `status/open-todos.md` rather than written here, because a count in a comment is the
+// copy that drifts. The chain-resolved set is the right one for the opposite question (is
+// a property a surface HAS a key of its counterpart), which is what
+// `check-vocabulary-alignment.mjs` uses it for.
 
 /** A GIR type that holds an object — a slot on either renderer, never an attribute. */
 const OBJECT_TYPE = /\b(?:Gtk|Adw|Gio|Gdk|Pango|GObject)\.\w+/;

--- a/scripts/gir-scalar-properties.mjs
+++ b/scripts/gir-scalar-properties.mjs
@@ -1,0 +1,213 @@
+// The GIR side of every "does this surface carry its widget's properties" check.
+//
+// ONE READER, TWO RATCHETS. `check-adwaita-element-properties.mjs` holds the web
+// elements against it and `check-nativescript-widget-coverage.mjs` holds the
+// NativeScript widgets against it. They ask the same question of the same file — which
+// scalar properties does `generated/props.ts` say this GType declares — and the moment
+// that lived in two places the two backlogs could disagree about what a property IS
+// while both stayed green. The repo rule this follows is the one about the SECOND copy
+// being where you lift.
+//
+// WHAT COUNTS AS A SCALAR, and why the two exclusions are not a way of hiding findings
+// (the reasoning is `check-adwaita-element-properties.mjs`'s, kept with the code it
+// belongs to):
+//
+//   · SIGNAL props (`on-clicked`, `on-notify-*`) are a JSX convention. A custom element
+//     dispatches events; a NativeScript view takes `addEventListener`. Neither is a
+//     property either surface could carry under that name.
+//   · WIDGET-VALUED props (`child`, `content`, `sidebar`, `title-widget` — anything
+//     typed `Gtk.*`/`Adw.*`/`Gio.*`/`Gdk.*`/`Pango.*`/`GObject.*` and NOT an enum) are
+//     SLOTS on both renderers: an HTML attribute cannot carry a widget and neither can
+//     an XML one, where `component-builder` assigns `instance[name] = "<raw string>"`.
+//
+// ENUMS ARE NOT EXCLUDED although the namespace test would catch them: the generator
+// spells one `AdwToolbarStyleNick | Adw.ToolbarStyle`, and a nick is a STRING — which is
+// exactly what ADR 0034 § 4 names as the convergent spelling for both surfaces.
+//
+// THE OWN BODY, NOT THE `extends` CHAIN. Both ratchets ask what the GType ITSELF
+// declares. Resolving the chain would put `GtkWidget`'s 59 keys behind every widget and
+// produce a number nobody can act on; the chain-resolved set is the right one for the
+// opposite question (is a property a surface HAS a key of its counterpart), which is
+// what `check-vocabulary-alignment.mjs` uses it for.
+
+/** A GIR type that holds an object — a slot on either renderer, never an attribute. */
+const OBJECT_TYPE = /\b(?:Gtk|Adw|Gio|Gdk|Pango|GObject)\.\w+/;
+
+/**
+ * An ENUM, which {@link OBJECT_TYPE} also matches and must not exclude.
+ *
+ * The generator spells an enum property `AdwToolbarStyleNick | Adw.ToolbarStyle`, so the
+ * namespaced half makes it look object-typed. It is not: a nick is a STRING, exactly what
+ * an attribute carries. The proof that these belong to the checked surface is that 17 of
+ * them are already observed as attributes today (`adw-banner/button-style`,
+ * `adw-dialog/presentation-mode`, `adw-toolbar-view/top-bar-style`, …). Excluding them
+ * would have hidden 14 real gaps behind a justification — "an attribute cannot carry a
+ * widget" — that does not apply to them.
+ */
+const ENUM_TYPE = /\b\w+Nick\b/;
+
+/** `canShrink` → `can-shrink`: the second spelling the generator emits beside it. */
+export const kebabName = (name) => name.replace(/([A-Z])/g, (c) => `-${c.toLowerCase()}`);
+
+/** `tag -> GType`, from the runtime widget table. */
+export function tagGTypes(widgetsSource) {
+    const map = new Map();
+    for (const m of widgetsSource.matchAll(/gtype: '([^']+)', tag: '([^']+)'/g)) map.set(m[2], m[1]);
+    return map;
+}
+
+/**
+ * `<GType> -> interface body`, brace-MATCHED rather than regex-bounded.
+ *
+ * A lazy `[\s\S]*?\n\}` reads an EMPTY interface as the next one's body, which silently
+ * credited `adw-spinner` with `AdwSplitButton`'s properties while this was being built.
+ */
+export function propsBodies(propsSource) {
+    const bodies = new Map();
+    // `extends\s`, NOT `extends ` — the generator wraps long heritage lists onto the
+    // next line, and a literal space missed 65 of 190 interfaces. Each one then had no
+    // body, and `propertyProblems` skipped its element as unmapped: eight `adw-*`
+    // elements passed by being invisible. A vector pins it.
+    //
+    // `\s*` before the brace is the SAME defect one clause over, and it was live here
+    // after the first one was fixed: `[^{]*` swallows the space only when `extends` is
+    // present, so an interface declared WITHOUT one — `export interface AdwToggleProps
+    // {` — never matched. 13 interfaces were invisible that way, and the @girs 4.5.0
+    // vocabulary took it to 25 by dropping the empty `GObject` base: `<adw-toggle>`
+    // left this check silently, and surfaced only as five KNOWN_GAPS entries reported
+    // as stale. `girs-vocabulary.mts` carries the identical rule and its own vector.
+    const head = /export interface (\w+)Props(?:\s+extends\s[^{]*)?\s*\{/g;
+    let m;
+    while ((m = head.exec(propsSource))) {
+        let depth = 1;
+        let i = head.lastIndex;
+        while (i < propsSource.length && depth > 0) {
+            const c = propsSource[i];
+            if (c === '{') depth++;
+            else if (c === '}') depth--;
+            i++;
+        }
+        bodies.set(m[1], propsSource.slice(head.lastIndex, i - 1));
+    }
+    return bodies;
+}
+
+/**
+ * The scalar properties of one interface body, as `kebab-spelling -> camelSpelling`.
+ *
+ * BOTH SPELLINGS, because the two surfaces write different ones and neither may be
+ * derived by a second transformation: an HTML attribute is `can-shrink` and a
+ * NativeScript setter is `canShrink`, and the generator itself emits the pair
+ * (`canShrink?: boolean;` beside `'can-shrink'?: boolean;`). Reading the camel spelling
+ * out of the source rather than mapping back from the kebab one is the difference
+ * between a fact and a round-trip assumption — `imModule`/`im-module` round-trips today
+ * and nothing guarantees the next generated name will.
+ *
+ * A property the generator emits ONLY as a quoted kebab name maps to the camelCase form
+ * derived from it, which is the honest fallback: there is no second spelling to read.
+ */
+export function scalarPropertyNames(body) {
+    /** @type {Map<string, string>} */
+    const names = new Map();
+    for (const line of body.split('\n')) {
+        const m = /^\s*(?:'([a-z0-9-]+)'|([a-zA-Z][a-zA-Z0-9]*))\?:\s*(.+?);\s*$/.exec(line);
+        if (!m) continue;
+        const camel = m[2] ?? m[1].replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+        const name = m[1] ?? kebabName(m[2]);
+        if (name.startsWith('on-')) continue;
+        if (OBJECT_TYPE.test(m[3]) && !ENUM_TYPE.test(m[3])) continue;
+        // The quoted kebab line usually comes SECOND, and it carries no camel spelling
+        // of its own; the camel line is the authority, so the first entry wins.
+        if (!names.has(name)) names.set(name, camel);
+    }
+    return names;
+}
+
+/**
+ * The scalar property names of one interface body, kebab-spelled and deduplicated.
+ *
+ * The generator emits multiword properties TWICE — `canOpen?: boolean;` and
+ * `'can-open'?: boolean;` — so without the dedupe every multiword gap counts double.
+ */
+export const scalarProps = (body) => new Set(scalarPropertyNames(body).keys());
+
+/**
+ * The fixture both ratchets prove the reader on, and every shape it has been wrong about.
+ *
+ * It lives here rather than in either check for the reason the reader does: two copies
+ * of a fixture is two definitions of what a scalar property is.
+ */
+export const GIR_FIXTURE_PROPS = `
+export interface DemoWidgetProps extends GtkWidgetProps {
+    /** A scalar. */
+    label?: string;
+    /** Multiword, emitted twice by the generator. */
+    canShrink?: boolean;
+    'can-shrink'?: boolean;
+    /** An ENUM — namespaced, but a nick is a string an attribute carries. */
+    barStyle?: AdwBarStyleNick | Adw.BarStyle;
+    'bar-style'?: AdwBarStyleNick | Adw.BarStyle;
+    /** A slot, not an attribute. */
+    child?: Gtk.Widget | null;
+    /** A signal, not a property. */
+    'on-clicked'?: () => void;
+}
+export interface RootWidgetProps {
+    /** Reachable ONLY if the head reader tolerates a space before the brace. */
+    rooted?: string;
+}
+export interface EmptyWidgetProps extends GtkWidgetProps {}
+export interface AfterEmptyProps extends GtkWidgetProps {
+    trap?: string;
+}
+export interface WrappedWidgetProps
+    extends GtkWidgetProps,
+        GtkAccessibleProps,
+        GtkBuildableProps {
+    /** Reachable ONLY if the head reader tolerates a newline after \`extends\`. */
+    wrapped?: string;
+}
+`;
+
+/** Every scalar `DemoWidget` offers, kebab-spelled — an enum among them, on purpose. */
+export const GIR_FIXTURE_SCALARS = ['label', 'can-shrink', 'bar-style'];
+
+/**
+ * The reader's own vectors, run by BOTH ratchets before either reads the repository.
+ *
+ * @returns {string[]} failures, empty when the reader is sound
+ */
+export function girReaderSelfTest() {
+    const failures = [];
+    const bodies = propsBodies(GIR_FIXTURE_PROPS);
+    if (scalarProps(bodies.get('EmptyWidget') ?? '').size !== 0) {
+        failures.push('an empty interface must have no properties — the body reader ran past its closing brace');
+    }
+    if (!scalarProps(bodies.get('AfterEmpty') ?? '').has('trap')) {
+        failures.push('the interface after an empty one must still be read');
+    }
+    if (!bodies.has('WrappedWidget')) {
+        failures.push('an interface whose `extends` list wraps must be found — the head reader needs `\\s`');
+    }
+    if (!bodies.has('RootWidget')) {
+        failures.push('an interface with no `extends` must be found — the head reader needs `\\s*` before `{`');
+    }
+    const demo = scalarProps(bodies.get('DemoWidget') ?? '');
+    for (const property of GIR_FIXTURE_SCALARS) {
+        if (!demo.has(property)) failures.push(`DemoWidget must expose '${property}' as a scalar`);
+    }
+    if (demo.has('child')) failures.push('a widget-valued property must not count as a scalar');
+    if (demo.size !== GIR_FIXTURE_SCALARS.length) {
+        failures.push(`DemoWidget must expose ${GIR_FIXTURE_SCALARS.length} scalars, got ${[...demo].join(', ')}`);
+    }
+    // The camel half, which the NativeScript ratchet keys on: it must be READ from the
+    // source line, not derived from the kebab one. A reader that returned the kebab name
+    // twice would satisfy every assertion above and hand that surface a setter name no
+    // class has.
+    const camels = scalarPropertyNames(bodies.get('DemoWidget') ?? '');
+    if (camels.get('can-shrink') !== 'canShrink') {
+        failures.push(`'can-shrink' must carry the camel spelling 'canShrink', got '${camels.get('can-shrink')}'`);
+    }
+    if (camels.get('label') !== 'label') failures.push("a single-word property's camel spelling is itself");
+    return failures;
+}

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -565,6 +565,156 @@ without its surface is a claim wider than its measurement.
 A full `tsc` conformance check remains the right oracle on the wrong instrument —
 `Gtk.Entry` is 509 members, and the gate job runs `checkout` + `setup-node` with no install.
 
+### The vocabulary gate measured ONE direction, and the other one is now a ratchet
+
+`NS_PROPERTY_ALIGNMENT` holds the port's SETTABLE properties against the counterpart's
+`ConstructorProps` and asks whether the NAME agrees. A GIR property the port simply does
+not HAVE is invisible to it, and to every other gate, because nothing iterated the
+counterpart's side. So the printed *"Distance to one vocabulary: N property name(s)"*
+measures disagreement among the properties that EXIST and says nothing about the ones that
+do not.
+
+Measured instance: `AdwAvatar` set `text` and `size` while `Adw.Avatar` declares four
+scalar properties — `icon-name`, `show-initials`, `size`, `text`. Two of four, with every
+check green, for as long as the widget existed. `<adw-avatar>` had been held against the
+same four since 2026-08-26 by `check-adwaita-element-properties.mjs`; the second renderer
+had no such gate at all.
+
+`scripts/check-nativescript-widget-coverage.mjs` closes it, in the shape the web surface
+already had — a per-widget declared backlog, a new gap fails, a closed gap fails until it
+leaves the ledger. The GIR side of both is one reader now
+(`scripts/gir-scalar-properties.mjs`): two definitions of "a scalar property" would be two
+backlogs that can disagree about what they are counting while both stay green.
+
+**The denominator is the deliverable, so here is the ladder it was chosen from**, all
+three measured over the same 43 widgets:
+
+| denominator | keys | the port does not set |
+|---|---:|---:|
+| the whole `extends` chain, everything in it | 5363 | 5142 |
+| the counterpart's OWN body, `onNotify*`/signals and kebab twins removed | 293 | 181 |
+| …and widget-valued slots removed — **what the gate uses** | 231 | 131 |
+
+The chain is what makes a number nobody can act on: it puts `GtkWidget`'s keys plus
+`GtkAccessible`/`GtkBuildable`/`GtkConstraintTarget` behind every widget, and 96 % of it is
+"missing" on a port whose views are `GridLayout`s. Own-body-only is symmetric instead —
+both sides count what the TYPE introduces — and it has one honest under-count, stated
+rather than hidden: a property a GIR type inherits from a GIR ancestor is measured on THAT
+ancestor's row when the port ships it as a widget too (`AdwSwitchRow`'s `title` is counted
+on `adw-action-row`) and is not counted at all when it does not.
+
+The live totals are the gate's summary line and are not restated here. What it does NOT
+print is the SHAPE of the backlog, which is the census — at the landing commit, 12 widgets
+short nothing, 7 short one, 6 short two, 6 short three, 3 short four, 3 short five, 3 short
+six, and then three long tails: `GtkMenuButton` (8 of 9 unset), `AdwAboutDialog` (15 of 22)
+and `GtkEntry` (26 of 28). Those three carry 49 of the total, so the backlog is not evenly
+spread and the obvious first pass is one widget, not a sweep. The three widgets whose file
+spelling is NOT a GTK tag (`adw-image-button`, `adw-slider-row`, `adw-data-grid`) are
+declared divergences `NS_WIDGET_ALIGNMENT` owns and are deliberately outside this gate;
+reading that ledger from a second script would be a second copy of it.
+
+**Two findings the census turned up that are not gaps.**
+
+`Gtk.Entry:visibility` is password masking; the port's `GtkEntry` already answers to
+`visibility` from NativeScript's `View`, meaning show-or-hide. Same spelling, two controls,
+and it is the only such collision in the corpus — measured against the ambient
+`ns-core.d.ts` slice, so a name NS core carries that the slice does not declare would be
+missed.
+
+`AdwViewSwitcher` HAS `Adw.ViewSwitcher:policy` and not under that name:
+`AdwViewSwitcherBase` declares a protected `policy` getter for the button orientation and
+exposes the settable door as `switcherPolicy` beside it. ADR 0034 § Amendment 11 already
+settled the shape — a collision with a port-owned member is a question about that member,
+not a reason the name cannot converge — and this one is internal, so it can be renamed.
+
+### A name can agree while the VALUE KIND disagrees, and the declarations mostly cannot tell
+
+The second census, and the reason it produced no gate. Of the 109 property names where the
+port and its counterpart agree, the two declared TYPES — the GIR annotation in
+`generated/props.ts` against the port's setter parameter — say:
+
+| | rows | what it is |
+|---|---:|---|
+| the same kind | 58 | 42 string/string, 13 enum, 3 object |
+| the port widened it with `\| string` | 42 | the XML-attribute coercion `xml-values.ts` exists for: `component-builder` assigns a raw string, so `boolean` becomes `boolean \| string` |
+| a different kind | **9** | below |
+| no annotation to read | 0 | every setter on this surface is typed |
+
+The nine, each read from both sides:
+
+| | GIR | port |
+|---|---|---|
+| `AdwComboRow.model`, `GtkDropDown.model` | `Gio.ListModel \| null` | an array of option specs (ADR 0046) |
+| `AdwSplitButton.menuModel`, `GtkMenuButton.menuModel` | `Gio.MenuModel \| null` | an array of menu entries (ADR 0042) |
+| `AdwTabView.selectedPage` | `Adw.TabPage \| null` | the page id, a string (ADR 0048) |
+| `AdwTabView.defaultIcon` | `Gio.Icon` | a symbolic SVG string |
+| `AdwSidebar.filter` | `Gtk.Filter \| null` | a predicate function |
+| `GtkImage.iconSize`, `AdwImageButton.iconSize` | `GtkIconSizeNick \| Gtk.IconSize` | a size in DIPs |
+
+Seven of the nine are DECIDED portable forms with an ADR behind them — the port has no list
+model, no menu model and no page type, and giving it one was the point of those changes.
+The last two are the interesting ones and they are the same defect twice:
+`Gtk.Image:icon-size` is a three-member enum (`inherit`/`normal`/`large`) and the port's
+`iconSize` is "the icon size in DIPs" (`gtk-image.ts:109`). GTK's number for that is
+`pixel-size` — which the coverage census above lists as a gap on both widgets. So the port
+carries GTK's `pixel-size` under GTK's `icon-size` name, and `<gtk:Image iconSize="large">`
+resolves to `NaN` and falls back to 16, silently. Not fixed here: it renames a published
+attribute on a surface `feat/ns-construct-props` is rewriting, and both censuses now make
+the question visible from two directions.
+
+**Why this is not a gate.** Getting from 26 raw disagreements to those 9 took four
+normalisations, and every one of them is a judgement a gate would be encoding rather than
+measuring: absorbing the enum CONSTANT half of `XNick | Ns.X` into the nick (ADR 0034 § 4
+says the nick is the convergent spelling), resolving port type aliases across
+`@gjsify/adwaita-core` (`AdwToolbarStyle` is `'flat' | 'raised' | 'raised-border'`),
+treating `View` and `Gtk.Widget` as one kind, and forgiving the `| string` widening. A
+checker that wanted to be honest would have to read: both type surfaces, the alias
+definitions in two packages, `xml-values.ts` for which coercions exist, and the nick tables
+— and it would still stop one step short of the thing that matters.
+
+Because the case the brief for this work names is exactly the one the declarations CANNOT
+decide. `Adw.ButtonRow:start-icon-name` is `string | null` and `AdwButtonRow.startIconName`
+is `string`: the gate above and this census both call that agreement, and GTK holds an
+icon-theme NAME while the port holds a rendered symbolic SVG. Nine of the 42 string/string
+rows are icon slots of that shape, and only four say so in a way a machine can see (the
+setter parameter is literally named `svg`). ADR 0034 § Amendment 7 already ruled on it —
+*"A string is a string whether it is a theme name or an SVG source"* — so it is a recorded
+decision rather than an undetected defect, and what closes the class is not a type
+comparison but ADR 0027 § 9's conformance vectors.
+
+### The vocabulary gate's port-side reader stops at the class body, and two base classes fall out of it
+
+Found while building the coverage census, and it is the same blind side one direction over.
+`check-vocabulary-alignment.mjs` reads a widget's settable properties with
+`settablePropertiesOfClass`, which reads ONE class body. That is right wherever a port
+widget's base is itself a widget file — `AdwSwitchRow`'s inherited `title` is held on
+`adw-action-row`'s own row — and wrong for a base that is not:
+`packages/nativescript-bridge/adwaita/src/widgets/split-view-base.ts` and
+`view-switcher-base.ts` are not `<library>-<name>.ts` files, so the 10 setters they declare
+are read by nothing.
+
+A chain-resolving port reader adds 56 rows to that gate, of which **18 are neither a key of
+the counterpart nor declared today**:
+
+    adw-inline-view-switcher   switcherPolicy  views  selected
+    adw-view-switcher          switcherPolicy  views  selected
+    adw-navigation-split-view  showSidebar  sidebarWidth
+    adw-overlay-split-view     sidebarWidth
+    adw-button-row             subtitle  activatableWidget
+    adw-entry-row              subtitle  activatableWidget
+    adw-password-entry-row     subtitle  activatableWidget
+    adw-expander-row           activatableWidget
+    gtk-menu-button            iconColor  iconSize
+
+The fix is a one-function change in that gate's world builder plus 18 ledger entries with
+reasons, and it is a separate PR on purpose: every one of the 18 needs a `gir`-or-`own`
+verdict, `feat/ns-construct-props` is currently rewriting every widget file under it, and
+landing it in the same change as the coverage ratchet would put two moving denominators in
+one diff. The reader that does it correctly already exists — the new coverage gate walks
+the chain across the whole package and FAILS when it leaves the package at a class
+`ns-core.d.ts` does not declare, because a chain that stops early hands the comparison a
+setter set that is short rather than wrong, and a false red is the expensive kind.
+
 ### The `@girs/*` vocabulary is consumed — what the migration cost, and the one open decision
 
 **Done.** `gtk-host` builds `props.ts`, `widgets.ts` and `surface-data.mts` from

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -597,21 +597,28 @@ three measured over the same 43 widgets:
 
 The chain is what makes a number nobody can act on: it puts `GtkWidget`'s keys plus
 `GtkAccessible`/`GtkBuildable`/`GtkConstraintTarget` behind every widget, and 96 % of it is
-"missing" on a port whose views are `GridLayout`s. Own-body-only is symmetric instead —
-both sides count what the TYPE introduces — and it has one honest under-count, stated
-rather than hidden: a property a GIR type inherits from a GIR ancestor is measured on THAT
-ancestor's row when the port ships it as a widget too (`AdwSwitchRow`'s `title` is counted
-on `adw-action-row`) and is not counted at all when it does not.
+"missing" on a port whose views are `GridLayout`s. Own-body-only keeps the GIR side to what
+the TYPE introduces — the PORT side is deliberately not symmetric with it and resolves the
+port's own `extends` chain, for the false-red reason the section below gives — and it has
+one honest under-count, stated rather than hidden: a property a GIR type inherits from a
+GIR ancestor is measured on THAT ancestor's row when the port ships the ancestor as a
+widget too (`AdwSwitchRow`'s `subtitle` is `AdwActionRow`'s and is counted on
+`adw-action-row`), and is not counted at all when it does not — `AdwSwitchRow`'s `title` is
+`AdwPreferencesRow`'s, the port ships no `adw-preferences-row`, and nothing measures it.
 
 The live totals are the gate's summary line and are not restated here. What it does NOT
 print is the SHAPE of the backlog, which is the census — at the landing commit, 12 widgets
 short nothing, 7 short one, 6 short two, 6 short three, 3 short four, 3 short five, 3 short
 six, and then three long tails: `GtkMenuButton` (8 of 9 unset), `AdwAboutDialog` (15 of 22)
-and `GtkEntry` (26 of 28). Those three carry 49 of the total, so the backlog is not evenly
-spread and the obvious first pass is one widget, not a sweep. The three widgets whose file
-spelling is NOT a GTK tag (`adw-image-button`, `adw-slider-row`, `adw-data-grid`) are
-declared divergences `NS_WIDGET_ALIGNMENT` owns and are deliberately outside this gate;
-reading that ledger from a second script would be a second copy of it.
+and `GtkEntry` (26 of 28). Three of the 12 short nothing are short nothing VACUOUSLY —
+`AdwPasswordEntryRow`, `AdwSpinner` and `AdwToastOverlay` declare no scalar property of
+their own at all, so there was nothing for the port to be short of, and the gate prints
+those apart from the nine that hold something. The three long tails carry 49 of the total,
+so the backlog is not evenly spread and the obvious first pass is one widget, not a sweep.
+The three widgets whose file spelling is NOT a GTK tag (`adw-image-button`,
+`adw-slider-row`, `adw-data-grid`) are declared divergences `NS_WIDGET_ALIGNMENT` owns and
+are deliberately outside this gate; reading that ledger from a second script would be a
+second copy of it.
 
 **Two findings the census turned up that are not gaps.**
 
@@ -687,9 +694,10 @@ comparison but ADR 0027 § 9's conformance vectors.
 Found while building the coverage census, and it is the same blind side one direction over.
 `check-vocabulary-alignment.mjs` reads a widget's settable properties with
 `settablePropertiesOfClass`, which reads ONE class body. That is right wherever a port
-widget's base is itself a widget file — `AdwSwitchRow`'s inherited `title` is held on
-`adw-action-row`'s own row — and wrong for a base that is not:
-`packages/nativescript-bridge/adwaita/src/widgets/split-view-base.ts` and
+widget's base is itself a widget file — the PORT's `AdwActionRow` declares `set title`, so
+`AdwSwitchRow`'s inherited `title` is held on `adw-action-row`'s own row (this is the port
+hierarchy, not the GIR one, where `title` is `AdwPreferencesRow`'s) — and wrong for a base
+that is not: `packages/nativescript-bridge/adwaita/src/widgets/split-view-base.ts` and
 `view-switcher-base.ts` are not `<library>-<name>.ts` files, so the 10 setters they declare
 are read by nothing.
 


### PR DESCRIPTION
Two independent findings hit the same blind side of the widget-vocabulary programme from
different directions. This measures both, builds a gate for the one that supports a
zero-false-positive gate, and says plainly why the other does not get one.

## The blind side

`NS_PROPERTY_ALIGNMENT` holds the port's SETTABLE properties against the counterpart's
`ConstructorProps` and asks whether the NAME agrees. Nothing iterates the counterpart's
side, so **a GIR property the port simply does not HAVE is invisible to every gate** — and
the printed *"Distance to one vocabulary: N property name(s)"* measures disagreement among
the properties that exist and says nothing about the ones that do not.

Re-measured rather than taken from the brief: `AdwAvatar` sets `text` and `size`, and
`Adw.Avatar` declares **four** scalar properties — `icon-name`, `show-initials`, `size`,
`text`. (The brief said two of five; the fifth is `custom-image`, typed `Gdk.Paintable`,
which is a slot on both renderers and is excluded with the count. `feat/ns-avatar-parity`
closes two of these four, and this PR's ledger will go red for `adw-avatar` on that
rebase — which is the ratchet working.)

## Census (a) — what the port does not have

The honesty of the denominator IS the deliverable, so here is the ladder it was chosen
from, all three measured over the same 43 widgets:

| denominator | keys | the port does not set |
|---|---:|---:|
| the whole `extends` chain, everything in it | 5363 | 5142 |
| the counterpart's OWN body, `onNotify*`/signals and kebab twins removed | 293 | 181 |
| …and widget-valued slots removed — **what the gate uses** | **231** | **131** |

The chain is what produces a number nobody can act on: `GtkWidget` plus
`GtkAccessible`/`GtkBuildable`/`GtkConstraintTarget` sit behind every widget and 96 % of it
reads as missing on a port whose views are `GridLayout`s. Own-body-only is symmetric —
both sides count what the TYPE introduces — and carries one under-count, stated rather than
hidden: a property a GIR type inherits from a GIR ancestor is counted on THAT ancestor's
row when the port ships the ancestor as a widget too (`AdwSwitchRow`'s `title` on
`adw-action-row`), and not at all when it does not.

Signals and slots are excluded for the reasons `check-adwaita-element-properties.mjs`
already argues on the web surface: a NativeScript view takes `addEventListener`, and
`component-builder` assigns `instance[name] = "<raw string>"`, so a view cannot arrive
through an attribute. Enums stay IN, because a nick is a string — ADR 0034 § 4's own
convergent spelling.

**Distribution** (the shape the gate does not print), at the landing commit:

| gaps on one widget | widgets |
|---:|---:|
| 0 | 12 |
| 1 | 7 |
| 2 | 6 |
| 3 | 6 |
| 4 | 3 |
| 5 | 3 |
| 6 | 3 |
| 8 | 1 — `GtkMenuButton` (8 of 9) |
| 15 | 1 — `AdwAboutDialog` (15 of 22) |
| 26 | 1 — `GtkEntry` (26 of 28) |

Three widgets carry 49 of the 131, so the obvious first pass is one widget, not a sweep.
The three widgets whose file spelling is not a GTK tag (`adw-image-button`,
`adw-slider-row`, `adw-data-grid`) are declared divergences `NS_WIDGET_ALIGNMENT` owns and
are deliberately outside this gate; reading that ledger from a second script would be a
second copy of it, and the count of them is printed so "not measured" cannot read as
"none".

**Zero false positives, and what it cost to get there.** `settablePropertiesOfClass` reads
ONE class body, and `AdwOverlaySplitView` inherits seven setters from `AdwSplitViewBase`,
which is not a `<library>-<name>.ts` widget file — reading the body alone reports six
properties the widget HAS as six it does not. So the port side walks the `extends` chain
across the whole package and FAILS where the chain leaves the package at a class
`ns-core.d.ts` does not declare. Measured after that: 0 collisions with a port public
field, 0 with a `Property<>` declaration (the port has none), and exactly 1 name the widget
already answers to from NativeScript core — see below.

## Census (b) — a name agrees, the value KIND does not

Of the 109 property names where the port and its counterpart agree, comparing the GIR
annotation in `generated/props.ts` against the port's setter parameter:

| | rows | what it is |
|---|---:|---|
| the same kind | 58 | 42 string/string, 13 enum, 3 object |
| the port widened it with `\| string` | 42 | the XML coercion `xml-values.ts` exists for |
| a different kind | **9** | below |
| **cannot tell from the declarations** | 0 by type, **and that is the finding** | see below |

The nine:

| | GIR | port |
|---|---|---|
| `AdwComboRow.model`, `GtkDropDown.model` | `Gio.ListModel \| null` | an array of option specs (ADR 0046) |
| `AdwSplitButton.menuModel`, `GtkMenuButton.menuModel` | `Gio.MenuModel \| null` | an array of menu entries (ADR 0042) |
| `AdwTabView.selectedPage` | `Adw.TabPage \| null` | the page id, a string (ADR 0048) |
| `AdwTabView.defaultIcon` | `Gio.Icon` | a symbolic SVG string |
| `AdwSidebar.filter` | `Gtk.Filter \| null` | a predicate function |
| `GtkImage.iconSize`, `AdwImageButton.iconSize` | `GtkIconSizeNick \| Gtk.IconSize` | a size in DIPs |

Seven are DECIDED portable forms with an ADR behind them. **The last two are one defect
twice**: `Gtk.Image:icon-size` is a three-member enum and the port's `iconSize` is "the icon
size in DIPs" (`gtk-image.ts:109`). GTK's number for that is `pixel-size` — which census
(a) lists as a gap on both widgets. So the port carries GTK's `pixel-size` under GTK's
`icon-size` name, and `<gtk:Image iconSize="large">` resolves to `NaN` and falls back to 16,
silently. Both censuses now point at it from opposite directions. Not fixed here: it renames
a published attribute on a surface `feat/ns-construct-props` is rewriting.

**Why census (b) gets no gate.** Getting from 26 raw disagreements to 9 took four
normalisations, each a judgement a checker would ENCODE rather than measure: absorbing the
enum constant half of `XNick | Ns.X`, resolving port type aliases across
`@gjsify/adwaita-core` (`AdwToolbarStyle` is `'flat' | 'raised' | 'raised-border'`), reading
`View` and `Gtk.Widget` as one kind, and forgiving the `| string` widening. A honest checker
would have to read both type surfaces, the alias definitions in two packages,
`xml-values.ts` for which coercions exist, and the nick tables — and it would still stop one
step short.

Because the case the brief names is exactly the one the declarations CANNOT decide.
`Adw.ButtonRow:start-icon-name` is `string | null` and `AdwButtonRow.startIconName` is
`string`; both this census and the gate call that agreement, and GTK holds an icon-theme
NAME while the port holds a rendered symbolic SVG. **Nine of the 42 string/string rows are
icon slots of that shape, and only four say so in a way a machine can see** (the setter
parameter is literally named `svg`). ADR 0034 § Amendment 7 already ruled on it — *"A string
is a string whether it is a theme name or an SVG source"* — so it is a recorded decision,
not an undetected defect, and what closes the class is ADR 0027 § 9's conformance vectors,
not a type comparison.

## What was built

`scripts/check-nativescript-widget-coverage.mjs`, wired into `audit-runtimes.yml` (the
required *Detect runtime-triplet drift* job, which installs nothing — this check reads only
in-repo files) and into `package.json`. Same shape as the web ratchet, one renderer over:
a per-widget declared backlog where an undeclared gap fails, a declared gap the widget now
sets fails, and a declared name that is no longer a scalar property of that GType fails.
Each of the 31 entries carries a `why` over the 40-character floor the sibling ledgers set,
grounded in the widget file it names.

`scripts/gir-scalar-properties.mjs` is the GIR side, LIFTED out of
`check-adwaita-element-properties.mjs` rather than copied: two definitions of "a scalar
property" is two backlogs that can disagree about what they are counting while both stay
green. Both checks run its `girReaderSelfTest()`.

**Not an ADR amendment**, deliberately: the sibling ratchet for the web surface is
documented in `status/open-todos.md` and has no ADR, and `feat/ns-construct-props` is
already claiming ADR 0034 § Amendment 12. Following the precedent also keeps this PR out of
that file entirely.

## Negative testing

A/B against the real tree, each branch separately, exit codes read without a pipe: a
declared gap deleted from the ledger; a widget that now sets a declared gap; a ledger name
that is not a scalar property; an entry for a widget that is not measured; a reason under
the floor; and a base class the chain walk cannot follow — **exit 1 each with its own
message, exit 0 restored each time**.

**17 rule-disable mutations, one at a time** (the six controls, the chain-end control, the
seven ledger rules, the reason floor, the generic-aware base pattern and the comment
stripper): every one is caught by the SELF-TEST rather than by the real data. Two of them
originally surfaced as a stack trace instead of a named failure, which is why the vector
runner now reports a throw as "that rule is not holding".

Five mutations of the shared GIR reader take BOTH ratchets to exit 1 through their
self-tests.

## A third finding, recorded rather than fixed

The vocabulary gate's port-side reader stops at the class body, so the 10 setters on
`AdwSplitViewBase` and `AdwViewSwitcherBase` — neither is a widget file — are read by
nothing. A chain-resolving reader adds 56 rows there, **18 of them neither a counterpart key
nor declared today**:

    adw-inline-view-switcher   switcherPolicy  views  selected
    adw-view-switcher          switcherPolicy  views  selected
    adw-navigation-split-view  showSidebar  sidebarWidth
    adw-overlay-split-view     sidebarWidth
    adw-button-row             subtitle  activatableWidget
    adw-entry-row              subtitle  activatableWidget
    adw-password-entry-row     subtitle  activatableWidget
    adw-expander-row           activatableWidget
    gtk-menu-button            iconColor  iconSize

The fix is one function in that gate's world builder plus 18 reasoned ledger entries. It is
a separate PR because each of the 18 needs a `gir`-or-`own` verdict,
`feat/ns-construct-props` is rewriting every widget file under it, and two moving
denominators in one diff is not reviewable. The reader that does it correctly ships here.

Two more, in `status/open-todos.md`: `Gtk.Entry:visibility` is password masking and the port
already answers to `visibility` from NativeScript `View` meaning show-or-hide (the only such
collision in the corpus, measured against the ambient `ns-core.d.ts` slice); and
`AdwViewSwitcher` HAS `Adw.ViewSwitcher:policy`, under `switcherPolicy`, because a
port-owned protected getter took the name — the shape ADR 0034 § Amendment 11 settled.

## Files touched

- `scripts/gir-scalar-properties.mjs` (new — the shared GIR reader)
- `scripts/check-nativescript-widget-coverage.mjs` (new — the gate)
- `scripts/check-adwaita-element-properties.mjs` (imports the reader instead of declaring it)
- `.github/workflows/audit-runtimes.yml`, `package.json` (wiring)
- `status/open-todos.md` (both censuses + the third finding)

**`scripts/check-vocabulary-alignment.mjs` is not touched at all**, so this rebases cleanly
past `feat/portable-style-classes` (#1575), `feat/one-authored-tree` (#1577) and
`feat/ns-construct-props`. The one expected conflict is semantic, not textual:
`feat/ns-avatar-parity` (#1578) adds `iconName` and `showInitials` to `AdwAvatar`, so this
branch's `adw-avatar` entry goes stale on that rebase and the gate says so — delete the
entry, and the widget joins the 12 that hold everything.

## Gates run

`check-vocabulary-alignment`, `check-generated-website-data`, `check-nativescript-xml-doors`,
`check-adwaita-element-properties`, `check-nativescript-widget-coverage`, `check-doc-fences`,
`check-storybook-widget-coverage`, `check-storybook-control-parity`,
`check-nativescript-theme-classes`, `check-adwaita-rn-platform-split`,
`check-adwaita-tag-vs-class`, `check-lint-visibility`, `check-source-visibility`,
`audit-runtimes --check` — all exit 0. `oxfmt --check` clean; `oxlint` clean on the changed
files, proven with a deliberate duplicate-identifier canary first (it found two real
`prefer-string-starts-ends-with` errors on the same run, both fixed). `check-comment-budget`
is advisory and the `scripts` row moves from −392 to −307 spare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQ87zT8bbwAhB1Hn264Krx
