### PR TITLE
docs(website): move Effect under a new Experiments rubric

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -154,7 +154,6 @@ export default defineConfig({
                     items: [
                         { slug: 'guides/native-adwaita-app' },
                         { slug: 'patterns/gobject-classes' },
-                        { slug: 'guides/effect' },
                         { slug: 'patterns/bridges', label: 'Bridge Widgets' },
                         { slug: 'guides/web-views' },
                         { slug: 'guides/storybook' },
@@ -240,6 +239,14 @@ export default defineConfig({
                         { slug: 'showcases/webrtc-video' },
                         { slug: 'showcases/express-webserver' },
                     ],
+                },
+                {
+                    // Third-party paradigms gjsify can host but does not own, and does not
+                    // recommend by default. A page here is an offer, not a route: it has to
+                    // say who should skip it before it says what it does.
+                    label: 'Experiments',
+                    collapsed: true,
+                    items: [{ slug: 'experiments/effect', label: 'Effect' }],
                 },
                 {
                     label: 'Internals',

--- a/website/src/content/docs/experiments/effect.mdx
+++ b/website/src/content/docs/experiments/effect.mdx
@@ -1,11 +1,44 @@
 ---
 title: Effect
-description: Typed errors from GIO, cancellation that actually stops the read, and cleanup that runs when the window closes. Effect's platform services over Gio.File and GLib, for GNOME apps written in TypeScript.
+description: An optional integration, not a recommended pattern. Effect's platform services over Gio.File and GLib - typed errors, cancellation that reaches GIO, and cleanup tied to a window. Most GNOME apps do not need it.
 ---
 
 import CommandTabs from '../../../components/CommandTabs.astro';
 
-Three things are awkward in every GJS app, and none of them is about widgets:
+:::caution[Read this first]
+This is an **experiment**, not part of the recommended way to build a GJSify app. Effect is a
+whole programming style, not a feature: adopting it changes how every function in your codebase
+is written, and nothing else on this site assumes you have.
+
+**Most GNOME apps should skip it.** If you are here because something on this page sounds
+useful, check the cheaper answer first — it usually exists.
+:::
+
+## Should you use this?
+
+Effect is a TypeScript library for programs whose hard part is failure, concurrency and
+cleanup rather than logic. It is very good at that, and it is a large thing to take on.
+
+**Probably not, if** your app opens a few files, does a couple of HTTP requests, and shows the
+result. Three lines of `try`/`finally`, one `Gio.Cancellable` passed by hand, and a small
+helper that turns a `GLib.Error` into something you can `switch` on will serve you better than
+a paradigm, and the next person reading your code will already know the language it is
+written in.
+
+**Possibly yes, if** your app runs a lot of I/O that can fail in ways you have to tell apart,
+that can be cancelled, and that overlaps — several services being reconciled against each
+other, a long import that a user may abandon halfway, a pipeline where "which step failed and
+why" is itself part of the domain. That is where `Effect<A, E, R>` starts giving back more
+than it costs, because the failure channel and the dependency set stop being conventions and
+become types the compiler checks.
+
+**In either case it stays optional.** `@gjsify/effect-platform` is a bridge, not a foundation:
+nothing else in GJSify depends on it, and no other page assumes it.
+
+## What the bridge actually provides
+
+If you have decided Effect is right for your app, three things about GNOME are otherwise
+awkward, and this is what the package answers:
 
 - **Every GIO failure looks the same.** A missing file, a permissions problem and a broken
   symlink all arrive as a `GLib.Error` carrying a number, and the number only means something
@@ -14,10 +47,6 @@ Three things are awkward in every GJS app, and none of them is about widgets:
   listing keeps going, finishes, and calls back into a widget that is gone.
 - **Cleanup is on you.** There is no place to say "release this when that window goes away",
   so it either happens by hand or it happens when the garbage collector feels like it.
-
-[Effect](https://effect.website) is a TypeScript library that answers all three, and
-`@gjsify/effect-platform` is its implementation over GNOME's own APIs: `Gio.File`, GLib, and
-GObject lifetimes.
 
 :::tip[This is not a UI framework]
 Effect does not render anything and does not replace Blueprint, Solid, Vue or React. Your
@@ -297,4 +326,4 @@ windows that use no Effect at all — tree-shaking works, and you pay for what y
 - The [`effect-adw-services` showcase](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/effect-adw-services)
   is a complete window built this way, and every snippet above is taken from it.
 - [UI Frameworks](/gjsify/frameworks/) for the rendering half, which Effect deliberately does
-  not touch.
+  not touch — and which, unlike this page, is part of the recommended path.

--- a/website/src/content/docs/frameworks/index.mdx
+++ b/website/src/content/docs/frameworks/index.mdx
@@ -486,6 +486,6 @@ the **real** widget tree on every launch:
   widget subclasses follow — the host resolves a subclass through its nearest registered
   ancestor
 - [Adwaita gallery](/gjsify/adwaita/) for the widgets themselves
-- [Effect](/gjsify/guides/effect/) for the half none of these covers — typed errors from GIO,
-  cancellation that stops the read, and cleanup tied to a window's lifetime. It renders nothing
-  and composes with whichever of the above you picked
+- [Effect](/gjsify/experiments/effect/) if you already write TypeScript in that style — an
+  optional, experimental integration for the non-rendering half. It is not part of the
+  recommended path and none of the above needs it


### PR DESCRIPTION
The page was under Guides, between GObject Classes and Bridge Widgets. Everything else
there is something an app author actually needs; Effect is a paradigm choice from outside.
The neighbourhood was an endorsement even though no sentence claimed one.

The text was the bigger problem. It opened on "three things are awkward in every GJS app",
which is an argument for adopting it, and it never said when not to. A page that only
argues for something is marketing, and moving it would just have hidden that one level down.

So: a new collapsed Experiments section at the foot of the sidebar, and a rewritten opening.
The page now leads with who should skip it, and says plainly that three lines of try/finally,
one Gio.Cancellable passed by hand and a small GLib.Error helper beat a paradigm for an app
that opens a few files. It names the case where Effect does earn its keep - a lot of
overlapping, cancellable I/O whose failure modes have to be told apart - and states that the
bridge stays optional, with nothing else in GJSify depending on it.

The UI Frameworks cross-link is neutral now: an optional, experimental integration that none
of the frameworks needs, rather than "the half none of these covers".

Note on tiers, since it looks like a shortcut and is not one: effect-platform is
gjsify.tier 3, but so are gtk-host and react-native, which are on the recommended path. Tier
does not carry this distinction and was not used as the reason.

Nothing moves in packages/ or tests/. The integration suite stays where it is and is worth
keeping regardless of whether anyone adopts Effect: it is the hardest scheduling consumer in
the tree, and the Path differential it brought found eleven real divergences in our own GLib
layer.
