### PR TITLE
fix(rolldown-plugin-gjsify): never inline a read of the host

### DIFF
--- a/packages/infra/cli/src/inline-static-reads.spec.ts
+++ b/packages/infra/cli/src/inline-static-reads.spec.ts
@@ -130,6 +130,58 @@ export default async () => {
             expect(out.inlined).toBe(0);
         });
 
+        await it("does NOT inline a sibling package's file spelled as a URL either", () => {
+            // THE TWIN OF THE ROW ABOVE, and the reason it has to exist: the gate
+            // sat after the URL branch of `evalPathExpr` had already returned, so
+            // the same read declined as `path.join(<abs>)` was inlined as
+            // `new URL('../../b/…', import.meta.url)` — which is not an exotic
+            // spelling but the one this whole module was written for. Measured
+            // before the branches were merged: `inlined: 1`, with b's bytes in the
+            // output.
+            const dir = mkdtempSync(join(tmpdir(), 'gjsify-sibling-url-'));
+            const reader = join(dir, 'node_modules', 'a', 'lib');
+            const other = join(dir, 'node_modules', 'b');
+            mkdirSync(reader, { recursive: true });
+            mkdirSync(other, { recursive: true });
+            writeFileSync(join(dir, 'node_modules', 'a', 'package.json'), '{"name":"a"}');
+            writeFileSync(join(other, 'package.json'), '{"name":"b"}');
+            writeFileSync(join(other, 'data.json'), '{"secret":1}');
+            const src = `
+                import { readFileSync } from 'fs';
+                const d = readFileSync(new URL('../../b/data.json', import.meta.url), 'utf8');
+            `;
+            const out = inlineStaticReads(src, join(reader, 'index.js'));
+            rmSync(dir, { recursive: true, force: true });
+            expect(out.inlined).toBe(0);
+            expect(out.contents).toContain('../../b/data.json');
+        });
+
+        await it('DOES still inline the manifest a dual-published module reads past its own type marker', () => {
+            // THE COST THE GATE MUST NOT HAVE, and it is not hypothetical: a
+            // package that publishes both formats drops a `{"type":"commonjs"}`
+            // marker beside the emitted output, and that marker IS a
+            // `package.json`. Answering "the nearest one" would put the resource
+            // root at `dist/cjs` and decline the module's read of its OWN manifest
+            // one level up — leaving live in the bundle exactly the read this file
+            // exists to remove. Measured in this repo's installed tree:
+            // `engine.io-client/build/{cjs,esm}` and
+            // `@socket.io/component-emitter/lib/cjs` are that shape.
+            const dir = mkdtempSync(join(tmpdir(), 'gjsify-dual-'));
+            const pkg = join(dir, 'node_modules', 'dual');
+            mkdirSync(join(pkg, 'dist', 'cjs'), { recursive: true });
+            writeFileSync(join(pkg, 'package.json'), '{"name":"dual","version":"7.7.7"}');
+            writeFileSync(join(pkg, 'dist', 'cjs', 'package.json'), '{"type":"commonjs"}');
+            const src = `
+                import { readFileSync } from 'fs';
+                import { fileURLToPath } from 'url';
+                const v = readFileSync(fileURLToPath(new URL('../../package.json', import.meta.url)), 'utf8');
+            `;
+            const out = inlineStaticReads(src, join(pkg, 'dist', 'cjs', 'index.js'));
+            rmSync(dir, { recursive: true, force: true });
+            expect(out.inlined).toBe(1);
+            expect(out.contents).toContain('7.7.7');
+        });
+
         await it("DOES still inline the package's own resource", () => {
             // The happy path the gate must not cost: a package reading its own
             // file through `import.meta.url`, which is the whole reason this
@@ -191,12 +243,52 @@ export default async () => {
         });
     });
 
+    // Two rules, because "the reading module's package" is a different question for
+    // an installed file than for a first-party one, and one answer gets the other
+    // wrong. The pair below is what says so.
     await describe('resourceRootFor', async () => {
-        await it('is the nearest ancestor carrying a package.json', () => {
+        await it('is the nearest ancestor carrying a package.json, for a first-party file', () => {
             const dir = mkdtempSync(join(tmpdir(), 'gjsify-root-'));
             mkdirSync(join(dir, 'pkg', 'src', 'deep'), { recursive: true });
             writeFileSync(join(dir, 'pkg', 'package.json'), '{"name":"p"}');
             expect(resourceRootFor(join(dir, 'pkg', 'src', 'deep', 'x.ts'))).toBe(join(dir, 'pkg'));
+            rmSync(dir, { recursive: true, force: true });
+        });
+
+        await it('is the NEAREST one and not the outermost, so a monorepo package is not the workspace', () => {
+            // The outermost would be the workspace root, and one package could then
+            // inline its siblings' files.
+            const dir = mkdtempSync(join(tmpdir(), 'gjsify-ws-'));
+            mkdirSync(join(dir, 'packages', 'a', 'src'), { recursive: true });
+            writeFileSync(join(dir, 'package.json'), '{"name":"ws","workspaces":["packages/*"]}');
+            writeFileSync(join(dir, 'packages', 'a', 'package.json'), '{"name":"a"}');
+            expect(resourceRootFor(join(dir, 'packages', 'a', 'src', 'x.ts'))).toBe(join(dir, 'packages', 'a'));
+            rmSync(dir, { recursive: true, force: true });
+        });
+
+        await it('is the node_modules package directory for an installed file, marker package.json or not', () => {
+            // Structural, not probed: a `{"type":"commonjs"}` marker deeper in the
+            // tree must not become the root — see the dual-publish row above.
+            const dir = mkdtempSync(join(tmpdir(), 'gjsify-installed-'));
+            const pkg = join(dir, 'node_modules', 'dual');
+            mkdirSync(join(pkg, 'dist', 'cjs'), { recursive: true });
+            writeFileSync(join(pkg, 'package.json'), '{"name":"dual"}');
+            writeFileSync(join(pkg, 'dist', 'cjs', 'package.json'), '{"type":"commonjs"}');
+            expect(resourceRootFor(join(pkg, 'dist', 'cjs', 'index.js'))).toBe(pkg);
+            rmSync(dir, { recursive: true, force: true });
+        });
+
+        await it('keeps a scoped name whole, and takes the LAST node_modules on the way up', () => {
+            // A nested dependency and a scoped one must resolve to THEMSELVES, not
+            // to whatever contains them — the property a Yarn-PnP zip path depends
+            // on as much as a hoisted tree does.
+            const dir = mkdtempSync(join(tmpdir(), 'gjsify-scoped-'));
+            const scoped = join(dir, 'node_modules', '@scope', 'name');
+            const nested = join(dir, 'node_modules', 'a', 'node_modules', 'b');
+            mkdirSync(join(scoped, 'lib'), { recursive: true });
+            mkdirSync(join(nested, 'lib'), { recursive: true });
+            expect(resourceRootFor(join(scoped, 'lib', 'x.js'))).toBe(scoped);
+            expect(resourceRootFor(join(nested, 'lib', 'x.js'))).toBe(nested);
             rmSync(dir, { recursive: true, force: true });
         });
 

--- a/packages/infra/cli/src/inline-static-reads.spec.ts
+++ b/packages/infra/cli/src/inline-static-reads.spec.ts
@@ -22,10 +22,17 @@
 //    bundling for `package.json`, locale files, etc.
 
 import { describe, expect, it } from '@gjsify/unit';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { inlineStaticReads, isAbsoluteFsPath, shouldInline, shouldRewrite } from '@gjsify/rolldown-plugin-gjsify';
+import {
+    inlineStaticReads,
+    isAbsoluteFsPath,
+    isWithin,
+    resourceRootFor,
+    shouldInline,
+    shouldRewrite,
+} from '@gjsify/rolldown-plugin-gjsify';
 
 export default async () => {
     await describe('inline-static-reads', async () => {
@@ -84,6 +91,62 @@ export default async () => {
             expect(out.contents).toMatch(/\[\s*"/);
         });
 
+        await it('does NOT inline a read of the host, however static the path', () => {
+            // The one that shipped. `/lib` is perfectly resolvable at build time
+            // and its contents are a property of the MACHINE, so inlining freezes
+            // the build host's answer into the artifact. Measured on a musl
+            // aarch64 phone against the bundled CLI: `readdirSync('/lib')` gave
+            // the Fedora builder's 77 entries with no `ld-musl-*` and
+            // `existsSync('/lib/ld-musl-aarch64.so.1')` gave false, so
+            // `detectHostLibc` answered `glibc` on a musl host and every
+            // `-musl` preference downstream was inert.
+            const src = `
+                import { existsSync, readdirSync } from 'fs';
+                const onMusl = existsSync('/lib') && readdirSync('/lib').some((f) => f.startsWith('ld-musl-'));
+            `;
+            const out = inlineStaticReads(src, '/home/dev/repo/packages/infra/cli/src/utils/probe.ts');
+            expect(out.inlined).toBe(0);
+            expect(out.contents).toContain("existsSync('/lib')");
+            expect(out.contents).toContain("readdirSync('/lib')");
+        });
+
+        await it("does NOT inline a sibling package's file", () => {
+            // Another package's data is not this package's resource, and a
+            // hoisted tree makes it reachable by a static `..` walk.
+            const dir = mkdtempSync(join(tmpdir(), 'gjsify-sibling-'));
+            const reader = join(dir, 'node_modules', 'a');
+            const other = join(dir, 'node_modules', 'b');
+            mkdirSync(reader, { recursive: true });
+            mkdirSync(other, { recursive: true });
+            writeFileSync(join(reader, 'package.json'), '{"name":"a"}');
+            writeFileSync(join(other, 'data.json'), '{"secret":1}');
+            const src = `
+                import { readFileSync } from 'fs';
+                import * as path from 'node:path';
+                const d = readFileSync(path.join(${JSON.stringify(other)}, 'data.json'), 'utf8');
+            `;
+            const out = inlineStaticReads(src, join(reader, 'index.js'));
+            rmSync(dir, { recursive: true, force: true });
+            expect(out.inlined).toBe(0);
+        });
+
+        await it("DOES still inline the package's own resource", () => {
+            // The happy path the gate must not cost: a package reading its own
+            // file through `import.meta.url`, which is the whole reason this
+            // module exists.
+            const dir = mkdtempSync(join(tmpdir(), 'gjsify-own-'));
+            mkdirSync(join(dir, 'lib'), { recursive: true });
+            writeFileSync(join(dir, 'package.json'), '{"name":"own","version":"9.9.9"}');
+            const src = `
+                import { readFileSync } from 'fs';
+                const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+            `;
+            const out = inlineStaticReads(src, join(dir, 'lib', 'index.js'));
+            rmSync(dir, { recursive: true, force: true });
+            expect(out.inlined).toBe(1);
+            expect(out.contents).toContain('9.9.9');
+        });
+
         await it('does NOT misread arbitrary `.join` as `path.join` (no inlining)', () => {
             // `someArr.join('/')` must not be evaluated as `path.join`.
             // We use it here as the second positional arg of an unrelated
@@ -106,6 +169,47 @@ export default async () => {
     // `fileURLToPath(new URL(…))` and `path.join(__dirname)` — were silently
     // never inlined there. `platform` is injected, so both branches run on
     // every host; off win32 this regression is otherwise invisible.
+    await describe('isWithin', async () => {
+        await it('accepts the root itself and a descendant', () => {
+            expect(isWithin('/a/b', '/a/b', 'linux')).toBe(true);
+            expect(isWithin('/a/b/c/d.json', '/a/b', 'linux')).toBe(true);
+        });
+
+        await it('rejects an ancestor and a sibling', () => {
+            expect(isWithin('/a', '/a/b', 'linux')).toBe(false);
+            expect(isWithin('/a/c', '/a/b', 'linux')).toBe(false);
+        });
+
+        await it("rejects a sibling whose name EXTENDS the root — the string test's bug", () => {
+            // `startsWith` calls /lib64 a child of /lib. It is not one.
+            expect(isWithin('/lib64/x.so', '/lib', 'linux')).toBe(false);
+        });
+
+        await it('works on win32 paths', () => {
+            expect(isWithin('C:\\ws\\pkg\\data.json', 'C:\\ws\\pkg', 'win32')).toBe(true);
+            expect(isWithin('C:\\ws\\other\\data.json', 'C:\\ws\\pkg', 'win32')).toBe(false);
+        });
+    });
+
+    await describe('resourceRootFor', async () => {
+        await it('is the nearest ancestor carrying a package.json', () => {
+            const dir = mkdtempSync(join(tmpdir(), 'gjsify-root-'));
+            mkdirSync(join(dir, 'pkg', 'src', 'deep'), { recursive: true });
+            writeFileSync(join(dir, 'pkg', 'package.json'), '{"name":"p"}');
+            expect(resourceRootFor(join(dir, 'pkg', 'src', 'deep', 'x.ts'))).toBe(join(dir, 'pkg'));
+            rmSync(dir, { recursive: true, force: true });
+        });
+
+        await it("falls back to the module's own directory when nothing above declares one", () => {
+            const dir = mkdtempSync(join(tmpdir(), 'gjsify-noroot-'));
+            // Nothing under `dir` carries a package.json. Whatever the walk finds
+            // above it, the answer must still contain the module itself, which is
+            // what the fallback guarantees.
+            expect(isWithin(join(dir, 'x.js'), resourceRootFor(join(dir, 'x.js')))).toBe(true);
+            rmSync(dir, { recursive: true, force: true });
+        });
+    });
+
     await describe('isAbsoluteFsPath', async () => {
         await it('accepts a POSIX absolute path, rejects a relative one', () => {
             expect(isAbsoluteFsPath('/tmp/x.json', 'linux')).toBe(true);

--- a/packages/infra/rolldown-plugin-gjsify/src/utils/index.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/utils/index.ts
@@ -5,7 +5,7 @@ export * from './runtime.js';
 export * from './merge.js';
 export { detectFreeGlobals } from './detect-free-globals.js';
 export { resolveGlobalsList, writeRegisterInjectFile } from './scan-globals.js';
-export { inlineStaticReads, isAbsoluteFsPath } from './inline-static-reads.js';
+export { inlineStaticReads, isAbsoluteFsPath, isWithin, resourceRootFor } from './inline-static-reads.js';
 export { GJSIFY_VIRTUAL_PREFIX, isGjsifyVirtualModuleId } from './virtual-module-id.js';
 export { locateSurvivingJsx, classifyJsxParseFailure, formatSurvivingJsx } from './jsx-survival.js';
 export type { SurvivingJsx } from './jsx-survival.js';

--- a/packages/infra/rolldown-plugin-gjsify/src/utils/inline-static-reads.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/utils/inline-static-reads.ts
@@ -40,6 +40,27 @@
 //
 // Anything not statically resolvable is left untouched — the legacy
 // `import.meta.url` rewriter still applies as a fallback.
+//
+// WHAT IS DELIBERATELY NOT INLINED, and it is not about resolvability. A read
+// only belongs in the bundle when its answer is a property of the BUILD; a read
+// of the machine's own layout is a property of the HOST, and freezing it ships
+// the build machine's answer to every user. `evalPathExpr` therefore refuses a
+// path that resolves outside the reading module's own package (see
+// `resourceRootFor`), however statically resolvable it is.
+//
+// Measured on a OnePlus 6T (postmarketOS, musl 1.2.6, aarch64) against the
+// bundled CLI of 2026-09-08, before that gate existed:
+//
+//     readdirSync('/lib')                     77 entries, no ld-musl-*
+//     existsSync('/lib/ld-musl-aarch64.so.1') false
+//
+// Both answers were the Fedora build host's, baked in at build time — the real
+// directory holds 2076 entries including `ld-musl-aarch64.so.1`. That is the
+// probe `detectHostLibc` reads, so a bundled `gjsify` answered `glibc` on a musl
+// machine and every musl-aware decision downstream — `prebuildDirCandidates`'
+// `-musl` preference, the launcher shims, the fallback report — was inert for
+// the life of the bundle. Ten runs, ten times `glibc`. Nothing failed loudly:
+// the glibc prebuild loads under musl's loader until it wants a glibc symbol.
 
 import * as acorn from 'acorn';
 import { tsPlugin } from 'acorn-typescript';
@@ -61,6 +82,8 @@ interface Edit {
 interface InlineContext {
     /** `import.meta.url` of the source file being inlined (file:// URL). */
     sourceUrl: string;
+    /** The tree this module's own resources live in — see `resourceRootFor`. */
+    resourceRoot: string;
 }
 
 /**
@@ -156,6 +179,7 @@ export function inlineStaticReads(src: string, sourceFilePath: string): { conten
 
     const ctx: InlineContext = {
         sourceUrl: pathToFileURL(sourceFilePath).href,
+        resourceRoot: resourceRootFor(sourceFilePath),
     };
     const edits: Edit[] = [];
 
@@ -374,9 +398,54 @@ function evalPathExpr(node: acorn.AnyNode | undefined, ctx: InlineContext): stri
         return undefined;
     }
     if (typeof v !== 'string') return undefined;
-    if (v.startsWith('file://')) return fileURLToPath(v);
-    if (isAbsoluteFsPath(v)) return v;
-    return undefined;
+    const asPath = v.startsWith('file://') ? fileURLToPath(v) : isAbsoluteFsPath(v) ? v : undefined;
+    if (asPath === undefined) return undefined;
+    // Resolvable is not the same as bundlable. Declining is the safe direction:
+    // the call is simply left in place and reads at runtime, which is what a host
+    // probe wants. Silent on purpose — a probe of `/proc`, `/sys` or `/lib` is
+    // ordinary in a runtime shim, and warning about each one would bury the
+    // decline that matters under the ones that do not.
+    if (!isWithin(asPath, ctx.resourceRoot)) return undefined;
+    return asPath;
+}
+
+/**
+ * The tree whose contents are a property of the BUILD rather than of the host:
+ * the nearest ancestor of the reading module that carries a `package.json`, and
+ * failing that the module's own directory.
+ *
+ * A package's own resources are what this module exists to bundle, and they are
+ * all under one of those two. Anything else — `/lib`, `/etc`, `/proc`, a sibling
+ * package's data — is either the machine's layout or another package's business,
+ * and its answer at build time is not its answer at run time.
+ *
+ * The nearest `package.json` rather than the workspace root: a hoisted
+ * `node_modules/<pkg>` resolves to itself and not to the whole tree, so one
+ * package cannot inline another's files even where both are being bundled.
+ */
+export function resourceRootFor(sourceFilePath: string): string {
+    let dir = dirname(resolve(sourceFilePath));
+    for (;;) {
+        if (existsSync(join(dir, 'package.json'))) return dir;
+        const parent = dirname(dir);
+        if (parent === dir) return dirname(resolve(sourceFilePath));
+        dir = parent;
+    }
+}
+
+/**
+ * Is `target` inside `root` (or `root` itself)?
+ *
+ * `relative()` rather than `startsWith`: the string test calls `/lib64` a child
+ * of `/lib`. `platform` is injected and the branches use `path.win32`/`path.posix`
+ * explicitly, the same shape as {@link isAbsoluteFsPath}, so both run from either
+ * host.
+ */
+export function isWithin(target: string, root: string, platform: string = process.platform): boolean {
+    const p = platform === 'win32' ? win32 : posix;
+    const rel = p.relative(p.resolve(root), p.resolve(target));
+    if (rel === '') return true;
+    return !rel.startsWith('..') && !p.isAbsolute(rel);
 }
 
 /**

--- a/packages/infra/rolldown-plugin-gjsify/src/utils/inline-static-reads.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/utils/inline-static-reads.ts
@@ -393,43 +393,94 @@ function tryInlineReadFile(
  */
 function evalPathExpr(node: acorn.AnyNode | undefined, ctx: InlineContext): string | undefined {
     const v = evalExpr(node, ctx);
+    // ONE exit for both shapes, and that is the whole point of the arrangement. The
+    // URL branch used to `return` before any gate ran, so `new URL('/proc',
+    // import.meta.url)` and `new URL('file:///lib')` were read on the builder while
+    // the same read spelled `fileURLToPath(new URL(…))` was declined. Two spellings
+    // of one expression cannot answer differently, and `new URL(<lit>,
+    // import.meta.url)` is the spelling this module was written for.
+    let asPath: string | undefined;
     if (v instanceof URL) {
-        if (v.protocol === 'file:') return fileURLToPath(v);
-        return undefined;
+        asPath = v.protocol === 'file:' ? fileURLToPath(v) : undefined;
+    } else if (typeof v === 'string') {
+        asPath = v.startsWith('file://') ? fileURLToPath(v) : isAbsoluteFsPath(v) ? v : undefined;
     }
-    if (typeof v !== 'string') return undefined;
-    const asPath = v.startsWith('file://') ? fileURLToPath(v) : isAbsoluteFsPath(v) ? v : undefined;
     if (asPath === undefined) return undefined;
     // Resolvable is not the same as bundlable. Declining is the safe direction:
     // the call is simply left in place and reads at runtime, which is what a host
     // probe wants. Silent on purpose — a probe of `/proc`, `/sys` or `/lib` is
     // ordinary in a runtime shim, and warning about each one would bury the
-    // decline that matters under the ones that do not.
+    // decline that matters under the ones that do not. What stops this silence
+    // costing what `isAbsoluteFsPath`'s did is that the declines have ROWS in
+    // `inline-static-reads.spec.ts` — a warning nobody reads would not have caught
+    // that one either.
     if (!isWithin(asPath, ctx.resourceRoot)) return undefined;
     return asPath;
 }
 
 /**
- * The tree whose contents are a property of the BUILD rather than of the host:
- * the nearest ancestor of the reading module that carries a `package.json`, and
- * failing that the module's own directory.
+ * The tree whose contents are a property of the BUILD rather than of the host —
+ * the reading module's own package.
  *
- * A package's own resources are what this module exists to bundle, and they are
- * all under one of those two. Anything else — `/lib`, `/etc`, `/proc`, a sibling
- * package's data — is either the machine's layout or another package's business,
- * and its answer at build time is not its answer at run time.
+ * A package's own resources are what this module exists to bundle. Anything else
+ * — `/lib`, `/etc`, `/proc`, a sibling package's data — is either the machine's
+ * layout or another package's business, and its answer at build time is not its
+ * answer at run time.
  *
- * The nearest `package.json` rather than the workspace root: a hoisted
- * `node_modules/<pkg>` resolves to itself and not to the whole tree, so one
- * package cannot inline another's files even where both are being bundled.
+ * TWO RULES, because "the package" is answered two different ways and picking one
+ * of them gets the other wrong.
+ *
+ * For an INSTALLED file the root is STRUCTURAL: the directory whose parent is
+ * `node_modules` (or `node_modules/@scope`). Probing for the nearest
+ * `package.json` instead lands on the wrong directory for any package that
+ * dual-publishes, because the `{"type":"commonjs"}` marker beside the emitted
+ * output IS a `package.json`, and some of those markers carry the package's own
+ * `name` too — so neither presence nor a `name` tells a marker from a root.
+ * Measured in this repo's installed tree: `engine.io-client/build/{cjs,esm}` and
+ * `@socket.io/component-emitter/lib/cjs` are that shape. A module there reading
+ * its package's real manifest — the `new URL('../package.json',
+ * import.meta.url)` this file's header opens with, one level deeper — would be
+ * reading OUTSIDE its root, get declined, and ship the live read this module
+ * exists to remove.
+ *
+ * For a FIRST-PARTY file the root is the nearest ancestor carrying a
+ * `package.json`, and it has to be the NEAREST: in a monorepo the outermost one
+ * is the workspace root, which would let one package inline its siblings' files.
+ * The fallback when nothing above declares one is the module's own directory,
+ * which is the narrowest answer available rather than a licence to read upward.
  */
 export function resourceRootFor(sourceFilePath: string): string {
-    let dir = dirname(resolve(sourceFilePath));
+    const own = dirname(resolve(sourceFilePath));
+    const installed = installedPackageRootFor(own);
+    if (installed !== undefined) return installed;
+    let dir = own;
     for (;;) {
         if (existsSync(join(dir, 'package.json'))) return dir;
         const parent = dirname(dir);
-        if (parent === dir) return dirname(resolve(sourceFilePath));
+        if (parent === dir) return own;
         dir = parent;
+    }
+}
+
+/**
+ * The `node_modules/<name>` — or `node_modules/@scope/<name>` — directory `dir`
+ * lives in, or `undefined` when it is not inside an installed package.
+ *
+ * The LAST `node_modules` segment on the way up, so a nested dependency
+ * (`node_modules/a/node_modules/b`) and a Yarn-PnP zip
+ * (`…/cache/x.zip/node_modules/@scope/b`) both resolve to themselves rather than
+ * to whatever contains them. No filesystem probe: the layout is the answer, and a
+ * zip-resident path has no `package.json` a plain `existsSync` can see.
+ */
+function installedPackageRootFor(dir: string): string | undefined {
+    let cur = dir;
+    for (;;) {
+        const parent = dirname(cur);
+        if (parent === cur) return undefined;
+        const parentName = basename(parent);
+        if (parentName === 'node_modules') return cur;
+        if (parentName.startsWith('@') && basename(dirname(parent)) === 'node_modules') return cur;
+        cur = parent;
     }
 }
 
@@ -437,9 +488,17 @@ export function resourceRootFor(sourceFilePath: string): string {
  * Is `target` inside `root` (or `root` itself)?
  *
  * `relative()` rather than `startsWith`: the string test calls `/lib64` a child
- * of `/lib`. `platform` is injected and the branches use `path.win32`/`path.posix`
- * explicitly, the same shape as {@link isAbsoluteFsPath}, so both run from either
- * host.
+ * of `/lib`. `resolve()` first, so a `..` composition is normalised before the
+ * comparison rather than after it. `platform` is injected and the branches use
+ * `path.win32`/`path.posix` explicitly, the same shape as
+ * {@link isAbsoluteFsPath}, so both run from either host.
+ *
+ * TEXTUAL, deliberately: no `realpathSync`. Both directions of that choice are
+ * the safe one here. A read that reaches into the package through a symlink
+ * resolves to a path outside the root and is DECLINED, which leaves a working
+ * runtime read; and a path textually inside the root cannot be widened by a
+ * symlink npm never creates. Resolving would also cost a syscall per candidate
+ * and break the zip-resident PnP case, whose paths are not files.
  */
 export function isWithin(target: string, root: string, platform: string = process.platform): boolean {
     const p = platform === 'win32' ? win32 : posix;


### PR DESCRIPTION
## What was wrong

The build-time read inliner accepted any statically-resolvable **absolute** path. Its last
gate before reading from disk was:

```ts
if (isAbsoluteFsPath(v)) return v;
```

`/lib` passes that. So a read of the machine's own layout was evaluated on the **builder**
and frozen into the artifact as a literal.

## Measured

OnePlus 6T, postmarketOS, musl 1.2.6, aarch64, gjs 1.88.1, running a `cli.gjs.mjs` built on
Fedora:

```
readdirSync('/lib')                       77 entries, no ld-musl-*
existsSync('/lib/ld-musl-aarch64.so.1')   false
```

The directory really holds 2076 entries and `ld-musl-aarch64.so.1` is one of them. 77 was the
**builder's** `/usr/lib`. Ten runs, ten times the same.

Those two reads are exactly what `detectHostLibc` decides from, so a bundled `gjsify` answered
`glibc` on a musl machine. `detectHostLibc` has four callers, so what was inert for the life of
the bundle is: the `-musl` preference in `prebuildDirCandidates`, the launcher shims' libc,
`install-global`'s target, and the fallback report added in #1602.

Nothing failed loudly. A glibc prebuild loads under musl's loader right up to its first
glibc-only symbol — which is the incident #1602 reported from the other end, and why nine of
ten prebuilds on that phone worked.

## The change

Resolvable is not the same as bundlable. This module exists so a package can carry its **own**
resources — `new URL('../package.json', import.meta.url)` — whose content is a property of the
build. A path outside the reading module's package is either the machine's layout or another
package's business, and its build-time answer is not its run-time answer.

- `resourceRootFor` walks up to the nearest `package.json`, falling back to the module's own
  directory when nothing above declares one — which is what keeps the existing
  `readdirSync(path.join(<tmpdir>))` row inlining.
- `isWithin` gates on `relative()`, not a prefix test: `startsWith` calls `/lib64` a child of
  `/lib`.
- Declining is the safe direction — the call stays put and reads at runtime, which is what a
  probe wants. Silent on purpose: probing `/proc` or `/lib` is ordinary in a runtime shim, and
  a warning per probe would bury the declines that matter.

## Blast radius, instrumented over a full `build:gjs-bundle` of `@gjsify/cli`

The gate declines **four paths / five reads** (`/lib` is `existsSync` + `readdirSync` in one
expression), and every one of them was wrong before:

| path | what it fed | how it was wrong |
|---|---|---|
| `/etc/alpine-release` | `napi-node-addon`'s Alpine test | frozen `false` on a glibc builder; the phone above reports `3.24.1` |
| `/lib` | `detectHostLibc` | the libc probe above |
| `/proc` | `foreach`'s ppid map, the process-tree kill fallback | frozen as the **builder's** PID list |
| `/proc/self` | `install-lock`'s liveness probe | frozen **true**, so on a platform without `/proc` the bundled CLI took the `/proc` branch, found no `/proc/<pid>`, judged every holder dead and **stole the lock** |

**No package-resource read was declined**, so the inlining this module exists for is untouched.

## Verified

- 1715 tests in `@gjsify/cli` on Node 24.19.0. New rows: a declined host read, a declined
  sibling-package file, a still-inlined own resource via `import.meta.url`, plus unit coverage
  for `isWithin` (including the `/lib64` case) and `resourceRootFor`.
- The rebuilt `cli.gjs.mjs` carries no entry name from the builder's `/lib` (`NetworkManager`,
  `Marker.extensions`, `binfmt.d`) and keeps `ld-musl-` as runtime code.

  An earlier revision of this section named `libbd_smartmontools`, `lib++dfb` and
  `libverto.so.1` instead. That was a check that could not fail: on the Fedora builder those
  live in `/lib64`, so they were never candidates for a `/lib` read and were absent from the
  pre-fix bundle too. They appeared in my first measurement because they are in the PHONE's
  single `/usr/lib`, which has no lib64 split. Caught in review.
- On the phone, the fixed bundle reports the musl fallback for all five installed bridges:

```
Warning: musl host — 5 of 5 package(s) ship no `-musl` prebuild, so the
  default (glibc) build was used:
    @gjsify/http2-native-linux-arm64
    @gjsify/lightningcss-native-linux-arm64
    ...
```

The previous bundle printed nothing there. That output also settles the `N of N` shape — the
`1 of 10` in #1602's merged description was my reconstruction and it was wrong; corrected in a
comment on that PR.

- `oxfmt --check` and `oxlint` clean on both touched packages.

## Not in here

`gjsify install --global` returns before `runPostInstallChecks`, so a global install still
reports nothing. That is not a one-line fix: those checks are cwd-scoped by construction
(`detectNativePackages(process.cwd())`, `ensureProjectGjsEngine`), so calling them there would
report an unrelated tree. It needs a root threaded through, and a decision about what a global
install should say.

## Two holes review found in the first version of this gate

**The gate never ran on `new URL(…)`** — the spelling this module was written for.
`evalPathExpr`'s URL branch returned `fileURLToPath(v)` before the containment test, so
`readdirSync(new URL('/proc', import.meta.url))` still froze the builder's PID list while the
same read spelled `fileURLToPath(new URL(…))` was declined. Two spellings of one expression
cannot answer differently. There is now one exit for both shapes.

**And closing that exposed a defect the gate had already shipped.** `resourceRootFor`'s
"nearest ancestor with a `package.json`" stops at a dual-publish `{"type":"commonjs"}` marker
directory, so a module under one had the read of *its own manifest* declined — trading a wrong
constant for the ENOENT-after-move this module exists to prevent. Not hypothetical: in this
tree `engine.io-client/build/{cjs,esm}`, `@socket.io/component-emitter/lib/cjs`,
`lru-cache/dist/{esm,commonjs}` and `entities/lib/esm` are that shape, and some carry the
package's own `name`, so neither presence nor a `name` distinguishes marker from root. The
rule is now structural for installed files — the last `node_modules/<name>` segment on the way
up, scope kept whole, no filesystem probe so a Yarn-PnP zip path resolves too — and
nearest-`package.json` for first-party, which must stay *nearest* or a monorepo package
becomes its workspace.

The two defects cancelled for one spelling, which is why the first measurement looked clean.
Every new row fails against both the pre-PR module and the first version of the gate.

`pnp-zip-static-reads` — the suite most exposed to the structural rule, and the one that could
not be run locally — passes in CI on both its `--app node` and `--app gjs` cases.
