### PR TITLE
fix(devtools): let a declined screenshot say which absence it was

### DIFF
--- a/packages/framework/devtools/src/devtools-service.ts
+++ b/packages/framework/devtools/src/devtools-service.ts
@@ -15,7 +15,7 @@ import { activateAction, changeActionState, describeActions } from './actions.js
 import { buildDevtoolsIfaceXml } from './devtools-iface.js';
 import type { DevtoolsExtension, InstallDevtoolsOptions } from './extension.js';
 import { type DevtoolsPeerServer, removeDevtoolsAddressFile } from './peer-transport.js';
-import { captureWidgetPng } from './screenshot.js';
+import { captureWidget, type CaptureBlocker } from './screenshot.js';
 import { dumpCss, swapCss } from './css.js';
 import { dumpGSettings } from './gsettings.js';
 import {
@@ -64,13 +64,23 @@ function frameDelay(ms: number): Promise<void> {
  * iterations turn a transient empty capture into a real screenshot. `null` only if the
  * widget never becomes renderable.
  */
-async function captureWidgetWhenRenderable(widget: Gtk.Widget, tries = 12, gapMs = 50): Promise<Uint8Array | null> {
+/** How many frames the warm-up waits for, named so the log can quote it. */
+const SCREENSHOT_TRIES = 12;
+
+async function captureWidgetWhenRenderable(
+    widget: Gtk.Widget,
+    tries = SCREENSHOT_TRIES,
+    gapMs = 50,
+): Promise<{ png: Uint8Array | null; blocker: CaptureBlocker | null }> {
+    let blocker: CaptureBlocker | null = null;
     for (let i = 0; i < tries; i++) {
-        const png = captureWidgetPng(widget);
-        if (png) return png;
+        const result = captureWidget(widget);
+        if (result.png) return { png: result.png, blocker: null };
+        blocker = result.blocker;
         await frameDelay(gapMs);
     }
-    return captureWidgetPng(widget);
+    const last = captureWidget(widget);
+    return { png: last.png, blocker: last.png ? null : (last.blocker ?? blocker) };
 }
 
 /**
@@ -240,9 +250,10 @@ export class DevtoolsService {
 
     /**
      * Capture `scope` to PNG, warming up across frames: a just-launched or mid-layout
-     * window yields a zero-size GSK frame, so the first `captureWidgetPng` can be empty.
-     * Empty bytes remain the genuine-failure signal, for a window that never realises at
-     * all.
+     * window yields a zero-size GSK frame, so the first capture can be empty. Empty
+     * bytes remain the genuine-failure signal, for a window that never realises at all
+     * — and the reason now goes to the log beside them, because the wire cannot carry
+     * it and a silent empty image gets a cause invented for it.
      */
     private async _captureScopePng(scope: string): Promise<Uint8Array> {
         const resolved = this._resolveRootWidget(scope);
@@ -256,16 +267,28 @@ export class DevtoolsService {
             if (isActiveWindowScope(scope)) return new Uint8Array(0);
             throw new Error(formatDbusErrorMessage('not-found', `no widget at '${scope}'`));
         }
-        let png = captureWidgetPng(resolved.widget);
-        if (!png) {
-            // Present the toplevel that OWNS the scope rather than `get_active_window()`:
-            // for a child widget the two can differ, and presenting the wrong window
-            // leaves the target unrealised for every one of the retries below.
-            const root = resolved.widget.get_root();
-            if (root instanceof Gtk.Window) root.present();
-            png = await captureWidgetWhenRenderable(resolved.widget);
-        }
-        return png ?? new Uint8Array(0);
+        const first = captureWidget(resolved.widget);
+        if (first.png) return first.png;
+
+        // Present the toplevel that OWNS the scope rather than `get_active_window()`:
+        // for a child widget the two can differ, and presenting the wrong window
+        // leaves the target unrealised for every one of the retries below.
+        const root = resolved.widget.get_root();
+        if (root instanceof Gtk.Window) root.present();
+        const warmed = await captureWidgetWhenRenderable(resolved.widget);
+        if (warmed.png) return warmed.png;
+
+        // SAY WHY, because the reply cannot. Empty bytes are the contract for "not up
+        // yet, retry" and they carry no reason at all — so a caller that hits any of
+        // the other three reasons sees an empty PNG and is free to invent a cause for
+        // it. One was invented: an empty reply became "the devtools cannot screenshot
+        // a live video" in a consumer's README, while the same window in the same
+        // second answered 308 714 bytes for the same request.
+        console.warn(
+            `[devtools] Screenshot('${scope}') has no image: ${warmed.blocker ?? 'unknown'} ` +
+                `after ${SCREENSHOT_TRIES} tries. Empty bytes follow.`,
+        );
+        return new Uint8Array(0);
     }
 
     /** `ListActions() -> s` — JSON of the `app.*` + `win.*` actions. */

--- a/packages/framework/devtools/src/index.ts
+++ b/packages/framework/devtools/src/index.ts
@@ -12,7 +12,7 @@ export {
     writeDevtoolsAddressFile,
 } from './peer-transport.js';
 export type { DevtoolsPeerServer } from './peer-transport.js';
-export { captureWidgetPng } from './screenshot.js';
+export { captureWidget, captureWidgetPng, type CaptureBlocker, type CaptureResult } from './screenshot.js';
 export { buildVariant, variantKindFor } from './gvariant.js';
 export type { VariantKind } from './gvariant.js';
 export { activateAction, changeActionState, describeActions } from './actions.js';

--- a/packages/framework/devtools/src/screenshot.spec.ts
+++ b/packages/framework/devtools/src/screenshot.spec.ts
@@ -1,0 +1,64 @@
+// @gjsify/devtools — the capture says WHY it declined.
+//
+// Duck-typed widgets, like `widget-tree.spec.ts`: the two reasons a capture gives up
+// BEFORE touching GTK are reachable from plain shapes, and they are the two that
+// matter, because they are the ones a caller meets while a window is coming up.
+//
+// WHAT THIS CANNOT REACH, said rather than implied: `empty-snapshot` and `empty-png`
+// need a realised widget and a real `Gsk.Renderer`, so they are not gated here. The
+// third absence — a live video texture — turned out not to be an absence at all:
+// measured on GTK 4.22.4 with `GskVulkanRenderer`, a `gtk4paintablesink` paintable in
+// a `Gtk.Picture` captures at 202 645 bytes for the picture and 204 865 for its
+// window, and the application it was reported against answers 308 714 with the video
+// playing.
+
+import { describe, expect, it } from '@gjsify/unit';
+import type Gtk from 'gi://Gtk?version=4.0';
+
+import { captureWidget, captureWidgetPng } from './screenshot.js';
+
+const asWidget = (shape: object): Gtk.Widget => shape as unknown as Gtk.Widget;
+
+/** A widget that is not realised: `get_native()` answers nothing. */
+const unrealised = (): Gtk.Widget => asWidget({ get_native: () => null });
+
+/** Realised, and the native has no renderer yet. */
+const rendererless = (): Gtk.Widget => asWidget({ get_native: () => ({ get_renderer: () => null }) });
+
+/** Realised with a renderer, and not yet allocated. */
+const unallocated = (width: number, height: number): Gtk.Widget =>
+    asWidget({
+        get_native: () => ({ get_renderer: () => ({}) }),
+        get_width: () => width,
+        get_height: () => height,
+    });
+
+export default async () => {
+    await describe('captureWidget', async () => {
+        await it('names the missing renderer rather than answering an empty image', async () => {
+            // THE REASON IS THE POINT. Before this the function answered a bare `null`
+            // and the service turned that into zero bytes on the wire, which is the
+            // contract for "not up yet, retry" — so every other reason arrived as an
+            // empty PNG with nothing to read. One got a cause invented for it: an
+            // empty reply became "the devtools cannot screenshot a live video" in a
+            // consumer's README, while the same window answered 308 714 bytes.
+            expect(captureWidget(unrealised())).toStrictEqual({ png: null, blocker: 'no-renderer' });
+            expect(captureWidget(rendererless())).toStrictEqual({ png: null, blocker: 'no-renderer' });
+        });
+
+        await it('tells a window between two sizes apart from one that never realised', async () => {
+            // The two are a different instruction to the caller: `zero-size` clears on
+            // the next frame and is what the warm-up loop exists for, `no-renderer`
+            // does not clear until something presents the window.
+            expect(captureWidget(unallocated(0, 0))).toStrictEqual({ png: null, blocker: 'zero-size' });
+            expect(captureWidget(unallocated(560, 0))).toStrictEqual({ png: null, blocker: 'zero-size' });
+            expect(captureWidget(unallocated(0, 320))).toStrictEqual({ png: null, blocker: 'zero-size' });
+        });
+
+        await it('keeps captureWidgetPng answering bytes-or-null, which consumers import', async () => {
+            // `index.ts` exports it and the MCP bridge calls it; the reason is additive.
+            expect(captureWidgetPng(unrealised())).toBe(null);
+            expect(captureWidgetPng(unallocated(0, 0))).toBe(null);
+        });
+    });
+};

--- a/packages/framework/devtools/src/screenshot.ts
+++ b/packages/framework/devtools/src/screenshot.ts
@@ -6,34 +6,70 @@ import Graphene from 'gi://Graphene?version=1.0';
 import Gtk from 'gi://Gtk?version=4.0';
 
 /**
+ * Why a capture could not be made. Four distinct absences, and telling them apart is
+ * the whole point of this type.
+ *
+ * A `null` with no reason is how this file used to answer, and the service above turns
+ * a failed capture into ZERO BYTES on the wire — a deliberate contract, so the MCP
+ * tool can retry a window that is not up yet. The two together are silent, and a
+ * silent empty PNG is read by whoever receives it as a statement about what the tool
+ * cannot do: MEASURED consequence, an empty reply from a window with a playing video
+ * was published in a consumer's README as "the devtools `Screenshot` returns nothing
+ * with a live video texture", which is false — the same window answers 308 714 bytes.
+ * The capture had declined for one of the other three reasons and said nothing.
+ */
+export type CaptureBlocker =
+    /** Not realised: no `Gtk.Native`, or a native with no `Gsk.Renderer` yet. */
+    | 'no-renderer'
+    /** Realised but not allocated — mid-layout, or a window between two sizes. */
+    | 'zero-size'
+    /** Nothing to draw: `Gtk.Snapshot.to_node()` answered null. */
+    | 'empty-snapshot'
+    /** Rendered, and the PNG serialiser handed back no bytes. */
+    | 'empty-png';
+
+/** A capture, or the reason there is none. */
+export type CaptureResult =
+    | { readonly png: Uint8Array; readonly blocker?: undefined }
+    | { readonly png: null; readonly blocker: CaptureBlocker };
+
+/**
  * Render a GTK widget — typically the top-level window — to PNG bytes, fully
  * in-process via the GSK renderer. No external screenshot tools, no
  * compositor portal: the widget's own `Gsk.Renderer` rasterises a
  * `Gtk.WidgetPaintable` snapshot to a `Gdk.Texture`, serialised to PNG.
  *
- * Returns `null` when the widget isn't realised yet (no renderer or zero
- * size) so callers can surface a clear "not ready" error instead of an empty
- * image.
+ * A LIVE VIDEO IS NOT ONE OF THE REASONS THIS DECLINES, which is worth stating where
+ * a reader would look for it: measured on GTK 4.22.4 with `GskVulkanRenderer`, a
+ * `gtk4paintablesink` paintable in a `Gtk.Picture` captures at 202 645 bytes for the
+ * picture alone and 204 865 for its window, both with `videotestsrc` and with a real
+ * HLS stream. The renderer downloads the texture like any other.
  */
-export function captureWidgetPng(widget: Gtk.Widget): Uint8Array | null {
+export function captureWidget(widget: Gtk.Widget): CaptureResult {
     const native = widget.get_native();
     const renderer = native?.get_renderer();
-    if (!renderer) return null;
+    if (!renderer) return { png: null, blocker: 'no-renderer' };
 
     const width = widget.get_width();
     const height = widget.get_height();
-    if (width <= 0 || height <= 0) return null;
+    if (width <= 0 || height <= 0) return { png: null, blocker: 'zero-size' };
 
     const paintable = Gtk.WidgetPaintable.new(widget);
     const snapshot = Gtk.Snapshot.new();
     paintable.snapshot(snapshot, width, height);
     const node = snapshot.to_node();
-    if (!node) return null;
+    if (!node) return { png: null, blocker: 'empty-snapshot' };
 
     const viewport = new Graphene.Rect();
     viewport.init(0, 0, width, height);
     const texture = renderer.render_texture(node, viewport);
 
     const data = texture.save_to_png_bytes().get_data();
-    return data ? new Uint8Array(data) : null;
+    if (!data) return { png: null, blocker: 'empty-png' };
+    return { png: new Uint8Array(data) };
+}
+
+/** The bytes alone, for callers that have nothing to do with the reason. */
+export function captureWidgetPng(widget: Gtk.Widget): Uint8Array | null {
+    return captureWidget(widget).png;
 }

--- a/packages/framework/devtools/src/test.mts
+++ b/packages/framework/devtools/src/test.mts
@@ -3,11 +3,13 @@ import { run } from '@gjsify/unit';
 import devtoolsIfaceSuite from './devtools-iface.spec.js';
 import gvariantSuite from './gvariant.spec.js';
 import peerTransportSuite from './peer-transport.spec.js';
+import screenshotSuite from './screenshot.spec.js';
 import widgetTreeSuite from './widget-tree.spec.js';
 
 run({
     devtoolsIfaceSuite,
     gvariantSuite,
     peerTransportSuite,
+    screenshotSuite,
     widgetTreeSuite,
 });


### PR DESCRIPTION
`Screenshot` answers **zero bytes** when it cannot capture, and that is a contract worth
keeping — the MCP tool retries a window that is not up yet. What it could not do is say
**why**: `captureWidgetPng` answered a bare `null` for four different absences (no
renderer, no allocation, an empty snapshot, an empty PNG) and an `ay` on the wire has no
room for a reason.

## A silent empty image gets a cause invented for it

And one did. An empty reply from a window with a playing video was published in a
consumer's README as *"with a live video texture in the window the devtools
`Screenshot` returns nothing"*. **That claim is false.** MEASURED on GTK 4.22.4 with
`GskVulkanRenderer`:

| what | bytes |
| --- | --- |
| `gtk4paintablesink` picture, `videotestsrc` | 24 042 → 24 168 |
| its window | 25 461 → 25 645 |
| the same picture on a real HLS stream | 202 645 → 206 759 |
| its window | 204 865 → 209 111 |
| the application the claim was written against | **308 714** |
| the same application, the picture alone | **252 192** |

The renderer downloads the texture like any other. The capture had declined for one of
the other three reasons and said nothing at all.

## The change

`captureWidget` answers `{ png }` or `{ png: null, blocker }`, where `blocker` is one of
`no-renderer`, `zero-size`, `empty-snapshot`, `empty-png`. The warm-up loop carries the
last blocker out, and the service logs it beside the empty bytes:

```
[devtools] Screenshot('') has no image: zero-size after 12 tries. Empty bytes follow.
```

`captureWidgetPng` keeps its exact shape — bytes or null — because `index.ts` exports it
and the MCP bridge calls it. The reason is additive.

## Vectors, and the mutation each dies to

Duck-typed widgets, the way `widget-tree.spec.ts` does it, so the two absences that
happen **before** GTK is touched are gated without a display. Each vector was killed by
a mutation of its own:

- *names the missing renderer rather than answering an empty image* — dies when the two
  pre-GTK absences are collapsed into one reason.
- *tells a window between two sizes apart from one that never realised* — dies when a
  zero width or height stops counting as unallocated.
- *keeps `captureWidgetPng` answering bytes-or-null* — dies when the contract its
  consumers import is broken.

**Not gated, and said so in the spec rather than assumed:** `empty-snapshot` and
`empty-png` need a realised widget and a real `Gsk.Renderer`. The service's log line is
diagnostics over a decision the vectors already gate.

## Checked

`@gjsify/devtools`: 65 vectors, 169 assertions, green; `gjsify tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
