### PR TITLE
fix(scripts): drop the closed avatar gaps

### DIFF
--- a/scripts/check-nativescript-widget-coverage.mjs
+++ b/scripts/check-nativescript-widget-coverage.mjs
@@ -170,10 +170,6 @@ const KNOWN_GAPS = {
         gaps: ['bodyUseMarkup', 'headingUseMarkup', 'preferWideLayout'],
         why: "There is no in-app dialog to carry them: this class maps onto the platform `confirm()` / `action()` sheet so the dialog looks like the user's OS rather than a libadwaita card (adw-alert-dialog.ts:12-16). A native sheet takes PLAIN strings — no Pango markup to enable — and picks its own width, so the wide-layout hint has nothing to hint to.",
     },
-    'adw-avatar': {
-        gaps: ['iconName', 'showInitials'],
-        why: 'The port renders one thing: "a circular accent-tinted background and a centered initials `Label`" (adw-avatar.ts:3-5). `Adw.Avatar` falls back to an icon when the text is empty or `show-initials` is FALSE, and neither the fallback nor the switch exists here — the initials are the only content path. This is the measured instance that motivated this check, and `<adw-avatar>` carries `icon-name` on the web surface for the same reason.',
-    },
     'adw-bottom-sheet': {
         gaps: ['align', 'canOpen', 'fullWidth', 'modal', 'revealBottomBar', 'showDragHandle'],
         why: 'The sheet is bottom-aligned in a `GridLayout` and toggled by `visibility` — "no upward slide, no dimming scrim/backdrop-blur" (adw-bottom-sheet.ts, FIDELITY). Alignment, full-width and modality are properties of a presentation this port does not perform; the bottom bar and the drag handle are the two sub-widgets it does not build, and `can-open` gates an interaction that is a plain `open` write here.',


### PR DESCRIPTION
`main` is red on `check-nativescript-widget-coverage`, which runs inside the required
`Detect runtime-triplet drift` job — so every open PR is blocked until this lands.

## What happened, and why no PR check could have caught it

- **#1583** landed the counterpart-coverage ratchet, whose ledger declares
  `adw-avatar: ['iconName', 'showInitials']` as an open backlog with a `why`.
- **#1578** landed the avatar fallback, which **sets both**.

Each was green against a `main` that did not contain the other. Merged together, the
declaration became a stale reason left standing — and the ratchet's second arm, the one
that fails a gap once it is CLOSED, fired exactly as designed. One merge too late to be
visible on a pull request.

That second arm is the reason this is a two-line fix rather than a silent wrong belief in
the ledger. It did its job.

## The fix

The whole `'adw-avatar'` entry goes. Both gaps are closed, and its `why` describes a port
that no longer renders only initials.

Measured before → after:

| | before | after |
|---|---:|---:|
| declared gaps | 131 across 31 widgets | **129 across 30** |
| widgets holding every property their counterpart declares | 9 | **10** |

`check-nativescript-widget-coverage` goes exit 1 → exit 0. Also run clean on the branch:
`check-vocabulary-alignment`, `check-adwaita-element-properties`,
`check-nativescript-xml-doors`, `check-adr-index`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQ87zT8bbwAhB1Hn264Krx