### PR TITLE
feat(devtools): a tree that says what it was given

### DIFF
--- a/docs/react-native-gtk-measurements.md
+++ b/docs/react-native-gtk-measurements.md
@@ -98,3 +98,25 @@ Design decisions: [ADR 0032](adr/0032-react-native-on-the-gtk-host.md),
    public getter. `has_role()` is the exception: it takes the role, so the ROLE is a
    real value check. Everything else is AT-SPI's to report, and every GTK CI leg runs
    with `GTK_A11Y=none`.
+
+9. **A wrapping `Gtk.Label` reports a natural width its own text does not fit into,
+   once anything is letter-spaced.** GTK's natural width is `ceil(logical width)`, and
+   Pango's logical extents EXCLUDE the spacing after the final glyph while its
+   line-breaker COUNTS it — so the breaker needs `ceil(logical + spacing)` and is handed
+   one or two pixels less. Measured over four strings and six spacings:
+
+   | spacing | 0.0 | 0.2 | 0.5 | 1.0 | 1.5 | 2.0 |
+   |---|---|---|---|---|---|---|
+   | short by | 0 | 0 | 0–1 | 1 | 1–2 | 2 |
+
+   `<Text>` is a label with `wrap: true`, so the consequence is a label that wraps onto
+   two lines **at its own natural width**, in a parent that measured its height for one
+   — and the second line is clipped. It reaches every flex child that does not expand,
+   which is most text in an application. Reached through CSS `letter-spacing` and
+   through a `Pango.AttrLetterSpacing` alike, unchanged by all three
+   `natural-wrap-mode` values, and not helped by excluding the final character from the
+   attribute (that lowers the natural width by the same amount). There is nothing for
+   this layer to set, so it is an `it.failing` vector in
+   `primitives/text-metrics.spec.ts` that retires itself the day GTK fixes it. Found in
+   a shipped application, in four labels of seventy-six — each one an overline or a
+   masthead date, i.e. exactly the letter-spaced kind.

--- a/packages/framework/devtools-protocol/src/types.ts
+++ b/packages/framework/devtools-protocol/src/types.ts
@@ -33,6 +33,64 @@ export interface ActionList {
 }
 
 /**
+ * What a widget WAS GIVEN beside what it ASKED FOR — the pair that says whether a
+ * layout is right, and the one an introspection tree could not previously answer.
+ *
+ * `mapped` says a widget is on screen and a property read says its properties are what
+ * the code set; neither distinguishes a label allocated the width it asked for from one
+ * allocated less and now showing two thirds of its text. The workaround was to
+ * rasterise the widget through `Screenshot(<path>)` and read the PNG header, which is
+ * three round trips per widget and answers only the allocation — never the request, so
+ * it says THAT a widget is the wrong size and never whose arithmetic made it so.
+ *
+ * The measured case: a `Gtk.Label` in a `flex-row` masthead came out 170x23 at every
+ * window width from 700 to 1400, while one line of its text needs 206. Everything
+ * readable about it was correct — `wrap: true`, `max-width-chars: -1`, `hexpand: false`
+ * — and the defect is entirely in the two numbers that were not readable.
+ *
+ * NO POSITION. `width`/`height` come off `get_width()`/`get_height()`; x/y would need
+ * `compute_bounds()` and a `Graphene.Rect` across the bridge, and the question this
+ * exists for is answered without it. `Screenshot(<path>)` already says where a widget
+ * is by showing it.
+ */
+export interface NodeGeometry {
+    /**
+     * Allocation in logical pixels, in the MARGIN box — content plus CSS padding, border
+     * and margin.
+     *
+     * That box and not another one because it is the box a size request speaks, so these
+     * two numbers and the two below are comparable. GTK has three: `get_width()` answers
+     * the content box, `compute_bounds()` the border box, and `measure()` the margin box,
+     * and mixing them is not a rounding error. Measured on GTK 4.22.4, a `Gtk.Label` with
+     * `padding: 3px 5px` over a 68x17 content box asks 78x23; asked for its height at 68
+     * — its content width read as a margin-box width — it answers 40, because 58 is left
+     * for text that then wraps.
+     */
+    width: number;
+    height: number;
+    /** [minimum, natural] width, measured with no height given. */
+    widthRequest: [number, number];
+    /**
+     * [minimum, natural] height, measured AT THE ALLOCATED WIDTH.
+     *
+     * At the allocated width and not at `-1`, because that is the whole question. A
+     * wrapping label asked for its height at its natural width answers one line; asked
+     * at the width it actually got, it answers two. A parent that measured the first
+     * and allocated the second is exactly the bug, and the two numbers differ only when
+     * it happened.
+     */
+    heightRequest: [number, number];
+    /**
+     * The allocation is below the minimum the widget asked for, so it is CLIPPED.
+     *
+     * Present only when true, like {@link NodeInfo.truncated}: a caller sweeping a tree
+     * for this key finds the defective widgets without a hypothesis about which one to
+     * suspect, which is the difference between an instrument and a readout.
+     */
+    short?: true;
+}
+
+/**
  * A node in an introspection tree — a GTK widget or a DOM element. The
  * shape is shared so the same MCP tools render both runtimes.
  */
@@ -48,6 +106,12 @@ export interface NodeInfo {
     visible: boolean;
     /** Shallow scalar properties, when requested. */
     props?: Record<string, unknown>;
+    /**
+     * Allocation and size request. Present for a MAPPED widget only — an unmapped one
+     * has no allocation, and measuring it reports what it would ask for in a place it
+     * is not, which is a number that reads like an answer and is not one.
+     */
+    geometry?: NodeGeometry;
     children: NodeInfo[];
     /**
      * This node HAS children the dump did not walk, because the depth bound

--- a/packages/framework/devtools-protocol/src/types.ts
+++ b/packages/framework/devtools-protocol/src/types.ts
@@ -48,10 +48,16 @@ export interface ActionList {
  * readable about it was correct — `wrap: true`, `max-width-chars: -1`, `hexpand: false`
  * — and the defect is entirely in the two numbers that were not readable.
  *
- * NO POSITION. `width`/`height` come off `get_width()`/`get_height()`; x/y would need
- * `compute_bounds()` and a `Graphene.Rect` across the bridge, and the question this
- * exists for is answered without it. `Screenshot(<path>)` already says where a widget
- * is by showing it.
+ * NO POSITION. Only a size: x/y would need the widget's bounds resolved against an
+ * ancestor and a `Graphene.Rect` carried across the bridge, and the question this exists
+ * for is answered without it. `Screenshot(<path>)` already says where a widget is by
+ * showing it.
+ *
+ * GTK ONLY, for now. The shape is shared with the DOM and NativeScript adapters (see
+ * {@link NodeInfo}) and neither fills it in, so an absent `geometry` means "this adapter
+ * does not measure", never "this widget was not measured" — the one distinction a caller
+ * sweeping a tree for {@link NodeGeometry.short} has to make before reading a clean sweep
+ * as good news.
  */
 export interface NodeGeometry {
     /**
@@ -59,12 +65,15 @@ export interface NodeGeometry {
      * and margin.
      *
      * That box and not another one because it is the box a size request speaks, so these
-     * two numbers and the two below are comparable. GTK has three: `get_width()` answers
-     * the content box, `compute_bounds()` the border box, and `measure()` the margin box,
-     * and mixing them is not a rounding error. Measured on GTK 4.22.4, a `Gtk.Label` with
-     * `padding: 3px 5px` over a 68x17 content box asks 78x23; asked for its height at 68
-     * — its content width read as a margin-box width — it answers 40, because 58 is left
-     * for text that then wraps.
+     * two numbers and the two below are comparable. GTK has FOUR and three of them are
+     * readable: `get_width()` answers the content box, `compute_bounds()` the border box,
+     * `get_allocation()` the CSS margin box, and `measure()` the box outside all of them —
+     * CSS margin plus the widget's own `margin-*` properties, which is the only rectangle
+     * with no accessor of its own and has to be summed. Mixing them is not a rounding
+     * error. Measured on GTK 4.22.4, a `Gtk.Label` with `padding: 3px 5px` over a 68x17
+     * content box asks 78x23; asked for its height at 68 — its content width read as a
+     * margin-box width — it answers 40, because 58 is left for text that then wraps. The
+     * table behind all four columns is on `geometryOf` in `@gjsify/devtools`.
      */
     width: number;
     height: number;
@@ -86,6 +95,14 @@ export interface NodeGeometry {
      * Present only when true, like {@link NodeInfo.truncated}: a caller sweeping a tree
      * for this key finds the defective widgets without a hypothesis about which one to
      * suspect, which is the difference between an instrument and a readout.
+     *
+     * NOT every one of them is a bug, and the exception is structural rather than rare. A
+     * `GtkViewport` inside a `GtkScrolledWindow` reports its child's request and is
+     * deliberately allocated less — that IS scrolling — so it carries this key in every
+     * window that scrolls (measured: the only `short` node in an Adwaita preferences
+     * window is its viewport, 900x613 against a minimum of 520x720). The key says the
+     * allocation is under the request, which is the fact; whether that is a defect is the
+     * reader's call, and a widget under a scrolled window is where the answer is no.
      */
     short?: true;
 }
@@ -109,7 +126,8 @@ export interface NodeInfo {
     /**
      * Allocation and size request. Present for a MAPPED widget only — an unmapped one
      * has no allocation, and measuring it reports what it would ask for in a place it
-     * is not, which is a number that reads like an answer and is not one.
+     * is not, which is a number that reads like an answer and is not one. Filled in by
+     * the GTK adapter alone; see {@link NodeGeometry}.
      */
     geometry?: NodeGeometry;
     children: NodeInfo[];

--- a/packages/framework/devtools/src/widget-tree.spec.ts
+++ b/packages/framework/devtools/src/widget-tree.spec.ts
@@ -292,20 +292,50 @@ export default async () => {
     });
 
     await describe('dumpTree', async () => {
+        /**
+         * One widget, sized. `measure` answers per orientation, and the VERTICAL answer
+         * is a function of the width it is asked for — which is the only reason the
+         * geometry half of the dump exists.
+         */
+        interface Sized {
+            /** The BORDER box, which is what `compute_bounds` answers. */
+            width?: number;
+            height?: number;
+            /** CSS margins, which `compute_bounds` excludes and `measure` includes. */
+            margin?: { start: number; end: number; top: number; bottom: number };
+            widthRequest?: [number, number];
+            /** Called with the width `dumpTree` measured at, so a spec can vary on it. */
+            heightRequest?: (forWidth: number) => [number, number];
+        }
+
+        const sizedWidget = (name: string, child: Gtk.Widget | null, size: Sized = {}): Gtk.Widget => {
+            const margin = size.margin ?? { start: 0, end: 0, top: 0, bottom: 0 };
+            return asWidget({
+                constructor: { $gtype: { name } },
+                get_name: () => '',
+                get_css_classes: () => [],
+                get_mapped: () => true,
+                get_visible: () => true,
+                get_first_child: () => child,
+                get_next_sibling: () => null,
+                compute_bounds: () => [
+                    true,
+                    { get_width: () => size.width ?? 100, get_height: () => size.height ?? 20 },
+                ],
+                get_margin_start: () => margin.start,
+                get_margin_end: () => margin.end,
+                get_margin_top: () => margin.top,
+                get_margin_bottom: () => margin.bottom,
+                measure: (orientation: number, forSize: number) =>
+                    orientation === 0 ? (size.widthRequest ?? [10, 100]) : (size.heightRequest?.(forSize) ?? [20, 20]),
+            });
+        };
+
         /** A chain of `depth` widgets, each the only child of the one above. */
         const chain = (depth: number): Gtk.Widget => {
             let node: Gtk.Widget | null = null;
             for (let i = depth; i > 0; --i) {
-                const child = node;
-                node = asWidget({
-                    constructor: { $gtype: { name: `GtkLevel${i}` } },
-                    get_name: () => '',
-                    get_css_classes: () => [],
-                    get_mapped: () => true,
-                    get_visible: () => true,
-                    get_first_child: () => child,
-                    get_next_sibling: () => null,
-                });
+                node = sizedWidget(`GtkLevel${i}`, node);
             }
             return node as Gtk.Widget;
         };
@@ -340,6 +370,129 @@ export default async () => {
             }
             expect(levels).toBe(12);
             expect(node.truncated).toBe(undefined);
+        });
+
+        await it('reports what a widget was given beside what it asked for', async () => {
+            const dumped = dumpTree(
+                sizedWidget('GtkLabel', null, {
+                    width: 170,
+                    height: 23,
+                    widthRequest: [78, 206],
+                    heightRequest: () => [17, 17],
+                }),
+                1,
+                'toplevel:0',
+            );
+            expect(dumped.geometry).toStrictEqual({
+                width: 170,
+                height: 23,
+                widthRequest: [78, 206],
+                heightRequest: [17, 17],
+            });
+        });
+
+        await it('measures the height AT THE ALLOCATED WIDTH, not at the natural one', async () => {
+            // The whole point of the field. A wrapping label answers one line at its
+            // natural width and two at the width it actually got; a dump that asked
+            // `-1` would report the number that agrees with the allocation and hide
+            // exactly the case worth finding.
+            let askedFor: number | null = null;
+            const dumped = dumpTree(
+                sizedWidget('GtkLabel', null, {
+                    width: 170,
+                    height: 23,
+                    widthRequest: [78, 206],
+                    heightRequest: (forWidth) => {
+                        askedFor = forWidth;
+                        return forWidth >= 206 ? [17, 17] : [40, 40];
+                    },
+                }),
+                1,
+                'toplevel:0',
+            );
+            expect(askedFor).toBe(170);
+            expect(dumped.geometry?.heightRequest).toStrictEqual([40, 40]);
+            expect(dumped.geometry?.short).toBe(true);
+        });
+
+        await it('works in the margin box, which is the one measure() speaks', async () => {
+            // Measured on GTK 4.22.4: `compute_bounds` answers the border box and
+            // `measure` the margin box, so a widget with margins compares two different
+            // rectangles unless the margins are added back. The first version of this
+            // compared against `get_width()` — the CONTENT box — and called 116 of 293
+            // widgets in a real window clipped.
+            let askedFor: number | null = null;
+            const dumped = dumpTree(
+                sizedWidget('GtkLabel', null, {
+                    width: 68,
+                    height: 17,
+                    margin: { start: 7, end: 7, top: 4, bottom: 4 },
+                    widthRequest: [49, 82],
+                    heightRequest: (forWidth) => {
+                        askedFor = forWidth;
+                        return [25, 25];
+                    },
+                }),
+                1,
+                'toplevel:0',
+            );
+            expect(dumped.geometry?.width).toBe(82);
+            expect(dumped.geometry?.height).toBe(25);
+            expect(askedFor).toBe(82);
+            // 82x25 against a request of 82x25 is exactly met, so nothing is flagged.
+            expect(dumped.geometry?.short).toBe(undefined);
+        });
+
+        await it('leaves out geometry when the toolkit cannot compute bounds', async () => {
+            const unbounded = asWidget({
+                constructor: { $gtype: { name: 'GtkLabel' } },
+                get_name: () => '',
+                get_css_classes: () => [],
+                get_mapped: () => true,
+                get_visible: () => true,
+                get_first_child: () => null,
+                get_next_sibling: () => null,
+                compute_bounds: () => [false, null],
+            });
+            expect(dumpTree(unbounded, 1, 'toplevel:0').geometry).toBe(undefined);
+        });
+
+        await it('measures at -1 when a mapped widget has no allocation yet', async () => {
+            // `measure(VERTICAL, 0)` is a legal call that answers about a zero-width
+            // widget, so a width of 0 has to become "no constraint" rather than a
+            // constraint of nothing.
+            let askedFor: number | null = null;
+            dumpTree(
+                sizedWidget('GtkBox', null, {
+                    width: 0,
+                    height: 0,
+                    heightRequest: (forWidth) => {
+                        askedFor = forWidth;
+                        return [0, 0];
+                    },
+                }),
+                1,
+                'toplevel:0',
+            );
+            expect(askedFor).toBe(-1);
+        });
+
+        await it('leaves an unmapped widget without geometry at all', async () => {
+            // An unmapped widget has no allocation, so its two zeros beside a request
+            // would read as "clipped to nothing" for every page of a stack that is not
+            // the visible one.
+            const unmapped = asWidget({
+                constructor: { $gtype: { name: 'GtkLabel' } },
+                get_name: () => '',
+                get_css_classes: () => [],
+                get_mapped: () => false,
+                get_visible: () => true,
+                get_first_child: () => null,
+                get_next_sibling: () => null,
+            });
+            const dumped = dumpTree(unmapped, 1, 'toplevel:0');
+            expect(dumped.geometry).toBe(undefined);
+            expect(dumped.mapped).toBe(false);
         });
     });
 };

--- a/packages/framework/devtools/src/widget-tree.spec.ts
+++ b/packages/framework/devtools/src/widget-tree.spec.ts
@@ -296,12 +296,32 @@ export default async () => {
          * One widget, sized. `measure` answers per orientation, and the VERTICAL answer
          * is a function of the width it is asked for — which is the only reason the
          * geometry half of the dump exists.
+         *
+         * This suite runs on plain gjs with NO DISPLAY (see `peer-transport.spec.ts`), so
+         * a real mapped widget is out of reach and this shape is the whole model of GTK
+         * the geometry vectors get. It therefore models GTK's boxes as GTK has them,
+         * measured on 4.22.4, rather than as the code happens to read them — the previous
+         * version modelled only the two the implementation touched, and the box it was
+         * missing was the one the implementation got wrong.
          */
         interface Sized {
-            /** The BORDER box, which is what `compute_bounds` answers. */
+            /**
+             * The CSS MARGIN box, which is what `get_allocation` answers: content plus CSS
+             * padding, border AND CSS margin. NOT what `compute_bounds` answers.
+             */
             width?: number;
             height?: number;
-            /** CSS margins, which `compute_bounds` excludes and `measure` includes. */
+            /**
+             * How much of {@link Sized.width} is CSS margin. A stylesheet margin is inside
+             * the allocation and outside `compute_bounds`, and NO `get_margin_*()` reports
+             * it — which is exactly the gap that made a correctly-sized widget read as
+             * clipped.
+             */
+            cssMargin?: { start: number; end: number; top: number; bottom: number };
+            /**
+             * The `margin-*` PROPERTIES, which sit outside the allocation and inside what
+             * `measure` speaks, so they are the half that has to be added back.
+             */
             margin?: { start: number; end: number; top: number; bottom: number };
             widthRequest?: [number, number];
             /** Called with the width `dumpTree` measured at, so a spec can vary on it. */
@@ -310,6 +330,8 @@ export default async () => {
 
         const sizedWidget = (name: string, child: Gtk.Widget | null, size: Sized = {}): Gtk.Widget => {
             const margin = size.margin ?? { start: 0, end: 0, top: 0, bottom: 0 };
+            const cssMargin = size.cssMargin ?? { start: 0, end: 0, top: 0, bottom: 0 };
+            const allocated = { width: size.width ?? 100, height: size.height ?? 20 };
             return asWidget({
                 constructor: { $gtype: { name } },
                 get_name: () => '',
@@ -318,9 +340,17 @@ export default async () => {
                 get_visible: () => true,
                 get_first_child: () => child,
                 get_next_sibling: () => null,
+                get_allocation: () => ({ x: 0, y: 0, ...allocated }),
+                // The BORDER box, which nothing here should read. Present so that a
+                // rewrite reaching for it again fails on the CSS-margin vector below
+                // instead of being right for every widget whose margins happen to come
+                // from a property.
                 compute_bounds: () => [
                     true,
-                    { get_width: () => size.width ?? 100, get_height: () => size.height ?? 20 },
+                    {
+                        get_width: () => allocated.width - cssMargin.start - cssMargin.end,
+                        get_height: () => allocated.height - cssMargin.top - cssMargin.bottom,
+                    },
                 ],
                 get_margin_start: () => margin.start,
                 get_margin_end: () => margin.end,
@@ -416,11 +446,11 @@ export default async () => {
         });
 
         await it('works in the margin box, which is the one measure() speaks', async () => {
-            // Measured on GTK 4.22.4: `compute_bounds` answers the border box and
-            // `measure` the margin box, so a widget with margins compares two different
-            // rectangles unless the margins are added back. The first version of this
-            // compared against `get_width()` — the CONTENT box — and called 116 of 293
-            // widgets in a real window clipped.
+            // Measured on GTK 4.22.4: `get_allocation` stops at the CSS margin box and
+            // `measure` speaks the box outside the `margin-*` PROPERTIES too, so a widget
+            // carrying those compares two different rectangles unless they are added
+            // back. The first version of this compared against `get_width()` — the
+            // CONTENT box — and called 116 of 293 widgets in a real window clipped.
             let askedFor: number | null = null;
             const dumped = dumpTree(
                 sizedWidget('GtkLabel', null, {
@@ -443,18 +473,63 @@ export default async () => {
             expect(dumped.geometry?.short).toBe(undefined);
         });
 
-        await it('leaves out geometry when the toolkit cannot compute bounds', async () => {
-            const unbounded = asWidget({
-                constructor: { $gtype: { name: 'GtkLabel' } },
-                get_name: () => '',
-                get_css_classes: () => [],
-                get_mapped: () => true,
-                get_visible: () => true,
-                get_first_child: () => null,
-                get_next_sibling: () => null,
-                compute_bounds: () => [false, null],
-            });
-            expect(dumpTree(unbounded, 1, 'toplevel:0').geometry).toBe(undefined);
+        await it('counts a CSS margin, which no get_margin_*() reports', async () => {
+            // The regression that rewrote this function. `get_margin_start()` answers the
+            // margin-start PROPERTY; a margin from a stylesheet is invisible to it and
+            // shows up only inside the allocation. Measured on GTK 4.22.4, a `Gtk.Label`
+            // with CSS `margin: 4px 7px` over a 306x18 content box: border box 306x18,
+            // allocation 320x26, natural request 320x26. So reading the border box makes
+            // an exactly-met request look 14x8 short — and, worse, measures its height at
+            // 306, where the text wraps and asks for 44. That version called 12 of 127
+            // mapped widgets in an ordinary Adwaita preferences window clipped, 11 of
+            // them wrongly, and GTK printed a warning for three of the twelve.
+            let askedFor: number | null = null;
+            const dumped = dumpTree(
+                sizedWidget('GtkLabel', null, {
+                    width: 320,
+                    height: 26,
+                    cssMargin: { start: 7, end: 7, top: 4, bottom: 4 },
+                    widthRequest: [143, 320],
+                    heightRequest: (forWidth) => {
+                        askedFor = forWidth;
+                        return forWidth >= 320 ? [26, 26] : [44, 44];
+                    },
+                }),
+                1,
+                'toplevel:0',
+            );
+            expect(dumped.geometry?.width).toBe(320);
+            expect(dumped.geometry?.height).toBe(26);
+            expect(askedFor).toBe(320);
+            expect(dumped.geometry?.short).toBe(undefined);
+        });
+
+        await it('never measures below the minimum width, which GTK warns about', async () => {
+            // A genuinely clipped widget is the case this whole field exists to find, and
+            // it is also the case where `measure(VERTICAL, allocated)` would hand GTK a
+            // width below the minimum: `Trying to measure GtkBox … for width of 34, but
+            // it needs at least 40`, once per clipped widget per dump. GTK clamps to the
+            // minimum and answers anyway, so clamping first costs no accuracy — the
+            // reported height is the same number — and the dump stops making the toolkit
+            // complain on its behalf. `short` is still set: it compares the ALLOCATION,
+            // not the width the measurement was taken at.
+            let askedFor: number | null = null;
+            const dumped = dumpTree(
+                sizedWidget('GtkBox', null, {
+                    width: 34,
+                    height: 34,
+                    widthRequest: [40, 60],
+                    heightRequest: (forWidth) => {
+                        askedFor = forWidth;
+                        return [34, 34];
+                    },
+                }),
+                1,
+                'toplevel:0',
+            );
+            expect(askedFor).toBe(40);
+            expect(dumped.geometry?.width).toBe(34);
+            expect(dumped.geometry?.short).toBe(true);
         });
 
         await it('measures at -1 when a mapped widget has no allocation yet', async () => {

--- a/packages/framework/devtools/src/widget-tree.ts
+++ b/packages/framework/devtools/src/widget-tree.ts
@@ -2,7 +2,7 @@
 // stable index paths, property read, focused-widget path). Original implementation.
 
 import Gtk from 'gi://Gtk?version=4.0';
-import type { NodeInfo } from '@gjsify/devtools-protocol';
+import type { NodeGeometry, NodeInfo } from '@gjsify/devtools-protocol';
 
 /** A parsed widget path: a toplevel index + a chain of child indices. */
 export interface ParsedWidgetPath {
@@ -260,6 +260,67 @@ export function findWidgetPath(root: Gtk.Widget, selector: WidgetSelector, baseP
 export const DEFAULT_DUMP_DEPTH = 40;
 
 /**
+ * What a mapped widget was given, beside what it asked for.
+ *
+ * MAPPED ONLY, and that is the whole guard: an unmapped widget has no allocation, so it
+ * reports zero and a measurement describes what it would want somewhere it is not. Two
+ * zeros beside a request would read as "clipped to nothing" for every page of a stack
+ * that is not the visible one.
+ *
+ * ## THREE BOXES BEHIND FOUR ACCESSORS, and getting this wrong is the whole difficulty
+ *
+ * Measured on GTK 4.22.4 with a `Gtk.Label` carrying `padding: 3px 5px` and, separately,
+ * `margin: 4px 7px`, over a content box of 68x17:
+ *
+ * | | padded | margined |
+ * |---|---|---|
+ * | `get_width()` / `get_height()` | 68x17 | 68x17 |
+ * | `compute_bounds(self)` | 78x23 | 68x17 |
+ * | `measure()` natural | 78x23 | 82x25 |
+ *
+ * So `get_width()` is the CONTENT box, `compute_bounds()` is the border box, and
+ * `measure()` speaks the MARGIN box. Comparing a request against `get_width()` compares
+ * two different rectangles, and the error is not a rounding one: measuring the height of
+ * the padded label at `get_width()` answers 40 where the correct question answers 23,
+ * because 68 as a margin-box width leaves 58 for the text and wraps it onto two lines.
+ *
+ * That mistake, made here first, flagged 116 of 293 widgets in a real window as clipped.
+ * Everything below therefore works in the margin box: `compute_bounds()` plus the four
+ * margins, which is `get_allocation()`'s rectangle without calling a function GTK 4.12
+ * deprecated.
+ *
+ * ## Why the height is measured at the allocated width
+ *
+ * Because that is the question. A wrapping label asked for its height at its natural
+ * width answers one line, and at the width it actually got answers two. The two agree
+ * except where a parent measured one and allocated the other, which is the defect.
+ *
+ * Two `gtk_widget_measure()` calls per mapped node. GTK caches a size request per
+ * (orientation, for_size), and the pair asked for here is the pair the layout just asked
+ * for itself, so this reads that cache rather than provoking a re-layout.
+ */
+function geometryOf(widget: Gtk.Widget): NodeGeometry | undefined {
+    if (!widget.get_mapped()) return undefined;
+    const [known, bounds] = widget.compute_bounds(widget);
+    if (!known) return undefined;
+    const width = bounds.get_width() + widget.get_margin_start() + widget.get_margin_end();
+    const height = bounds.get_height() + widget.get_margin_top() + widget.get_margin_bottom();
+    const [minWidth, natWidth] = widget.measure(Gtk.Orientation.HORIZONTAL, -1);
+    // `-1` when there is no allocation to speak of: `measure(VERTICAL, 0)` is a legal
+    // call that answers about a zero-width widget, which is a constraint rather than the
+    // absence of one.
+    const [minHeight, natHeight] = widget.measure(Gtk.Orientation.VERTICAL, width > 0 ? width : -1);
+    const geometry: NodeGeometry = {
+        width,
+        height,
+        widthRequest: [minWidth, natWidth],
+        heightRequest: [minHeight, natHeight],
+    };
+    if (width < minWidth || height < minHeight) geometry.short = true;
+    return geometry;
+}
+
+/**
  * Dump a widget subtree to {@link NodeInfo}, bounded by `maxDepth`.
  *
  * The bound LEAVES A TRACE, and that is the half worth stating: a node cut off
@@ -267,6 +328,13 @@ export const DEFAULT_DUMP_DEPTH = 40;
  * of the two zeros it got (#1553). A bound itself is right — an unbounded dump of
  * a deep tree over D-Bus is not free — and it is only expensive when it is
  * invisible in the answer.
+ *
+ * Every mapped node also carries {@link NodeGeometry}: what it was allocated and what
+ * it asked for, with `short: true` where the first is less than the second. That is
+ * unconditional rather than a flag, and the reason is that the caller who needs it does
+ * not yet know which widget to ask about — sweeping the dump for `short` finds the
+ * clipped widget, and a flag would have to be turned on by someone who already
+ * suspected one.
  */
 export function dumpTree(root: Gtk.Widget, maxDepth: number, basePath: string): NodeInfo {
     const node: NodeInfo = {
@@ -278,6 +346,8 @@ export function dumpTree(root: Gtk.Widget, maxDepth: number, basePath: string): 
         visible: root.get_visible(),
         children: [],
     };
+    const geometry = geometryOf(root);
+    if (geometry !== undefined) node.geometry = geometry;
     if (maxDepth <= 0) {
         // `get_first_child()` rather than a count: one call answers "is there more
         // below this", and the marker must mean HAS CHILDREN — a leaf reached

--- a/packages/framework/devtools/src/widget-tree.ts
+++ b/packages/framework/devtools/src/widget-tree.ts
@@ -267,27 +267,46 @@ export const DEFAULT_DUMP_DEPTH = 40;
  * zeros beside a request would read as "clipped to nothing" for every page of a stack
  * that is not the visible one.
  *
- * ## THREE BOXES BEHIND FOUR ACCESSORS, and getting this wrong is the whole difficulty
+ * ## FOUR BOXES BEHIND FOUR ACCESSORS, and getting this wrong is the whole difficulty
  *
- * Measured on GTK 4.22.4 with a `Gtk.Label` carrying `padding: 3px 5px` and, separately,
- * `margin: 4px 7px`, over a content box of 68x17:
+ * Measured on GTK 4.22.4 with one `Gtk.Label` over a content box of 306x18, under each of
+ * the four things that can sit around it: CSS `padding: 3px 5px`, CSS `border: 2px solid`,
+ * CSS `margin: 4px 7px`, and the `margin-start`/`-end`/`-top`/`-bottom` WIDGET PROPERTIES
+ * at that same 7px/4px.
  *
- * | | padded | margined |
- * |---|---|---|
- * | `get_width()` / `get_height()` | 68x17 | 68x17 |
- * | `compute_bounds(self)` | 78x23 | 68x17 |
- * | `measure()` natural | 78x23 | 82x25 |
+ * | | none | padding | border | CSS margin | widget margin | all four |
+ * |---|---|---|---|---|---|---|
+ * | `get_width()`/`get_height()` | 306x18 | 306x18 | 306x18 | 306x18 | 306x18 | 306x18 |
+ * | `compute_bounds(self)` | 306x18 | 316x24 | 310x22 | 306x18 | 306x18 | 320x28 |
+ * | `get_allocation()` | 306x18 | 316x24 | 310x22 | 320x26 | 306x18 | 334x36 |
+ * | + the four `get_margin_*()` | 306x18 | 316x24 | 310x22 | 320x26 | 320x26 | 348x44 |
+ * | `measure()` natural | 306x18 | 316x24 | 310x22 | 320x26 | 320x26 | 348x44 |
  *
- * So `get_width()` is the CONTENT box, `compute_bounds()` is the border box, and
- * `measure()` speaks the MARGIN box. Comparing a request against `get_width()` compares
- * two different rectangles, and the error is not a rounding one: measuring the height of
- * the padded label at `get_width()` answers 40 where the correct question answers 23,
- * because 68 as a margin-box width leaves 58 for the text and wraps it onto two lines.
+ * So `get_width()` answers the CONTENT box, `compute_bounds()` the BORDER box,
+ * `get_allocation()` the CSS MARGIN box, and `measure()` speaks the box outside all of
+ * them: CSS margin AND the widget's own margin properties. Only the fourth row tracks the
+ * fifth in every column, so that sum is the one allocation worth holding a request
+ * against; any other pairing subtracts two different questions from each other.
  *
- * That mistake, made here first, flagged 116 of 293 widgets in a real window as clipped.
- * Everything below therefore works in the margin box: `compute_bounds()` plus the four
- * margins, which is `get_allocation()`'s rectangle without calling a function GTK 4.12
- * deprecated.
+ * The error is not a rounding one. The padded label measured for height at its
+ * `get_width()` of 306 answers 42 where the same question in the right box (316) answers
+ * 24, because 306 read as a margin-box width leaves 296 for the text and wraps it.
+ *
+ * Two earlier versions each compared against the wrong rectangle, and each called
+ * correctly-sized widgets clipped:
+ *
+ *  - against `get_width()`, the content box: 116 of 293 widgets in a real window.
+ *  - against `compute_bounds()` plus the four margin PROPERTIES: 12 of 127 mapped widgets
+ *    in an ordinary Adwaita preferences window, 11 of them false. Its comment claimed
+ *    that sum "is `get_allocation()`'s rectangle without calling a function GTK 4.12
+ *    deprecated", and the CSS-margin column above is why it is not — `get_margin_start()`
+ *    answers the PROPERTY and knows nothing about a stylesheet, while Adwaita's own
+ *    stylesheet puts margins on boxes.
+ *
+ * `gtk_widget_get_allocation()` IS deprecated (4.12), and its notice points at
+ * `compute_bounds()`/`get_width()`, the two rectangles this must not use. It is the only
+ * public reader of the CSS margin rect, so the deprecation is taken deliberately: a
+ * deprecated call that is right is worth more than a current one that is quietly wrong.
  *
  * ## Why the height is measured at the allocated width
  *
@@ -295,21 +314,35 @@ export const DEFAULT_DUMP_DEPTH = 40;
  * width answers one line, and at the width it actually got answers two. The two agree
  * except where a parent measured one and allocated the other, which is the defect.
  *
+ * ## Why that width is then clamped to the minimum
+ *
+ * `gtk_widget_measure()` WARNS on a `for_size` below the widget's minimum in the other
+ * orientation — `Trying to measure GtkBox … for width of 34, but it needs at least 40` —
+ * and then clamps to that minimum and answers anyway. Clamping first therefore changes no
+ * number (measured: every `for_size` from 0 up to the minimum returns the minimum's
+ * answer) and keeps a dump of a window that HAS a clipped widget from printing one GTK
+ * warning per clipped widget per dump. An instrument that reports a defect by making the
+ * toolkit complain cannot be told, in a log, from the defect complaining on its own.
+ *
  * Two `gtk_widget_measure()` calls per mapped node. GTK caches a size request per
- * (orientation, for_size), and the pair asked for here is the pair the layout just asked
- * for itself, so this reads that cache rather than provoking a re-layout.
+ * (orientation, for_size) — measured with a counting `vfunc_measure`: repeated calls at
+ * one `for_size` reach the widget once, and twenty distinct sizes did not evict an earlier
+ * entry — and the pair asked for here is the pair the layout just asked for itself, so
+ * this reads that cache rather than provoking a re-layout. That is only true in the right
+ * box: the border-box width missed the cache on every CSS-margined widget, because the
+ * layout had asked at the margin-box width.
  */
 function geometryOf(widget: Gtk.Widget): NodeGeometry | undefined {
     if (!widget.get_mapped()) return undefined;
-    const [known, bounds] = widget.compute_bounds(widget);
-    if (!known) return undefined;
-    const width = bounds.get_width() + widget.get_margin_start() + widget.get_margin_end();
-    const height = bounds.get_height() + widget.get_margin_top() + widget.get_margin_bottom();
+    const allocation = widget.get_allocation();
+    const width = allocation.width + widget.get_margin_start() + widget.get_margin_end();
+    const height = allocation.height + widget.get_margin_top() + widget.get_margin_bottom();
     const [minWidth, natWidth] = widget.measure(Gtk.Orientation.HORIZONTAL, -1);
     // `-1` when there is no allocation to speak of: `measure(VERTICAL, 0)` is a legal
     // call that answers about a zero-width widget, which is a constraint rather than the
     // absence of one.
-    const [minHeight, natHeight] = widget.measure(Gtk.Orientation.VERTICAL, width > 0 ? width : -1);
+    const forWidth = width > 0 ? Math.max(width, minWidth) : -1;
+    const [minHeight, natHeight] = widget.measure(Gtk.Orientation.VERTICAL, forWidth);
     const geometry: NodeGeometry = {
         width,
         height,

--- a/packages/framework/react-native/src/primitives/text-metrics.spec.ts
+++ b/packages/framework/react-native/src/primitives/text-metrics.spec.ts
@@ -17,7 +17,16 @@ import { describe, expect, it, on, type Runtime } from '@gjsify/unit';
 
 const GTK_HOSTS: Runtime[] = ['Gjs', 'Node.js', 'Bun', 'Deno'];
 
-/** A label under a window, because a detached widget resolves no CSS. */
+/**
+ * A label under a window, which is the shape an application has.
+ *
+ * The rooting is NOT what makes the measurement valid, and it is worth saying so because
+ * the opposite is the natural assumption: measured on GTK 4.22.4, an unrooted label
+ * resolves the display's CSS and answers the identical natural width, letter-spacing from
+ * a stylesheet included (172 plain / 241 under `letter-spacing: 3px`, rooted or not). So a
+ * re-measurement of any of this needs no window, and a vector that drops one has not
+ * quietly changed what it measures.
+ */
 function labelled(text: string, letterSpacingPx: number): { label: Gtk.Label; window: Gtk.Window } {
     const window = new Gtk.Window();
     const label = new Gtk.Label({ label: text, wrap: true, xalign: 0, yalign: 0 });
@@ -36,7 +45,11 @@ function lines(label: Gtk.Label): { natural: number; atNatural: number; unconstr
     return {
         natural,
         atNatural: label.measure(Gtk.Orientation.VERTICAL, natural)[0],
-        unconstrained: label.measure(Gtk.Orientation.VERTICAL, 4000)[0],
+        // The one-line height, taken relative to the natural width rather than at a fixed
+        // large number: the shortfall this file is about is one or two pixels, so any
+        // width comfortably past the natural one is a line, and a constant would stop
+        // being one the day a vector carries a longer string.
+        unconstrained: label.measure(Gtk.Orientation.VERTICAL, natural + 200)[0],
     };
 }
 

--- a/packages/framework/react-native/src/primitives/text-metrics.spec.ts
+++ b/packages/framework/react-native/src/primitives/text-metrics.spec.ts
@@ -1,0 +1,106 @@
+// What `<Text>` gets from Pango, held against what React Native promises.
+//
+// `<Text>` is `Gtk.Label` with `wrap: true` (`defaults.ts`), which is the right
+// normalisation and puts this layer's text on GTK's height-for-width path. That path
+// has one property React Native's does not, and it is the reason this file exists: a
+// wrapping label's NATURAL width is the width of its text on one line, so a parent that
+// gives a label exactly its natural width is giving it exactly enough. Every flex
+// container does that for a child that does not expand — which is most text in an
+// application.
+//
+// The vector below asserts that property. It is `it.failing` because GTK does not have
+// it once letter-spacing is in play, and the marker retires itself the day GTK does.
+
+import Gtk from 'gi://Gtk?version=4.0';
+import Pango from 'gi://Pango?version=1.0';
+import { describe, expect, it, on, type Runtime } from '@gjsify/unit';
+
+const GTK_HOSTS: Runtime[] = ['Gjs', 'Node.js', 'Bun', 'Deno'];
+
+/** A label under a window, because a detached widget resolves no CSS. */
+function labelled(text: string, letterSpacingPx: number): { label: Gtk.Label; window: Gtk.Window } {
+    const window = new Gtk.Window();
+    const label = new Gtk.Label({ label: text, wrap: true, xalign: 0, yalign: 0 });
+    if (letterSpacingPx > 0) {
+        const attributes = Pango.AttrList.new();
+        attributes.insert(Pango.attr_letter_spacing_new(Math.round(letterSpacingPx * Pango.SCALE)));
+        label.set_attributes(attributes);
+    }
+    window.set_child(label);
+    return { label, window };
+}
+
+/** The height a label asks for at `forWidth`, and the height of one line. */
+function lines(label: Gtk.Label): { natural: number; atNatural: number; unconstrained: number } {
+    const natural = label.measure(Gtk.Orientation.HORIZONTAL, -1)[1];
+    return {
+        natural,
+        atNatural: label.measure(Gtk.Orientation.VERTICAL, natural)[0],
+        unconstrained: label.measure(Gtk.Orientation.VERTICAL, 4000)[0],
+    };
+}
+
+export default async () => {
+    await on(GTK_HOSTS, async () => {
+        Gtk.init();
+
+        await describe('a wrapping label at its own natural width', async () => {
+            await it('fits on one line when nothing is letter-spaced', async () => {
+                // The control. Without this the vector below could be failing because
+                // the harness is wrong, and an expected failure that fails for the
+                // wrong reason retires nothing when the real defect is fixed.
+                for (const text of [
+                    'Ermöglicht durch Unterstützer:innen wie Sie',
+                    'Backstage · Früher lesen',
+                    'Samstag, 5. September 2026',
+                ]) {
+                    const { label, window } = labelled(text, 0);
+                    const measured = lines(label);
+                    expect(measured.atNatural).toBe(measured.unconstrained);
+                    window.destroy();
+                }
+            });
+
+            await it.failing(
+                'fits on one line when the text is letter-spaced',
+                async () => {
+                    for (const text of [
+                        'Ermöglicht durch Unterstützer:innen wie Sie',
+                        'Backstage · Früher lesen',
+                        'Samstag, 5. September 2026',
+                    ]) {
+                        const { label, window } = labelled(text, 1.5);
+                        const measured = lines(label);
+                        try {
+                            expect(measured.atNatural).toBe(measured.unconstrained);
+                        } finally {
+                            window.destroy();
+                        }
+                    }
+                },
+                // MEASURED on gjs 1.88.1 / GTK 4.22.4 / Pango 1.57, over four strings and
+                // six letter-spacings. GTK's natural width is `ceil(logical width)`, and
+                // Pango's logical extents EXCLUDE the spacing after the final glyph while
+                // its line-breaker COUNTS it — so the breaker needs
+                // `ceil(logical + spacing)` and is handed one or two pixels less:
+                //
+                //   spacing   0.0   0.2   0.5   1.0   1.5   2.0   (px)
+                //   short by    0     0   0-1     1   1-2     2   (px)
+                //
+                // The consequence is a label that wraps onto two lines at its OWN natural
+                // width, in a parent that measured its height for one — so the second
+                // line is clipped. Reached through CSS `letter-spacing` and through a
+                // Pango attribute alike, and unchanged by all three `natural-wrap-mode`
+                // values, so there is nothing for this layer to set. Excluding the final
+                // character from the attribute lowers the natural width by the same
+                // amount and does not help either.
+                //
+                // Found in a shipped application: four labels of seventy-six, each one
+                // an `Overline` or a masthead date, i.e. exactly the letter-spaced kind.
+                // No upstream issue found on 2026-09-05; not filed from here because the
+                // reproduction wants a C test case rather than a GJS one.
+                'GTK 4.22.4: a wrapping label reports a natural width one to two pixels below what Pango needs to lay the text out on one line, when letter-spacing is set. See the table in this vector.',
+            );
+        });
+    });
+};

--- a/packages/framework/react-native/src/test.mts
+++ b/packages/framework/react-native/src/test.mts
@@ -11,6 +11,7 @@ import listsSuite from './lists/lists.spec.js';
 import classesSuite from './primitives/classes.spec.js';
 import defaultsSuite from './primitives/defaults.spec.js';
 import primitivesSuite from './primitives/primitives.spec.js';
+import textMetricsSuite from './primitives/text-metrics.spec.js';
 import widgetsSuite from './primitives/widgets.spec.js';
 import propTableSuite from './prop-table.spec.js';
 import hrefSuite from './router/href.spec.js';
@@ -70,6 +71,7 @@ run({
     primitivesSuite,
     apisSuite,
     widgetsSuite,
+    textMetricsSuite,
     easingSuite,
     animatedSuite,
     listsSuite,


### PR DESCRIPTION
## The gap

`DumpTree` says a widget is mapped and `GetProperty` says its properties are what the code set. Neither distinguishes a label allocated the width it asked for from one allocated less and now showing two thirds of its text — so a **layout** defect was the one class of defect this control plane could see and could not diagnose.

The workaround was `Screenshot(<widget path>)` per widget and a read of the PNG header. Three round trips, and it reports the allocation without the request: it says *that* a widget is the wrong size and never whose arithmetic made it so.

## What lands

Every mapped node in a `DumpTree` result now carries `geometry`:

```jsonc
{
  "type": "GtkLabel",
  "geometry": {
    "width": 170, "height": 23,          // the MARGIN box, see below
    "widthRequest": [67, 170],           // [minimum, natural]
    "heightRequest": [42, 42],           // measured AT THE ALLOCATED WIDTH
    "short": true                        // allocated below the minimum: clipped
  }
}
```

Unconditional rather than behind a flag, because the caller who needs it does not know which widget to suspect — sweeping a dump for `short` finds them. On a real 954-node application window that is 294 measured nodes and 14 findings: two are the defect being chased, two are viewports inside scrolled windows, five are `AdwGizmo` indicator dots.

## Two decisions worth reviewing

**The height is measured at the allocated width.** A wrapping label asked for its height at its *natural* width answers one line; asked at the width it actually got, two. The two numbers agree except where a parent measured one and allocated the other, which is exactly the defect. Measuring at `-1` would report the number that agrees with the allocation and hide the case worth finding.

**GTK has three boxes behind four accessors, and the first version of this mixed them.** Measured on GTK 4.22.4, a `Gtk.Label` with `padding: 3px 5px` over a 68×17 content box:

| | padded | margined |
|---|---|---|
| `get_width()` / `get_height()` | 68×17 | 68×17 |
| `compute_bounds(self)` | 78×23 | 68×17 |
| `measure()` natural | 78×23 | 82×25 |

So `get_width()` is the **content** box, `compute_bounds()` the **border** box, and `measure()` speaks the **margin** box. Asking the padded label's height at 68 answers 40 rather than 23, because 68 read as a margin-box width leaves 58 for text that then wraps. That mistake called **116 of 293** widgets in that same window clipped. Everything here works in the margin box — `compute_bounds()` plus the four margins, which is the rectangle `get_allocation()` returns without calling what GTK 4.12 deprecated.

Position is deliberately absent: x/y would need a `Graphene.Rect` across the bridge, `Screenshot(<path>)` already answers where a widget is by showing it, and the question this exists for is answered without it.

## Cost

Two `gtk_widget_measure()` calls per mapped node. GTK caches a size request per `(orientation, for_size)`, and the pair asked for here is the pair the layout just asked for itself, so it reads that cache rather than provoking a re-layout.

## Tests

Six new specs in `widget-tree.spec.ts`, all on duck-typed shapes so they run on Node and GJS: the pair is reported; the height is measured at the allocated width and not the natural one; the margin box is the one used; `compute_bounds` failing leaves the field out; a mapped widget with no allocation measures at `-1`; an unmapped widget carries no geometry at all — its two zeros beside a request would read as "clipped to nothing" for every page of a stack that is not visible.

`@gjsify/devtools`: 61 passed · 156 assertions.

## What found it

The [CORRECTIV desktop host](https://github.com/faktenforum/correctiv-app/tree/desktop/apps/desktop), a React-Native-on-GTK4 application, had a masthead date allocated 170×23 at every window width from 700 to 1400 while one line of it needs 206. Every readable property was correct — `wrap: true`, `max-width-chars: -1`, `hexpand: false` — and the defect lived entirely in the two numbers that were not readable.

With this, the cause took one dump: the label is allocated its own natural width, and at its own natural width it asks for two lines. That turns out to be a GTK/Pango accounting fault with letter-spacing, characterised separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)