### PR TITLE
fix(npm-registry): retry past a registry blip, body included

### DIFF
--- a/packages/infra/npm-registry/src/errors.ts
+++ b/packages/infra/npm-registry/src/errors.ts
@@ -42,3 +42,36 @@ export class RegistryTimeoutError extends Error {
         this.name = 'RegistryTimeoutError';
     }
 }
+
+/**
+ * Thrown when every retry attempt against a registry URL fails at the network
+ * layer (`fetch` rejects, the connection resets, the body stops arriving
+ * mid-stream). The sibling of {@link RegistryTimeoutError} for the case where
+ * the request does not hang but dies.
+ *
+ * It exists for the same reason: the raw error the runtime hands us is
+ * `TypeError: fetch failed` (undici) or a bare `FetchError` (GJS/libsoup),
+ * neither of which says WHICH of an install's several thousand requests died,
+ * how many attempts it got, or how long it was given. A CI log that ends in one
+ * unattributed `fetch failed` line is not enough to tell a registry outage from
+ * a bug, which is what happened to gjsify's own macOS run on 2026-09-08.
+ *
+ * The underlying error stays reachable as `cause`.
+ */
+export class RegistryUnreachableError extends Error {
+    constructor(
+        public readonly url: string,
+        public readonly attempts: number,
+        public readonly elapsedMs: number,
+        cause: unknown,
+    ) {
+        const seconds = Math.round(elapsedMs / 100) / 10;
+        const reason = cause instanceof Error ? cause.message : String(cause);
+        super(
+            `@gjsify/npm-registry: GET ${url} failed after ${attempts} attempt(s) over ~${seconds}s: ${reason}. ` +
+                `This usually means the registry or the network dropped out.`,
+        );
+        this.name = 'RegistryUnreachableError';
+        this.cause = cause;
+    }
+}

--- a/packages/infra/npm-registry/src/index.spec.ts
+++ b/packages/infra/npm-registry/src/index.spec.ts
@@ -12,6 +12,7 @@ import {
     fetchTarball,
     PackageNotFoundError,
     IntegrityError,
+    RegistryUnreachableError,
     type NpmrcConfig,
 } from './index.js';
 
@@ -500,11 +501,16 @@ export default async () => {
             expect(calls).toBe(3); // initial + 2 retries
         });
 
-        await it('throws the underlying error after exhausting retries', async () => {
+        await it('names the URL and the attempts after exhausting retries', async () => {
+            // A bare `TypeError: fetch failed` used to propagate, which says
+            // nothing about which request of an install died or how hard it was
+            // tried — what made the red macOS run of 2026-09-08 unreadable. The
+            // underlying error stays reachable as `cause`.
             let calls = 0;
+            const underlying = new TypeError('fetch failed');
             const mock = makeMockFetch(async () => {
                 calls++;
-                throw new TypeError('fetch failed');
+                throw underlying;
             });
             let caught: Error | null = null;
             try {
@@ -512,8 +518,12 @@ export default async () => {
             } catch (e) {
                 caught = e as Error;
             }
-            expect(caught instanceof TypeError).toBe(true);
-            expect(caught?.message).toBe('fetch failed');
+            expect(caught instanceof RegistryUnreachableError).toBe(true);
+            expect((caught as RegistryUnreachableError).attempts).toBe(3);
+            expect((caught as RegistryUnreachableError).url).toMatch(/lodash$/);
+            expect(String(caught?.message)).toMatch(/3 attempt\(s\)/);
+            expect(String(caught?.message)).toMatch(/fetch failed/);
+            expect((caught as { cause?: unknown }).cause).toBe(underlying);
             // 1 initial + 2 retries = 3 total.
             expect(calls).toBe(3);
         });
@@ -542,6 +552,93 @@ export default async () => {
             expect(caught?.name).toBe('AbortError');
             // 1 initial attempt, then the abort fires during backoff.
             expect(calls).toBe(1);
+        });
+
+        await it('retries a tarball body that dies mid-stream', async () => {
+            // The regression: fetchWithRetry used to return as soon as the
+            // HEADERS were in, so `res.arrayBuffer()` ran outside every retry
+            // and a connection dropped mid-body ended the install where it stood.
+            let calls = 0;
+            const mock = makeMockFetch(async () => {
+                calls++;
+                if (calls < 3) {
+                    // undici's shape for a body that stops arriving: the status
+                    // line was fine, the stream was not.
+                    return new Response(
+                        new ReadableStream({
+                            start(controller) {
+                                controller.error(new TypeError('terminated'));
+                            },
+                        }),
+                        { status: 200 },
+                    );
+                }
+                return new Response(new Uint8Array([0x1f, 0x8b, 0x08]), { status: 200 });
+            });
+            const got = await fetchTarball('https://r/x.tgz', { fetch: mock, retries: 3, retryDelayMs: 1 });
+            expect(got.length).toBe(3);
+            expect(calls).toBe(3);
+        });
+
+        await it('retries a packument body that dies mid-stream', async () => {
+            let calls = 0;
+            const mock = makeMockFetch(async () => {
+                calls++;
+                if (calls < 2) {
+                    return new Response(
+                        new ReadableStream({
+                            start(controller) {
+                                controller.enqueue(new TextEncoder().encode('{"name":"lod'));
+                                controller.error(new TypeError('terminated'));
+                            },
+                        }),
+                        { status: 200, headers: { 'content-type': 'application/json' } },
+                    );
+                }
+                return new Response(JSON.stringify({ name: 'lodash', 'dist-tags': {}, versions: {} }), {
+                    status: 200,
+                });
+            });
+            const p = await fetchPackument('lodash', { fetch: mock, retries: 3, retryDelayMs: 1 });
+            expect(p.name).toBe('lodash');
+            expect(calls).toBe(2);
+        });
+
+        await it('does NOT retry a packument that arrived whole but malformed', async () => {
+            // `assertPackument` throws TypeError, which isRetryableError reads
+            // as transient, so it has to stay OUTSIDE the retried read or a bad
+            // packument costs the whole budget before anyone is told why.
+            let calls = 0;
+            const mock = makeMockFetch(async () => {
+                calls++;
+                return new Response(JSON.stringify({ name: 'lodash' }), { status: 200 });
+            });
+            let threw = false;
+            try {
+                await fetchPackument('lodash', { fetch: mock, retries: 3, retryDelayMs: 1 });
+            } catch (e) {
+                threw = true;
+                expect(String((e as Error).message)).toMatch(/missing versions map/);
+            }
+            expect(threw).toBe(true);
+            expect(calls).toBe(1);
+        });
+
+        await it('defaults to 6 attempts', async () => {
+            // The shipped budget, asserted because it is the number that decides
+            // whether a real registry blip fails an install. retryDelayMs is
+            // overridden so the test does not actually wait the default ~23s.
+            let calls = 0;
+            const mock = makeMockFetch(async () => {
+                calls++;
+                throw new TypeError('fetch failed');
+            });
+            try {
+                await fetchPackument('lodash', { fetch: mock, retryDelayMs: 1 });
+            } catch {
+                /* expected — we are counting attempts, not asserting the throw */
+            }
+            expect(calls).toBe(6);
         });
 
         await it('retries: 0 disables retry path', async () => {

--- a/packages/infra/npm-registry/src/index.ts
+++ b/packages/infra/npm-registry/src/index.ts
@@ -4,7 +4,8 @@
 //
 // Barrel — re-exports only. Implementation lives in the sibling modules:
 //   types.ts      shared shapes (NpmrcConfig, Packument*, FetchOptions)
-//   errors.ts     PackageNotFoundError / IntegrityError / RegistryTimeoutError
+//   errors.ts     PackageNotFoundError / IntegrityError / RegistryTimeoutError /
+//                 RegistryUnreachableError
 //   npmrc.ts      DEFAULT_REGISTRY, registryFor, parseNpmrc
 //   auth.ts       buildHeaders, resolveAuthForUrl
 //   retry.ts      fetchWithRetry (backoff + per-request timeout)
@@ -14,7 +15,7 @@
 //   whoami.ts     whoami
 
 export type { FetchOptions, NpmrcConfig, Packument, PackumentDist, PackumentVersion } from './types.js';
-export { IntegrityError, PackageNotFoundError, RegistryTimeoutError } from './errors.js';
+export { IntegrityError, PackageNotFoundError, RegistryTimeoutError, RegistryUnreachableError } from './errors.js';
 export { DEFAULT_REGISTRY, parseNpmrc, registryFor } from './npmrc.js';
 export { buildHeaders, resolveAuthForUrl } from './auth.js';
 export { fetchWithRetry } from './retry.js';

--- a/packages/infra/npm-registry/src/packument.ts
+++ b/packages/infra/npm-registry/src/packument.ts
@@ -55,6 +55,14 @@ export function packumentUrl(name: string, registry: string): string {
 }
 
 /** Outcome of a conditional packument fetch ({@link fetchPackumentConditional}). */
+/**
+ * What the retried read hands back: the response classified, the body decoded,
+ * nothing validated. Separate from {@link ConditionalPackument} because that
+ * one carries a `Packument`, and knowing the body IS a packument is exactly the
+ * step that must happen after the last retry rather than inside it.
+ */
+type TransportResult = { status: 'not-modified' } | { status: 'fresh'; body: unknown; etag?: string };
+
 export interface ConditionalPackument {
     /** `'fresh'` — the registry returned a new body (200). `'not-modified'` —
      *  a 304, so the caller's cached copy is still current. */
@@ -99,7 +107,10 @@ export async function fetchPackumentConditional(
     headers['accept'] ??= opts.fullMetadata ? FULL_ACCEPT : CORGI_ACCEPT;
     if (opts.ifNoneMatch) headers['if-none-match'] = opts.ifNoneMatch;
 
-    const res = await fetchWithRetry(
+    // `read` keeps the body inside the retried region: a full packument for a
+    // popular package is megabytes, and a stream that stopped half way used to
+    // throw at `decodeJsonBody`, outside every retry (see fetchWithRetry).
+    const fetched = await fetchWithRetry(
         url,
         { headers, signal: opts.signal },
         {
@@ -108,37 +119,50 @@ export async function fetchPackumentConditional(
             retryDelayMs: opts.retryDelayMs,
             timeoutMs: opts.timeoutMs,
             onRetry: opts.onRetry,
+            read: async (res: Response): Promise<TransportResult> => {
+                if (res.status === 304) {
+                    // 304 is not `res.ok`; fetchWithRetry returns it un-retried
+                    // because isRetryableStatus(304) is false. Drain any (empty)
+                    // body so the connection can be reused.
+                    try {
+                        await res.arrayBuffer();
+                    } catch {
+                        /* empty 304 body — nothing to drain */
+                    }
+                    return { status: 'not-modified' };
+                }
+                if (!res.ok) {
+                    // 404 = package not found. 406 = Not Acceptable — with the q-list
+                    // `accept` above a registry that simply lacks the abbreviated document
+                    // no longer answers 406 (it falls back to `application/json`), so what
+                    // remains here is the addressability case: npm returns 406 when the URL
+                    // path is unrecognised (e.g. `%40scope/name` is parsed
+                    // as a sub-path of the synthetic `%40scope` resource rather than a
+                    // scoped package name). Both indicate the package is not addressable
+                    // in this registry and should surface as PackageNotFoundError so
+                    // optional deps are silently skipped and required-dep errors are
+                    // reported consistently.
+                    //
+                    // Both are non-transient, so raising them from inside `read`
+                    // propagates on the spot rather than costing the budget.
+                    if (res.status === 404 || res.status === 406) throw new PackageNotFoundError(name, url);
+                    throw new Error(`registry GET ${url} -> ${res.status} ${res.statusText}`);
+                }
+                return {
+                    status: 'fresh',
+                    body: await decodeJsonBody(res),
+                    etag: res.headers.get('etag') ?? undefined,
+                };
+            },
         },
     );
-    if (res.status === 304) {
-        // 304 is not `res.ok`; fetchWithRetry returns it un-retried because
-        // isRetryableStatus(304) is false. Drain any (empty) body so the
-        // connection can be reused.
-        try {
-            await res.arrayBuffer();
-        } catch {
-            /* empty 304 body — nothing to drain */
-        }
-        return { status: 'not-modified', etag: opts.ifNoneMatch };
-    }
-    if (!res.ok) {
-        // 404 = package not found. 406 = Not Acceptable — with the q-list
-        // `accept` above a registry that simply lacks the abbreviated document
-        // no longer answers 406 (it falls back to `application/json`), so what
-        // remains here is the addressability case: npm returns 406 when the URL
-        // path is unrecognised (e.g. `%40scope/name` is parsed
-        // as a sub-path of the synthetic `%40scope` resource rather than a
-        // scoped package name). Both indicate the package is not addressable
-        // in this registry and should surface as PackageNotFoundError so
-        // optional deps are silently skipped and required-dep errors are
-        // reported consistently.
-        if (res.status === 404 || res.status === 406) throw new PackageNotFoundError(name, url);
-        throw new Error(`registry GET ${url} -> ${res.status} ${res.statusText}`);
-    }
-    const etag = res.headers.get('etag') ?? undefined;
-    const body = await decodeJsonBody(res);
+    if (fetched.status === 'not-modified') return { status: 'not-modified', etag: opts.ifNoneMatch };
+    // Out here on purpose: `assertPackument` throws TypeError, which the retry
+    // loop reads as transient, so inside `read` a malformed packument would
+    // spend the whole budget before anyone was told why.
+    const body = fetched.body;
     assertPackument(name, body);
-    return { status: 'fresh', packument: body, etag };
+    return { status: 'fresh', packument: body, etag: fetched.etag };
 }
 
 /**

--- a/packages/infra/npm-registry/src/retry.ts
+++ b/packages/infra/npm-registry/src/retry.ts
@@ -1,7 +1,14 @@
 // Exponential-backoff retry + per-request timeout around a single registry GET.
 
-import { RegistryTimeoutError } from './errors.js';
+import { RegistryTimeoutError, RegistryUnreachableError } from './errors.js';
 import type { FetchOptions } from './types.js';
+
+/** `compress` is forwarded verbatim to the fetch impl. On @gjsify/fetch (GJS)
+ * `compress: false` disables transparent gzip decoding so the caller can
+ * buffer-then-gunzip itself; Node's undici ignores the field. */
+type RetryInit = { headers: Record<string, string>; signal?: AbortSignal; compress?: boolean };
+
+type RetryOpts = Pick<FetchOptions, 'fetch' | 'retries' | 'retryDelayMs' | 'timeoutMs' | 'onRetry' | 'retryNotFound'>;
 
 /**
  * Wrap a single GET in exponential-backoff retry for transient failures.
@@ -16,6 +23,8 @@ import type { FetchOptions } from './types.js';
  *     surfaced by a fired timeout signal is treated as transient (slow
  *     CDN) and retried like any other network blip; distinguished from
  *     a caller-triggered abort via the abort signal's `reason` identity.
+ *   - a body that stops arriving mid-stream, but ONLY when the caller passes
+ *     `opts.read` (see below)
  *
  * Does NOT retry on:
  *   - 4xx other than 408/425/429 (semantic errors — 404 surfaces via the
@@ -25,30 +34,52 @@ import type { FetchOptions } from './types.js';
  *   - AbortError from the CALLER's signal (`opts.signal` — caller wants out)
  *   - any other thrown shape that doesn't look transient
  *
- * Default schedule: 250ms, 500ms, 1000ms (3 retries → 4 total attempts);
- * capped at 8s per delay. Caller can tune via opts.retries / opts.retryDelayMs
- * / opts.timeoutMs.
+ * `opts.read` brings the BODY inside the retried region. Without it this
+ * returns once the HEADERS are in, so a caller's `res.arrayBuffer()` /
+ * `res.json()` runs outside every retry and a connection dying mid-body throws
+ * there, unretried.
  *
- * When ALL retries exhaust because of per-request timeouts, throws a
- * typed `RegistryTimeoutError` (not the raw "signal is aborted without
- * reason" the underlying fetch would surface) so the user gets a clear
- * "<url> timed out after Xs × N attempts" message.
+ * Keep VALIDATION out of `read` (`assertPackument`, SRI): `assertPackument`
+ * throws `TypeError`, which {@link isRetryableError} reads as transient, so a
+ * malformed packument would spend the whole budget and then be reported as a
+ * network fault. `read` covers transport; the caller checks what arrived.
+ *
+ * Default schedule: 1s, 2s, 4s, 8s, 8s (5 retries → 6 attempts, ~23s of
+ * patience), capped at 8s per delay. Tunable via opts.retries /
+ * opts.retryDelayMs / opts.timeoutMs. The previous 250/500/1000ms was two
+ * orders of magnitude under npm, whose defaults (`fetch-retries=2`,
+ * `fetch-retry-mintimeout=10s`, `fetch-retry-factor=10`) wait ~70s, and pnpm
+ * ships npm's numbers. A cold install fans the whole dependency closure out at
+ * 16-way concurrency for minutes, so a blip need only outlast the budget ONCE
+ * to fail the run: this repository's macOS CI went red that way on 2026-09-08,
+ * at 32% of an `install --immutable`, on a single `fetch failed`.
+ *
+ * When ALL retries exhaust, throws a typed error naming the URL and the
+ * attempts spent instead of whatever shape the runtime hands us:
+ * `RegistryTimeoutError` for per-request timeouts, `RegistryUnreachableError`
+ * (original error as `cause`) at the network layer. An unattributed
+ * `fetch failed` does not say which request of an install died, or how hard it
+ * was tried.
  */
-export async function fetchWithRetry(
+export async function fetchWithRetry(url: string, init: RetryInit, opts: RetryOpts): Promise<Response>;
+export async function fetchWithRetry<T>(
     url: string,
-    // `compress` is forwarded verbatim to the fetch impl. On @gjsify/fetch
-    // (GJS) `compress: false` disables transparent gzip decoding so the caller
-    // can buffer-then-gunzip itself; Node's undici ignores the field.
-    init: { headers: Record<string, string>; signal?: AbortSignal; compress?: boolean },
-    opts: Pick<FetchOptions, 'fetch' | 'retries' | 'retryDelayMs' | 'timeoutMs' | 'onRetry' | 'retryNotFound'>,
-): Promise<Response> {
+    init: RetryInit,
+    opts: RetryOpts & { read: (res: Response) => Promise<T> },
+): Promise<T>;
+export async function fetchWithRetry<T>(
+    url: string,
+    init: RetryInit,
+    opts: RetryOpts & { read?: (res: Response) => Promise<T> },
+): Promise<T | Response> {
     const fetchImpl = opts.fetch ?? globalThis.fetch;
     if (!fetchImpl) throw new Error('@gjsify/npm-registry: globalThis.fetch is missing');
 
-    const maxRetries = Math.max(0, opts.retries ?? 3);
-    const baseDelay = Math.max(0, opts.retryDelayMs ?? 250);
+    const maxRetries = Math.max(0, opts.retries ?? 5);
+    const baseDelay = Math.max(0, opts.retryDelayMs ?? 1000);
     const timeoutMs = Math.max(0, opts.timeoutMs ?? 30_000);
     const retryNotFound = opts.retryNotFound ?? false;
+    const startedAt = Date.now();
     let attempt = 0;
     let lastErr: unknown;
     let timeoutHits = 0;
@@ -79,7 +110,10 @@ export async function fetchWithRetry(
             const res = await fetchImpl(url, { ...init, signal: composedSignal });
             const retryable = isRetryableStatus(res.status) || (retryNotFound && res.status === 404);
             if (res.ok || !retryable || attempt >= maxRetries) {
-                return res;
+                // `read` runs INSIDE the try, so a body that stops arriving
+                // mid-stream is classified and retried like any other network
+                // error instead of throwing at the caller, unretried.
+                return opts.read ? await opts.read(res) : res;
             }
             // Drain the body so the underlying connection can be reused.
             try {
@@ -112,7 +146,10 @@ export async function fetchWithRetry(
                 // upstream `try/catch` patterns recognize the shape.
                 throw signalAbortError(init.signal);
             } else {
-                if (!isRetryableError(err) || attempt >= maxRetries) throw err;
+                if (!isRetryableError(err)) throw err;
+                if (attempt >= maxRetries) {
+                    throw new RegistryUnreachableError(url, attempt + 1, Date.now() - startedAt, err);
+                }
                 lastErr = err;
             }
         } finally {

--- a/packages/infra/npm-registry/src/tarball.ts
+++ b/packages/infra/npm-registry/src/tarball.ts
@@ -13,7 +13,9 @@ export async function fetchTarball(url: string, opts: FetchOptions & { integrity
     const headers = buildHeaders(url, { ...opts, acceptEncoding: 'identity' });
     headers['accept'] ??= 'application/octet-stream';
 
-    const res = await fetchWithRetry(
+    // `read`, not a read after the call: a tarball is the body most likely to be
+    // dropped part-way, and outside the retried region that throws unretried.
+    const buf = await fetchWithRetry(
         url,
         { headers, signal: opts.signal },
         {
@@ -25,10 +27,16 @@ export async function fetchTarball(url: string, opts: FetchOptions & { integrity
             // A tarball URL came from a resolved packument, so a 404 on the
             // `.tgz` is a transient CDN hiccup, not a missing artifact — retry it.
             retryNotFound: opts.retryNotFound ?? true,
+            read: async (res: Response) => {
+                // Reached only on a final status; a retryable one with attempts
+                // left never gets here.
+                if (!res.ok) throw new Error(`tarball GET ${url} -> ${res.status} ${res.statusText}`);
+                return new Uint8Array(await res.arrayBuffer());
+            },
         },
     );
-    if (!res.ok) throw new Error(`tarball GET ${url} -> ${res.status} ${res.statusText}`);
-    const buf = new Uint8Array(await res.arrayBuffer());
+    // Integrity stays OUTSIDE `read`: a mismatch is not a transport fault, and
+    // raised inside it the bytes would be re-fetched before anyone was told.
     if (opts.integrity) {
         const ok = await verifyIntegrity(buf, opts.integrity);
         if (!ok) throw new IntegrityError(url, opts.integrity);

--- a/packages/infra/npm-registry/src/types.ts
+++ b/packages/infra/npm-registry/src/types.ts
@@ -90,13 +90,20 @@ export interface FetchOptions {
     fetch?: typeof fetch;
     /**
      * Max retry attempts on transient failures (network errors, TLS handshake
-     * resets, 5xx, 408, 429). Default 3 → up to 4 total attempts. Set to 0
-     * to disable retry.
+     * resets, a body that stops arriving, 5xx, 408, 429). Default 5 → up to 6
+     * total attempts. Set to 0 to disable retry.
      */
     retries?: number;
     /**
-     * Initial backoff in ms; doubles per attempt. Default 250 → 250, 500, 1000.
-     * The cap is 8s per delay so a bad spell stays bounded.
+     * Initial backoff in ms; doubles per attempt. Default 1000 → 1s, 2s, 4s,
+     * 8s, 8s, so the default budget is ~23s of patience. The cap is 8s per
+     * delay so a bad spell stays bounded.
+     *
+     * Sized against npm, which waits ~70s across three attempts
+     * (`fetch-retries=2`, `fetch-retry-mintimeout=10s`, `fetch-retry-factor=10`)
+     * and pnpm, which ships the same numbers. The 1.75s this used to allow was
+     * short enough that one blip during a multi-thousand-request cold install
+     * failed the whole run.
      */
     retryDelayMs?: number;
     /**
@@ -110,7 +117,8 @@ export interface FetchOptions {
      * loop treats as transient (CDN slowdowns recover), so a slow attempt
      * gets retried per the retries / retryDelayMs schedule. When ALL
      * retries exhaust because of timeouts, a `RegistryTimeoutError` is
-     * thrown with a clear "timed out after Xs × N attempts" message.
+     * thrown with a clear "timed out after Xs × N attempts" message; when they
+     * exhaust at the network layer instead, a `RegistryUnreachableError`.
      */
     timeoutMs?: number;
     /**


### PR DESCRIPTION
## What happened

`main` went red on 2026-09-08. The `darwin-x64` leg of **macOS suites** died at 32% of an
`install --immutable`, on one line:

```
gjsify install: downloading 530/1658 (32%)
fetch failed
##[error]Process completed with exit code 1.
```

Nothing else on that commit failed. `darwin-arm64` was green on the same tree, so were the
other eight workflows, and **macOS suites** had passed on the twelve runs before it. Between
the last progress line and the error sit 53 seconds in which nothing downloaded. The registry,
or that runner's route to it, went away for about a minute.

An installer is supposed to absorb that. Three reasons this one did not.

## 1. The budget was 1.75 seconds

`fetchWithRetry` defaulted to `retries: 3` at 250/500/1000 ms.

For comparison, npm's own defaults are `fetch-retries=2` with `fetch-retry-mintimeout=10s`
and `fetch-retry-factor=10`, so npm waits about seventy seconds across three attempts; pnpm
ships npm's numbers. A cold install of this tree fans the whole dependency closure out at
16-way concurrency for minutes, so a blip only has to outlast the budget **once** to fail the
run — and with 1.75 s, most blips do.

Now 1s, 2s, 4s, 8s, 8s: six attempts, ~23 s of patience, still capped at 8 s per delay. It is
a default, so a caller wanting the old impatience passes `retries` / `retryDelayMs`.

## 2. Only the headers were retried

This is the sharper bug, and it survives any retry budget.

`fetchWithRetry` returned a `Response` once the status line was in. Both callers then read the
body **outside** the retried region:

```ts
const res = await fetchWithRetry(url, ...);      // retried
const buf = new Uint8Array(await res.arrayBuffer());  // not retried
```

A connection that dies mid-stream throws there with nothing to catch it. For a tarball that is
the body most likely to be dropped part-way, and for a full packument it is megabytes.

`opts.read` now brings the body inside the loop, so a body that stops arriving is classified and
retried like any other network error.

Validation deliberately stays **outside** it. `assertPackument` throws `TypeError`, and
`isRetryableError` reads every `TypeError` as transient — inside `read`, a malformed packument
would have been re-fetched six times and then reported as a network fault. `read` covers
transport; the caller checks what arrived. A test pins that: a malformed packument is fetched
exactly once.

## 3. The failure named nothing

The raw `TypeError: fetch failed` propagated, which is why the CI log above is one unactionable
line: it says neither which of an install's several thousand requests died, nor how hard it was
tried.

`RegistryUnreachableError` names the URL and the attempts spent and keeps the original error as
`cause`. It is the sibling of the existing `RegistryTimeoutError`, which already did this for
requests that hang rather than die — the same argument, applied to the branch that had been
left raw.

This changes a tested contract: the old test asserted that the underlying `TypeError` came
through verbatim. That test is now the assertion that the URL and the attempt count are named.

## Verified

- `gjsify run test` in `packages/infra/npm-registry` — 48 tests, both **Node 24.19.0** and
  **GJS 1.88.1**. New: a tarball body and a packument body that error mid-stream and are
  retried; a malformed packument fetched exactly once; the six-attempt default.
- `gjsify tsc --noEmit` clean in `npm-registry` and in the CLI that consumes it.
- `oxlint` and `oxfmt --check` clean.

## Scope

This does not explain the outage away, it survives it. Jitter across the concurrent downloads
is a separate question — 16 requests currently retry in lockstep, which is the wrong shape
against a rate-limiting CDN — and is deliberately not in here.
