### PR TITLE
fix(adwaita-nativescript): rename shadowed fields

### DIFF
--- a/packages/nativescript-bridge/adwaita/src/ns-core.d.ts
+++ b/packages/nativescript-bridge/adwaita/src/ns-core.d.ts
@@ -11,6 +11,17 @@
 // This is the NativeScript analogue of how `packages/framework/*` lean on the
 // generated `@girs/*` types for GNOME classes: we describe the native host API
 // surface, we don't reimplement it.
+//
+// WHAT THIS FILE CANNOT CATCH. A member declared below makes a shadowing widget fail
+// HERE; a member left out stays invisible until a consumer compiles. So this is a
+// growing list, never a guarantee. Measured against `@nativescript/core@9.1.0-alpha.11`,
+// three shadowings remain that this file deliberately does NOT declare, because each is
+// a name the Adwaita vocabulary owns on purpose and declaring it would fail the build
+// here for a decision already taken: `AdwDataGrid.rows`/`.columns` over
+// `GridLayoutBase`'s track spellings (the trade `SETTER_ONLY_ON_BASE` in
+// `scripts/nativescript-xml-doors.mjs` records), and `AdwSplitButton.direction` over
+// `ViewCommon.direction`, NativeScript's RTL layout property. All three are a type
+// error for a consumer that compiles our `lib/types` without `skipLibCheck`.
 
 declare module '@nativescript/core' {
     /** Payload shape for NativeScript's `Observable.notify` / event listeners. */
@@ -252,6 +263,13 @@ declare module '@nativescript/core' {
         protected _rows: ItemSpec[];
         addColumn(itemSpec: ItemSpec): void;
         addRow(itemSpec: ItemSpec): void;
+        /**
+         * `GridLayoutBase.removeRow(itemSpec: ItemSpec)`
+         * (`ui/layouts/grid-layout/grid-layout-common.d.ts:41`). While this file listed
+         * only `removeRows()`, a widget could narrow `removeRow` and nothing here
+         * objected — `AdwExpanderRow` took a `View`, and only a consumer saw it.
+         */
+        removeRow(itemSpec: ItemSpec): void;
         /** Remove every column definition (lets a layout re-declare its columns,
          *  e.g. to flip the fixed/expanding column for a trailing sidebar). */
         removeColumns(): void;

--- a/packages/nativescript-bridge/adwaita/src/ns-core.d.ts
+++ b/packages/nativescript-bridge/adwaita/src/ns-core.d.ts
@@ -21,6 +21,15 @@ declare module '@nativescript/core' {
 
     /** Base of every NativeScript object — carries the event system. */
     export class Observable {
+        /**
+         * Declared here ONLY so a widget cannot shadow it. `@nativescript/core`
+         * has `_emit(eventName: string): void` PUBLIC on `Observable`
+         * (`data/observable/index.d.ts:199`), so a subclass that declares its own
+         * `private _emit` both narrows the visibility and changes the signature.
+         * This file left it out, which is why that went unseen until a consumer
+         * compiled against the real package.
+         */
+        _emit(eventName: string): void;
         /** Subscribe to an event (e.g. `'checkedChange'`, `'notify::active'`). */
         addEventListener(
             eventName: string,
@@ -42,6 +51,14 @@ declare module '@nativescript/core' {
 
     /** Base view — every visual element. */
     export class View extends Observable {
+        /**
+         * `ViewCommon` declares `private _measuredWidth`
+         * (`ui/core/view/view-common.d.ts:80`). Declared here so a widget that
+         * gives itself a field of that name fails to compile instead of colliding
+         * silently — a private base member cannot be redeclared by a subclass at
+         * any visibility.
+         */
+        private _measuredWidth: number;
         /** CSS class list applied to this view (space-separated). */
         className: string;
         /**
@@ -224,6 +241,15 @@ declare module '@nativescript/core' {
 
     /** Grid of children addressed by row/column — `<GridLayout>`. */
     export class GridLayout extends LayoutBase {
+        /**
+         * `GridLayoutBase` declares `protected _rows: Array<ItemSpec>`
+         * (`ui/layouts/grid-layout/grid-layout-common.d.ts:24`) and its constructor
+         * assigns `this._rows = new Array()`, with `addRow`/`removeRow`/`getRows`
+         * reading it. A subclass field of the same name is not only a type error:
+         * its initialiser runs AFTER the base constructor and replaces that array,
+         * so both sides then write the same slot with incompatible element types.
+         */
+        protected _rows: ItemSpec[];
         addColumn(itemSpec: ItemSpec): void;
         addRow(itemSpec: ItemSpec): void;
         /** Remove every column definition (lets a layout re-declare its columns,

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-clamp.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-clamp.ts
@@ -35,7 +35,7 @@ export class AdwClamp extends GridLayout {
     private _props: ClampProps = defaultClampProps();
     private _child: View | null = null;
     /** The container width the child was last clamped against, in DIPs. */
-    private _measuredWidth = 0;
+    private _clampWidth = 0;
 
     constructor(props?: ConstructProps<AdwClamp>) {
         super();
@@ -127,10 +127,10 @@ export class AdwClamp extends GridLayout {
      */
     private _allocate(): void {
         const size = this.getActualSize?.();
-        if (size && size.width > 0) this._measuredWidth = size.width;
+        if (size && size.width > 0) this._clampWidth = size.width;
         if (!this._child) return;
 
-        const { width, sizeClass } = clampAllocationFor(this._measuredWidth, this._props);
+        const { width, sizeClass } = clampAllocationFor(this._clampWidth, this._props);
         this._child.width = width;
         const className = clampChildClassName(this._child.className, sizeClass);
         if (this._child.className !== className) this._child.className = className;

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-data-grid.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-data-grid.ts
@@ -94,11 +94,11 @@ interface DataGridRowNodes {
 
 export class AdwDataGrid extends GridLayout {
     private _columns: AdwDataGridColumn[] = [];
-    private _rows: AdwDataGridRow[] = [];
+    private _dataRows: AdwDataGridRow[] = [];
     private _interactive = false;
     /** The header row's nodes, or `null` while there are no columns. */
     private _header: DataGridRowNodes | null = null;
-    /** One entry per data row, index-aligned with {@link _rows}. */
+    /** One entry per data row, index-aligned with {@link _dataRows}. */
     private _rowNodes: DataGridRowNodes[] = [];
     /** The tracks the declared columns were built from — the re-declare guard. */
     private _trackKey = '';
@@ -124,11 +124,11 @@ export class AdwDataGrid extends GridLayout {
 
     /** The row objects (copied, like the browser element does). */
     get rows(): AdwDataGridRow[] {
-        return this._rows;
+        return this._dataRows;
     }
 
     set rows(value: ReadonlyArray<AdwDataGridRow>) {
-        this._rows = Array.isArray(value) ? value.map((row) => ({ ...row })) : [];
+        this._dataRows = Array.isArray(value) ? value.map((row) => ({ ...row })) : [];
         this._render();
     }
 
@@ -180,7 +180,7 @@ export class AdwDataGrid extends GridLayout {
      */
     private _syncNodes(): void {
         const columnCount = this._columns.length;
-        const key = dataGridShapeKey(columnCount, this._rows.length);
+        const key = dataGridShapeKey(columnCount, this._dataRows.length);
         if (key === this._shapeKey) return;
         this._shapeKey = key;
 
@@ -198,7 +198,7 @@ export class AdwDataGrid extends GridLayout {
         // the boxed-list rhythm the cell padding sets.
         this.addRow(new ItemSpec(1, 'auto'));
         this._header = this._buildRow(0, columnCount, false);
-        this._rowNodes = this._rows.map((_row, index) => {
+        this._rowNodes = this._dataRows.map((_row, index) => {
             this.addRow(new ItemSpec(1, 'auto'));
             return this._buildRow(index + 1, columnCount, true);
         });
@@ -252,7 +252,7 @@ export class AdwDataGrid extends GridLayout {
             this._showCell(cell, 1);
         });
 
-        this._rows.forEach((rowData, index) => {
+        this._dataRows.forEach((rowData, index) => {
             const nodes = this._rowNodes[index];
             if (nodes === undefined) return;
             const variant = normalizeDataGridVariant(rowData.variant);
@@ -303,7 +303,7 @@ export class AdwDataGrid extends GridLayout {
      * length, so a captured row would be the previous data set's.
      */
     private _activate(index: number): void {
-        const rowData = this._rows[index];
+        const rowData = this._dataRows[index];
         if (rowData === undefined) return;
         const variant = normalizeDataGridVariant(rowData.variant);
         if (!dataGridRowInteractive(variant, rowData.interactive, this._interactive)) return;

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-expander-row.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-expander-row.ts
@@ -151,9 +151,21 @@ export class AdwExpanderRow extends AdwActionRow {
         this._disclosure.addChild(viewOrSpec);
     }
 
-    /** Remove a previously-added child row from the disclosure container. */
-    removeRow(view: View): void {
-        this._disclosure.removeChild(view);
+    /**
+     * Remove a previously-added child row from the disclosure container.
+     *
+     * Takes `View | ItemSpec` for the same reason `addRow` does: `GridLayout` already
+     * declares `removeRow(itemSpec: ItemSpec)`, so accepting only a `View` NARROWS an
+     * inherited signature. That is a type error for anyone compiling against the real
+     * `@nativescript/core`, and it left the base's own track teardown unreachable
+     * through this name.
+     */
+    removeRow(viewOrSpec: View | ItemSpec): void {
+        if (viewOrSpec instanceof ItemSpec) {
+            super.removeRow(viewOrSpec);
+            return;
+        }
+        this._disclosure.removeChild(viewOrSpec);
     }
 
     /**
@@ -177,7 +189,8 @@ export class AdwExpanderRow extends AdwActionRow {
      * which every NativeScript bundle is. Measured against that prototype shape, and
      * it would have broken apps that never touch XML. `rows` and `columns` are the
      * only two accessors of that shape on the bases this package extends —
-     * `scripts/check-nativescript-accessor-shadowing.mjs` holds both.
+     * `scripts/check-nativescript-xml-doors.mjs` holds both (in `SETTER_ONLY_ON_BASE`,
+     * `scripts/nativescript-xml-doors.mjs:116`).
      */
     get disclosureRows(): readonly View[] {
         const out: View[] = [];

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-navigation-view.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-navigation-view.ts
@@ -74,7 +74,7 @@ export class AdwNavigationView extends GridLayout {
                 setPageVisibility: (view, visibility) => {
                     view.visibility = visibility;
                 },
-                emit: (event) => this._emit(event),
+                emit: (event) => this._emitNavigation(event),
             },
             {
                 // The C prints these with g_critical; staying silent about a
@@ -252,7 +252,7 @@ export class AdwNavigationView extends GridLayout {
         this._nav.setPopOnEscape(value);
     }
 
-    private _emit(event: NsNavigationEvent): void {
+    private _emitNavigation(event: NsNavigationEvent): void {
         const data: AdwNavigationEventData = {
             eventName: event.name,
             object: this,

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-preferences-page.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-preferences-page.ts
@@ -24,8 +24,24 @@ import { xmlBoolean } from './xml-values.js';
 import { applyConstructProps, type ConstructProps } from './construct-props.js';
 
 export class AdwPreferencesPage extends ScrollView implements NsSearchablePage {
-    /** The vertical stack that actually holds the groups. */
-    protected readonly _content: StackLayout;
+    /**
+     * The vertical stack that actually holds the groups.
+     *
+     * NOT `_content`, which is what it was called first. `ContentView` — in this
+     * class's chain via `ScrollView` — uses `this._content` as the backing store for
+     * its own `content` accessor (`ui/content-view/index.js:12,15-21`). Sharing that
+     * name does not shadow the field, it IS the field: `readonly` becomes a
+     * compile-time fiction, because `set content` writes it, so any `page.content = x`
+     * silently re-points this handle and `addGroup`/`searchGroups`/`groups` then work
+     * on the wrong view. No type-checker can catch it — `_content` appears in no
+     * `.d.ts` of `@nativescript/core`, only in the compiled JS.
+     *
+     * Five sibling widgets keep `_content` safely, because their chain runs
+     * `GridLayout → LayoutBase → CustomLayoutView` and never reaches `ContentView`.
+     * This class and `AdwSidebar` (which calls its stack `_list`) are the two on
+     * `ScrollView`, and so the two where the name is taken.
+     */
+    protected readonly _groups: StackLayout;
 
     private _title = '';
     private _name = '';
@@ -44,8 +60,10 @@ export class AdwPreferencesPage extends ScrollView implements NsSearchablePage {
 
         // ScrollView holds exactly one scrollable child via its `content` slot.
         this.content = content;
-        this._content = content;
+        this._groups = content;
 
+        // After `_groups`, because a construct prop assigns through the public
+        // setters and `addGroup` reads it.
         applyConstructProps(this, props);
     }
 
@@ -94,12 +112,12 @@ export class AdwPreferencesPage extends ScrollView implements NsSearchablePage {
 
     /** Append a preferences group (or any view) to the page. */
     addGroup(view: View): void {
-        this._content.addChild(view);
+        this._groups.addChild(view);
     }
 
     /** Remove a previously-added group from the page. */
     removeGroup(view: View): void {
-        this._content.removeChild(view);
+        this._groups.removeChild(view);
     }
 
     /**
@@ -119,9 +137,9 @@ export class AdwPreferencesPage extends ScrollView implements NsSearchablePage {
      */
     searchGroups(): readonly NsSearchableGroup[] {
         const groups: NsSearchableGroup[] = [];
-        const count = this._content.getChildrenCount();
+        const count = this._groups.getChildrenCount();
         for (let index = 0; index < count; index++) {
-            const child = this._content.getChildAt(index) as unknown as Partial<NsSearchableGroup>;
+            const child = this._groups.getChildAt(index) as unknown as Partial<NsSearchableGroup>;
             // A page may hold plain views next to its groups; only something
             // that can enumerate rows is part of the corpus.
             if (typeof child.searchRows === 'function') groups.push(child as NsSearchableGroup);
@@ -131,6 +149,6 @@ export class AdwPreferencesPage extends ScrollView implements NsSearchablePage {
 
     /** The vertical content stack holding the groups. */
     get groups(): StackLayout {
-        return this._content;
+        return this._groups;
     }
 }

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-spinner.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-spinner.ts
@@ -49,7 +49,12 @@ export class AdwSpinner extends GridLayout {
         const indicator = new ActivityIndicator();
         indicator.className = 'adw-spinner-ring';
         indicator.horizontalAlignment = 'center';
-        indicator.verticalAlignment = 'center';
+        // `'middle'`, not `'center'`: `CoreTypes.VerticalAlignmentType` is
+        // `'top' | 'middle' | 'bottom' | 'stretch'`. Both behave the same at runtime —
+        // NativeScript aliases the one to the other in `VerticalAlignmentText.parse`
+        // (`core-types/index.js:112`) — but only `'middle'` type-checks against the
+        // real `@nativescript/core`. The horizontal axis DOES spell it `'center'`.
+        indicator.verticalAlignment = 'middle';
         this._indicator = indicator;
         this.addChild(indicator);
 

--- a/packages/nativescript-bridge/adwaita/src/widgets/split-view-base.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/split-view-base.ts
@@ -60,7 +60,7 @@ export abstract class AdwSplitViewBase<TState extends NsSplitViewState = NsSplit
     /** The three width PROPERTIES; the drawn width is derived from them. */
     protected _widthProps: SidebarWidthProps = defaultSidebarWidthProps();
     /** The container width the sidebar was last sized against, in DIPs. */
-    protected _measuredWidth = 0;
+    protected _splitWidth = 0;
     /** An explicit `sidebarWidth` assignment, which overrides the derivation. */
     protected _sidebarWidthOverride: number | null = null;
 
@@ -283,7 +283,7 @@ export abstract class AdwSplitViewBase<TState extends NsSplitViewState = NsSplit
     get sidebarWidth(): number {
         return (
             this._sidebarWidthOverride ??
-            sidebarWidthFor(this._measuredWidth, this._widthProps, this._widthRule, {
+            sidebarWidthFor(this._splitWidth, this._widthProps, this._widthRule, {
                 collapsed: this._state.collapsed,
             })
         );
@@ -339,7 +339,7 @@ export abstract class AdwSplitViewBase<TState extends NsSplitViewState = NsSplit
      */
     protected _applySidebarWidth(): void {
         const size = this.getActualSize?.();
-        if (size && size.width > 0) this._measuredWidth = size.width;
+        if (size && size.width > 0) this._splitWidth = size.width;
         if (!this._sidebar) return;
         // Guarded: writing the derived width unconditionally undoes a collapsed pane's
         // `'auto'` one frame later. The rule lives in the pure sibling so a spec can


### PR DESCRIPTION
Four private members of `@gjsify/adwaita-nativescript` share a name with a member their
NativeScript base class already declares. This repository cannot see it: the package
type-checks against `ns-core.d.ts`, an ambient stand-in that leaves those members out.
**The under-declaration is what hid them** — a consumer compiling against the real
`@nativescript/core` gets the errors immediately.

That is how this surfaced: Learn6502's `packages/app-android/app/utils/as-view.ts` carries
a `fixed upstream in gjsify` shim for two of them, with no PR behind it. Per the
fix-at-the-core rule, the shim should not become permanent.

## The four, measured against `@nativescript/core@9.1.0-alpha.11`

| ours | upstream | why it is in the chain |
|---|---|---|
| `AdwClamp._measuredWidth` | `private _measuredWidth` — `ui/core/view/view-common.d.ts:80` | `extends GridLayout` |
| `AdwSplitViewBase._measuredWidth` | same | `extends GridLayout` |
| `AdwNavigationView._emit` | `_emit(eventName: string): void` **public** — `data/observable/index.d.ts:199` | `extends GridLayout` → … → `Observable` |
| `AdwDataGrid._rows` | `protected _rows: Array<ItemSpec>` — `grid-layout-common.d.ts:24` | `extends GridLayout` |

**`_rows` is a runtime defect; calling it a type error was too strong.** Review measured
that the public `ui/layouts/grid-layout/index.d.ts` declares `GridLayout extends LayoutBase`,
not `GridLayoutBase`, so under default module resolution TypeScript never sees the
declaration and reports nothing. Against `GridLayoutBase` — the class that actually exists at
runtime — it is TS2416. The reason to rename it is the runtime one below, not the type. `GridLayoutBase`'s constructor assigns
`this._rows = new Array()` and `addRow` / `removeRow` / `removeRows` / `getRows` read it
(`grid-layout-common.js:129, 159, 207, 239, 275`). A subclass field initialiser runs *after*
the base constructor, so `AdwDataGrid`'s `= []` replaces the base's array in the same slot —
after which both sides write one array with incompatible element types.

They become `_clampWidth`, `_splitWidth`, `_emitNavigation`, `_dataRows`, each contained to
its own file (`grep` for the old names in the package returns nothing).

## Review round — three more, one of them worse than any of the four

An independent review rebased onto current `main`, got a type-check running that the author
could not (TypeScript 6.0.3 from a sibling checkout, two configs: one against the ambient
stand-in, one against the real package), and found:

- **`AdwExpanderRow.removeRow`** narrowed the inherited `removeRow(itemSpec: ItemSpec)` to
  `View` — TS2416 for any consumer. Invisible here because `ns-core.d.ts` listed
  `removeRows()` but not `removeRow()`. Its sibling `addRow` already handled this correctly.
- **`AdwPreferencesPage._content`** — the serious one, and **not a shadow at all**.
  `ContentView` uses `this._content` as the backing store behind its `content` accessor, so
  the two are ONE slot: `readonly` is fiction, `set content` writes it, and any
  `page.content = x` silently re-points the handle while `addGroup`/`searchGroups`/`groups`
  keep working on the wrong view. **No type-checker can find this** — `_content` appears in
  zero `.d.ts`, only in compiled JS. Renamed to `_groups`.
- **`AdwSpinner.verticalAlignment = 'center'`** — type-only. NativeScript aliases
  `'center' → 'middle'` at runtime (`core-types/index.js:112`), so this was never a rendering
  bug, and the review says so rather than claiming one.

Three further errors against the real package are documented rather than fixed:
`AdwDataGrid.rows`/`.columns` (a recorded `SETTER_ONLY_ON_BASE` trade) and
`AdwSplitButton.direction`, which shadows `ViewCommon.direction` — NativeScript's RTL
property — and was recorded nowhere. Renaming public, vocabulary-aligned names is not a
reviewer's call.

The `_rows` runtime aliasing was **executed, not argued**: on `main` the base's `ItemSpec`
track list is destroyed (`getRows()` returns data rows); on the branch it survives.

## The mechanism

The three shadowed members are now declared in `ns-core.d.ts`, faithfully to upstream
visibility, so the next collision fails here rather than at a consumer.

## What is NOT claimed

**This is not a complete census.** A name-based scan cannot decide the question, and mine
proved it twice: a first pass missed every `private readonly _x` and every class with a
generic parameter (which is how `AdwSplitViewBase` was nearly left out), and a second pass
produced two false positives by matching base-class *filenames* as substrings —
`tab-view-common.d.ts` contains `view-common`. Each of the four above was then confirmed
individually against the declaring `.d.ts` and, for `_rows`, against the shipped `.js`.

The honest instrument is a type-checker against the real package, which no job here runs.
Making `ns-core.d.ts` faithful — this PR does three members of 726 — is the incremental
path to it.

**The ambient additions are now verified.** The author could not run `tsc`; the review
could, and confirmed the specific worry: `private _measuredWidth` on the ambient `View`
breaks nothing, because nothing assigns a non-subclass to `View` — the `ViewConstructor` map
in `widgets/index.ts` holds real subclasses. Zero errors in `src/` under both configs, with a
positive control on the parent commit reproducing exactly the claimed errors and no others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQ87zT8bbwAhB1Hn264Krx
