### PR TITLE
fix(react-native): let a truncating Text break inside a word it cannot break between

### DIFF
--- a/packages/framework/react-native/src/primitives/defaults.ts
+++ b/packages/framework/react-native/src/primitives/defaults.ts
@@ -115,6 +115,15 @@ export const DEFAULT_ROWS: readonly DefaultRow[] = [
     },
     {
         gtype: 'GtkLabel',
+        property: 'wrap-mode',
+        gtk: 'word',
+        reactNative: 'a token that cannot be broken overflows its box, it does not widen it',
+        source: 'React Native lays text out with its own breaker and lets an unbreakable run spill; the box keeps the width the layout gave it.',
+        verdict: 'kept',
+        reason: 'GTK has no spelling for "overflow": a label’s MINIMUM width is its contribution to the layout, and at `word` that minimum is its longest word — MEASURED on GTK 4.22.4 with a 48-character filename, 394 px at `word` against 13 px at `word-char`, natural 394 either way. GTK’s default is KEPT because normalising it globally is visibly worse: a short label in a tight box then breaks mid-word instead of asking for room, and a "Live" badge rendered as "LIV-". `word-char` is written by the `numberOfLines` route instead — that prop is the author saying this text may be truncated, and a text that may be truncated should yield before the window does.',
+    },
+    {
+        gtype: 'GtkLabel',
         property: 'xalign',
         gtk: 0.5,
         reactNative: 'the script’s natural alignment — start, i.e. left in LTR',

--- a/packages/framework/react-native/src/primitives/primitives.spec.ts
+++ b/packages/framework/react-native/src/primitives/primitives.spec.ts
@@ -487,6 +487,11 @@ export default async () => {
             // declared no-op adds nothing to them.
             const p = plan('Text', { allowFontScaling: true, maxFontSizeMultiplier: 2 }).plan;
             expect(p.node.props).toStrictEqual({ wrap: true, xalign: 0, yalign: 0 });
+            // `wrap-mode` is NOT among them: it rides on `numberOfLines`, because a
+            // label that may be truncated should yield before the window does and one
+            // that may not should ask for its room. A default here read "LIV-".
+            const truncating = plan('Text', { numberOfLines: 2 }).plan;
+            expect(truncating.node.props['wrap-mode']).toBe('word-char');
         });
     });
 

--- a/packages/framework/react-native/src/primitives/table.ts
+++ b/packages/framework/react-native/src/primitives/table.ts
@@ -844,11 +844,26 @@ export const PRIMITIVES: Readonly<Record<string, PrimitiveSpec>> = {
             // label BOTH wraps and ellipsizes (the property's own documentation, and
             // measured — a `lines: 2` label with `ellipsize: none` renders all its
             // lines). So the route carries the two companions the value needs.
+            // `wrap-mode` rides along for a reason of its own, and only HERE.
+            //
+            // GTK breaks at WORD boundaries, so a label's MINIMUM width is its longest
+            // word, and a token with no break in it pins the layout open at that
+            // width. MEASURED on GTK 4.22.4 with a 48-character filename: minimum
+            // 394 px at `word`, 13 px at `word-char`, natural 394 either way — a card
+            // that would not shrink with its window, because a live-radio stream
+            // announced its track as `20260901_Gamescom_Laberpocast_…`.
+            //
+            // NOT a default on every `Text`, which was the first shape and is visibly
+            // wrong: a short label in a tight box then breaks mid-word rather than
+            // asking for room, and a "Live" badge rendered as "LIV-". The two cases
+            // are told apart by the author, not by the layer — `numberOfLines` is
+            // someone saying this text may be truncated, and a text that may be
+            // truncated should yield before the window does.
             numberOfLines: {
                 to: 'property',
                 names: ['lines'],
                 as: 'int',
-                also: { ellipsize: 'end', wrap: true },
+                also: { ellipsize: 'end', wrap: true, 'wrap-mode': 'word-char' },
             },
             ellipsizeMode: {
                 to: 'property',


### PR DESCRIPTION
`Gtk.Label` wraps at WORD boundaries only, so a label's MINIMUM width is its longest word — and a token with no break in it pins the layout open at that width, however narrow the window gets.

MEASURED on GTK 4.22.4 with one 48-character filename as the text:

| `wrap-mode` | minimum | natural |
| --- | --- | --- |
| `word` | **394 px** | 394 px |
| `word-char` | **13 px** | 394 px |

So the change costs nothing where the text can already be broken; it only stops one long run from deciding how narrow an application may be. That 394 was a card in a real application that would not shrink with its window, because a live-radio stream announced its track as `20260901_Gamescom_Laberpocast_Sophie_Amelie_final`.

React Native has no such failure mode, and not because its breaker is cleverer: a string it cannot break **overflows** its box rather than widening it. GTK has no spelling for that — a label's minimum IS its contribution to the layout — so `word-char` is the nearest thing that lets the text yield instead of the window.

## It rides on `numberOfLines` and is not a default

That is the second half and it was learned by looking. As a default on every `Text` it is visibly worse: a short label in a tight box breaks mid-word instead of asking for room, and a "Live" badge rendered as **"LIV-"**.

The two cases are told apart by the AUTHOR rather than by the layer — `numberOfLines` is someone saying this text may be truncated, and a text that may be truncated should yield before the window does.

So the ledger row is `kept`, not `normalised`: GTK's default stands, and the route writes the other value where the author asked for truncation. `defaults.spec.ts` is closed in both directions and refuses the other spelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQMZfw5A1RPVCUZwLvcZhF
