### PR TITLE
fix(react-native): answer a horizontal ScrollView's height with a layout manager

### DIFF
--- a/packages/framework/react-native/src/components.ts
+++ b/packages/framework/react-native/src/components.ts
@@ -30,8 +30,12 @@
 // (`ResolvedEvent.read`); this file reads it off the widget its ref holds.
 
 import Gio from 'gi://Gio?version=2.0';
+import GLib from 'gi://GLib?version=2.0';
+import GObject from 'gi://GObject?version=2.0';
+import Gtk from 'gi://Gtk?version=4.0';
 import {
     createElement,
+    useCallback,
     useContext,
     useEffect,
     useMemo,
@@ -549,8 +553,265 @@ export interface ScrollViewProps extends CommonProps {
     contentContainerClassName?: ClassNameInput;
 }
 
+/**
+ * A HORIZONTAL scroller's content answers for its own height, because GTK will
+ * never ask it for one.
+ *
+ * MEASURED on GTK 4.22.4 with a recording layout manager under a real window: a
+ * horizontal `Gtk.ScrolledWindow` asks its child `VERTICAL for_size -1`, and
+ * nothing changes that — plain, `propagate-natural-height`, `propagate-natural-
+ * width`, both together, and a width request of 380 or 1 000 on the child all asked
+ * it. That is right for a scroller — the child scrolls, so the viewport's width is
+ * not the child's width — and it is fatal to anything whose height is a FUNCTION of
+ * its width. A row of five 116 px tiles with three-line labels is 54 px tall and
+ * the scroller reserved 18, one line per tile; in the application this came from,
+ * a rail of cards needed 161 and GTK answered 83.
+ *
+ * ## It is a layout manager, and TWO things is what that buys
+ *
+ * `Gtk.BoxLayout` subclass on the content box, answering VERTICAL at `for_size -1`
+ * with the height at the width the content will actually be given. The version
+ * before this one wrote a `set_size_request` from a layout effect instead, and it
+ * is worth being precise about why that went, because the reason first given for it
+ * was wrong:
+ *
+ *   - NOT because a request cannot reach the answer. That was the headline reason
+ *     given for this rewrite and IT IS FALSE, caught in review. Four instruments on
+ *     one card tree under a real window, wanting 36:
+ *
+ *         plain GtkBox   18     layout manager, no watch   160
+ *         layout+watch   36     request at the same width, one idle later   36
+ *
+ *     A request only RAISES a height, and that never bites, because GTK's own
+ *     `for_size -1` answer is a wrapping row's height at its NATURAL width and
+ *     therefore the SMALLEST height it has — measured on that card,
+ *     `76:160 100:125 150:71 200:54 300:36 400:36 600:18`, monotone, with -1
+ *     answering 18. Every target is above the floor, so a request can always lift
+ *     the answer to it. The 160 in that table is this very class with its watch
+ *     removed, and the old code's own failure was its FORMULA and its TIMING: it
+ *     measured at `page-size` or the natural width and applied inline, which read
+ *     `scrollerH=18` while writing `height-request=36`, and on an overflowing rail
+ *     printed `Trying to measure GtkBox for width of 400, but it needs at least 580`.
+ *   - **THE FIRST REASON: no staleness.** GTK re-measures on the child's own
+ *     `queue_resize`, so a title that arrives from a re-render BELOW the scroller is
+ *     picked up — measured 18 → 54 → 18 across a child-only commit and back. A hook
+ *     that measures in a layout effect runs when the `<ScrollView>` itself commits,
+ *     which a child's own state change does not do, so it keeps its first answer for
+ *     ever unless something else hands it one.
+ *
+ *     WHAT THE APPLICATION SHOWS IS THE SHAPE OF THAT DEPENDENCE, and the numbers
+ *     here are corrected from an earlier draft: the published request version wrote
+ *     161 into a rail needing 161 — measured on a rebuild of it, twenty samples at
+ *     250 ms — because its `notify::page-size` watch fires once at the first
+ *     allocation and that one shot happened to land after the titles arrived. Strip
+ *     the watch and the same rail reads 93 against the same 161 — the height at the
+ *     content's natural width, 4 880, which is what that version fell back to with
+ *     nothing to correct it — with the third line of every card title clipped. So
+ *     the request instrument was right by ordering rather than by construction, and
+ *     its own diagnostic says so: `Trying to measure GtkBox for width of 1052, but
+ *     it needs at least 2052`, which this class does not print; the watch-stripped
+ *     variant prints none at all, which is where that warning comes from. The VECTOR is the gate, because a vector can
+ *     make the child commit late on purpose.
+ *   - **THE SECOND REASON: it cannot clobber a declared height.** `<ScrollView
+ *     contentContainerStyle={{ height: 200 }}>` lands on this very node and
+ *     `style.height` routes to `height-request`, so the instrument and the
+ *     consumer's value were the same field. Writing nothing has nothing to clear
+ *     and nothing to ratchet — a written height is read back by the next
+ *     measurement as if the content had asked for it, and measured that way the
+ *     rails grew until they filled the window.
+ * ## The one place the instrument still chooses: the natural height, as both
+ *
+ * A scroller reserves the MINIMUM its child answers, and a `Gtk.Picture`'s vertical
+ * minimum is 0 at every width — `can-shrink` lets it be squeezed away — while its
+ * natural is the height its width implies. So this returns the natural for both.
+ *
+ * MEASURED BY SHIPPING IT WRONG FIRST: forwarding both of `Gtk.BoxLayout`'s answers
+ * unchanged read `heightRequest=[58, 202]` on the application's podcast rail, the
+ * scroller took the 58, and every cover vanished — this file's own defect wearing a
+ * different hat. The version before this one wrote index [1] and so never faced the
+ * question; a layout manager answers both numbers and has to decide. A rail has no
+ * "smaller but scrollable" size anyway, because it does not scroll vertically.
+ *
+ * ## The width it answers at
+ *
+ * `max(hadjustment:page-size, the content's own minimum)`, which is what a viewport
+ * allocates: the minimum when the row overflows and scrolls, the viewport's width
+ * when it fits. Both halves are load-bearing — measured, the overflowing rail needs
+ * the minimum (54 at 580, not 18) and the card that fills the rail needs the page
+ * size (36 at 400, not the 160 its own minimum width implies).
+ *
+ * ONE CONFIGURATION WHERE THAT IS NOT THE ALLOCATION, found in review and latent:
+ * `Gtk.Viewport:hscroll-policy = NATURAL` allocated 511 where the formula answers
+ * 500. Nothing in this layer sets it and the default is MINIMUM, so it is written
+ * down rather than handled.
+ *
+ * ## Why the notify defers, and the vector that finally fails on it
+ *
+ * `page-size` is read for the SIGNAL and not for the value: `gtk_widget_get_width()`
+ * exists and answers the same number, and review measured that swapping the whole
+ * `hadjustment` read for it passes every vector. What a widget has no equivalent of
+ * is the NOTIFICATION, which is why the watch hangs off the adjustment — and one
+ * source for both is why the value is read there too. It is written during the
+ * scroller's own `size_allocate`.
+ * A `queue_resize` issued from that handler does not reach the pass in progress:
+ * MEASURED against a real presented window, with the invalidation inline the
+ * measurement was already right (36) while the scroller stayed at 160, and with the
+ * same call one idle later the scroller followed to 36. So the notify hands the
+ * invalidation to an idle. Nothing else in this hook needs one.
+ *
+ * ## The trap on the way here
+ *
+ * Overriding `vfunc_measure` on a `Gtk.Box` SUBCLASS is silently dead code:
+ * `gtk_widget_measure` goes to the layout manager and never calls the widget's
+ * class vfunc. Measured — 0 calls for a measurement that answered 18 — and worth
+ * stating, because the override looks installed and the numbers do not move.
+ */
+const RailLayout = GObject.registerClass(
+    { GTypeName: 'GjsifyReactNativeRailLayout' },
+    class RailLayout extends Gtk.BoxLayout {
+        vfunc_measure(
+            widget: Gtk.Widget,
+            orientation: Gtk.Orientation,
+            forSize: number,
+        ): [number, number, number, number] {
+            const plain = (size: number): [number, number, number, number] =>
+                super.vfunc_measure(widget, orientation, size) as [number, number, number, number];
+            // ONLY the height-regardless-of-width question, which is the one a
+            // horizontal scroller asks and the only one whose answer is wrong.
+            //
+            // AND ONLY WHILE THE BOX IS A ROW, which is a test and not a comment
+            // because a `<ScrollView>` can flip `horizontal` and this manager stays
+            // installed. Measured with a recording layout manager under a real
+            // window: a vertical `Gtk.ScrolledWindow` asks `VERTICAL for_size -1` zero
+            // times at every `hscrollbar-policy` — never, external and automatic alike
+            // — which is why the first version of this file called the question
+            // unreachable and dropped the test. THAT WAS WRONG: with
+            // `propagate-natural-height` it asks once, and the answer this class would
+            // give is wrong there — measured on the shape a flip leaves behind, a
+            // wrapping paragraph in a column: `Gtk.BoxLayout` answers 18, its height
+            // at its own natural width, where this correction would answer 178, its
+            // height at its longest word. The vector for the flip asserts the 18.
+            if (
+                orientation !== Gtk.Orientation.VERTICAL ||
+                forSize >= 0 ||
+                this.get_orientation() !== Gtk.Orientation.HORIZONTAL
+            ) {
+                return plain(forSize);
+            }
+            const minimum = (
+                super.vfunc_measure(widget, Gtk.Orientation.HORIZONTAL, -1) as [number, number, number, number]
+            )[0];
+            const scroller = widget.get_ancestor(Gtk.ScrolledWindow.$gtype) as Gtk.ScrolledWindow | null;
+            const page = scroller === null ? 0 : Math.round(scroller.get_hadjustment().get_page_size());
+            const width = Math.max(page, minimum);
+            if (width <= 0) return plain(forSize);
+            const [, natural, , natBaseline] = super.vfunc_measure(widget, Gtk.Orientation.VERTICAL, width) as [
+                number,
+                number,
+                number,
+                number,
+            ];
+            // THE NATURAL HEIGHT AS THE MINIMUM TOO, and this is not tidiness: a
+            // scroller reserves the MINIMUM its child reports, and a `Gtk.Picture`'s
+            // vertical minimum is 0 because `can-shrink` lets it be squeezed to
+            // nothing while its natural is the height its width implies. Measured on
+            // the application's podcast rail, forwarding both answers gave
+            // `heightRequest=[58, 202]` and the covers vanished — 58 px of label with
+            // no room for the images, which is the very defect this file is about.
+            // A rail cannot scroll vertically either, so "smaller but scrollable" is
+            // not a size it has.
+            // THE NATURAL'S BASELINE FOR BOTH, because the height reported for both
+            // IS the natural one and a baseline belongs to a height. Pairing the
+            // minimum's baseline with the natural's height is the mistake this
+            // replaced, and review measured a box where the two differ by 33 px.
+            //
+            // GATED, on a tree that took two rounds of review to find: `baseline-child`
+            // has to point at a child whose MIN AND NATURAL HEIGHTS DIFFER, which
+            // needs a `can-shrink` `Gtk.Picture` above a label. Three earlier shapes
+            // answered `[…, 15, 15]` for both and could not tell the candidates
+            // apart; on that one `Gtk.BoxLayout` answers `[18, 84, 15, 48]`, and the
+            // vector kills both the mistake and dropping the baselines entirely.
+            return [natural, natural, natBaseline, natBaseline];
+        }
+    },
+);
+
+/** Live `notify::page-size` subscriptions, for the same reason `announce.ts` counts its own. */
+let railWatches = 0;
+
+/**
+ * How many scrollers are currently watching their viewport's width.
+ *
+ * A column has nothing to invalidate when that width changes — its height is not a
+ * function of it — and a column that subscribed anyway would render identically to
+ * one that did not, queueing a resize per window resize with nothing to show for it.
+ * Only a count tells them apart.
+ */
+export const railWatchCount = (): number => railWatches;
+
+function useIntrinsicContentHeight(horizontal: boolean): (widget: unknown) => void {
+    const watchRef = useRef<{ adjustment: Gtk.Adjustment; id: number } | null>(null);
+    const pendingRef = useRef<number | null>(null);
+
+    return useCallback(
+        (widget: unknown): void => {
+            const previous = watchRef.current;
+            if (previous !== null) {
+                previous.adjustment.disconnect(previous.id);
+                watchRef.current = null;
+                railWatches -= 1;
+            }
+            if (pendingRef.current !== null) {
+                GLib.source_remove(pendingRef.current);
+                pendingRef.current = null;
+            }
+            const content = (widget ?? null) as Gtk.Widget | null;
+            // A COLUMN IS LEFT ENTIRELY ALONE — no manager of ours, no watch — which
+            // is what keeps this change to the axis it measured.
+            if (content === null || !horizontal) return;
+            const installed = content.get_layout_manager();
+            if (!(installed instanceof RailLayout)) {
+                // The box's own orientation and spacing LIVE IN the manager, so they
+                // are carried across rather than left at this class's defaults.
+                // HORIZONTAL unconditionally, because the swap runs only for a row:
+                // review measured both branches of a `box.get_orientation()` ternary
+                // here as unreachable, and this repository deletes what it cannot
+                // reach. The SPACING does have to come across — a `Gtk.Box`'s spacing
+                // lives in its manager — and `set_homogeneous` went the same way as
+                // the ternary: nothing in this layer writes it (`defaults.ts` records
+                // `GtkBox:homogeneous` as having no React Native counterpart) and
+                // nothing can reach the box before the swap.
+                const swapped = new RailLayout({ orientation: Gtk.Orientation.HORIZONTAL });
+                // THE METHOD AND NOT THE PROPERTY. `Gtk.BoxLayout:spacing` is
+                // annotated `int` where `get_spacing` returns `guint`, and touching it
+                // as a property prints two GJS diagnostics per process — "does not
+                // match return type … Falling back to slow path" — which a consumer
+                // would then carry for every rail it renders.
+                if (installed instanceof Gtk.BoxLayout) swapped.set_spacing(installed.get_spacing());
+                content.set_layout_manager(swapped);
+            }
+            const scroller = content.get_ancestor(Gtk.ScrolledWindow.$gtype) as Gtk.ScrolledWindow | null;
+            if (scroller === null) return;
+            const adjustment = scroller.get_hadjustment();
+            const id = adjustment.connect('notify::page-size', () => {
+                if (pendingRef.current !== null) return;
+                pendingRef.current = GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+                    pendingRef.current = null;
+                    content.queue_resize();
+                    return GLib.SOURCE_REMOVE;
+                });
+            });
+            watchRef.current = { adjustment, id };
+            railWatches += 1;
+        },
+        [horizontal],
+    );
+}
+
 export function ScrollView(props: ScrollViewProps): ReactElement {
-    return render(usePlan('ScrollView', props));
+    const rendered = usePlan('ScrollView', props);
+    const attachContent = useIntrinsicContentHeight(props.horizontal === true);
+    return render({ ...rendered, contentExtra: { ...rendered.contentExtra, ref: attachContent } });
 }
 
 export interface ActivityIndicatorProps extends CommonProps {

--- a/packages/framework/react-native/src/primitives/widgets.spec.ts
+++ b/packages/framework/react-native/src/primitives/widgets.spec.ts
@@ -41,6 +41,7 @@
 // earns its place by being the one declaration of what a gated block means.
 
 import Adw from 'gi://Adw?version=1';
+import GLib from 'gi://GLib?version=2.0';
 import Gdk from 'gi://Gdk?version=4.0';
 import Gio from 'gi://Gio?version=2.0';
 import GObject from 'gi://GObject?version=2.0';
@@ -50,7 +51,7 @@ import { lookupWidget, paramSpecs, registerBuiltinWidgets } from '@gjsify/gtk-ho
 import { descriptorProblems, dumpTree, gtkChildren, installDiagnosticsGate } from '@gjsify/gtk-host/conformance';
 import { MINIMAL_TOKENS, StyleSheet as GeneratedStyleSheet, type StyleTokens } from '@gjsify/gtk-host/style';
 import { createRoot, flushSync } from '@gjsify/gtk-host/react';
-import { createElement, Fragment, type ReactNode } from 'react';
+import { createElement, Fragment, useState, type ReactNode } from 'react';
 
 import { PrimitiveError } from './errors.js';
 import { createHandle, type TextInputHandle } from './handles.js';
@@ -64,6 +65,7 @@ import {
     KeyboardAvoidingView,
     Modal,
     Pressable,
+    railWatchCount,
     SafeAreaView,
     ScrollView,
     StatusBar,
@@ -793,6 +795,442 @@ export default async () => {
                         expect(pressed).toBe(1);
                     },
                 );
+            });
+
+            await it('gives a horizontal ScrollView’s content the height its own width needs', async () => {
+                // THE ONE VECTOR THAT NEEDS A PRESENTED WINDOW, because the defect is
+                // in an allocation: a `Gtk.ScrolledWindow` measures its child's height
+                // at `for_size -1`, so a row whose height depends on its width — three
+                // lines of label here, an aspect-framed image in the application this
+                // came from — is reserved the height it would have if it were as wide
+                // as it liked, and renders clipped inside it.
+                //
+                // THE CONTROL IS THE SAME TREE WITHOUT THE LAYOUT MANAGER, put back
+                // straight after, because no other control is honest: every `measure`
+                // on this box now goes through the override, and asserting a pixel
+                // count would pass against a box that answered it by accident.
+                const long = 'Ein Titel, der über mehrere Zeilen läuft';
+                const tile = (key: string): ReactNode =>
+                    createElement(
+                        View,
+                        { key, style: { width: 116 } },
+                        createElement(Text, { numberOfLines: 3 }, long),
+                    );
+                const window = new Gtk.Window({ defaultWidth: 400, defaultHeight: 300 });
+                const container = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL });
+                window.set_child(container);
+                const root = createRoot(container);
+                try {
+                    root.render(
+                        createElement(
+                            ScrollView,
+                            { horizontal: true },
+                            ['a', 'b', 'c', 'd', 'e'].map((key) => tile(key)),
+                        ),
+                    );
+                    const scrolled = gtkChildren(container)[0] as Gtk.ScrolledWindow;
+                    const content = find(scrolled, 'GtkBox') as Gtk.Box;
+                    window.present();
+                    const context = GLib.MainContext.default();
+                    for (let turn = 0; turn < 200; turn++) {
+                        if (content.get_width() > 0 && scrolled.get_height() > 0) break;
+                        context.iteration(false);
+                        await Promise.resolve();
+                    }
+                    const minimum = content.measure(Gtk.Orientation.HORIZONTAL, -1)[0];
+                    // `for_size >= 0` goes straight to `Gtk.BoxLayout`, so this is the
+                    // box's own answer at the width it is given, not the override's.
+                    const wanted = content.measure(Gtk.Orientation.VERTICAL, minimum)[0];
+
+                    const ours = content.get_layout_manager();
+                    content.set_layout_manager(new Gtk.BoxLayout({ orientation: Gtk.Orientation.HORIZONTAL }));
+                    const unfixed = content.measure(Gtk.Orientation.VERTICAL, -1)[0];
+                    content.set_layout_manager(ours);
+
+                    // Measured on this tree: 18 px for content that needs 54 — one
+                    // line per tile, and the rest of every label clipped.
+                    expect(wanted > unfixed).toBe(true);
+                    expect(content.measure(Gtk.Orientation.VERTICAL, -1)[0]).toBe(wanted);
+                    // AND IT REACHED THE LAYOUT, which the measurement alone does not
+                    // say: the scroller asks once and keeps the answer.
+                    expect(scrolled.get_height()).toBe(wanted);
+                    // WRITTEN BY NOTHING. A size request was the first instrument and
+                    // it could only ever RAISE a height, which is the whole reason for
+                    // the vector below.
+                    expect(content.heightRequest).toBe(-1);
+                } finally {
+                    root.unmount();
+                    window.destroy();
+                }
+            });
+
+            await it('lets a card that fills the rail be as SHORT as its real width allows', async () => {
+                // THE HALF A SIZE REQUEST COULD NOT EXPRESS, and this was a declared
+                // limit until the layout manager replaced it.
+                //
+                // A wrapping card that fills the rail is allocated the VIEWPORT, much
+                // wider than its own minimum — a label's minimum width is its longest
+                // word — so it needs 36 px where the height at that minimum width is
+                // 160. `measure` answers `max(natural, request)`, so the request
+                // version computed the 36 correctly and the scroller stayed at 160: a
+                // request cannot ask for less. The override is the answer GTK uses
+                // rather than a floor under it, so this rail is now simply right.
+                const long = 'Ein Kartentitel, der die ganze Breite der Leiste ausfüllt und dabei umbricht';
+                const window = new Gtk.Window({ defaultWidth: 400, defaultHeight: 300 });
+                const container = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL });
+                window.set_child(container);
+                const root = createRoot(container);
+                try {
+                    root.render(createElement(ScrollView, { horizontal: true }, createElement(Text, null, long)));
+                    const scrolled = gtkChildren(container)[0] as Gtk.ScrolledWindow;
+                    const content = find(scrolled, 'GtkBox') as Gtk.Box;
+                    window.present();
+                    const context = GLib.MainContext.default();
+                    // BLOCKING ITERATION UNDER A DEADLINE, because this case waits for
+                    // a frame and not just for a pending source: `queue_resize` is
+                    // handed to an idle and the layout pass that answers it belongs to
+                    // the frame clock, which runs on real time. A non-blocking spin
+                    // returns immediately and measures the frame that has not happened.
+                    const settle = (ready: () => boolean, ms: number): void => {
+                        let expired = false;
+                        const guard = GLib.timeout_add(GLib.PRIORITY_LOW, ms, () => {
+                            expired = true;
+                            return GLib.SOURCE_REMOVE;
+                        });
+                        while (!expired && !ready()) context.iteration(true);
+                        if (!expired) GLib.source_remove(guard);
+                    };
+                    settle(() => Math.round(scrolled.get_hadjustment().get_page_size()) > 0, 2000);
+                    const page = Math.round(scrolled.get_hadjustment().get_page_size());
+                    const minimum = content.measure(Gtk.Orientation.HORIZONTAL, -1)[0];
+                    const atMinimum = content.measure(Gtk.Orientation.VERTICAL, minimum)[0];
+                    const wanted = content.measure(Gtk.Orientation.VERTICAL, page)[0];
+
+                    // The control: the content FITS, so the two widths disagree, and
+                    // measured they disagree by a lot — a 76 px longest word inside a
+                    // 400 px viewport, 160 px tall against 36.
+                    expect(page).toBeGreaterThan(minimum);
+                    expect(wanted < atMinimum).toBe(true);
+                    // ON THE ALLOCATION, not the measurement: the measurement is
+                    // already right before any frame happens, and the whole question
+                    // this vector answers is whether the invalidation REACHES a
+                    // layout pass.
+                    settle(() => scrolled.get_height() === wanted, 2000);
+                    // The short one, which is the one a request could not reach. This
+                    // is also the vector that fails when the invalidation runs INLINE
+                    // in `notify::page-size` instead of one idle later: measured, the
+                    // measurement was already 36 and the scroller stayed at 160.
+                    // The short one, which is the one a request could not reach.
+                    expect(content.measure(Gtk.Orientation.VERTICAL, -1)[0]).toBe(wanted);
+                    expect(scrolled.get_height()).toBe(wanted);
+                } finally {
+                    root.unmount();
+                    window.destroy();
+                }
+            });
+
+            await it('reserves the height an image NEEDS, not the nothing it can be squeezed to', async () => {
+                // THE INDEX, and it is the difference between a rail of covers and a
+                // rail of captions. A scroller reserves the MINIMUM its child answers,
+                // and a `Gtk.Picture`'s vertical minimum is 0 because `can-shrink`
+                // lets it be squeezed away, while its natural is the height its width
+                // implies. So this override answers the natural for both.
+                //
+                // MEASURED IN THE APPLICATION this came from, with `Gtk.BoxLayout`'s
+                // two answers forwarded unchanged: the podcast rail read
+                // `heightRequest=[58, 202]`, the scroller took the 58 and every cover
+                // vanished — the same "labels and nothing for the images" the whole
+                // change exists to fix.
+                //
+                // 16x9 of opaque bytes is enough of an image. What matters is that the
+                // paintable HAS an aspect, so the picture's height is a function of
+                // its width; the file `<Image source>` points at does not exist, which
+                // is why the texture goes on through a ref.
+                const texture = Gdk.MemoryTexture.new(
+                    16,
+                    9,
+                    Gdk.MemoryFormat.R8G8B8A8,
+                    GLib.Bytes.new(new Uint8Array(16 * 9 * 4).fill(0xff)),
+                    16 * 4,
+                );
+                const tile = (key: string): ReactNode =>
+                    createElement(
+                        View,
+                        { key, style: { width: 116 } },
+                        createElement(Image, {
+                            source: { uri: IMAGE_SOURCE },
+                            style: { width: 116 },
+                            ref: (widget: unknown) => {
+                                if (widget !== null) (widget as Gtk.Picture).set_paintable(texture);
+                            },
+                        } as ImageProps & { ref: (widget: unknown) => void }),
+                        createElement(Text, null, 'Ein Titel'),
+                    );
+                const container = new Gtk.Box();
+                const root = createRoot(container);
+                try {
+                    root.render(
+                        createElement(
+                            ScrollView,
+                            { horizontal: true },
+                            ['a', 'b', 'c'].map((key) => tile(key)),
+                        ),
+                    );
+                    const content = find(gtkChildren(container)[0] as Gtk.Widget, 'GtkBox') as Gtk.Box;
+                    const width = content.measure(Gtk.Orientation.HORIZONTAL, -1)[0];
+
+                    const ours = content.get_layout_manager();
+                    content.set_layout_manager(new Gtk.BoxLayout({ orientation: Gtk.Orientation.HORIZONTAL }));
+                    const [squeezed, needed] = content.measure(Gtk.Orientation.VERTICAL, width);
+                    content.set_layout_manager(ours);
+
+                    // The control: the two answers really do differ on this tree, so
+                    // the assertion below is about the index and not about a number.
+                    expect(needed).toBeGreaterThan(squeezed);
+                    const answer = content.measure(Gtk.Orientation.VERTICAL, -1);
+                    expect(answer[0]).toBe(needed);
+                    expect(answer[1]).toBe(needed);
+                } finally {
+                    root.unmount();
+                }
+            });
+
+            await it('pairs the baseline it reports with the height it reports', async () => {
+                // THE LAST DECLARED GAP, closed with the tree review handed over. The
+                // override answers the natural height for BOTH numbers, so it has to
+                // answer the natural's baseline for both as well — pairing the
+                // minimum's baseline with the natural's height is off by the
+                // difference between them.
+                //
+                // The ingredient every earlier attempt here missed: `baseline-child`
+                // has to point at a child whose MIN AND NATURAL HEIGHTS DIFFER, which
+                // needs a `can-shrink` `Gtk.Picture` — vertical minimum 0, natural the
+                // height its width implies — above a label. On this tree
+                // `Gtk.BoxLayout` answers `[min 18, nat 84, minBaseline 15,
+                // natBaseline 48]`, so all three candidate answers are distinct: 48
+                // for both is this code, 15 for both was the mistake, -1 for both was
+                // the third option.
+                const texture = Gdk.MemoryTexture.new(
+                    16,
+                    9,
+                    Gdk.MemoryFormat.R8G8B8A8,
+                    GLib.Bytes.new(new Uint8Array(16 * 9 * 4).fill(0xff)),
+                    16 * 4,
+                );
+                const container = new Gtk.Box();
+                const root = createRoot(container);
+                try {
+                    root.render(
+                        createElement(
+                            ScrollView,
+                            { horizontal: true },
+                            createElement(
+                                View,
+                                { key: 'tile', style: { width: 116 } },
+                                createElement(Image, {
+                                    source: { uri: IMAGE_SOURCE },
+                                    style: { width: 116 },
+                                    ref: (widget: unknown) => {
+                                        if (widget !== null) (widget as Gtk.Picture).set_paintable(texture);
+                                    },
+                                } as ImageProps & { ref: (widget: unknown) => void }),
+                                createElement(Text, null, 'Ein Titel'),
+                            ),
+                            createElement(Text, { key: 'beside' }, 'beside'),
+                        ),
+                    );
+                    const content = find(gtkChildren(container)[0] as Gtk.Widget, 'GtkBox') as Gtk.Box;
+                    // Through the widget, as this file's spacing assertion already
+                    // does: `baseline-child` has no React Native counterpart to route.
+                    content.set_baseline_child(0);
+                    const width = content.measure(Gtk.Orientation.HORIZONTAL, -1)[0];
+
+                    const ours = content.get_layout_manager();
+                    content.set_layout_manager(new Gtk.BoxLayout({ orientation: Gtk.Orientation.HORIZONTAL }));
+                    content.set_baseline_child(0);
+                    const [, , minBaseline, natBaseline] = content.measure(Gtk.Orientation.VERTICAL, width);
+                    content.set_layout_manager(ours);
+
+                    // The control: the two baselines differ here, which is what no
+                    // earlier shape in this file managed and why this was declared
+                    // ungated rather than asserted.
+                    expect(natBaseline).toBeGreaterThan(minBaseline);
+                    const answer = content.measure(Gtk.Orientation.VERTICAL, -1);
+                    expect(answer[2]).toBe(natBaseline);
+                    expect(answer[3]).toBe(natBaseline);
+                } finally {
+                    root.unmount();
+                }
+            });
+
+            await it('follows a title that arrives from a re-render BELOW the scroller', async () => {
+                // THE LIMIT THAT USED TO BE PROSE. The request version measured once
+                // per commit OF THE SCROLLVIEW, and a `<ScrollView>` does not re-render
+                // when a child's own state changes — so a title arriving from a second
+                // fetch, a font load re-wrapping a label or an image finishing its
+                // decode left the height at its first answer for ever. In the
+                // application that was the third line of every card title, clipped.
+                //
+                // A layout manager has nothing to go stale: GTK re-measures on the
+                // child's own `queue_resize`. No window and no main loop, because the
+                // answer does not wait for an allocation.
+                let grow: ((text: string) => void) | null = null;
+                function Tile(): ReactNode {
+                    const [title, setTitle] = useState('kurz');
+                    grow = setTitle;
+                    return createElement(
+                        View,
+                        { style: { width: 116 } },
+                        createElement(Text, { numberOfLines: 3 }, title),
+                    );
+                }
+                const container = new Gtk.Box();
+                const root = createRoot(container);
+                try {
+                    root.render(createElement(ScrollView, { horizontal: true }, createElement(Tile)));
+                    const content = find(gtkChildren(container)[0] as Gtk.Widget, 'GtkBox') as Gtk.Box;
+                    const needed = (): number =>
+                        content.measure(
+                            Gtk.Orientation.VERTICAL,
+                            content.measure(Gtk.Orientation.HORIZONTAL, -1)[0],
+                        )[0];
+                    const short = needed();
+                    expect(content.measure(Gtk.Orientation.VERTICAL, -1)[0]).toBe(short);
+
+                    // The tile's OWN state, so the ScrollView's fiber never re-renders
+                    // and any commit-time measurement never runs again.
+                    flushSync(() => (grow as (text: string) => void)('Ein Titel, der über mehrere Zeilen läuft'));
+                    expect(needed()).toBeGreaterThan(short);
+                    expect(content.measure(Gtk.Orientation.VERTICAL, -1)[0]).toBe(needed());
+                } finally {
+                    root.unmount();
+                }
+            });
+
+            await it('leaves a ScrollView’s own contentContainerStyle height alone, on both axes and every commit', async () => {
+                // `contentContainerStyle` lands on the very node this hook touches, and
+                // `style.height` routes to `height-request`. The request version reset
+                // a declared height to -1 — on the vertical axis on the first commit,
+                // and MEASURED by review, on the horizontal axis one commit later:
+                // `declared=200 afterFirst=200 afterSecond=18`, because the clear ran
+                // before the re-measure. Writing nothing is what makes both safe, so
+                // the second render is the half that matters.
+                for (const horizontal of [false, true]) {
+                    const container = new Gtk.Box();
+                    const root = createRoot(container);
+                    try {
+                        const tree = (label: string): ReactNode =>
+                            createElement(
+                                ScrollView,
+                                { horizontal, contentContainerStyle: { height: 200 } },
+                                createElement(Text, null, label),
+                            );
+                        root.render(tree('row'));
+                        const scrolled = gtkChildren(container)[0] as Gtk.ScrolledWindow;
+                        const content = find(scrolled, 'GtkBox') as Gtk.Box;
+                        expect(content.heightRequest).toBe(200);
+                        flushSync(() => root.render(tree('row two')));
+                        expect(content.heightRequest).toBe(200);
+                    } finally {
+                        root.unmount();
+                    }
+                }
+            });
+
+            await it('leaves the content box a Gtk.Box, with the spacing and orientation the host gave it', async () => {
+                // THE HAZARD OF THE INSTRUMENT. A `Gtk.Box`'s orientation and spacing
+                // LIVE IN its layout manager, so swapping the manager out is exactly
+                // how a row silently becomes a column with no gaps. Measured: both
+                // read back through the subclass, and `Gtk.Box`'s own setters keep
+                // working because it casts its manager to `Gtk.BoxLayout`, which this
+                // still is.
+                mounted(
+                    createElement(
+                        ScrollView,
+                        { horizontal: true, contentContainerStyle: { gap: 12 } },
+                        createElement(Text, null, 'row'),
+                    ),
+                    (container) => {
+                        const content = find(gtkChildren(container)[0] as Gtk.Widget, 'GtkBox') as Gtk.Box;
+                        expect(content.get_orientation()).toBe(Gtk.Orientation.HORIZONTAL);
+                        expect(content.get_spacing()).toBe(12);
+                        content.set_spacing(4);
+                        expect(content.get_spacing()).toBe(4);
+                    },
+                );
+                // …and a vertical one keeps the manager the host installed.
+                mounted(createElement(ScrollView, null, createElement(Text, null, 'column')), (container) => {
+                    const content = find(gtkChildren(container)[0] as Gtk.Widget, 'GtkBox') as Gtk.Box;
+                    expect(content.get_orientation()).toBe(Gtk.Orientation.VERTICAL);
+                });
+                // A `horizontal` THAT TURNS FALSE gives the host's own manager back,
+                // which is the case a swap done once and never undone leaves behind —
+                // and `horizontal` is a prop like any other, so a screen really can
+                // flip it. The override answers the height at a width, which is the
+                // wrong question for a column: there the scroller scrolls vertically
+                // and GTK's own -1 is the right answer.
+                // A WRAPPING PARAGRAPH, so the two widths this class chooses between
+                // are far apart on the axis the flip lands on.
+                const paragraph = 'Ein Absatz, der über mehrere Zeilen läuft und dabei umbricht, mehrfach sogar';
+                const container = new Gtk.Box();
+                const root = createRoot(container);
+                const watchesBefore = railWatchCount();
+                try {
+                    root.render(createElement(ScrollView, { horizontal: true }, createElement(Text, null, paragraph)));
+                    const content = find(gtkChildren(container)[0] as Gtk.Widget, 'GtkBox') as Gtk.Box;
+                    const swapped = content.get_layout_manager();
+                    expect(railWatchCount()).toBe(watchesBefore + 1);
+                    flushSync(() =>
+                        root.render(
+                            createElement(ScrollView, { horizontal: false }, createElement(Text, null, paragraph)),
+                        ),
+                    );
+                    // The manager STAYS — putting the host's own back would lose the
+                    // orientation the host has just written onto this one — so it has
+                    // to go INERT, and this is the assertion that says it does.
+                    //
+                    // A column asks the question rarely and answering it is wrong when
+                    // it does: measured on this shape, `Gtk.BoxLayout` answers 18 for
+                    // a wrapping paragraph at `for_size -1` (its height at its own
+                    // natural width) where the correction would answer 178 (its height
+                    // at its longest word). A vertical `Gtk.ScrolledWindow` does not
+                    // ask it at any `hscrollbar-policy` — measured, zero calls at
+                    // never, external and automatic alike — but it asks once under
+                    // `propagate-natural-height`, which a consumer can set, and that
+                    // is the 160 px the first version of this file would have been out
+                    // by while calling the case unreachable.
+                    expect(content.get_layout_manager() === swapped).toBe(true);
+                    expect(content.get_orientation()).toBe(Gtk.Orientation.VERTICAL);
+                    expect(railWatchCount()).toBe(watchesBefore);
+
+                    const asOurs = content.measure(Gtk.Orientation.VERTICAL, -1)[0];
+                    const atLongestWord = content.measure(
+                        Gtk.Orientation.VERTICAL,
+                        content.measure(Gtk.Orientation.HORIZONTAL, -1)[0],
+                    )[0];
+                    const plain = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL });
+                    plain.append(new Gtk.Label({ label: paragraph, wrap: true, xalign: 0 }));
+                    expect(atLongestWord).toBeGreaterThan(asOurs);
+                    expect(asOurs).toBe(plain.measure(Gtk.Orientation.VERTICAL, -1)[0]);
+                } finally {
+                    root.unmount();
+                }
+            });
+
+            await it('watches the viewport width for a rail and for nothing else', async () => {
+                // The `liveRegionWatchCount` shape, for the same reason: a column that
+                // subscribed anyway renders identically to one that did not, and only a
+                // count tells them apart. The unmount half matters on its own — GJS
+                // blocks a JS callback during the sweeping phase of GC, so a handler
+                // left connected is one connected for the life of the process.
+                const before = railWatchCount();
+                mounted(createElement(ScrollView, null, createElement(Text, null, 'column')), () =>
+                    expect(railWatchCount()).toBe(before),
+                );
+                mounted(createElement(ScrollView, { horizontal: true }, createElement(Text, null, 'row')), () =>
+                    expect(railWatchCount()).toBe(before + 1),
+                );
+                expect(railWatchCount()).toBe(before);
             });
 
             await it('puts a ScrollView’s children in the implicit content box', async () => {


### PR DESCRIPTION
A horizontal `<ScrollView>` renders one line of label and nothing for its images. A
`Gtk.ScrolledWindow` asks its child `VERTICAL for_size -1` — MEASURED with a recording
layout manager under a real window, and nothing changes it: plain,
`propagate-natural-height`, `propagate-natural-width`, both, and a width request of
380 or 1 000 on the child all asked it. A row of five 116 px tiles with three-line
labels is 54 px tall and the scroller reserved 18.

A **`Gtk.BoxLayout` subclass** on the content box answers that one question with the
height at `max(hadjustment:page-size, the content's own minimum)` — what a viewport
allocates: the minimum when the row overflows, the viewport's width when it fits. Both halves are load-bearing: the overflowing rail needs the minimum (54 at 580, not 18) and the card needs the page size (36 at 400, not the 160 its own minimum width implies).

## Corrected after review: why NOT a size request

**The reason first given for this rewrite was false**, and the review that caught it
is the reason this section exists. Four instruments on one card tree, wanting 36:

| instrument | scroller height |
| --- | --- |
| plain `Gtk.Box` | 18 |
| this layout manager with its watch removed | **160** |
| this layout manager | **36** |
| a size request at the same width, one idle later | **36** |

A request only RAISES a height and that never bites: GTK's `for_size -1` answer is a
wrapping row's height at its NATURAL width, so it is the SMALLEST height the row has.
Measured on that card — `76:160 100:125 150:71 200:54 300:36 400:36 600:18`, monotone,
`-1` answering 18 — every target sits above that floor. **The 160 was this PR's own
code with its watch removed**, not the request version; the old code's real failure was
its formula and its timing (`scrollerH=18` while writing `height-request=36`, plus
`Trying to measure GtkBox for width of 400, but it needs at least 580`).

The two justifications that survive measurement:

| | measured |
| --- | --- |
| **No staleness** | GTK re-measures on the child's own `queue_resize`: **18 → 54** across a child-only commit, which a layout effect never sees because it runs when the `<ScrollView>` itself commits. **These app numbers are corrected after review:** the published request version wrote **161** into a rail needing 161, measured on a rebuild of it over twenty samples at 250 ms, because its watch fires once at the first allocation and that shot happened to land after the titles arrived. Strip the watch and the same rail reads **93** against the same 161 — the height at the content's natural width, 4 880, which is what that version fell back to with nothing to correct it — third line of every card title clipped. (An earlier revision of this description said 145; that belonged to a variant of mine that was never published, and review re-measured the real one.) The watch-stripped variant prints no diagnostic at all, which is where the published version's one comes from: its watch measuring at the page size. Right by ordering, not by construction — and its own diagnostic says so: `Trying to measure GtkBox for width of 1052, but it needs at least 2052`. |
| **It cannot clobber a declared height** | `contentContainerStyle={{ height: 200 }}` lands on this very node and `style.height` routes to `height-request`: the instrument and the consumer's value were the same field. Writing nothing also has nothing to ratchet — a written height is read back as the content's own, and the rails grew until they filled the window. |

## The natural height, reported as the minimum too

A scroller reserves the MINIMUM its child answers, and a `Gtk.Picture`'s vertical
minimum is **0** at every width. Measured by shipping it wrong first: forwarding both
of `Gtk.BoxLayout`'s answers gave the podcast rail `heightRequest=[58, 202]`, the
scroller took the 58 and **every cover vanished**. Verified again in the counterfactual
direction by review, with lib and bundle rebuilt: three rails read 58, 79, 79 with the
minimum forwarded and 209, 166, 166 without.

## Vectors, and the mutation each one dies to

Eight, all against the real reconciler; two need a presented window. A ninth row appeared in the previous revision of this description for a vector that did not exist — review caught it, and the behaviour it named (a ratchet moved inside the manager) does die on the card vector.

| Vector | Fails when |
| --- | --- |
| gives a horizontal ScrollView's content the height its own width needs | the manager is not installed, or the width drops the minimum term |
| lets a card that fills the rail be as SHORT as its real width allows | the page-size term goes, the watch goes, or the invalidation runs inline instead of one idle later |
| follows a title that arrives from a re-render BELOW the scroller | anything measures at commit time instead of answering on demand |
| reserves the height an image NEEDS, not the nothing it can be squeezed to | `Gtk.BoxLayout`'s minimum is forwarded instead of its natural |
| pairs the baseline it reports with the height it reports | the minimum's baseline is paired with the natural height, or the baselines are dropped — needs `baseline-child` over a `can-shrink` `Gtk.Picture`, where `Gtk.BoxLayout` answers `[18, 84, 15, 48]` |
| leaves a ScrollView's own contentContainerStyle height alone, on both axes and every commit | a request comes back; the SECOND render is the half that matters |
| leaves the content box a Gtk.Box, with the spacing and orientation the host gave it | the swap drops `spacing`, a column gets swapped, or the manager fails to go inert after a `horizontal` flip (measured, 178 against the plain box's 18) |
| watches the viewport width for a rail and for nothing else | a column subscribes, or the cleanup block goes |

**Surviving mutants, stated because the previous revision claimed one and review found
twelve.** Three of them were code that should not exist and are now gone:
`set_homogeneous` (nothing in this layer writes it), the `box.get_orientation()`
ternary (both branches unreachable — the swap only runs for a row), and the wrong
baseline pairing. What still survives: dropping `adjustment.disconnect` while keeping
the counter's decrement; dropping `GLib.source_remove` (measured harmless —
`queue_resize()` on a destroyed widget is a silent no-op; its cost is that one later
invalidation is swallowed for a main-loop turn); the idle's coalescing guard; the
`width <= 0` guard; `Math.round`; `for_size > 0` versus `>= 0`; the idle's priority;
and reading `widget.get_width()` instead of the adjustment's page size, which answers
the same number — `page-size` is read for the SIGNAL, and the docblock now says so
instead of claiming a widget has no width.

The baseline choice **is now gated**, on a tree review handed over after I failed to
build one: `baseline-child` has to point at a child whose min and natural heights
differ, which needs a `can-shrink` `Gtk.Picture` above a label. Three earlier shapes
answered `[…, 15, 15]` for both and could not separate the candidates; on that one
`Gtk.BoxLayout` answers `[18, 84, 15, 48]`, and both the mistake and dropping the
baselines entirely now fail.

## Scope, and the traps

A column is left alone — no manager, no watch — and the manager a `horizontal` flip
leaves behind goes **inert**, asserted rather than argued. A vertical
`Gtk.ScrolledWindow` asks this question **zero** times at every `hscrollbar-policy`,
never/external/automatic alike, but **once under `propagate-natural-height`**, and
answering it there is wrong. The previous revision called the case unreachable and
gave `hscrollbar-policy: never` as the reason; both halves were wrong.

**Overriding `vfunc_measure` on a `Gtk.Box` subclass is silently dead code** —
`gtk_widget_measure` goes to the layout manager and never calls the widget's class
vfunc. Measured: 0 calls for a measurement that answered 18.

Latent, found in review: `Gtk.Viewport:hscroll-policy = NATURAL` allocates 511 where
the formula answers 500. Nothing here sets it and the default is MINIMUM.

## One leg hung, and it is not this change

`GTK suites on the shipped closure (win32-x64 / node)` — the non-gating
`@gjsify/react-native` probe — was cancelled at 61 minutes on this commit
(run 34194448712). The same leg passed this branch twice, in 11 and 8 minutes.

Its log stops after `publishes the window chrome, so a routed tree draws ONE set of
controls (301ms)` at 06:30:22 and says nothing until the kill at 07:24:22. **None of
this PR's vectors appear in those 1 625 lines, and neither does the test that follows
that one locally** (`runs the chrome check ITSELF, and reports what it found (#1546)`),
so the suite hung in `AppRegistry` before it reached anything this PR adds. Re-run
rather than argued about.

## Checked

- `@gjsify/react-native`: 637 vectors, 2 749 assertions, green; `gjsify tsc --noEmit` clean.
- The CORRECTIV desktop host, rebuilt from source between variants: the home rail
  reads `scroller 1052x161, content 2052x161` across 1100 → 780 → 1400 → 700 → 1100,
  the Mediathek's three rails read 209, 166 and 166, and the podcast covers that host
  had been showing as grey placeholders are the artwork at its own square aspect.
- Its GTK diagnostics: **0** per run, where a rebuild of the request version prints one `Trying to measure GtkBox for width of 1052, but it needs at least 2052`. (An earlier revision of this description said seven; that count came from the stale bundle described above.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
