### PR TITLE
fix(gtk-host): keep a flow box's per-line cap at its child count

### DIFF
--- a/packages/framework/gtk-host/src/conformance/index.ts
+++ b/packages/framework/gtk-host/src/conformance/index.ts
@@ -157,6 +157,30 @@ export function descriptorProblems(
             }
         }
 
+        if (d.children.kind === 'indexed' && d.children.perLineCap !== undefined) {
+            // The same check `textSink` gets, for the same reason: a declared
+            // PROPERTY NAME that the class does not carry fails silently. MEASURED —
+            // `listBox.set_property('max-children-per-line', 3)` logs
+            // `GLib-GObject-CRITICAL: object class 'GtkListBox' has no property named
+            // …` and returns, at exit 0, so a typo here would simply stop capping.
+            const cap = d.children.perLineCap;
+            const specs = (Klass as unknown as { list_properties(): GObject.ParamSpec[] }).list_properties();
+            const spec = specs.find((x) => x.get_name() === cap);
+            if (!spec) {
+                problems.push({
+                    gtype: d.gtype,
+                    problem: `declares perLineCap "${cap}", which ${actual} does not have`,
+                });
+            } else if ((spec.flags & GObject.ParamFlags.WRITABLE) === 0) {
+                problems.push({ gtype: d.gtype, problem: `declares a READ-ONLY perLineCap "${cap}"` });
+            } else if (!GObject.type_is_a(spec.value_type, GObject.TYPE_UINT)) {
+                problems.push({
+                    gtype: d.gtype,
+                    problem: `declares perLineCap "${cap}", which is ${GObject.type_name(spec.value_type)}, not a count`,
+                });
+            }
+        }
+
         problems.push(...policyProblems(d, Klass as unknown as { prototype: object }, actual));
     }
     return problems;

--- a/packages/framework/gtk-host/src/descriptors/gtk.ts
+++ b/packages/framework/gtk-host/src/descriptors/gtk.ts
@@ -112,7 +112,19 @@ export const GTK_DESCRIPTORS: readonly WidgetDescriptor[] = [
     {
         gtype: 'GtkFlowBox',
         ctor: () => Gtk.FlowBox,
-        children: { kind: 'indexed', insert: 'insert', remove: 'remove', wrap: 'flow-box-child' },
+        // `perLineCap` is a CORRECTNESS rule that happens to also be the cheap one.
+        // Without it a `Gtk.FlowBox` sits at GTK's default of 7 and a wrap caps a
+        // line at seven children however much room is left. Holding it at the child
+        // count costs nothing — MEASURED, 0.098 ms per height-for-width measure of
+        // two children at the default and 0.024 ms at their count — while the
+        // G_MAXUINT that used to carry this rule cost 1393 ms. See `ChildPolicy`.
+        children: {
+            kind: 'indexed',
+            insert: 'insert',
+            remove: 'remove',
+            wrap: 'flow-box-child',
+            perLineCap: 'max-children-per-line',
+        },
     },
     {
         gtype: 'GtkListBoxRow',

--- a/packages/framework/gtk-host/src/host.spec.ts
+++ b/packages/framework/gtk-host/src/host.spec.ts
@@ -173,6 +173,93 @@ export default async () => {
             });
         });
 
+        await gated(diagnostics, 'indexed — Gtk.FlowBox (the per-line cap tracks the child count)', async () => {
+            await it('sets the cap to the child count on every insert and every remove', async () => {
+                // WHY this is maintained rather than pinned high once: GTK measures
+                // the CAP and not the children, quadratically. A two-child box at
+                // 65535 takes 1517.9 ms per measure and at 64 takes 0.018 ms
+                // (measured, GTK 4.22.4), and both lay the two children out the same,
+                // which is what let the cost sit unnoticed behind a correct screen.
+                const flow = createElement('GtkFlowBox');
+                const widget = materialize(flow) as unknown as Gtk.FlowBox;
+                const [a, b, c] = labels(3);
+                insert(a, flow);
+                expect(widget.maxChildrenPerLine).toBe(1);
+                insert(b, flow);
+                insert(c, flow);
+                expect(widget.maxChildrenPerLine).toBe(3);
+                remove(b);
+                expect(widget.maxChildrenPerLine).toBe(2);
+            });
+
+            await it('asks for one when the box is empty, because 0 is refused', async () => {
+                // `GLib-GObject-CRITICAL: value "0" … is invalid or out of range for
+                // property 'max-children-per-line' of type 'guint'` — and the property
+                // KEEPS ITS OLD VALUE behind that critical, so a 0 written here would
+                // leave the cap wherever it happened to be.
+                //
+                // THREE children and not one, which is the difference between a vector
+                // and a vector that cannot fail: emptying a box that only ever held one
+                // leaves the cap at 1 either way, so the assertion passed for a write
+                // of 0 too and only the diagnostics gate caught it.
+                const flow = createElement('GtkFlowBox');
+                const widget = materialize(flow) as unknown as Gtk.FlowBox;
+                const three = labels(3);
+                for (const label of three) insert(label, flow);
+                expect(widget.maxChildrenPerLine).toBe(3);
+                for (const label of three) remove(label);
+                expect(widget.maxChildrenPerLine).toBe(1);
+            });
+
+            await it('never overwrites a cap the author asked for', async () => {
+                // `maxChildrenPerLine={3}` is an instruction to put three on a line.
+                // The sync exists to remove a silent cost, and taking this over would
+                // be a silent change of layout — the same kind of wrong, pointed the
+                // other way.
+                // The CAMELCASE spelling, because that is the one the docblock
+                // advertises and the one an author writes; `setProp` normalises it to
+                // the kebab key the sync reads, and a vector written in kebab would
+                // never have tested that hop.
+                const flow = createElement('GtkFlowBox', { maxChildrenPerLine: 3 });
+                const widget = materialize(flow) as unknown as Gtk.FlowBox;
+                const [a, b] = labels(2);
+                insert(a, flow);
+                insert(b, flow);
+                expect(widget.maxChildrenPerLine).toBe(3);
+            });
+
+            await it('measures the same natural width as the cap the author would write', async () => {
+                // The cap is not merely expensive, it is WRONG in the answer: a
+                // natural width carries `column-spacing × (cap - 1)` of gaps that do
+                // not exist, so the pinned 65535 measured 524 867 px for content
+                // 683 px wide. Asserted as an equivalence rather than against a
+                // number, because the number is the thing under test: an authored cap
+                // the sync leaves alone must measure what the synced one measures.
+                const authored = createElement('GtkFlowBox', { 'max-children-per-line': 2, 'column-spacing': 8 });
+                const synced = createElement('GtkFlowBox', { 'column-spacing': 8 });
+                const [aw, sw] = [authored, synced].map((flow) => {
+                    const widget = materialize(flow) as unknown as Gtk.FlowBox;
+                    for (const label of labels(2)) insert(label, flow);
+                    return widget.measure(Gtk.Orientation.HORIZONTAL, -1)[1];
+                });
+                expect(sw).toBe(aw);
+            });
+
+            await it('leaves a Gtk.ListBox alone, which declares no cap', async () => {
+                // Asserted on the DATA, because the placement assertion below is true
+                // whatever the sync does and pinned the intent through nothing but the
+                // diagnostics gate. `Gtk.ListBox` has no such property at all, and
+                // writing one is a `GLib-GObject-CRITICAL` at exit 0.
+                const policy = lookupWidget('GtkListBox').children;
+                expect(policy.kind === 'indexed' && policy.perLineCap === undefined).toBe(true);
+                const list = createElement('GtkListBox');
+                const widget = materialize(list) as unknown as Gtk.ListBox;
+                const [a] = labels(1);
+                insert(a, list);
+                expect(gtkChildTypes(widget as unknown as Gtk.Widget)).toStrictEqual(['GtkListBoxRow']);
+            });
+        });
+
         await gated(diagnostics, 'single, slotted, keyed, coords', async () => {
             await it('single: set_child replaces, it does not append', async () => {
                 const bin = createElement('AdwBin');

--- a/packages/framework/gtk-host/src/policies.ts
+++ b/packages/framework/gtk-host/src/policies.ts
@@ -387,6 +387,11 @@ export function insertChild(place: Placement): void {
         // two names it does know.
         throw err.rejectedChild(place.parent.descriptor.gtype, place.child.descriptor.gtype, (e as Error).message);
     }
+    // AFTER the catch, not inside it. The sync is not part of the placement, and a
+    // throw from in there would be rewritten as a refusal that never happened, on a
+    // child GTK has already taken — after which `attach` never marks it attached and
+    // the node is unlinked from a tree it is physically in.
+    syncPerLineCap(place.parent);
 }
 
 function placeChild(place: Placement): void {
@@ -622,6 +627,58 @@ export function removeChild(parent: HostElement, child: HostElement): void {
     // whole teardown so handlers stay connected for the life of the process.
     if (!child.attached) return;
     detachChild(parent, child, host);
+    syncPerLineCap(parent);
+}
+
+/**
+ * Keep an `indexed` parent's per-line cap equal to its child count.
+ *
+ * WHY a cap has to be maintained at all rather than pinned high once is on
+ * `ChildPolicy`'s `perLineCap`: GTK measures the cap and not the children, and
+ * the cost is quadratic in it.
+ *
+ * The walk is O(children) and runs after every insert, so a build of n children is
+ * O(n²) in POINTER HOPS. That is the honest cost and it is nanoseconds: MEASURED,
+ * 200 inserts into a flow box take 4.97 ms in total, and an insert does not measure
+ * at all — it queues a resize. So the trade is not against a measure this saves; it
+ * is that a counter kept on the element would be a second source for a number GTK
+ * already holds, and this asks the container.
+ *
+ * An AUTHORED value is left alone, and one that is later REMOVED is not recovered:
+ * the removal puts the class default back and nothing here runs until the next
+ * insert or remove. Declared rather than silent — a container given a cap and then
+ * relieved of it keeps GTK's 7 until its children change.
+ *
+ * The write is bracketed as the HOST's so a consumer that never wrote this property
+ * is not told it changed (measured: four raw `notify::max-children-per-line` over
+ * three inserts and a remove, none delivered to a bound handler). `null` as the
+ * target rather than the widget only because there is no non-notify consequence to
+ * preserve here, which is where this differs from `writeVisible`.
+ */
+function syncPerLineCap(parent: HostElement): void {
+    const policy = parent.descriptor.children;
+    if (policy.kind !== 'indexed' || policy.perLineCap === undefined) return;
+    if (parent.props[policy.perLineCap] !== undefined) return;
+    const host = parent.widget as unknown as Gtk.Widget | null;
+    if (!host) return;
+    let children = 0;
+    for (let c = host.get_first_child(); c !== null; c = c.get_next_sibling()) children += 1;
+    // BOTH ends are clamped, and the messages below are the ones THIS route produces
+    // — `set_property`, which is rejected at GValue validation before the C setter's
+    // own `assertion 'n_children > 0'` can run. MEASURED on GTK 4.22.4: `0` gives
+    // `GLib-GObject-CRITICAL: value "0" of type 'gint' is invalid or out of range for
+    // property 'max-children-per-line' of type 'guint'`, and the value is kept.
+    //
+    // The ceiling is the worse one, because it says NOTHING: 65536 stores 0 — the one
+    // value the line above refuses — 65537 stores 1 and 70000 stores 4464, all at
+    // exit 0. No container has 65536 children; a package whose reason for existing is
+    // refusing exit-0 mis-stores should still not be the one writing them.
+    beginHostWrite(null);
+    try {
+        host.set_property(policy.perLineCap, Math.min(65535, Math.max(1, children)));
+    } finally {
+        endHostWrite();
+    }
 }
 
 /** Does this parent reorder in place, or does it pay a full re-append? Declared, not guessed. */

--- a/packages/framework/gtk-host/src/types.ts
+++ b/packages/framework/gtk-host/src/types.ts
@@ -183,8 +183,53 @@ export type ChildPolicy =
      * and pays a full re-append per reorder. That degradation is DECLARED, never silent.
      */
     | { kind: 'ordered'; append: string; after?: string; remove: string; reorder: 'native' | 'remove-all' }
-    /** `Gtk.ListBox`/`Gtk.FlowBox`: index-addressed, and the parent addresses a WRAPPER row. */
-    | { kind: 'indexed'; insert: string; remove: string; wrap: 'list-box-row' | 'flow-box-child' | null }
+    /**
+     * `Gtk.ListBox`/`Gtk.FlowBox`: index-addressed, and the parent addresses a WRAPPER row.
+     *
+     * `perLineCap` names a property the host keeps EQUAL TO THE CHILD COUNT, and
+     * `Gtk.FlowBox:max-children-per-line` is the only one. It is a cap, so every
+     * value at or above the child count lays the children out identically — and
+     * that equivalence is exactly what hid the cost, because GTK MEASURES THE CAP
+     * RATHER THAN THE CHILDREN.
+     *
+     * MEASURED on GTK 4.22.4, one `Gtk.FlowBox` holding TWO children, per
+     * HEIGHT-FOR-WIDTH measure — `measure(VERTICAL, 400)`, which is the one a
+     * container in a window asks for:
+     *
+     * | cap | 7 | 64 | 1024 | 8192 | 32768 | 65535 |
+     * | --- | --- | --- | --- | --- | --- | --- |
+     * | ms | 0.021 | 0.025 | 0.43 | 18.6 | 391.5 | 1393.2 |
+     *
+     * Quadratic in the cap, so "as many as fit" spelled as G_MAXUINT cost a second
+     * and a half to measure two chips, and a real application froze its main loop
+     * for 12.7 s at startup over five two-child rows. The ORIENTATION is part of
+     * the claim and not a detail: `measure(HORIZONTAL, -1)` stays under 0.1 ms at
+     * every one of those caps, so a re-measurement that asks for the width alone
+     * reproduces none of this.
+     *
+     * The cap is wrong in the ANSWER too, not only in what the answer costs.
+     * Natural width is `content + column-spacing × (cap - 1)` — measured, exactly,
+     * over five caps — so a cap above the child count `n` carries
+     * `column-spacing × (cap - n)` px of gaps that do not exist. 12 children at
+     * `column-spacing: 8`: 683 px natural at a cap of 12 and 524 867 px at 65535,
+     * the excess exactly 8 × 65 523. At `column-spacing: 0` there is no difference
+     * at all, which is how a pinned cap passed for as long as it did.
+     *
+     * The child count is the exact answer rather than a smaller cap chosen to be
+     * safe: a line can never hold more children than exist, so it forbids nothing
+     * G_MAXUINT allowed, and it is the largest value that costs nothing.
+     *
+     * An AUTHORED value wins. `<GtkFlowBox maxChildrenPerLine={3}>` is someone
+     * asking for three per line, and a sync that overwrote it would be the same
+     * silent kind of wrong this field exists to remove.
+     */
+    | {
+          kind: 'indexed';
+          insert: string;
+          remove: string;
+          wrap: 'list-box-row' | 'flow-box-child' | null;
+          perLineCap?: string;
+      }
     /**
      * `Adw.HeaderBar`, `Adw.ToolbarView`, `Adw.ActionRow`: named attachment points.
      *

--- a/packages/framework/react-native/src/primitives/primitives.spec.ts
+++ b/packages/framework/react-native/src/primitives/primitives.spec.ts
@@ -275,16 +275,23 @@ export default async () => {
             expect(plan('View', { className: 'flex-row flex-wrap' }).plan.node.props.orientation).toBe('horizontal');
         });
 
-        await it('corrects the two GtkFlowBox defaults that would make it not a flex container', async () => {
-            // Both silent. `max-children-per-line` defaults to 7, so a wrap would cap
-            // a line at seven children however much room was left; `selection-mode`
-            // defaults to SINGLE, so a click would select a child and draw a focus
-            // ring a flexbox container never draws. 65535 is not a round number
-            // picked for looks — it is what GTK stores when handed G_MAXUINT, and `0`
-            // is out of range for the `guint` rather than meaning "no limit".
+        await it('corrects the GtkFlowBox default that would make it not a flex container', async () => {
+            // Silent, like the cap below it: `selection-mode` defaults to SINGLE, so a
+            // click would select a child and draw a focus ring a flexbox container
+            // never draws.
             const p = plan('View', { className: 'flex-wrap' }).plan;
-            expect(p.node.props['max-children-per-line']).toBe(65535);
             expect(p.node.props['selection-mode']).toBe('none');
+        });
+
+        await it('leaves `max-children-per-line` to the host, which is the layer that knows the count', async () => {
+            // This table pinned 65535 — GTK's spelling of "as many as fit" — and it
+            // was quadratically expensive to MEASURE: 1517.9 ms per measure of a
+            // two-child box, against 0.018 ms at 64. The cap is the child count now,
+            // maintained by `@gjsify/gtk-host` on every insert and remove, so the
+            // plan must carry no value at all. A plan that emitted one would win over
+            // the sync, which reads an authored value as an instruction.
+            const p = plan('View', { className: 'flex-wrap' }).plan;
+            expect(p.node.props['max-children-per-line']).toBeUndefined();
         });
 
         await it('sends a wrapping element’s gap to the two spacings, never to `spacing`', async () => {

--- a/packages/framework/react-native/src/primitives/table.ts
+++ b/packages/framework/react-native/src/primitives/table.ts
@@ -329,10 +329,31 @@ export interface PrimitiveSpec {
  *   seven children on a line and wrap the eighth however much room was left — a
  *   layout that is plausible on screen and wrong. There is no "no limit" spelling:
  *   `0` is OUT OF RANGE for the `guint` (a GLib-GObject-CRITICAL, and the property
- *   keeps its old value), and writing G_MAXUINT stores 65535. So 65535 IS GTK's
- *   spelling of "as many as fit", and the natural width is unaffected by it — it
- *   tracks the child count, measured identical for 12 children at 12, 1024 and
- *   65535.
+ *   keeps its old value), and writing G_MAXUINT stores 65535.
+ *
+ *   This table therefore pinned 65535, and **that correction is not made here any
+ *   more** — the cap is kept equal to the child count by `@gjsify/gtk-host`, the
+ *   only layer that knows the count (`ChildPolicy`'s `perLineCap`). A line can
+ *   never hold more children than exist, so the count forbids nothing 65535
+ *   allowed, and two things stop costing what they did.
+ *
+ *   The MEASURE, whose cost is quadratic in the cap rather than in the children.
+ *   One `Gtk.FlowBox` holding TWO children, per HEIGHT-FOR-WIDTH measure, GTK
+ *   4.22.4: 0.025 ms at 64, 18.6 ms at 8192, 391.5 ms at 32768, **1393.2 ms at
+ *   65535**. An application with five two-chip rows froze its main loop for 12.7 s
+ *   at startup, and every screenshot of it looked right. (The width alone —
+ *   `measure(HORIZONTAL, -1)` — stays under 0.1 ms at every cap, so the
+ *   orientation is part of the claim.)
+ *
+ *   The NATURAL WIDTH, which is `content + column-spacing × (cap - 1)`, so a cap
+ *   above the child count `n` carries `column-spacing × (cap - n)` px of gaps that
+ *   do not exist. 12 children, `column-spacing: 8`: 683 px at a cap of 12 and
+ *   **524 867 px** at 65535, the excess exactly 8 × 65 523. The old note here said
+ *   the natural width was "unaffected by it — measured identical for 12 children
+ *   at 12, 1024 and 65535", and that holds ONLY AT `column-spacing: 0`. Which is
+ *   the measurement this table was least entitled to make, because the same table
+ *   routes every `gap-*` into `column-spacing` (below) — a wrapping row with a gap
+ *   is the case it creates, and it is the case the claim excluded.
  *
  *   `selection-mode` defaults to SINGLE. A `Gtk.FlowBox` is a selection widget
  *   before it is a layout one, so a plain `<View>` would gain a focus ring and a
@@ -351,7 +372,7 @@ const WRAPS_INTO_FLOW_BOX: WrapsInto = {
     // announced a LAYOUT container to a screen reader as a data grid — a widget
     // swap made for a styling reason, changing what the element IS to assistive
     // technology, silently. GENERIC is what the unwrapped element already was.
-    widgetProps: { 'max-children-per-line': 65535, 'selection-mode': 'none', 'accessible-role': 'generic' },
+    widgetProps: { 'selection-mode': 'none', 'accessible-role': 'generic' },
 };
 
 const BOX: WidgetFacts = { box: true, alignsText: false, wrapsInto: WRAPS_INTO_FLOW_BOX };

--- a/packages/framework/react-native/src/primitives/widgets.spec.ts
+++ b/packages/framework/react-native/src/primitives/widgets.spec.ts
@@ -760,10 +760,13 @@ export default async () => {
                         const flow = gtkChildren(container)[0] as Gtk.FlowBox;
                         expect(typeOf(flow)).toBe('GtkFlowBox');
                         expect(flow.orientation).toBe(Gtk.Orientation.HORIZONTAL);
-                        // The two corrected defaults, read back off the widget rather
-                        // than off the plan: 7 children per line and a SINGLE
-                        // selection are what a `Gtk.FlowBox` is without them.
-                        expect(flow.maxChildrenPerLine).toBe(65535);
+                        // The corrected defaults, read back off the widget rather than
+                        // off the plan: a SINGLE selection is what a `Gtk.FlowBox` is
+                        // without the correction, and seven children per line is what
+                        // its cap is without the host's sync. TWO children here, so
+                        // the cap is two — the largest value that changes no layout
+                        // and the only one that is cheap to measure.
+                        expect(flow.maxChildrenPerLine).toBe(2);
                         expect(flow.selectionMode).toBe(Gtk.SelectionMode.NONE);
                         // `gap-2` reached the two spacings, and NOT `Gtk.Box:spacing`
                         // — a property this class does not install at all.


### PR DESCRIPTION
`@gjsify/react-native` maps `flex-wrap` to `Gtk.FlowBox` and pinned `max-children-per-line` to 65535, for a reason that was right: GTK's default of 7 wraps a chip row after seven chips, `0` is out of range rather than meaning "no limit", and 65535 is what GTK stores when handed `G_MAXUINT`. What was never measured is what the cap COSTS, and **GTK measures the cap rather than the children**.

## The cost

MEASURED on GTK 4.22.4, one `Gtk.FlowBox` holding **two** children, per measure:

| cap | 64 | 1024 | 8192 | 32768 | 65535 |
| --- | --- | --- | --- | --- | --- |
| ms | 0.018 | 0.40 | 19.3 | 421.8 | **1517.9** |

Quadratic in the cap: 8x the cap is 64x the cost, over three points. A second and a half to measure two chips.

The hot frame is `gather_aligned_item_requests` under `gtk_flow_box_measure`, sampled three times out of three with `eu-stack` during a real application's startup — a GTK4 host for a news reader, which **froze its main loop for 12.7 s on every cold start** over five two-child rows, one per article in its feed. Its window was mapped and correct throughout, so every screenshot of it was right.

Four other explanations died first, each by measurement: not the network (identical inside `unshare -rn`), not the stylesheet (`StyleSheet.flush()` instrumented — four flushes, 2 ms total), not layout in general (a resize on the settled window costs 2 to 33 ms), not the size of the tree (the same app's login gate burns 300 ms all in).

## The cap is wrong in the answer too

Worse than what it costs, and found on the way out: a natural width carries `column-spacing * (cap - 1)` of gaps that do not exist.

| cap | 12 | 64 | 1024 | 8192 | 65535 |
| --- | --- | --- | --- | --- | --- |
| natural width, 12 children, `column-spacing: 8` | 683 | 1099 | 8779 | 66123 | **524 867** |

The difference is exactly `8 * (cap - 1)` in every row. At `column-spacing: 0` there is none — which is how the pinned value passed for as long as it did: the note in `table.ts` recorded "the natural width is unaffected by it, measured identical for 12 children at 12, 1024 and 65535", and that measurement excluded the one case the same table produces, since it routes every `gap-*` into `column-spacing`.

## The change

Data on the policy rather than a smaller constant. `ChildPolicy`'s `indexed` arm gains `perLineCap`, `GtkFlowBox` declares it, and `policies.ts` — the only file that reads container rules — keeps it equal to the child count on every insert and every remove.

A line can never hold more children than exist, so the count forbids nothing 65535 allowed; it is the largest value that costs nothing, and it is exact rather than a bound chosen to be safe. An **authored** value wins: `maxChildrenPerLine={3}` asks for three per line, and a sync that overwrote it would be the same silent kind of wrong pointed the other way.

## Vectors

Five in `host.spec.ts`: the cap tracks inserts and removes, an empty box asks for 1 (`0` is refused by assertion and leaves the old value), an authored cap survives, `Gtk.ListBox` reaches none of it, and the natural width equals the one an authored cap measures — asserted as an equivalence, because the number is the thing under test.

## Measured end to end

In the application that found it: **13 510 ms of startup burn to 700 ms**, 24 of 24 routes rendering, and its chip row still wrapping into three lines at 560 px. `@gjsify/gtk-host` 531 tests, `@gjsify/react-native` 627, `@gjsify/adwaita-react-native` 198 + 125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQMZfw5A1RPVCUZwLvcZhF
