### PR TITLE
fix(ship-oracle): stop blaming the artifact for a fault in the reader

### DIFF
--- a/.github/ship-oracle/verify-msi.sh
+++ b/.github/ship-oracle/verify-msi.sh
@@ -96,11 +96,13 @@ require msiinfo msiextract find sort cmp awk tr
 # print `error: libmsi_database_export / msiinfo: internal error (function failed)`
 # on EPIPE, which reads as a corrupt database and is nothing but the pipe closing —
 # the same run that measured the CRLF chased that for ten minutes first.
-# An IDT export, with the reader held to the same standard as `msiextract`
-# below: three header lines (columns, types, table+keys) precede the rows, which
-# is the assumption every `NR > 3` in this file already makes. Fewer than three
-# means the READER produced nothing usable, and that is not the same fact as a
-# table without the row being looked for.
+#
+# THE READER IS HELD TO THE SAME STANDARD AS `msiextract` BELOW. An IDT export
+# carries three header lines — columns, types, table+keys — before any row, which
+# is the assumption every `NR > 3` in this file already makes, and an
+# empty-but-present table still has all three. Fewer than three means the READER
+# produced nothing usable, and that is not the same fact as a table without the
+# row being looked for.
 #
 # Measured 2026-09-08, `E2E 1/4` on `main`: this script reported "there is no
 # INSTALLDIR row, so `msiexec INSTALLDIR=…` has nothing to override" for an
@@ -117,7 +119,7 @@ idt() {
         fail "msiinfo export $1 exited non-zero on $MSI. That is the reader failing, not a finding about the installer."
     fi
     local lines
-    lines=$(printf '%s\n' "$out" | grep -c . || true)
+    lines=$(grep -c . <<<"$out" || true)
     if [ "$lines" -lt 3 ]; then
         fail "msiinfo export $1 returned $lines usable line(s) for $MSI, and an IDT export carries three header lines before any row. The reader produced nothing, so nothing below is a claim about the installer — re-read the file before believing any row is missing."
     fi

--- a/.github/ship-oracle/verify-msi.sh
+++ b/.github/ship-oracle/verify-msi.sh
@@ -58,8 +58,18 @@ MSI=${1:?usage: verify-msi.sh <artifact.msi> <program directory> <producer|!prod
 DIR=${2:?usage: verify-msi.sh <artifact.msi> <program directory> <producer|!producer>}
 PRODUCER=${3:?usage: verify-msi.sh <artifact.msi> <program directory> <producer|!producer>}
 
+# STDERR, not stdout, and it is load-bearing rather than tidy. Several readers
+# here are called as `VAR=$(idt Directory)`, and a `fail` inside a command
+# substitution writes into VAR: the message is captured instead of shown, and
+# `exit 1` leaves only the subshell, so `set -e` aborts the script with nothing
+# printed at all. On stderr the message survives the substitution, and it cannot
+# contaminate the value a reader returns on stdout either.
+#
+# GitHub reads `::error` workflow commands from stderr the same as from stdout,
+# and `tests/e2e/ship-msi`'s `oracleExpectingFailure` concatenates both streams,
+# so nothing downstream can tell the difference except by working.
 fail() {
-    echo "::error title=Ship msi::$*"
+    echo "::error title=Ship msi::$*" >&2
     exit 1
 }
 
@@ -86,8 +96,32 @@ require msiinfo msiextract find sort cmp awk tr
 # print `error: libmsi_database_export / msiinfo: internal error (function failed)`
 # on EPIPE, which reads as a corrupt database and is nothing but the pipe closing —
 # the same run that measured the CRLF chased that for ten minutes first.
+# An IDT export, with the reader held to the same standard as `msiextract`
+# below: three header lines (columns, types, table+keys) precede the rows, which
+# is the assumption every `NR > 3` in this file already makes. Fewer than three
+# means the READER produced nothing usable, and that is not the same fact as a
+# table without the row being looked for.
+#
+# Measured 2026-09-08, `E2E 1/4` on `main`: this script reported "there is no
+# INSTALLDIR row, so `msiexec INSTALLDIR=…` has nothing to override" for an
+# installer that HAS one — four other cases in `tests/e2e/ship-msi` read that row
+# out of the same file in the same run, one of them reaching the byte round trip
+# beyond it. So a `msiinfo export` answered 0 without the table it had just
+# listed, and the accusation landed on the artifact. The mechanism is still
+# unexplained; what is settled is that the artifact was not at fault, and a
+# diagnostic pointing at the file for a fault in the reader is the direction the
+# header of this file calls the worst one.
 idt() {
-    msiinfo export "$MSI" "$1" | tr -d '\r'
+    local out
+    if ! out=$(msiinfo export "$MSI" "$1" | tr -d '\r'); then
+        fail "msiinfo export $1 exited non-zero on $MSI. That is the reader failing, not a finding about the installer."
+    fi
+    local lines
+    lines=$(printf '%s\n' "$out" | grep -c . || true)
+    if [ "$lines" -lt 3 ]; then
+        fail "msiinfo export $1 returned $lines usable line(s) for $MSI, and an IDT export carries three header lines before any row. The reader produced nothing, so nothing below is a claim about the installer — re-read the file before believing any row is missing."
+    fi
+    printf '%s\n' "$out"
 }
 
 [ -f "$MSI" ] || fail "$MSI does not exist"

--- a/tests/e2e/ship-msi/run.mjs
+++ b/tests/e2e/ship-msi/run.mjs
@@ -38,7 +38,7 @@
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 

--- a/tests/e2e/ship-msi/run.mjs
+++ b/tests/e2e/ship-msi/run.mjs
@@ -58,8 +58,8 @@ const MSI_NAME = `${BINARY}-1.2.3-1.${ARCH}.msi`;
  */
 const READERS = ['wixl', 'msiinfo', 'msiextract', 'msibuild'];
 
-function oracle(args) {
-    return execFileSync('bash', [join(ORACLE, 'verify-msi.sh'), ...args], { encoding: 'utf-8' });
+function oracle(args, opts) {
+    return execFileSync('bash', [join(ORACLE, 'verify-msi.sh'), ...args], { encoding: 'utf-8', ...opts });
 }
 
 /** Run the oracle from a working directory, the way the CI leg does. */
@@ -67,9 +67,19 @@ function oracleFrom(cwd, args) {
     return execFileSync('bash', [join(ORACLE, 'verify-msi.sh'), ...args], { encoding: 'utf-8', cwd });
 }
 
-function oracleExpectingFailure(args) {
+/**
+ * Run the oracle expecting a refusal, and return everything it said.
+ *
+ * `stdio` IS NAMED, and that is not tidiness. `verify-msi.sh`'s `fail` writes its
+ * `::error` workflow command to stderr, and `execFileSync` given no `stdio` of its
+ * own re-emits a captured stderr on the PARENT's. The runner reads workflow
+ * commands off stderr exactly as it does off stdout, so every refusal this suite
+ * ASKS for would annotate a job that passed. Naming the streams keeps the message
+ * on `error.stderr`, which is where the assertions read it from anyway.
+ */
+function oracleExpectingFailure(args, opts) {
     try {
-        oracle(args);
+        oracle(args, { stdio: ['ignore', 'pipe', 'pipe'], ...opts });
     } catch (error) {
         assert.equal(error.status, 1, `verify-msi.sh must exit 1, not ${error.status}`);
         return `${error.stdout ?? ''}${error.stderr ?? ''}`;
@@ -357,6 +367,35 @@ describe('CLI ship Windows installer E2E', { timeout: 10 * 60 * 1000 }, () => {
         cpSync(programDir, wrongName, { recursive: true });
         const failure = oracleExpectingFailure([msi, wrongName, 'msitools']);
         assert.match(failure, /INSTALLDIR is named/);
+    });
+
+    it('blames the READER, not the installer, when an export comes back empty', () => {
+        // THE INCIDENT, REPRODUCED — `E2E 1/4` on `main`, 2026-09-08: a
+        // `msiinfo export Directory` returned exit 0 without the table it had just
+        // listed, and the script reported "there is no INSTALLDIR row" about a file
+        // that has one, in a run where four other cases read that row out of it.
+        // The mechanism behind the empty export is unexplained; that the
+        // MISATTRIBUTION is a defect in this script is not, and this is what says
+        // so. A wrapper forwards every msiinfo call to the real one except that
+        // one, which is the smallest reproduction of what was observed.
+        //
+        // The discriminator is the second assertion. Remove `idt`'s header guard
+        // and the script still exits 1 here — on the sentence about the artifact.
+        const stub = join(tmpDir, 'reader-stub');
+        mkdirSync(stub, { recursive: true });
+        const realMsiinfo = execFileSync('bash', ['-c', 'command -v msiinfo'], { encoding: 'utf-8' }).trim();
+        writeFileSync(
+            join(stub, 'msiinfo'),
+            '#!/usr/bin/env bash\n' +
+                'if [ "$1" = export ] && [ "$3" = Directory ]; then exit 0; fi\n' +
+                `exec ${JSON.stringify(realMsiinfo)} "$@"\n`,
+            { mode: 0o755 },
+        );
+        const failure = oracleExpectingFailure([msi, programDir, 'msitools'], {
+            env: { ...process.env, PATH: `${stub}:${process.env.PATH}` },
+        });
+        assert.match(failure, /msiinfo export Directory returned 0 usable line\(s\)/);
+        assert.doesNotMatch(failure, /there is no INSTALLDIR row/);
     });
 
     it('the oracle refuses a producer the file does not claim', () => {

--- a/tests/e2e/ship-msi/run.mjs
+++ b/tests/e2e/ship-msi/run.mjs
@@ -471,7 +471,13 @@ describe('CLI ship Windows installer E2E', { timeout: 10 * 60 * 1000 }, () => {
         const notAnMsi = join(tmpDir, 'not-an.msi');
         writeFileSync(notAnMsi, 'this is not a compound file\n');
         try {
-            oracle([notAnMsi, programDir, 'msitools']);
+            // Named streams for the same reason `oracleExpectingFailure` names them,
+            // and this case needs it just as much. Measured in `E2E 1/4`, run
+            // 34227868797: `msiinfo suminfo` on a file that is not a compound file
+            // prints a WARNING, EXITS 0 and names no creating application, so the
+            // script's own `fail` fires — and its `::error` annotated that passing
+            // job with "the summary information names no creating application".
+            oracle([notAnMsi, programDir, 'msitools'], { stdio: ['ignore', 'pipe', 'pipe'] });
             assert.fail('verify-msi.sh accepted a file that is not an MSI');
         } catch (error) {
             assert.notEqual(error.status, 0);


### PR DESCRIPTION
## What happened

`E2E 1/4` on `main`, 2026-09-08. `tests/e2e/ship-msi`'s "refuses to report on an extraction
that produced nothing" failed because the oracle refused for the **wrong reason**: it said

```
::error title=Ship msi::there is no INSTALLDIR row, so `msiexec INSTALLDIR=…` has
nothing to override and the install location is not addressable
```

for an installer that **has** one. Four other cases in that file read that row out of the same
file in the same run — including the positive oracle 110 ms earlier, which prints
`INSTALLDIR = ProgramFiles64Folder\Ship Demo`, and one that reaches the byte round trip *beyond*
that check. So a `msiinfo export Directory` returned exit 0 without the table it had just
listed, and the accusation landed on the artifact.

That is the direction this file's own header calls the worst one for a diagnostic to point, and
it argues the case at length for `msiextract` — "a reader whose EXIT CODE is not an answer" —
while `idt()` right beside it was ungated:

```bash
idt() {
    msiinfo export "$MSI" "$1" | tr -d '\r'
}
```

The run went green on re-run and the scheduled run of the identical commit was green too, so the
artifact was never at fault. **The mechanism behind the empty export is still unexplained** —
`set -euo pipefail` rules out a crash, and there is no msitools on the machine I could hammer it
from. What is settled is the misattribution, and that is what this fixes.

## The change

**`idt` holds the reader to the same standard as `msiextract`.** An IDT export carries three
header lines — columns, types, table+keys — which is the assumption every `NR > 3` in this file
already makes. Fewer than three means the reader produced nothing usable, and that is a
different fact from a table without the row being looked for. Both outcomes now say so, and say
that nothing below is a claim about the installer.

**`fail` writes to stderr, and this half is load-bearing rather than tidy.** Every reader here
is called as `VAR=$(idt Directory)`, and `fail` inside a command substitution wrote its message
*into VAR*: captured instead of shown, with `exit 1` leaving only the subshell, so `set -e`
aborted the script having printed nothing at all. Without this, the guard above would have made
the failure **less** legible, not more. On stderr the message survives the substitution and
cannot contaminate the value a reader returns on stdout.

GitHub reads `::error` workflow commands from stderr the same as from stdout, and
`oracleExpectingFailure` concatenates both streams, so nothing downstream can tell the
difference except by working.

## Verified

No msitools on this machine, so the four reader outcomes were exercised against a stubbed
`msiinfo` with the real `fail` and `idt` bodies:

| stub | result |
|---|---|
| normal table (3 headers + 1 row) | passed through, 4 lines, `INSTALLDIR` row visible to the caller |
| exit 0, no output | `msiinfo export Directory returned 0 usable line(s)` |
| exit 0, 1 line | `msiinfo export Directory returned 1 usable line(s)` |
| exit 3 | `msiinfo export Directory exited non-zero` |

All three failures are visible on stderr from inside `$(...)`, which is the case that produced
nothing before. `bash -n` clean.

CI's `ship-msi` e2e is the real exercise of the happy path — it is what runs the oracle against
a genuine wixl-built installer.

## Two things review added

**Every deliberate refusal was annotating the job it passed.** `execFileSync` given no
`stdio` of its own re-emits a captured stderr on the parent's, and the runner reads `::error`
workflow commands off stderr as off stdout. So moving `fail` to stderr — necessary for the
guard above to be visible at all — handed all five `oracleExpectingFailure` refusals to the
runner as red annotations inside a *passing* shard. The harness now names its streams.

That fix then missed one call, excluded by reasoning rather than measurement: `the oracle
refuses a file it cannot read at all` goes through plain `oracle()`, and `msiinfo suminfo` on
a non-compound file prints a warning, **exits 0** and names no creating application — so the
script's own `fail` fires there too. Caught by reading the run's annotations. Comparing the
shard across the two heads:

| head | `E2E 1/4` | annotations |
|---|---|---|
| `457a10c0ad` | fail | `exit code 1` + `the summary information names no creating application…` |
| `e97ed3f9fe` | **pass** | **none** |

**The new guard now has the discriminator this file demands of every refusal in it.** A `PATH`
wrapper forwards every `msiinfo` call to the real binary except `export Directory`, which
exits 0 with no output — the smallest reproduction of what was observed. Its second assertion
is the discriminator: `assert.doesNotMatch(/there is no INSTALLDIR row/)` fails if the header
guard is removed. It ran at 80 ms against a real wixl-built installer, having previously died
at 0.7 ms on a missing `mkdirSync` import that neither `node --check` nor `oxlint` can see
(`no-undef` is off for `tests/`, since `process` is not declared a global there).

The four green cases that read `Directory` out of the real installer all passed *through* the
new guard without tripping it, which is the empty-table worry answered by measurement.
