### PR TITLE
fix(cli): warn on musl fallback to glibc prebuilds

### DIFF
--- a/packages/infra/cli/src/commands/install.ts
+++ b/packages/infra/cli/src/commands/install.ts
@@ -1496,7 +1496,7 @@ async function runPostInstallChecks(args: InstallOptions): Promise<void> {
             );
             for (const name of fellBack) console.warn(`  ! ${name}`);
             console.warn(
-                '\nThese load only as far as musl\'s libc.so.6 alias carries them. A glibc-only\n' +
+                "\nThese load only as far as musl's libc.so.6 alias carries them. A glibc-only\n" +
                     'symbol fails at dlopen with "Error relocating … symbol not found", which can\n' +
                     'surface much later as an unrelated build error.',
             );

--- a/packages/infra/cli/src/commands/install.ts
+++ b/packages/infra/cli/src/commands/install.ts
@@ -25,7 +25,7 @@ import { forceExit } from '../utils/force-exit.js';
 import { discoverWorkspaces } from '@gjsify/workspace';
 import type { Command } from '../types/index.js';
 import { buildInstallCommand, detectPackageManager, runMinimalChecks } from '../utils/check-system-deps.js';
-import { detectNativePackages } from '../utils/detect-native-packages.js';
+import { detectHostLibc, detectNativePackages, muslPrebuildFallbacks } from '../utils/detect-native-packages.js';
 import { buildLauncherShims, buildNativeEnvPreamble } from '../utils/bin-shim.js';
 import { installPackages, makeProgressReporter } from '../utils/install-backend.js';
 import { atomicWriteStrict } from '../utils/install-cache-fs.js';
@@ -1484,6 +1484,23 @@ async function runPostInstallChecks(args: InstallOptions): Promise<void> {
             console.log(`  • ${pkg.name}`);
         }
         console.log('\nUse `gjsify run <bundle>` to launch with LD_LIBRARY_PATH/GI_TYPELIB_PATH set.');
+
+        // A musl host resolves `libc.so.6` to its own loader, so a glibc
+        // prebuild loads and mostly works — the failure lands later, on the
+        // first glibc-only symbol, and reads as a bundler error rather than a
+        // libc one. Say it here, where the fallback is actually chosen.
+        const fellBack = muslPrebuildFallbacks(detectHostLibc(process.platform), native);
+        if (fellBack.length > 0) {
+            console.warn(
+                `\nmusl host: ${fellBack.length} package(s) ship no musl prebuild, so the glibc build was used:`,
+            );
+            for (const name of fellBack) console.warn(`  ! ${name}`);
+            console.warn(
+                '\nThese load only as far as musl\'s libc.so.6 alias carries them. A glibc-only\n' +
+                    'symbol fails at dlopen with "Error relocating … symbol not found", which can\n' +
+                    'surface much later as an unrelated build error.',
+            );
+        }
     }
 
     maybeInstallGitHooks();

--- a/packages/infra/cli/src/commands/install.ts
+++ b/packages/infra/cli/src/commands/install.ts
@@ -1485,20 +1485,27 @@ async function runPostInstallChecks(args: InstallOptions): Promise<void> {
         }
         console.log('\nUse `gjsify run <bundle>` to launch with LD_LIBRARY_PATH/GI_TYPELIB_PATH set.');
 
-        // A musl host resolves `libc.so.6` to its own loader, so a glibc
-        // prebuild loads and mostly works — the failure lands later, on the
-        // first glibc-only symbol, and reads as a bundler error rather than a
-        // libc one. Say it here, where the fallback is actually chosen.
+        // The install is the ONLY moment this is knowable: the libc axis is decided
+        // here, the failure it predicts happens in another process, days later, and
+        // names something else entirely (see `muslPrebuildFallbacks`). The list is
+        // the point — it is what lets a later `Error relocating` line be matched to
+        // a package.
         const fellBack = muslPrebuildFallbacks(detectHostLibc(process.platform), native);
         if (fellBack.length > 0) {
             console.warn(
-                `\nmusl host: ${fellBack.length} package(s) ship no musl prebuild, so the glibc build was used:`,
+                `\nWarning: musl host — ${fellBack.length} of ${native.length} package(s) ship no \`-musl\`` +
+                    ' prebuild, so the\n  default (glibc) build was used:',
             );
-            for (const name of fellBack) console.warn(`  ! ${name}`);
+            for (const name of fellBack) console.warn(`    ${name}`);
             console.warn(
-                "\nThese load only as far as musl's libc.so.6 alias carries them. A glibc-only\n" +
-                    'symbol fails at dlopen with "Error relocating … symbol not found", which can\n' +
-                    'surface much later as an unrelated build error.',
+                '  Most of these run anyway: a bridge that links only GLib records no libc at all.\n' +
+                    '  One that links glibc loads too — musl aliases `libc.so.6` to itself — and then\n' +
+                    '  fails at dlopen on its first glibc-only symbol:\n' +
+                    '    Error relocating <prebuild>.so: <symbol>: symbol not found\n' +
+                    '  A bridge lost that way is silently absent from the next build rather than\n' +
+                    '  reported, so the first symptom can be an unrelated-looking bundler error\n' +
+                    '  (`Could not load <file>` from rolldown, for the CSS bridge). Nothing to\n' +
+                    '  install: no `-musl` package is published for any target yet.',
             );
         }
     }

--- a/packages/infra/cli/src/utils/detect-native-packages.spec.ts
+++ b/packages/infra/cli/src/utils/detect-native-packages.spec.ts
@@ -690,19 +690,19 @@ export default async () => {
                 pkg('@gjsify/lightningcss-native-linux-arm64', 'linux-arm64'),
                 pkg('@gjsify/webgl-linux-arm64-musl', 'linux-arm64-musl'),
             ]);
-            expect(fellBack).toEqual(['@gjsify/lightningcss-native-linux-arm64']);
+            expect(fellBack).toStrictEqual(['@gjsify/lightningcss-native-linux-arm64']);
         });
 
         await it('says nothing when every package has a musl build', async () => {
-            expect(muslPrebuildFallbacks('musl', [pkg('@gjsify/webgl', 'linux-arm64-musl')])).toEqual([]);
+            expect(muslPrebuildFallbacks('musl', [pkg('@gjsify/webgl', 'linux-arm64-musl')])).toStrictEqual([]);
         });
 
         // The warning exists for musl hosts only. A glibc host resolving a
         // `linux-arm64` directory is the correct outcome, not a fallback.
         await it('stays quiet on glibc and where there is no libc axis', async () => {
             const packages = [pkg('@gjsify/webgl', 'linux-arm64')];
-            expect(muslPrebuildFallbacks('glibc', packages)).toEqual([]);
-            expect(muslPrebuildFallbacks(null, packages)).toEqual([]);
+            expect(muslPrebuildFallbacks('glibc', packages)).toStrictEqual([]);
+            expect(muslPrebuildFallbacks(null, packages)).toStrictEqual([]);
         });
 
         // `-musl` is a suffix of the DIRECTORY, and only the last segment of the
@@ -712,9 +712,7 @@ export default async () => {
             const fellBack = muslPrebuildFallbacks('musl', [
                 { name: '@gjsify/webgl', prebuildsDir: '/home/me/src-musl/node_modules/x/prebuilds/linux-arm64' },
             ]);
-            expect(fellBack).toEqual(['@gjsify/webgl']);
+            expect(fellBack).toStrictEqual(['@gjsify/webgl']);
         });
     });
-
-
 };

--- a/packages/infra/cli/src/utils/detect-native-packages.spec.ts
+++ b/packages/infra/cli/src/utils/detect-native-packages.spec.ts
@@ -619,6 +619,31 @@ export default async () => {
                     join(root, 'node_modules/@gjsify/duallibc-native/prebuilds/linux-x64'),
                 );
             });
+
+            await it('reports what a real WALK fell back on, not a hand-built package list', async () => {
+                // The join the unit cases below cannot make: they are handed
+                // `NativePackage`s, so nothing else proves a real walk spells
+                // `prebuildsDir` the way the report reads it. `duallibc-native`
+                // (seeded above) ships a `-musl` build and must be absent; the four
+                // packages with only a default build must all be named, the
+                // pre-rename `linux-x86_64` one included — a legacy spelling is
+                // still a glibc build.
+                const onMusl = detectNativePackages(root, { platform: 'linux', arch: 'x64', libc: 'musl' });
+                const fellBack = muslPrebuildFallbacks('musl', onMusl);
+                expect(fellBack.includes('@gjsify/duallibc-native')).toBe(false);
+                for (const name of ['@gjsify/tls-native', '@gjsify/node-gi', '@gjsify/sab-native']) {
+                    expect(fellBack.includes(name)).toBe(true);
+                }
+                expect(fellBack.includes('@gjsify/legacy-native')).toBe(true);
+                // The same walk on glibc: each of those directories is the RIGHT
+                // answer there, so the report is empty rather than inverted.
+                expect(
+                    muslPrebuildFallbacks(
+                        'glibc',
+                        detectNativePackages(root, { platform: 'linux', arch: 'x64', libc: 'glibc' }),
+                    ),
+                ).toStrictEqual([]);
+            });
         } finally {
             rmSync(root, { recursive: true, force: true });
         }
@@ -643,6 +668,14 @@ export default async () => {
                 prebuildDirs: ['linux-x64-musl'],
                 platforms: ['linux-x64-musl'],
                 nodeModulesOf: '@gjsify/split-native',
+            });
+            // The shape the incident had: a bridge split per target with the musl
+            // companion never published, so the walk resolves the glibc one.
+            seedPackage(root, '@gjsify/glibconly-native', { prebuildDirs: [], platforms: ['linux-x64'] });
+            seedPackage(root, '@gjsify/glibconly-native-linux-x64', {
+                prebuildDirs: ['linux-x64'],
+                platforms: ['linux-x64'],
+                nodeModulesOf: '@gjsify/glibconly-native',
             });
 
             const byName = (pkgs: Array<{ name: string; prebuildsDir: string }>) =>
@@ -670,6 +703,18 @@ export default async () => {
                     nested('@gjsify/split-native-linux-x64-musl', 'linux-x64-musl'),
                 );
                 expect(found['@gjsify/split-native-linux-x64']).toBeUndefined();
+            });
+
+            await it('reports a companion-package fallback — the shape that was measured', async () => {
+                // A split bridge moves the target into the package NAME, so the
+                // fallback happens a level earlier than the directory probe. The
+                // report still reads the directory, which is what makes one function
+                // cover both: the companion carries its own target-named dir.
+                const fellBack = muslPrebuildFallbacks(
+                    'musl',
+                    detectNativePackages(root, { platform: 'linux', arch: 'x64', libc: 'musl' }),
+                );
+                expect(fellBack).toStrictEqual(['@gjsify/glibconly-native-linux-x64']);
             });
 
             await it('adds nothing for a host with no companion package', async () => {
@@ -705,14 +750,24 @@ export default async () => {
             expect(muslPrebuildFallbacks(null, packages)).toStrictEqual([]);
         });
 
-        // `-musl` is a suffix of the DIRECTORY, and only the last segment of the
-        // path is the target token — a checkout that happens to live under a
-        // path with "-musl" in it must not read as a musl prebuild.
+        // Only the LAST path segment is a target token, so a checkout that happens
+        // to live under a `-musl` directory must not read as a musl prebuild.
         await it('reads the target from the directory name, not the whole path', async () => {
             const fellBack = muslPrebuildFallbacks('musl', [
                 { name: '@gjsify/webgl', prebuildsDir: '/home/me/src-musl/node_modules/x/prebuilds/linux-arm64' },
             ]);
             expect(fellBack).toStrictEqual(['@gjsify/webgl']);
+        });
+
+        await it('does not credit a `-musl` suffix on a target that cannot have one', async () => {
+            // `parsePlatformToken` honours the suffix on linux ONLY, because musl
+            // targets no other kernel — so `darwin-arm64-musl` is a malformed token,
+            // not a musl build, and reporting it as covered would hide the only
+            // package in the list. This is the difference between asking the grammar
+            // and testing the suffix by hand.
+            expect(muslPrebuildFallbacks('musl', [pkg('@gjsify/webgl', 'darwin-arm64-musl')])).toStrictEqual([
+                '@gjsify/webgl',
+            ]);
         });
     });
 };

--- a/packages/infra/cli/src/utils/detect-native-packages.spec.ts
+++ b/packages/infra/cli/src/utils/detect-native-packages.spec.ts
@@ -22,6 +22,7 @@ import {
     detectNativePackages,
     hostPlatformTokens,
     libraryPathVar,
+    muslPrebuildFallbacks,
     parsePlatformToken,
     platformPackageName,
     prebuildDirCandidates,
@@ -680,4 +681,40 @@ export default async () => {
             rmSync(root, { recursive: true, force: true });
         }
     });
+
+    await describe('muslPrebuildFallbacks', async () => {
+        const pkg = (name: string, dir: string) => ({ name, prebuildsDir: `/p/node_modules/${name}/prebuilds/${dir}` });
+
+        await it('names the packages a musl host had to take the glibc build of', async () => {
+            const fellBack = muslPrebuildFallbacks('musl', [
+                pkg('@gjsify/lightningcss-native-linux-arm64', 'linux-arm64'),
+                pkg('@gjsify/webgl-linux-arm64-musl', 'linux-arm64-musl'),
+            ]);
+            expect(fellBack).toEqual(['@gjsify/lightningcss-native-linux-arm64']);
+        });
+
+        await it('says nothing when every package has a musl build', async () => {
+            expect(muslPrebuildFallbacks('musl', [pkg('@gjsify/webgl', 'linux-arm64-musl')])).toEqual([]);
+        });
+
+        // The warning exists for musl hosts only. A glibc host resolving a
+        // `linux-arm64` directory is the correct outcome, not a fallback.
+        await it('stays quiet on glibc and where there is no libc axis', async () => {
+            const packages = [pkg('@gjsify/webgl', 'linux-arm64')];
+            expect(muslPrebuildFallbacks('glibc', packages)).toEqual([]);
+            expect(muslPrebuildFallbacks(null, packages)).toEqual([]);
+        });
+
+        // `-musl` is a suffix of the DIRECTORY, and only the last segment of the
+        // path is the target token — a checkout that happens to live under a
+        // path with "-musl" in it must not read as a musl prebuild.
+        await it('reads the target from the directory name, not the whole path', async () => {
+            const fellBack = muslPrebuildFallbacks('musl', [
+                { name: '@gjsify/webgl', prebuildsDir: '/home/me/src-musl/node_modules/x/prebuilds/linux-arm64' },
+            ]);
+            expect(fellBack).toEqual(['@gjsify/webgl']);
+        });
+    });
+
+
 };

--- a/packages/infra/cli/src/utils/detect-native-packages.ts
+++ b/packages/infra/cli/src/utils/detect-native-packages.ts
@@ -23,7 +23,7 @@
 // are read only at the outermost call site, as a default.
 
 import { readdirSync, existsSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { basename, join, resolve } from 'node:path';
 import { readPackageJson } from './pkg-json.js';
 import { composeDyldFallback, systemGiLibraryDirs, type SystemGiOptions } from './system-gi.js';
 
@@ -566,6 +566,33 @@ export function detectNativePackages(startDir: string, target: HostTarget = {}):
  * @param platform `process.platform` value; the axis is Linux-only (as npm's own
  *   `libc` field is), so every other OS returns null.
  */
+/**
+ * The packages a musl host had to take the glibc build of, because they ship no
+ * musl prebuild.
+ *
+ * Returning names rather than warning here keeps the decision pure: the musl
+ * branch is only reachable from this repo's CI by injecting `libc`, since there
+ * is no musl runner (see this module's spec header).
+ *
+ * Why the fallback is worth saying out loud. musl's loader resolves
+ * `libc.so.6`/`libm.so.6` to ITSELF, so a glibc-linked prebuild loads and mostly
+ * works — until it wants a symbol musl does not implement. Measured on a
+ * OnePlus 6 (postmarketOS v26.06, musl 1.2.6, aarch64) against the published
+ * 0.48.0 train: nine of ten prebuilds loaded, and
+ * `@gjsify/lightningcss-native-linux-arm64` failed on `gnu_get_libc_version`.
+ * That surfaces far from its cause — `gjsify install` reports "System
+ * dependencies OK", and the first symptom is the CSS plugin missing during a
+ * later build, which rolldown reports as `Could not load src/application.css`.
+ * Nothing in that chain names libc, so the report belongs at install time where
+ * the fallback is chosen.
+ */
+export function muslPrebuildFallbacks(libc: HostLibc | null, packages: readonly NativePackage[]): string[] {
+    if (libc !== 'musl') return [];
+    return packages
+        .filter((pkg) => !basename(pkg.prebuildsDir).endsWith(MUSL_SUFFIX))
+        .map((pkg) => pkg.name);
+}
+
 export function resolveHostLibc(input: {
     platform: string;
     glibcVersionRuntime?: string | undefined;

--- a/packages/infra/cli/src/utils/detect-native-packages.ts
+++ b/packages/infra/cli/src/utils/detect-native-packages.ts
@@ -588,9 +588,7 @@ export function detectNativePackages(startDir: string, target: HostTarget = {}):
  */
 export function muslPrebuildFallbacks(libc: HostLibc | null, packages: readonly NativePackage[]): string[] {
     if (libc !== 'musl') return [];
-    return packages
-        .filter((pkg) => !basename(pkg.prebuildsDir).endsWith(MUSL_SUFFIX))
-        .map((pkg) => pkg.name);
+    return packages.filter((pkg) => !basename(pkg.prebuildsDir).endsWith(MUSL_SUFFIX)).map((pkg) => pkg.name);
 }
 
 export function resolveHostLibc(input: {

--- a/packages/infra/cli/src/utils/detect-native-packages.ts
+++ b/packages/infra/cli/src/utils/detect-native-packages.ts
@@ -566,31 +566,6 @@ export function detectNativePackages(startDir: string, target: HostTarget = {}):
  * @param platform `process.platform` value; the axis is Linux-only (as npm's own
  *   `libc` field is), so every other OS returns null.
  */
-/**
- * The packages a musl host had to take the glibc build of, because they ship no
- * musl prebuild.
- *
- * Returning names rather than warning here keeps the decision pure: the musl
- * branch is only reachable from this repo's CI by injecting `libc`, since there
- * is no musl runner (see this module's spec header).
- *
- * Why the fallback is worth saying out loud. musl's loader resolves
- * `libc.so.6`/`libm.so.6` to ITSELF, so a glibc-linked prebuild loads and mostly
- * works — until it wants a symbol musl does not implement. Measured on a
- * OnePlus 6 (postmarketOS v26.06, musl 1.2.6, aarch64) against the published
- * 0.48.0 train: nine of ten prebuilds loaded, and
- * `@gjsify/lightningcss-native-linux-arm64` failed on `gnu_get_libc_version`.
- * That surfaces far from its cause — `gjsify install` reports "System
- * dependencies OK", and the first symptom is the CSS plugin missing during a
- * later build, which rolldown reports as `Could not load src/application.css`.
- * Nothing in that chain names libc, so the report belongs at install time where
- * the fallback is chosen.
- */
-export function muslPrebuildFallbacks(libc: HostLibc | null, packages: readonly NativePackage[]): string[] {
-    if (libc !== 'musl') return [];
-    return packages.filter((pkg) => !basename(pkg.prebuildsDir).endsWith(MUSL_SUFFIX)).map((pkg) => pkg.name);
-}
-
 export function resolveHostLibc(input: {
     platform: string;
     glibcVersionRuntime?: string | undefined;
@@ -622,6 +597,42 @@ export function detectHostLibc(platform: string): HostLibc | null {
     // this file already documents why the repo keeps exactly one.
     const muslLoaderPresent = existsSync('/lib') && readdirSync('/lib').some((f) => f.startsWith('ld-musl-'));
     return resolveHostLibc({ platform, glibcVersionRuntime, muslLoaderPresent });
+}
+
+/**
+ * The packages a musl host had to take the DEFAULT prebuild of, because they ship
+ * no `-musl` directory — the fallback {@link hostPlatformTokens} deliberately
+ * allows, named so a caller can report it. Returns names and prints nothing: this
+ * module resolves, and `libc` is a parameter for the same reason it is on every
+ * other function here (there is no musl runner in this repo's CI, so an injected
+ * `libc: 'musl'` is the only way the branch executes).
+ *
+ * Why a fallback that mostly WORKS is worth naming. musl's loader resolves
+ * `libc.so.6`/`libm.so.6` to itself, so a glibc-linked prebuild loads — and a
+ * bridge that records no libc at all then runs correctly, which is why the
+ * fallback exists rather than resolving to null. The one that is NOT agnostic dies
+ * at `dlopen` on its first glibc-only symbol, far from its cause. Measured on a
+ * OnePlus 6 (postmarketOS v26.06, musl 1.2.6, aarch64, gjs 1.88.1) against the
+ * published 0.48.0 train: nine of ten prebuilds loaded, while
+ * `@gjsify/lightningcss-native-linux-arm64` answered `gnu_get_libc_version: symbol
+ * not found`. `gjsify install` had printed "System dependencies OK", and the first
+ * symptom was rolldown reporting `Could not load src/application.css` — the CSS
+ * bridge silently absent from the bundle. Nothing in that chain names libc, which
+ * is what makes the report worth more than the failure.
+ *
+ * Membership goes through {@link parsePlatformToken}, not the suffix constant, so
+ * this does not become a second reader of the libc half of the token grammar —
+ * `darwin-arm64-musl` is a malformed token rather than a musl build, and only the
+ * grammar knows that.
+ *
+ * TODO(open-todos: `-musl` prebuild package is published): naming the fallback is
+ * not fixing it. No `-musl` target is published for any bridge, so on a musl host
+ * this reports every prebuild in the tree and there is nothing to fall back FROM.
+ */
+export function muslPrebuildFallbacks(libc: HostLibc | null, packages: readonly NativePackage[]): string[] {
+    if (libc !== 'musl') return [];
+    const fellBack = packages.filter((pkg) => parsePlatformToken(basename(pkg.prebuildsDir)).libc !== 'musl');
+    return fellBack.map((pkg) => pkg.name);
 }
 
 /**

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -5482,3 +5482,83 @@ re-run is how a guard gets quietly weakened. The arm ships with the narrower rul
 EMITTED refusal may not quote a `gi://` URL), and this entry is the retirement condition for
 that rule. Retiring it needs only the two sites in `gi-renderer-arms` — the twelve elsewhere
 constrain nothing about the arm.
+
+
+### No `-musl` prebuild package is published, so the libc axis has nothing to resolve to
+
+The CLI's libc axis is complete on the READ side. `detectHostLibc()` classifies the host under
+GJS as well as Node, `hostPlatformTokens()` puts `linux-<arch>-musl` ahead of the default build,
+`prebuildDirCandidates()` probes the suffixed directory first, `platformPackageName()` applies the
+same preference to the companion NAME, and `applyPlatformFilter` honours npm's `libc` field.
+Every one of those is unit-tested with an injected `libc: 'musl'`.
+
+Nothing is published for any of it to find. Registry check against `registry.npmjs.org`, all ten
+native bridges, measured 2026-09-08:
+
+| target | published |
+|---|---|
+| `linux-arm64` | 10 / 10 |
+| `linux-arm64-musl` | 0 / 10 — every one a 404 |
+| `linux-x64-musl` | 0 / 10 — every one a 404 |
+
+So `resolvePrebuildDirName()` falls back to the default build on every musl host, and
+`muslPrebuildFallbacks()` (`packages/infra/cli/src/utils/detect-native-packages.ts`) exists to say
+so at install time rather than let it stay silent. That report is a diagnosis, not a fix.
+
+**What it costs, measured.** OnePlus 6, postmarketOS v26.06, musl 1.2.6, aarch64, gjs 1.88.1,
+against the published 0.48.0 train: nine of the ten glibc prebuilds loaded and ran — musl aliases
+`libc.so.6`/`libm.so.6` to itself, and a bridge linking only GLib records no libc at all. The
+tenth, `@gjsify/lightningcss-native-linux-arm64`, answered
+`Error relocating …/libgjsify_lightningcss.so: gnu_get_libc_version: symbol not found`. It failed
+where nothing names libc: `gjsify install` had printed `System dependencies OK`, and the first
+symptom was rolldown reporting `Could not load src/application.css`, the CSS bridge silently
+absent from the bundle.
+
+**Why this is an entry and not a fix.** `prebuilds.yml` already carries a `build-prebuilds-musl`
+leg, so compilation is proven; what is missing is everything after it. `release.yml` does not
+mention musl once, and as `prebuilds.yml` notes, `-musl` "is not a `gjsify.platforms` token in the
+first place" — so the leg produces no publishable per-target package. Closing it means adding
+`-musl` to the platform grammar's WRITE side, generating the per-target manifests
+(`scripts/generate-platform-packages.mjs`), and extending the publish matrix. That is release
+infrastructure whose first-publish bootstrap ([docs/publishing.md](../docs/publishing.md)) cannot
+be rehearsed from a working copy, and every new `@gjsify/*` name needs a Trusted-Publisher
+bootstrap before the release that ships it. `oxlint`, vendored in this very repo, ships
+`@oxlint/binding-linux-arm64-musl`, so the shape is not in doubt — only the wiring.
+
+**The whole incident reproduces from the committed artifacts, with `readelf` and no phone.** That
+is worth more than the install-time report, because it is a gate rather than a message. Of the ten
+`linux-arm64` bridges, exactly one image references a glibc-only symbol:
+
+    $ readelf -sW packages/infra/lightningcss-native-linux-arm64/prebuilds/linux-arm64/\
+        libgjsify_lightningcss.so | grep gnu_get_libc_version
+    83: 0000000000000000  0 FUNC  GLOBAL DEFAULT  UND gnu_get_libc_version@GLIBC_2.17
+
+The other nine reference none, which is exactly why nine of ten loaded on that phone. So the
+symptom was predictable from this tree before it shipped, and the machinery to act on it already
+exists: npm's `libc` field, honoured by `applyPlatformFilter`, would have marked the package
+`inert` on a musl host — not downloaded, not installed — and `gjsify build` would have reported a
+missing CSS bridge instead of dying inside one. `tests/e2e/install-platform-filter` was written
+for precisely that outcome ("on Alpine the installer handed a glibc-only prebuild to a musl host
+and failed at `dlopen` instead of at install time").
+
+**Why the filter did not fire, measured.** `generate-platform-packages.mjs` writes `libc:
+["glibc"]` only when `measurePrebuildLibc` finds a glibc DYNAMIC LOADER recorded, and that is a
+deliberate, documented choice: musl resolves a `DT_NEEDED` of `libc.so.6` to itself, so declaring
+`glibc` on the libc-agnostic bridges would refuse the install on the hosts where they work. The
+hole is that the loader is not recorded consistently for the same source:
+
+| target | `DT_NEEDED` loader | npm `libc` written | glibc-only symbol |
+|---|---|---|---|
+| `linux-x64` | `ld-linux-x86-64.so.2` | `["glibc"]` | yes |
+| `linux-arm64` | none | none | yes |
+
+Same package, same glibc floor (`2.39`), and the x64 half is filtered out on musl by an accident
+of `DT_NEEDED` while the arm64 half installs and breaks. The predicate reads the loader; the
+question is the SYMBOL.
+
+**What has to be decided, and by whom.** Widening the predicate — `libc: ["glibc"]` for any image
+whose undefined symbols include one musl does not export — makes more packages `inert` on musl and
+needs a musl symbol set to be sound, so it is a policy change to `prebuild-libc`, not a repair.
+Publishing `-musl` packages makes the question moot for the bridges that can be built twice.
+Either way the CLI's install-time report stays useful for the residue, and neither is decidable
+from a working copy.


### PR DESCRIPTION
## The problem

`prebuildDirCandidates` already prefers `<target>-musl` on a musl host and falls back to the glibc directory when the package ships none. That fallback is **silent**, and it is not harmless.

musl's loader resolves `libc.so.6` and `libm.so.6` to itself, so a glibc-built prebuild loads and mostly works — until it reaches a symbol musl does not implement.

## Measured

OnePlus 6, postmarketOS v26.06, musl 1.2.6, aarch64, GJS 1.88.1, against the published 0.48.0 train. Nine of ten prebuilds loaded. One did not:

```
Error relocating …/@gjsify/lightningcss-native-linux-arm64/prebuilds/linux-arm64/libgjsify_lightningcss.so:
gnu_get_libc_version: symbol not found
```

**Nothing in the resulting failure names libc.** `gjsify install` prints `System dependencies OK`, and the first symptom arrives much later — the CSS plugin is simply absent from a build, which rolldown reports as:

```
rolldown: Bundler::generate: UNLOADABLE_DEPENDENCY "Could not load src/application.css"
```

Working back from that to "one prebuild wants a glibc symbol" took a while. Hence: report it where the fallback is actually chosen.

## The wider gap this does *not* fix

The root cause is that no `-musl` package exists to fall back *from*. Registry check (`registry.npmjs.org`, all ten native packages):

| target | result |
|---|---|
| `linux-arm64` | **10 / 10 published** |
| `linux-arm64-musl` | **0 / 10** — all 404 |
| `linux-x64-musl` | **0 / 10** — all 404 |

The machinery is otherwise in place: the CLI detects the host libc and globs `linux-arm64-musl` first (with specs), and `prebuilds.yml` carries a `build-prebuilds-musl` leg. But `release.yml` does not mention musl once, and as `prebuilds.yml` notes, `-musl` "is not a `gjsify.platforms` token in the first place" — the leg proves compilation, it does not produce publishable per-target packages.

Closing that means adding `-musl` to the platform grammar, per-target packages, and a publish matrix — release infrastructure I can't validate from here, so it is deliberately out of scope. This PR makes the fallback legible in the meantime.

For contrast, `oxlint` — vendored in this very repo — ships `@oxlint/binding-linux-arm64-musl`.

## The change

- `muslPrebuildFallbacks(libc, packages)` — pure, takes libc as a parameter like the rest of the module, since there is no musl runner in CI and an injected `libc: 'musl'` is the only way that branch executes there. It asks `parsePlatformToken` what a musl prebuild is rather than testing the `-musl` suffix itself: the suffix is honoured on linux ONLY, so `darwin-arm64-musl` is a malformed token and not a musl build, and a suffix test reads it as covered.
- `install.ts` prints the affected packages after the existing prebuild report.

Output on the host above:

```
Warning: musl host — 1 of 10 package(s) ship no `-musl` prebuild, so the
  default (glibc) build was used:
    @gjsify/lightningcss-native-linux-arm64
  Most of these run anyway: a bridge that links only GLib records no libc at all.
  One that links glibc loads too — musl aliases `libc.so.6` to itself — and then
  fails at dlopen on its first glibc-only symbol:
    Error relocating <prebuild>.so: <symbol>: symbol not found
  A bridge lost that way is silently absent from the next build rather than
  reported, so the first symptom can be an unrelated-looking bundler error
  (`Could not load <file>` from rolldown, for the CSS bridge). Nothing to
  install: no `-musl` package is published for any target yet.
```

It leads with the proportion because on a musl host the count is EVERY prebuild in
the tree and nine of ten are fine, quotes both error strings because the reverse
mapping from the bundler one is what took a while to work out, and states that
there is nothing to install — a fact now carried in `status/open-todos.md` and
checked from both sides by `generate-status.mjs`.

## Validation

- 9 spec cases in `detect-native-packages.spec.ts`: the musl fallback, all-musl,
  glibc/null quiet, directory-vs-path, the malformed `darwin-arm64-musl` token,
  and a real `detectNativePackages` walk over the existing fixtures in BOTH
  shapes — the directory fallback and the companion-package fallback, which is
  the one actually measured on the phone and which fires a level earlier.
- The five original assertions were additionally executed against the
  **compiled** `lib/utils/detect-native-packages.js` on the musl host.
- CI is green, including the CLI unit suite this branch could not run locally:
  the host has no Node, which is rather the point of the bug.
- `oxfmt --check` over the tree, `oxlint`, `generate-status.mjs --check` and
  `audit-runtimes.mjs --check` clean.

## Reviewed

Reviewed independently before merge; four defects found and fixed, and what the
review deliberately left alone is recorded with it:
https://github.com/gjsify/gjsify/pull/1602#issuecomment-5582331484

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01123EBLUnMaph7EQWiNU8GV

