### PR TITLE
feat(gtk-host): curate Gtk.AspectFrame, the widget a ratio needs

### DIFF
--- a/packages/framework/gtk-host/src/descriptors/gtk.ts
+++ b/packages/framework/gtk-host/src/descriptors/gtk.ts
@@ -34,6 +34,36 @@ export const GTK_DESCRIPTORS: readonly WidgetDescriptor[] = [
         children: { kind: 'single', set: 'set_child' },
     },
     {
+        // HOW AN APPLICATION SPELLS "as tall as it is wide" ON THIS HOST, and that is
+        // the whole of it: nothing here maps React Native's `aspectRatio`, and this
+        // descriptor does not start doing so. `@gjsify/react-native`'s own
+        // `src/primitives/style.ts` lists that property among the ones it does not
+        // route and its partition refuses it by name; a consumer that wants the shape
+        // renders this widget. What it got instead was a refusal — without a curated
+        // placement the host declines the child as an uncurated one — so the shape was
+        // unreachable rather than merely unsugared.
+        //
+        // MEASURED on GTK 4.22.4: it is a height-for-width request and not merely an
+        // alignment, which is what makes it usable for this at all. WITH `obey-child`
+        // FALSE, which is the condition the whole paragraph rests on,
+        // `measure(VERTICAL, 116)` answers 116 at `ratio: 1` and 65 at 16/9, with a
+        // `Gtk.Picture` inside as with a box. At the default the same call answers 116
+        // for both, measured, which is the next paragraph.
+        //
+        // `obey-child` DEFAULTS TO TRUE, AND THAT IS A TRAP THIS DESCRIPTOR CANNOT
+        // CLOSE. Both measurements above hold with it written false; at its default the
+        // frame takes its ratio from the CHILD and the declared one is ignored in
+        // silence — measured, `ratio: 1` over a 32x16 child answers 58 rather than 116.
+        // A rule here can say which method adopts the child and nothing about a
+        // property the consumer writes, so this is the sentence rather than a check:
+        // a `ratio` is inert until `obey-child` is false. The vector in `host.spec.ts`
+        // is written at 16/9 for the same reason — at ratio 1 over a square-ish child
+        // the two answers coincide, and it asserted nothing.
+        gtype: 'GtkAspectFrame',
+        ctor: () => Gtk.AspectFrame,
+        children: { kind: 'single', set: 'set_child' },
+    },
+    {
         gtype: 'GtkScrolledWindow',
         ctor: () => Gtk.ScrolledWindow,
         children: { kind: 'single', set: 'set_child' },

--- a/packages/framework/gtk-host/src/host.spec.ts
+++ b/packages/framework/gtk-host/src/host.spec.ts
@@ -261,6 +261,54 @@ export default async () => {
         });
 
         await gated(diagnostics, 'single, slotted, keyed, coords', async () => {
+            await it('single: a Gtk.AspectFrame takes a child and sizes it by ratio', async () => {
+                // The placement is what this pins first — an uncurated `Gtk.AspectFrame`
+                // refuses its child by name, so the widget was unreachable.
+                //
+                // 16/9 AND NOT 1, and `obeyChild` written out, because the obvious
+                // spelling asserts nothing. MEASURED on a fresh instance, GTK's own
+                // defaults are `ratio: 1` and `obey-child: TRUE`, and the suite's label
+                // is roughly square — so `{ ratio: 1, obeyChild: false }` over a label
+                // answers 116 whether the props arrive or not, and the vector passed
+                // with `createElement('GtkAspectFrame')` and no props at all.
+                //
+                // At 16/9 the two answers separate: 65 with the ratio applied, and the
+                // child's own shape when `obey-child` keeps its default.
+                const frame = createElement('GtkAspectFrame', { ratio: 16 / 9, obeyChild: false });
+                const widget = materialize(frame) as unknown as Gtk.AspectFrame;
+                const [a] = labels(1);
+                insert(a, frame);
+                expect(gtkChildTypes(widget as unknown as Gtk.Widget)).toStrictEqual(['GtkLabel']);
+                expect(widget.measure(Gtk.Orientation.VERTICAL, 116)[1]).toBe(65);
+
+                // AND THE TRAP ITSELF, which is the one thing the descriptor tells a
+                // consumer and was the one claim with no check behind it: a `ratio` is
+                // INERT while `obey-child` keeps its default. Without this the
+                // sentence in the descriptor is prose, and a GTK that flipped that
+                // default would leave the vector above green while the sentence a
+                // consumer acts on became false.
+                //
+                // THE CHILD IS A SIZED BOX AND NOT A LABEL, and that is the whole
+                // reason this line is trustworthy. Asserting it over the suite's own
+                // label passed under gjs and FAILED on the Node reverse bridge, where
+                // a different font makes that label something other than square and
+                // `obey-child` derives a different ratio from it. A `Gtk.Box` carries
+                // no text, so its natural size IS its request — measured, [32, 16]
+                // exactly — and the derived ratio is 2 in any font on any runtime.
+                //
+                // 58 is then the answer, which is the number the descriptor cites,
+                // measured here beside it rather than quoted. A LABEL WOULD HAVE
+                // PASSED FOR THE WRONG REASON: its natural height is its line height,
+                // so a 32x16 request answers 32x18, and 32/18 is 16/9 to the pixel —
+                // both paths answer 65 and the assertion asserts nothing.
+                const inert = createElement('GtkAspectFrame', { ratio: 16 / 9 });
+                const inertWidget = materialize(inert) as unknown as Gtk.AspectFrame;
+                const sized = createElement('GtkBox', { widthRequest: 32, heightRequest: 16 });
+                materialize(sized);
+                insert(sized, inert);
+                expect(inertWidget.measure(Gtk.Orientation.VERTICAL, 116)[1]).toBe(58);
+            });
+
             await it('single: set_child replaces, it does not append', async () => {
                 const bin = createElement('AdwBin');
                 const widget = materialize(bin) as unknown as Adw.Bin;


### PR DESCRIPTION
`Gtk.AspectFrame` is the only GTK expression of "as tall as it is wide", and it was unreachable: without a curated placement the host declines its child as an uncurated one, so a consumer that reaches for it gets a refusal instead of a frame. It has `set_child`/`get_child` and nothing else to declare.

**This is how an application spells that shape on this host, and that is the whole of it.** Nothing here maps React Native's `aspectRatio` and this descriptor does not start doing so: `@gjsify/react-native`'s own `src/primitives/style.ts` lists that property among the ones it does not route, and its partition refuses it by name. A consumer that wants the shape renders this widget — and what it got was the refusal, so the shape was unreachable rather than merely unsugared.

## It is a request, not an alignment

MEASURED on GTK 4.22.4, **with `obey-child` false**, which is the condition the whole table rests on:

| ratio | `measure(VERTICAL, 116)` |
| --- | --- |
| 1 | 116 |
| 16/9 | 65 |

With a `Gtk.Picture` inside as with a box. At the default, both rows answer 116.

## `obey-child` defaults to TRUE, and the descriptor cannot close that trap

At its default the frame takes its ratio from the **child** and the declared one is ignored in silence — measured, `ratio: 1` over a 32x16 child answers **58** rather than 116. A rule here can say which method adopts the child and nothing about a property the consumer writes, so it is a sentence in the descriptor rather than a rule.

**But the sentence is now asserted**, which is what changed after review: it was the one claim in this PR with nothing behind it, and it is the claim a consumer acts on. The vector renders a second frame at 16/9 with `obeyChild` left out, over a 32x16 `GtkBox`, and requires **58** — the child's own shape, the same number the paragraph above cites. Without that line a GTK that flipped the default would leave the vector green while the sentence became false.

Its child is a **box and not a label**, measured the hard way: written over the suite's own label the assertion passed under gjs and **failed on the Node reverse bridge**, where a different font leaves that label something other than square. A `Gtk.Box` carries no text, so its natural size *is* its request — `[32, 16]` exactly — in any font on any runtime. A 32x16 *label* would have passed for the wrong reason: its natural height is its line height, so the request answers 32x18, and 32/18 is 16/9 to the pixel.

## The vector is at 16/9 because at ratio 1 it asserted nothing

Measured by mutation: `createElement('GtkAspectFrame')` with **no props at all** left the suite green. Two coincidences carried it — GTK's own default ratio *is* 1, and the suite's label is roughly square, so `obey-child: true` derives a ratio of about 1 from the child and answers 116 as well.

At 16/9 the answers separate, and the vector fails all three mutants:

| mutant | dies on |
| --- | --- |
| `createElement('GtkAspectFrame')`, no props | the 65 |
| `{ ratio: 16 / 9 }`, `obeyChild` left out | the 65 |
| the inert frame given `obeyChild: false` | the 58, answering 65 |

A misspelled setter is already caught by the existing conformance gate, which demands the `get_` counterpart too: `children.set_chlid() … GtkAspectFrame has no get_chlid(), so removal cannot check whether this child is still the one in place`.

## Reported and not fixed here

- Declaring this row as `slotted` with one slot routing to `set_child` leaves the suite green. Both shapes really do route through `set_child`, so it is a near-equivalent mutant, and it is table-wide rather than introduced here.
- A second child is not *rejected*: `insert(b, frame)` with `a` in place unparents `a` silently. That is generic `single` behaviour shared by every single-child descriptor in the table, pre-existing and out of scope.

## Where it came from

An application whose podcast covers came out **99x31 px** where the phone shows them square.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
