### PR TITLE
perf(prebuilds): a checker need not rebuild what it checks

### DIFF
--- a/.github/prebuild-toolchain/changed-packages.mjs
+++ b/.github/prebuild-toolchain/changed-packages.mjs
@@ -102,6 +102,54 @@ const WORKFLOW = join(ROOT, '.github', 'workflows', 'prebuilds.yml');
  * the filter too (so a change to one triggers a run at all); this list is what
  * makes them rebuild EVERY package once a run has started.
  */
+/**
+ * Trigger paths that must START a run but must NOT rebuild every package.
+ *
+ * THE CRITERION IS "CAN IT CHANGE THE BYTES", which is narrower than "the
+ * build calls it". Rebuilding proves something about an artifact only when the
+ * changed input could have altered that artifact. A CHECKER cannot, however
+ * central it is to whether the artifact is accepted: a changed rule has to be
+ * re-VERIFIED, and re-verification needs the committed binary and the rule, not
+ * a compiler.
+ *
+ * All three entries below are checkers. `scripts/manifest-conformance/rules/`
+ * holds manifest and workflow rules only — `platforms-ci`, `pr-trigger-parity`,
+ * `tier`, `release-train`, `status-data` and so on. The two rules that do read a
+ * compiled binary, `prebuild-artifacts` and `prebuild-libc`, live in
+ * `packages/infra/manifest-conformance/lib/rules/` and are not under this path
+ * at all — so the glob forced eight architectures to recompile for changes that
+ * cannot reach a byte of any prebuild, while covering none of the half that can.
+ *
+ * NOTHING GOES UNVERIFIED BY THIS. They stay in the `paths:` filter, so a run
+ * still starts and the jobs that read the COMMITTED artifacts still run — and
+ * `audit-runtimes.yml` executes the whole registry, both halves, over the
+ * committed tree on every pull request and every push. That is where a rule
+ * change is answered, and it needs no rebuild to answer it.
+ *
+ * The case worth naming, because it is the one this trades away: a rule that
+ * TIGHTENS what an artifact must satisfy — a higher glibc floor, a narrower
+ * `DT_NEEDED` set — can make an already-committed binary invalid, and no
+ * rebuild here will notice. It does not go quiet, though: the audit reads those
+ * bytes against the new rule and goes RED, which is the loud half of the
+ * trade. The repair is then a toolchain or workflow change, and both of those
+ * ARE on the shared list, so the rebuild happens under the input that actually
+ * causes it. A stale binary passing silently is the failure this file exists to
+ * prevent, and that one is still impossible.
+ *
+ * MEASURED on the #1607 merge (`ba6ddd795c..c8ae146b84`), which touched
+ * `platforms-ci.mjs` plus two lines of workflow wiring: all 12 bridges were
+ * marked BUILD with `reason: shared input changed (…platforms-ci.mjs)` — an
+ * eight-architecture rebuild whose critical path is ~97 minutes of emulated
+ * riscv64. `prebuilds.yml` is still a shared input, because its steps DO shape
+ * the bytes, so that particular merge still rebuilds; what stops is a rebuild
+ * triggered by a rule ALONE.
+ */
+const VERIFY_ONLY_TRIGGERS = [
+    'scripts/check-refs-pin.mjs',
+    'scripts/check-prebuild-loader-path.mjs',
+    'scripts/manifest-conformance/**',
+];
+
 const SHARED_SCRIPTS = [
     'scripts/stage-prebuild.mjs',
     'scripts/check-refs-pin.mjs',
@@ -321,7 +369,10 @@ function buildSharedMatchers(pathFilters, packageDirs) {
     for (const s of SHARED_SCRIPTS) {
         if (!out.some((o) => o.glob === s)) out.push({ glob: s, re: globToRegExp(s) });
     }
-    return out;
+    // Applied LAST, so it holds whether the entry arrived from the `paths:`
+    // filter or from the supplement above — see VERIFY_ONLY_TRIGGERS for why a
+    // checker triggers a run without rebuilding what it checks.
+    return out.filter((o) => !VERIFY_ONLY_TRIGGERS.includes(o.glob));
 }
 
 // ─── self-check: the gate and the trigger must agree ───────────────────────

--- a/tests/e2e/prebuild-change-gate/run.mjs
+++ b/tests/e2e/prebuild-change-gate/run.mjs
@@ -259,23 +259,53 @@ describe('prebuild change gate — what counts as changed', () => {
         assert.deepEqual(classify(['refs/oxc']).build, ['oxfmt-native']);
     });
 
-    it('rebuilds every package when a shared input changes', () => {
+    it('rebuilds every package when an input that shapes the BYTES changes', () => {
         for (const shared of [
             '.github/workflows/prebuilds.yml',
             '.github/prebuild-toolchain/emulated-build.sh',
             'scripts/stage-prebuild.mjs',
-            'scripts/check-refs-pin.mjs',
-            'scripts/check-prebuild-loader-path.mjs',
-            // The three scripts above are thin CLI entry points; their substance lives in
-            // the conformance registry. A rule change alters what every build verifies, so
-            // naming only the wrappers would let the check move out from under the gate.
-            'scripts/manifest-conformance/rules/refs-pin.mjs',
-            'scripts/manifest-conformance/rules/platforms-ci.mjs',
-            'scripts/manifest-conformance/unchecked-fields.mjs',
         ]) {
             const { build, skip } = classify([shared]);
             assert.deepEqual(skip, [], `${shared} must rebuild everything`);
             assert.equal(build.length, packageCount());
+        }
+    });
+
+    it('a CHECKER starts a run and rebuilds nothing', () => {
+        // The distinction the shared list used to collapse. These three entries used to
+        // rebuild all twelve bridges, on the reasoning that "a rule change alters what
+        // every build verifies". It does — but verifying needs the COMMITTED binary and
+        // the rule, not a compiler, and `scripts/manifest-conformance/rules/` holds
+        // manifest and workflow rules only. The two rules that read a compiled binary,
+        // `prebuild-artifacts` and `prebuild-libc`, live under
+        // `packages/infra/manifest-conformance/lib/rules/` and were never in that glob.
+        //
+        // Measured on the #1607 merge: `platforms-ci.mjs` plus two lines of workflow
+        // wiring marked all twelve BUILD, an eight-architecture rebuild whose critical
+        // path is ~97 minutes of emulated riscv64.
+        const text = readFileSync(workflow, 'utf8');
+        for (const checker of [
+            'scripts/check-refs-pin.mjs',
+            'scripts/check-prebuild-loader-path.mjs',
+            'scripts/manifest-conformance/rules/refs-pin.mjs',
+            'scripts/manifest-conformance/rules/platforms-ci.mjs',
+            'scripts/manifest-conformance/unchecked-fields.mjs',
+        ]) {
+            const { build } = classify([checker]);
+            assert.deepEqual(build, [], `${checker} must rebuild nothing on its own`);
+        }
+        // The other half of the argument, and the half that makes the first half safe:
+        // they are still TRIGGERS, so the run starts and the jobs that read the committed
+        // artifacts still execute. Both `paths:` blocks, per the workflow's own
+        // repeated-VERBATIM rule — a trigger present on one event and not the other is
+        // how this would rot silently.
+        for (const glob of [
+            'scripts/check-refs-pin.mjs',
+            'scripts/check-prebuild-loader-path.mjs',
+            'scripts/manifest-conformance/**',
+        ]) {
+            const occurrences = text.split(`- '${glob}'`).length - 1;
+            assert.equal(occurrences, 2, `${glob} must stay in BOTH on: paths: blocks, so a run still starts`);
         }
     });
 


### PR DESCRIPTION
Every `paths:` entry outside a package directory became a SHARED input, so
changing a conformance rule recompiled all twelve native bridges. Rebuilding
proves something about an artifact only when the changed input could have
altered that artifact, and a checker cannot: a changed rule has to be
re-VERIFIED, and verifying needs the committed binary and the rule, not a
compiler.

The reasoning that put the glob there — "a rule change alters what every build
verifies, so naming only the wrappers would let the substance move out from
under the gate" — was right about the risk and wrong about the address. The
substance had moved, but not to where the glob points:
`scripts/manifest-conformance/rules/` holds manifest and workflow rules only
(`platforms-ci`, `pr-trigger-parity`, `tier`, `release-train`, `status-data`);
the two rules that read a compiled binary, `prebuild-artifacts` and
`prebuild-libc`, live in `packages/infra/manifest-conformance/lib/rules/` and
were never covered. So it recompiled eight architectures for changes that
cannot reach a byte, while covering none of the half that can.

MEASURED on the #1607 merge (`ba6ddd795c..c8ae146b84`), which touched
`platforms-ci.mjs` plus two lines of workflow wiring: all 12 bridges marked
BUILD with `reason: shared input changed (…platforms-ci.mjs)`, an
eight-architecture rebuild whose critical path is ~97 minutes of emulated
riscv64. After: a rule alone rebuilds 0 of 12; `stage-prebuild.mjs` still
rebuilds 12 of 12; that merge still rebuilds, because `prebuilds.yml` shapes
the bytes and stays on the list.

Nothing goes unverified. The three entries stay in BOTH `paths:` blocks, so a
run still starts and the jobs reading the committed artifacts still execute,
and `audit-runtimes.yml` runs the whole registry over the committed tree on
every pull request and push — which is where a rule change is answered.

The case this trades away, named rather than hoped away: a rule that TIGHTENS
what an artifact must satisfy can invalidate an already-committed binary, and
no rebuild here notices. It does not go quiet — the audit reads those bytes
against the new rule and goes red. The repair is then a toolchain or workflow
change, and both are on the shared list, so the rebuild happens under the input
that actually causes it. A stale binary passing SILENTLY is what this file
exists to prevent, and that stays impossible.

`tests/e2e/prebuild-change-gate` pins both directions: a checker rebuilds
nothing, an input that shapes the bytes rebuilds everything, and the three
checkers are asserted to remain in both `paths:` blocks — the half that makes
the first half safe. 38 tests pass.

