### PR TITLE
docs(website): the gallery's two panes, converged and measured

### DIFF
--- a/docs/adr/0034-widget-vocabulary-convergence.md
+++ b/docs/adr/0034-widget-vocabulary-convergence.md
@@ -27,7 +27,9 @@
   and `--app nativescript` instead of to an empty module, and § Amendment 13, which lands
   stage 8 — the construct-props bag on all 46 NativeScript widgets, the first change here to
   reach a CONSTRUCTOR, and the one that found § Context wrong about NativeScript's alignment
-  vocabulary.
+  vocabulary. § Amendment 14, 2026-09-09, CASHES stages 8 and 9 in on the documentation
+  surface — the move § Amendment 12 named and deliberately did not make — and puts a printed
+  distance behind it, so "the two snippets are closer" stops being unfalsifiable.
 - Date: 2026-08-29
 - Deciders: Pascal Garber
 - Related: [ADR 0027 § 9 (the goal)](0027-gtk-host-layer.md), [ADR 0028 § 6 (the alignment mechanism)](0028-widget-table-provenance.md), [ADR 0029 (the vocabulary in `@girs/*`)](0029-girs-widget-vocabulary.md), [ADR 0019 (ts-for-gir as a library; where the `.gir` travels)](0019-ts-for-gir-as-library.md), [ADR 0004 (headless core)](0004-headless-adwaita-core.md), [ADR 0032 (React Native on the host)](0032-react-native-on-the-gtk-host.md), [ADR 0033 (templates preferred)](0033-declarative-templates-preferred.md)
@@ -2532,3 +2534,119 @@ than closed: the attribute door has no coercer to hang it on, and a per-widget
 `set verticalAlignment` would shadow `View`'s own, which is the hazard
 `check-nativescript-xml-doors.mjs` arm 2 exists for. Same convergence question as
 `halign` / `valign`, and it retires with it.
+
+## Amendment 14, 2026-09-09 — the two snippets, cashed in and measured
+
+§ Amendment 12 closed with *"the two snippets are still not the same text, and this stage
+did not rewrite them"*, naming the `Adw.Avatar` block on `presentation.mdx` as the example.
+This amendment makes that move, and the interesting half is not the rewrite: it is that
+until now nothing in this repository could have told you whether stages 8 and 9 had bought
+anything on the surface they were argued for.
+
+### What moved
+
+Every `<Fragment slot="nativescript">` pane in the gallery is now written the way the port
+actually supports since 2026-09-05: `import Adw from 'gi://Adw?version=1'` where the pane
+needs only widgets, and the construct-props bag in place of the `new X(); x.a = …; x.b = …`
+run. Measured on `origin/main` before the change, across all `.mdx` under
+`website/src/content/docs/{adwaita,gtk}/`: **40 blocks carry both panes, 0 of 40 used the
+bag, 36 used the assignment form**, and every one imported `@gjsify/adwaita-nativescript`.
+
+Four panes keep that package import and each says why in the fence: three bind the TYPE
+`AdwViewPage` and one binds `NOTIFY_SIDEBAR_SELECTED`, a signal name. Neither is a widget,
+so neither has a namespace member, and § 3's "never a rename" is why they are not given one.
+The four `layout.mdx` panes keep it too, for a different reason: those are the blocks whose
+NativeScript window is an XML template plus a loader, so the pane is a `~/adw` barrel and a
+`Builder.load()` and never constructs a widget at all.
+
+### Two panes were DRIFT rather than a gap, and the arm is how they surfaced
+
+Neither was found by reading the port; both were found by putting the two texts side by
+side and asking what the difference was FOR. That is the census's real yield, one surface
+over from the `Typescript`/`TypeScript` finding the tree census produced.
+
+- **`Adw.ShortcutLabel`** showed one keycap where the preview, the `gjs` pane and the
+  Blueprint pane show five — alternatives, a range, a sequence, keys held together, and the
+  disabled placeholder. The port parses the same grammar: `shortcut-label.ts` calls
+  `@gjsify/adwaita-core`'s `parseShortcutLabel`, and both its setters rebuild. So the pane
+  was short for no reason, and it is now byte-identical to its sibling.
+- **`Adw.AlertDialog`** never marked its Delete response destructive, though
+  `setResponseAppearance` is right there. It takes the NICK
+  (`'default' | 'suggested' | 'destructive'`, `@gjsify/adwaita-core`'s own union) rather
+  than an `Adw.ResponseAppearance` constant — which is § 4's rule about enums, reached from
+  the documentation side rather than the constructor side.
+
+Both are the same shape as the `Adw.WrapBox` chip count the tree census found: a snippet
+that quietly showed less than the block it documents, with nothing comparing it to anything.
+
+### The measurement, and why it is a printed distance rather than a sentence
+
+`check-website-adwaita-gallery.mjs` arm 12 reads the two panes of each block and compares
+them after **one declared normalisation**: the lines that BIND the widget namespaces are read
+as the namespaces they bind, so `import { Adw, Gtk } from '@gjsify/adwaita-nativescript'` and
+the two `gi://` lines beside each other compare equal. That equivalence is exactly what stage
+9 established, and declaring it is what makes the number honest — **without it this very
+change would have cut the printed distance by forty lines while moving no program.**
+
+It lives in that file and not in `check-generated-website-data.mjs`, whose arm 11 holds the
+same claim over the gallery's two authored TREES: that arm's corpus is two generated data
+files, this one's is the authored `.mdx` blocks and their fences, which arm 5 there already
+reads.
+
+Measured, and PRINTED on every run rather than written here: 40 pairs, **0 identical and a
+line distance of 599 before**, 5 identical after, the remaining 35 ledgered with a reason
+that opens with the KIND of work closing it would take — `vocabulary` (a rename), `glyph`
+(the port's icon properties take an SVG source), `property` (renderer work, or never), or
+`composition` (two different programs). Where an entry names more than one, the most
+expensive kind wins, or the cheapest word would win every argument and the ledger would read
+as a rename list over a set of renderer gaps.
+
+Ledger entries are self-retiring, the shape arm 5b and arm 11 already have: a ledgered block
+whose two panes have BECOME one text fails. Both directions were A/B-proven on the real
+gallery — breaking an identical pair reports it as unledgered, closing a ledgered one reports
+the entry as stale.
+
+### One thing the self-test found about its own normalisation
+
+The partition vectors — a rule each, failing before any page is read, as
+`check-vocabulary-alignment.mjs` requires of itself — can only see a widening that changes a
+VERDICT, and the dangerous widenings mostly do not. Measured: widening the specifier set from
+`@gjsify/adwaita-nativescript` to `@gjsify/*`, so that a glyph import is swallowed into the
+marker too, left **every partition vector green** and moved only the distance. The marker
+carries the namespaces it binds, so two panes stayed two texts either way.
+
+So the transform is held on its OWN OUTPUT by a second vector list, and that is the only
+place "one declared normalisation" is a fact rather than a claim in a comment. Both
+widenings — the specifier set, and dropping the names from the marker — now go red there
+before a page is read.
+
+### A converged pane had to become MORE checkable, not less
+
+Stage 8's bag would have taken coverage away: `check-doc-fences.mjs`'s NativeScript arm holds
+every `x.p = v` in a `nativescript` fence against the port's declared members, and moving
+those writes into `new Adw.Avatar({ … })` would have moved them out of its sight — with its
+own vacuity guard the only thing left to notice. So the arm learned the second door, held by
+the SAME predicate, because they are the same claim about the widget; and both doors now
+refuse a getter with no setter, which a bag rejects by name and a bare assignment throws on in
+strict mode. Measured: 143 property writes held before, 153 after, and two A/B probes — an
+unknown key (`showInitals`) and a read-only one (`Adw.StatusPage.child`) — each red with its
+own message. The bag reader carries vectors of its own, because a key reader that quietly
+finds nothing passes every bag in the gallery.
+
+### What is deliberately left open
+
+- **Five of forty, and the rest is renderer work.** The `glyph` kind is one decision — the
+  port resolves no theme name, so every icon pane imports its glyph — and would close a whole
+  bucket at once. The `composition` kind splits into the four XML-loader panes, which are not
+  a divergence a rename could close, and the blocks where a `@nativescript/core` layout stands
+  in for a widget the port does not ship.
+- **`Gtk` is 5 of 106 on this renderer**, so a gjs pane reaching for any GTK widget outside
+  Button/DropDown/Entry/Image/MenuButton is a `property` entry by construction, not by
+  authoring.
+- **Nothing here runs either pane.** The panes are compared as TEXT and their properties are
+  held against the port's SOURCE; that a converged pane renders the same tree on a phone is
+  the same open question ADR 0027 § 9's conformance vectors close, and it is not closed here.
+- **The `--gi-renderer` flag is now load-bearing for a reader.** A NativeScript snippet opens
+  with a `gi://` line that resolves only when the build passes the flag, so each gallery page
+  says so in the paragraph that already explains how the two ports follow libadwaita's naming.
+  Nothing holds that sentence; arm 10 holds window TITLES in prose and this is not one.

--- a/scripts/check-doc-fences.mjs
+++ b/scripts/check-doc-fences.mjs
@@ -76,6 +76,17 @@
 //               a photograph instead: `shotEvidence`/`blankReason` in that package's
 //               `probe.ts`, which exist because a non-empty PNG is not proof.
 //
+//   NATIVESCRIPT
+//               inside a `nativescript` fence, every property a constructed widget
+//               is given — through `x.p = v` OR through the construct-props bag
+//               `new Adw.Avatar({ p: v })` (ADR 0034 § Amendment 13) — is one that
+//               widget declares or the ambient core slice does, and is not a getter
+//               with no setter. Both doors, one predicate: they are the same claim
+//               about the widget, and they fail differently for a reader — an
+//               unknown assignment sticks as a dead own-property at exit 0, an
+//               unknown bag key THROWS. The bag reader carries its own vectors,
+//               because a key reader that quietly finds nothing passes every bag.
+//
 //   CLASSES     every `adw-`-prefixed class in a `class=`/`className` value must
 //               appear somewhere in the tracked SCSS. The SCSS side is read as a
 //               loose token scan rather than a selector parse, because the
@@ -97,6 +108,8 @@ import { dirname, join, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+    chainOf,
+    matchingParen,
     membersOf,
     NS_CORE_TYPES,
     readCoreProperties,
@@ -617,18 +630,135 @@ const NS_CONSTRUCTION = new RegExp(
     'g',
 );
 
+/**
+ * Every `new Adw.Avatar(` in a fence, bound to a name or not.
+ *
+ * The SECOND door (ADR 0034 § Amendment 13) needs no variable: the class is in the `new`
+ * expression and the keys are in the argument list, so `group.addRow(new Adw.EntryRow({…}))`
+ * is judged where the assignment reader — which has to follow a binding — sees nothing.
+ */
+const NS_ANY_CONSTRUCTION = new RegExp(`\\bnew\\s+(${WIDGET_REFERENCE})\\s*\\(`, 'g');
+
+/**
+ * The TOP-LEVEL keys of an object literal, as written.
+ *
+ * A construct-props bag is authored by hand in a doc fence, so it carries the two shapes a
+ * naive `\w+:` scan gets wrong in opposite directions: a NESTED literal
+ * (`adjustment: { lower: 8 }`) whose inner keys belong to no widget, and a `// …` comment
+ * above a key, which is where these fences explain why a value is an SVG source. Depth is
+ * tracked over `{}`, `[]`, `()` and every quote form so that both land right.
+ *
+ * Shorthand (`{ title, description }`) is a key too — `title` there is `title: title` — and
+ * it is what the arrow-function pages in `view-switching.mdx` are written with.
+ */
+function objectLiteralKeys(text, open, close) {
+    const keys = [];
+    let depth = 0;
+    let atSegmentStart = true;
+    for (let i = open + 1; i < close; i += 1) {
+        const ch = text[i];
+        if (ch === '/' && text[i + 1] === '/') {
+            i = text.indexOf('\n', i);
+            if (i === -1) break;
+            continue;
+        }
+        if (ch === "'" || ch === '"' || ch === '`') {
+            for (i += 1; i < close && text[i] !== ch; i += 1) if (text[i] === '\\') i += 1;
+            atSegmentStart = false;
+            continue;
+        }
+        if (ch === '{' || ch === '[' || ch === '(') depth += 1;
+        else if (ch === '}' || ch === ']' || ch === ')') depth -= 1;
+        else if (ch === ',' && depth === 0) {
+            atSegmentStart = true;
+            continue;
+        }
+        if (depth !== 0 || !atSegmentStart) continue;
+        if (/\s/.test(ch)) continue;
+        const key = /^([A-Za-z_$][\w$]*)\s*[:,}]/.exec(`${text.slice(i, close)}}`);
+        if (key !== null) keys.push(key[1]);
+        atSegmentStart = false;
+    }
+    return keys;
+}
+
+/**
+ * The construct-props bag in `new Klass(…)`, or null when the call passes none.
+ *
+ * The LAST top-level object literal in the argument list, because that is where the bag is
+ * declared on all 46 classes: 45 take `constructor(props?)` and `AdwAlertDialog` takes
+ * `constructor(heading, body, props?)`. Reading the FIRST would hand `AdwAlertDialog`'s
+ * heading string to the key check on the day someone writes the third argument.
+ */
+function constructBagKeys(text, afterParen) {
+    const close = matchingParen(text, afterParen);
+    if (close === -1) return null;
+    let depth = 0;
+    let open = null;
+    let bag = null;
+    for (let i = afterParen + 1; i < close; i += 1) {
+        const ch = text[i];
+        if (ch === '/' && text[i + 1] === '/') {
+            const eol = text.indexOf('\n', i);
+            if (eol === -1 || eol > close) break;
+            i = eol;
+            continue;
+        }
+        // A quote inside a value carries braces of its own — `title: "a { b"` — and
+        // `matchingBrace` counts them, which is why this scan matches its own close
+        // rather than borrowing that reader.
+        if (ch === "'" || ch === '"' || ch === '`') {
+            for (i += 1; i < close && text[i] !== ch; i += 1) if (text[i] === '\\') i += 1;
+            continue;
+        }
+        if (ch === '{' || ch === '(' || ch === '[') {
+            if (ch === '{' && depth === 0) open = i;
+            depth += 1;
+        } else if (ch === '}' || ch === ')' || ch === ']') {
+            depth -= 1;
+            if (ch === '}' && depth === 0 && open !== null) bag = [open, i];
+        }
+    }
+    return bag === null ? null : objectLiteralKeys(text, bag[0], bag[1]);
+}
+
+/**
+ * Members of `klass` that a bag or an assignment cannot reach: a getter with no setter
+ * anywhere in the in-package chain.
+ *
+ * `membersOf` folds getters, setters and methods into one set, which is right for "does
+ * this widget know that word" and wrong for "can a caller write it". `applyConstructProps`
+ * walks the descriptors and refuses a `set: undefined` by name; a bare assignment to one
+ * throws in strict mode, which every NativeScript bundle is. So a fence handing
+ * `Adw.StatusPage` a `child` key is a crash a reader meets on the first run, and the
+ * looser set says the widget has it.
+ */
+function readOnlyMembers(sources, klass) {
+    const getters = new Set();
+    const setters = new Set();
+    for (const text of chainOf(sources, klass)) {
+        for (const [, name] of text.matchAll(/^ {4}get (\w+)[(<]/gm)) getters.add(name);
+        for (const [, name] of text.matchAll(/^ {4}set (\w+)[(<]/gm)) setters.add(name);
+    }
+    return new Set([...getters].filter((name) => !setters.has(name)));
+}
+
 function checkNativescriptFence(fence, where, nsWidgets, coreProperties, spellings) {
     const held = new Map();
     for (const [, variable, spelling] of fence.body.matchAll(NS_CONSTRUCTION)) {
         const klass = widgetClassOf(spelling, spellings);
         if (klass !== null && nsWidgets.has(klass)) held.set(variable, klass);
     }
+    /** Can a caller write `klass.name`, through either door? */
+    const writable = (klass, name) =>
+        (coreProperties.has(name) || membersOf(nsWidgets, klass).has(name)) &&
+        !(readOnlyMembers(nsWidgets, klass).has(name) && !coreProperties.has(name));
     let writes = 0;
     for (const [, variable, property] of fence.body.matchAll(/\b([A-Za-z0-9_$]+)\.([A-Za-z0-9_$]+)\s*=[^=]/g)) {
         const klass = held.get(variable);
         if (klass === undefined) continue;
         writes += 1;
-        if (coreProperties.has(property) || membersOf(nsWidgets, klass).has(property)) continue;
+        if (writable(klass, property)) continue;
         fail(
             `${where}:${fence.line}`,
             `\`${variable}.${property} = …\` — ${klass} has no such member, and NativeScript takes an ` +
@@ -637,7 +767,59 @@ function checkNativescriptFence(fence, where, nsWidgets, coreProperties, spellin
                 `(${NS_CORE_TYPES}) is the other place the name could legitimately live.`,
         );
     }
+    // The bag door. `x.p = v` and `new X({ p: v })` are the same claim about the widget,
+    // so they are held by the same predicate — and the bag is the door that TELLS the
+    // reader, because an unknown key throws where an assignment sticks silently.
+    for (const match of fence.body.matchAll(NS_ANY_CONSTRUCTION)) {
+        const klass = widgetClassOf(match[1], spellings);
+        if (klass === null || !nsWidgets.has(klass)) continue;
+        const keys = constructBagKeys(fence.body, match.index + match[0].length - 1);
+        if (keys === null) continue;
+        for (const key of keys) {
+            writes += 1;
+            if (writable(klass, key)) continue;
+            fail(
+                `${where}:${fence.line}`,
+                `\`new ${match[1]}({ ${key}: … })\` — ${klass} has no settable \`${key}\`, and a ` +
+                    'construct-props bag goes through the declared setters (ADR 0034 § Amendment 13), so ' +
+                    'this one THROWS on the first run rather than rendering nothing. The ambient core ' +
+                    `slice (${NS_CORE_TYPES}) is the other place the name could legitimately live.`,
+            );
+        }
+    }
     return writes;
+}
+
+/**
+ * Vectors for {@link constructBagKeys}, run before any fence is read.
+ *
+ * A key reader that quietly returns nothing reports every bag as clean, which is the
+ * vacuous pass this file refuses everywhere else — and the four shapes below are the ones
+ * the gallery actually writes, each of which a `\w+:` scan gets wrong: a nested literal
+ * whose inner keys belong to no widget, a comment above a key, a string value containing a
+ * brace, and property shorthand.
+ */
+const NS_BAG_FIXTURES = [
+    ['new Adw.Avatar()', []],
+    ['new Adw.Avatar({ size: 96, text: "Ada" })', ['size', 'text']],
+    ['new Adw.SpinRow({ title: "n", adjustment: { lower: 8, upper: 24 } })', ['title', 'adjustment']],
+    ['new Adw.Banner({\n// `title` takes plain text\ntitle: "x",\nrevealed: true })', ['title', 'revealed']],
+    ['new Adw.Banner({ title: "a { b", buttonLabel: "c" })', ['title', 'buttonLabel']],
+    ['new Adw.StatusPage({ iconName: icon, title, description })', ['iconName', 'title', 'description']],
+    ['new Adw.AlertDialog("Delete?", "body", { closeResponse: "cancel" })', ['closeResponse']],
+    ['new Adw.ToggleGroup({ }); group.setToggles([{ label: "List" }])', []],
+];
+
+for (const [source, want] of NS_BAG_FIXTURES) {
+    const at = /\bnew\s+[A-Za-z.]+\s*\(/.exec(source);
+    const got = constructBagKeys(source, at.index + at[0].length - 1) ?? [];
+    if (got.join(',') === want.join(',')) continue;
+    fail(
+        'nativescript/self-test',
+        `constructBagKeys(${JSON.stringify(source)}) read [${got.join(', ')}] and must read ` +
+            `[${want.join(', ')}]. The bag reader is wrong, so nothing it says about a fence can be ` +
+            'believed — and a reader that finds no key passes every bag in the gallery.',
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/check-website-adwaita-gallery.mjs
+++ b/scripts/check-website-adwaita-gallery.mjs
@@ -84,6 +84,33 @@
 //      exists, and growing the frameworks window from three blocks to forty left
 //      seven intros enumerating two windows where the reader meets three. Arms 1-9
 //      see neither: the strings never leave the prose.
+//  12. The `gjs` pane and the `nativescript` pane of one block are the SAME TEXT,
+//      or the block is ledgered in {@link PANE_TEXT_DIVERGENCES} with the reason and
+//      the KIND of work that would close it. ADR 0034 § Amendment 12 said the `gi://`
+//      arms were "the last of the two things keeping the website's Native TypeScript
+//      and NativeScript snippets from being the same text" and then left the snippets
+//      alone; nothing measured how far apart they were, so nothing could say whether
+//      the two stages that landed had bought anything.
+//
+//      THIS FILE AND NOT `check-generated-website-data.mjs`, whose arm 11 holds the
+//      same claim over the gallery's two authored TREES: that arm's corpus is two
+//      generated data files and it never opens an `.mdx`, while this file's corpus IS
+//      the authored blocks and their `<Fragment>` panes — arm 5 already reads them.
+//
+//      ONE declared normalisation, and its reason: the lines that BIND the widget
+//      namespaces are read as the namespaces they bind, so
+//      `import { Adw, Gtk } from '@gjsify/adwaita-nativescript'` and
+//      `import Adw from 'gi://Adw?version=1'` beside `import Gtk from 'gi://Gtk?version=4.0'`
+//      compare equal. That equivalence is what stage 9 established, and holding it
+//      here is what stops the printed distance from being bought by editing forty
+//      import lines. Nothing else is normalised: an `@gjsify/adwaita-icons` or
+//      `@nativescript/core` import is a real difference and stays one.
+//
+//      Self-retiring, the shape arm 5b and arm 11 of the sibling gate already have —
+//      a ledgered block whose two panes have BECOME the same text fails, so a reason
+//      cannot outlive what it was recorded for. The partition and the DISTANCE are
+//      PRINTED on every run and written down nowhere: a count in a header is the
+//      drift this gallery has already paid for twice.
 //   9. The LIVE PREVIEW is the FIRST pane of the window that runs the widget, in
 //      {@link WINDOW_COMPONENT} — the file that draws a window, which is where pane
 //      order is decided.
@@ -395,6 +422,418 @@ function sidebarGroup(text, label) {
     const end = text.indexOf(']', start);
     if (end === -1) return null;
     return [...text.slice(start, end).matchAll(/\bslug:\s*'([^']+)'/g)].map(([, slug]) => slug);
+}
+
+// --- arm 12: the two authored PANES of one block, and the distance between them ---
+
+/**
+ * The two panes of a block, dedented, as line arrays — or null where the block has
+ * fewer than two.
+ *
+ * The fence body and not the fragment: a `<Fragment>` carries MDX indentation and a
+ * ```ts opener, neither of which is part of the program a reader copies.
+ */
+function panePair(body) {
+    const panes = {};
+    const fence = /<Fragment slot="(gjs|nativescript)">\s*```[a-z]*\n([\s\S]*?)```/g;
+    for (const [, slot, code] of body.matchAll(fence)) panes[slot] = code;
+    if (panes.gjs === undefined || panes.nativescript === undefined) return null;
+    const dedent = (text) => {
+        const lines = text.replace(/^\n+|\s+$/g, '').split('\n');
+        const filled = lines.filter((line) => line.trim() !== '');
+        const indent = filled.length === 0 ? 0 : Math.min(...filled.map((line) => /^ */.exec(line)[0].length));
+        return lines.map((line) => line.slice(indent));
+    };
+    return { gjs: dedent(panes.gjs), nativescript: dedent(panes.nativescript) };
+}
+
+/**
+ * A line that BINDS the widget namespaces, either way it can be spelled.
+ *
+ * `Gio` is deliberately absent: the `gi://` arms answer `Adw` and `Gtk` and nothing
+ * else (ADR 0034 § Amendment 12), so a `gi://Gio` import is a namespace the port has
+ * no counterpart for and a real difference between two panes.
+ */
+const NAMESPACE_IMPORT =
+    /^import (?:(Adw|Gtk)|\{\s*(Adw|Gtk)(?:,\s*(Adw|Gtk))?\s*\}) from '(?:gi:\/\/(?:Adw|Gtk)\?version=[^']+|@gjsify\/adwaita-nativescript)';$/;
+
+/**
+ * THE ONE NORMALISATION. A run of namespace-import lines becomes a single marker
+ * naming the namespaces it binds.
+ *
+ * A run and not a line, because `gi://` needs one import per namespace where the
+ * package barrel needs one for both — the two spellings differ in LINE COUNT, and a
+ * per-line rewrite would leave that difference standing while claiming to have
+ * removed it.
+ */
+function normalisePane(lines) {
+    const out = [];
+    let bound = null;
+    const flush = () => {
+        if (bound === null) return;
+        out.push(`«widget vocabulary: ${[...bound].sort().join(', ')}»`);
+        bound = null;
+    };
+    for (const line of lines) {
+        const match = NAMESPACE_IMPORT.exec(line.trim());
+        if (match === null) {
+            flush();
+            out.push(line);
+            continue;
+        }
+        bound ??= new Set();
+        for (const name of match.slice(1)) if (name !== undefined) bound.add(name);
+    }
+    flush();
+    return out;
+}
+
+/** Levenshtein over LINES: how many lines a reader would have to add, drop or retype. */
+function paneDistance(a, b) {
+    const row = Array.from({ length: b.length + 1 }, (_, i) => i);
+    for (let i = 1; i <= a.length; i += 1) {
+        let diagonal = row[0];
+        row[0] = i;
+        for (let j = 1; j <= b.length; j += 1) {
+            const above = row[j];
+            row[j] = a[i - 1] === b[j - 1] ? diagonal : 1 + Math.min(row[j], row[j - 1], diagonal);
+            diagonal = above;
+        }
+    }
+    return row[b.length];
+}
+
+/**
+ * The kinds a divergence reason may open with, and the WORK each names.
+ *
+ * The kind is what closing the WHOLE entry would take, so where an entry carries more
+ * than one the most expensive wins: `composition` > `property` > `glyph` > `vocabulary`.
+ * Without that rule the cheapest word would win every argument, and the ledger would
+ * read as a rename list over a set of renderer gaps.
+ */
+const PANE_DIVERGENCE_KINDS = new Map([
+    ['vocabulary', 'same widgets and same UI; a method, property or value is spelled differently — a rename'],
+    [
+        'glyph',
+        "the port's icon properties take an SVG SOURCE, so the pane imports the glyph — closes when the " +
+            'port resolves theme names',
+    ],
+    ['property', 'one side sets something the other has no counterpart for — renderer work, or never'],
+    [
+        'composition',
+        'two different programs: an XML template plus its loader, or a @nativescript/core layout standing ' +
+            'in for a widget',
+    ],
+]);
+
+/** The kinds and what each one MEANS, for the two failures that ask an author to pick one. */
+const paneKindMenu = () =>
+    [...PANE_DIVERGENCE_KINDS].map(([kind, means]) => `      ${kind}: ${means}`).join('\n');
+
+/**
+ * Blocks whose two panes are NOT the same text, and why.
+ *
+ * Every entry is self-retiring: the day its two panes agree, arm 12 fails here rather
+ * than passing over a reason whose cause is gone. The blocks that DO agree are
+ * deliberately absent — that set is derived and printed on every run, and writing it
+ * down beside this one would be the second copy that drifts.
+ */
+const PANE_TEXT_DIVERGENCES = {
+    'Adw.PreferencesGroup':
+        "vocabulary: rows go in through addRow() where libadwaita's add() takes any widget, the header " +
+        'button is text/styleClasses against label/add_css_class(), and it takes no alignment — the port ' +
+        'places a header suffix itself.',
+    'Adw.ActionRow':
+        'property: the port’s Gtk.Button is text-only, so the trailing chevron is a Gtk.Image rather than ' +
+        'a flat button; add_prefix/add_suffix are setPrefix/setSuffix, and both glyphs are SVG sources.',
+    'Adw.ComboRow':
+        'vocabulary: the model is a string array where GTK takes a Gtk.StringList. The portable value shape ' +
+        'is what would close it, and it is the same question ADR 0034 § 1 asks of every value.',
+    'Adw.SpinRow':
+        "property: the adjustment is @gjsify/adwaita-core's AdwAdjustment where GTK takes a Gtk.Adjustment, " +
+        'and the port installs no `digits` — it renders the value the state machine holds.',
+    'Adw.ExpanderRow': 'vocabulary: add_row() is addRow() on the port, and nothing else differs.',
+    'Adw.ButtonRow':
+        'glyph: startIconName takes an SVG source rather than a theme name, so the pane imports the glyph; ' +
+        'and a style class is className rather than add_css_class().',
+    'Adw.ButtonContent':
+        "composition: the port's Gtk.Button is text-only, so the button around the content is a " +
+        '@nativescript/core StackLayout carrying the Adwaita classes; the icon is an SVG source.',
+    'Adw.SplitButton':
+        'vocabulary: the menu is a plain array where GTK takes a Gio.Menu with action names — a namespace ' +
+        'the gi:// arms deliberately do not answer — and the icon is an SVG source.',
+    'Adw.ToggleGroup':
+        'property: the port has no Adw.Toggle widget; setToggles() takes plain descriptors, and each icon is ' +
+        'an SVG source.',
+    'Adw.Toast':
+        'property: the port has no Adw.Toast widget at all — showToast() is the whole API, its timeout is in ' +
+        'milliseconds, and the overlay takes its content through setContent().',
+    'Adw.AlertDialog':
+        'composition: heading and body are constructor positionals, the response appearance is the NICK ' +
+        'rather than an Adw.ResponseAppearance constant, and present() RESOLVES to the chosen response ' +
+        "instead of taking a parent — the platform's own confirm chrome stands in for the dialog.",
+    'Adw.AboutDialog':
+        'property: the port exposes scalar fields only — no developers, designers or licenseType — so the ' +
+        'credits fold into the developer line and the application icon is a character rather than a theme name.',
+    'Adw.PreferencesDialog':
+        "glyph: the page icon is an SVG source; beside it the group's rows go in through addRow()/addGroup(), " +
+        'the combo model is an array and the adjustment is the portable shape.',
+    'Adw.Clamp':
+        'composition: the NativeScript window splits into an XML template and a loader, so this pane is the ' +
+        '`~/adw` barrel the template’s xmlns resolves to plus a Builder.load(), not a widget construction.',
+    'Adw.HeaderBar':
+        'composition: same split as Adw.Clamp — two barrels (`~/adw`, `~/gtk`) and the loader; the tree the ' +
+        'gjs pane builds is the XML tab beside this one.',
+    'Adw.ToolbarView':
+        'composition: same split as Adw.Clamp, plus the three glyphs an XML attribute cannot carry, which the ' +
+        'loader hands to views the template gave ids.',
+    'Adw.WrapBox':
+        'composition: same split as Adw.Clamp — the chip run is a fixed tree, so it lives in the template and ' +
+        'this pane loads it.',
+    'Adw.NavigationSplitView':
+        'property: the port has no Adw.NavigationPage, Adw.SidebarSection or Adw.SidebarItem, so the sidebar ' +
+        'takes a flat label list and each pane is a toolbar view directly.',
+    'Adw.OverlaySplitView': 'property: the same three missing widgets as Adw.NavigationSplitView, one block over.',
+    'Adw.NavigationView':
+        'property: pages are pushed by TAG rather than by widget, there is no Adw.NavigationPage to wrap them, ' +
+        'and the port’s Gtk.Button is text-only with a `tap` listener rather than a `clicked` signal.',
+    'Adw.Sidebar':
+        'composition: the port’s sidebar takes a flat label list with no per-item subtitle or icon, the ' +
+        'selection notify is an event NAME, and the two panes sit in a @nativescript/core GridLayout.',
+    'Adw.BottomSheet':
+        'composition: @nativescript/core’s StackLayout and Label stand in for Gtk.Box and Gtk.Label, which ' +
+        'the port does not ship, and the boxed list is built without prefixes.',
+    'Adw.Avatar':
+        'glyph: iconName takes the SVG SOURCE rather than a theme name, so the fallback glyph is imported and ' +
+        'handed in. Everything else about the two panes is already one text.',
+    'Adw.Banner':
+        'composition: the gjs pane wraps the banner in a sized Gtk.Box to give a full-width widget something ' +
+        'to fill; the port lays that out itself, and its banner label is plain text with no markup subset.',
+    'Adw.Spinner':
+        'property: the port sizes a spinner with `size`, where GTK asks for a width, a height and two ' +
+        'alignments — the port has no layout surface to put a size request on.',
+    'Adw.StatusPage':
+        'glyph: the icon is an SVG source; beside it `child` is setChild() and the button’s caption and ' +
+        'classes are text/styleClasses.',
+    'Adw.ViewSwitcher':
+        'property: the port has no Adw.ViewStack page API behind the switcher — setViews() takes title, icon ' +
+        'and content together — and each icon is an SVG source.',
+    'Adw.ViewSwitcherBar':
+        'property: the port’s view stack has no items-changed signal, so refresh() stands in for it by hand, ' +
+        'and each page icon is an SVG source.',
+    'Adw.TabView':
+        'property: the port has no Adw.TabBar and no Adw.TabPage; setViews() carries the chips and the pages ' +
+        'together, and the page icon is an SVG source.',
+    'Adw.InlineViewSwitcher':
+        'property: the port has no displayMode enum — an empty title is icons-only and an absent icon is ' +
+        'labels-only — and the switcher takes its pages through setViews() rather than binding a stack.',
+    'Adw.Carousel':
+        'composition: the port has no Adw.CarouselIndicatorDots (the carousel draws its own row) and no ' +
+        'Gtk.Box or Gtk.Label, so each card is a @nativescript/core StackLayout.',
+    'Gtk.Button':
+        'property: the port’s Gtk.Button is text-only, so the circular icon-only variant has no counterpart ' +
+        'at all; label/add_css_class() are text/styleClasses and the wrap box takes no alignment.',
+    'Gtk.MenuButton':
+        'property: the menu is a plain array where GTK takes a Gio.Menu with action names, there is no popover ' +
+        'so `primary` has no counterpart, and the icon is an SVG source.',
+    'Gtk.Entry':
+        'property: widthRequest and halign are GTK size and alignment requests, and the port has no layout ' +
+        'surface to put them on.',
+    'Gtk.DropDown':
+        'property: the port has no Gtk.PropertyExpression, no Gtk.StringObject and no search field, so the ' +
+        'model is a string array and enableSearch has no counterpart.',
+};
+
+/**
+ * The rules of arm 12, over a world of pairs — a pure function, so the vectors below
+ * can break each one with no gallery on disk.
+ */
+function panePartitionProblems(world) {
+    const problems = [];
+    let identical = 0;
+    let distance = 0;
+    for (const { title, gjs, nativescript } of world.pairs) {
+        const a = normalisePane(gjs);
+        const b = normalisePane(nativescript);
+        const gap = paneDistance(a, b);
+        const same = gap === 0;
+        if (same) identical += 1;
+        distance += gap;
+        const ledgered = Object.hasOwn(world.ledger, title);
+        if (same && ledgered) {
+            problems.push(
+                `${title}: ledgered as a pane divergence and its two panes are now the SAME TEXT. The reason ` +
+                    'has been closed — delete the entry, so the gallery stops carrying a reason for a difference ' +
+                    'that is gone.',
+            );
+        }
+        if (!same && !ledgered) {
+            problems.push(
+                `${title}: its \`gjs\` and \`nativescript\` panes are ${gap} line(s) apart and ` +
+                    'nothing says why. ADR 0034 stages 8 and 9 make the two the same text wherever the port has ' +
+                    'the widget and the property; where it does not, record the reason and its kind in ' +
+                    `PANE_TEXT_DIVERGENCES:\n${paneKindMenu()}`,
+            );
+        }
+    }
+    const titles = new Set(world.pairs.map((pair) => pair.title));
+    for (const [title, reason] of Object.entries(world.ledger)) {
+        if (!titles.has(title)) {
+            problems.push(
+                `${title}: ledgered as a pane divergence, and no block has both a \`gjs\` and a ` +
+                    '`nativescript` pane under that title. A stale entry reads as considered when it is merely ' +
+                    'forgotten.',
+            );
+        }
+        const kind = /^([a-z]+):/.exec(reason)?.[1];
+        if (kind !== undefined && PANE_DIVERGENCE_KINDS.has(kind)) continue;
+        problems.push(
+            `${title}: its divergence reason opens with ${kind === undefined ? 'no kind' : `"${kind}"`}, and a ` +
+                `reason must open with one of:\n${paneKindMenu()}`,
+        );
+    }
+    if (world.pairs.length === 0) {
+        problems.push('no gallery block carries both a `gjs` and a `nativescript` pane — arm 12 proved nothing');
+    }
+    return { problems, identical, distance };
+}
+
+/**
+ * Vectors for arm 12, every one of which must FAIL before a page is read.
+ *
+ * The last two are about the NORMALISATION itself and are the reason this list exists:
+ * one proves it applies (the two import spellings really do compare equal), the other
+ * that it is no WIDER than declared (a glyph import is not erased with them). A
+ * normalisation that quietly grew would make every pane agree and every ledger entry
+ * fail as stale, which reads like progress.
+ */
+const PANE_VECTORS = [
+    ['the aligned baseline', { pairs: [{ title: 'A', gjs: ['x'], nativescript: ['x'] }], ledger: {} }, null],
+    [
+        'two panes apart with nothing saying why',
+        { pairs: [{ title: 'A', gjs: ['x'], nativescript: ['y'] }], ledger: {} },
+        'nothing says why',
+    ],
+    [
+        'a ledger entry whose two panes have become one text',
+        { pairs: [{ title: 'A', gjs: ['x'], nativescript: ['x'] }], ledger: { A: 'vocabulary: gone' } },
+        'now the SAME TEXT',
+    ],
+    [
+        'a ledger entry for a block with no pair',
+        {
+            pairs: [{ title: 'A', gjs: ['x'], nativescript: ['y'] }],
+            ledger: { A: 'vocabulary: r', B: 'vocabulary: r' },
+        },
+        'no block has both',
+    ],
+    [
+        'a reason that opens with no kind',
+        { pairs: [{ title: 'A', gjs: ['x'], nativescript: ['y'] }], ledger: { A: 'they differ' } },
+        'opens with no kind',
+    ],
+    [
+        'a reason that opens with a kind nothing declares',
+        { pairs: [{ title: 'A', gjs: ['x'], nativescript: ['y'] }], ledger: { A: 'style: they differ' } },
+        'opens with "style"',
+    ],
+    ['no pair at all', { pairs: [], ledger: {} }, 'arm 12 proved nothing'],
+    [
+        'THE NORMALISATION APPLIES: the two import spellings are one text',
+        {
+            pairs: [
+                {
+                    title: 'A',
+                    gjs: ["import Adw from 'gi://Adw?version=1';", "import Gtk from 'gi://Gtk?version=4.0';", 'x'],
+                    nativescript: ["import { Adw, Gtk } from '@gjsify/adwaita-nativescript';", 'x'],
+                },
+            ],
+            ledger: { A: 'vocabulary: stale, because the two are one text' },
+        },
+        'now the SAME TEXT',
+    ],
+    [
+        // A CONTROL, clean on purpose: its cleanliness is what a WIDER normalisation
+        // would destroy. The marker carries the namespaces it binds, so a pane that
+        // reaches for `Gtk` and one that does not are still two texts. Drop the names
+        // from the marker — the tempting simplification, since every marker then reads
+        // alike — and these two become one text, at which point the self-retiring rule
+        // fires on an entry that is still true. Measured both ways.
+        'THE NORMALISATION IS NO WIDER: binding Gtk is not the same as not binding it',
+        {
+            pairs: [
+                {
+                    title: 'A',
+                    gjs: ["import Adw from 'gi://Adw?version=1';", "import Gtk from 'gi://Gtk?version=4.0';", 'x'],
+                    nativescript: ["import Adw from 'gi://Adw?version=1';", 'x'],
+                },
+            ],
+            ledger: { A: 'property: the port has no counterpart for the Gtk widget beside it' },
+        },
+        null,
+    ],
+];
+
+/**
+ * What the one normalisation does, asserted directly.
+ *
+ * The partition vectors above can only see a widening that changes a VERDICT, and the
+ * dangerous ones mostly do not: swallowing a glyph import into the marker run still
+ * leaves two panes two texts, because the marker names what it binds. Measured — with
+ * the specifier alternative widened to `@gjsify/*`, every partition vector stayed
+ * green and only the distance moved. So the transform is held on its own OUTPUT, which
+ * is the only place "one declared normalisation" is a fact rather than a claim in a
+ * comment.
+ */
+const PANE_NORMALISATION_VECTORS = [
+    [
+        ["import Adw from 'gi://Adw?version=1';", "import Gtk from 'gi://Gtk?version=4.0';", 'x'],
+        ['«widget vocabulary: Adw, Gtk»', 'x'],
+    ],
+    [["import { Adw, Gtk } from '@gjsify/adwaita-nativescript';", 'x'], ['«widget vocabulary: Adw, Gtk»', 'x']],
+    [["import { Adw } from '@gjsify/adwaita-nativescript';"], ['«widget vocabulary: Adw»']],
+    // NOT normalised, each for its own reason: a glyph is a value the port needs and
+    // libadwaita does not, `@nativescript/core` is a toolkit GJS has no counterpart
+    // for, and `gi://Gio` is a namespace the arms deliberately do not answer.
+    [
+        ["import { folderSymbolic } from '@gjsify/adwaita-icons/places';"],
+        ["import { folderSymbolic } from '@gjsify/adwaita-icons/places';"],
+    ],
+    [["import { StackLayout } from '@nativescript/core';"], ["import { StackLayout } from '@nativescript/core';"]],
+    [["import Gio from 'gi://Gio?version=2.0';"], ["import Gio from 'gi://Gio?version=2.0';"]],
+    // A RUN, not a line: only lines that sit together collapse into one marker.
+    [
+        ["import Adw from 'gi://Adw?version=1';", '', "import Gtk from 'gi://Gtk?version=4.0';"],
+        ['«widget vocabulary: Adw»', '', '«widget vocabulary: Gtk»'],
+    ],
+];
+
+const paneSelfTestFailures = [];
+for (const [input, want] of PANE_NORMALISATION_VECTORS) {
+    const got = normalisePane(input);
+    if (got.join('\n') === want.join('\n')) continue;
+    paneSelfTestFailures.push(
+        `normalisePane(${JSON.stringify(input)}) produced ${JSON.stringify(got)} and must produce ` +
+            `${JSON.stringify(want)}. The one declared normalisation is not the one that runs.`,
+    );
+}
+for (const [label, world, expected] of PANE_VECTORS) {
+    const { problems } = panePartitionProblems(world);
+    if (expected === null) {
+        if (problems.length > 0) paneSelfTestFailures.push(`${label} should be clean, got: ${problems.join(' | ')}`);
+        continue;
+    }
+    if (problems.length === 0) paneSelfTestFailures.push(`${label} produced NO problem — that rule is not holding`);
+    else if (!problems.some((problem) => problem.includes(expected))) {
+        paneSelfTestFailures.push(
+            `${label} failed for the wrong reason (wanted "${expected}"): ${problems.join(' | ')}`,
+        );
+    }
+}
+if (paneSelfTestFailures.length > 0) {
+    console.error('check-website-adwaita-gallery: arm 12 SELF-TEST failed — the check itself is broken:');
+    for (const failure of paneSelfTestFailures) console.error(`  - ${failure}`);
+    process.exit(1);
 }
 
 // A section declares the GIR namespace its widgets carry, and `bareName` decides
@@ -798,6 +1237,15 @@ for (const section of GALLERY_SECTIONS) {
     );
 }
 
+// --- arm 12: the same block, written twice, and how far apart the two are ---
+
+const panePairs = blocks.flatMap((block) => {
+    const pair = panePair(block.body);
+    return pair === null ? [] : [{ title: block.title, ...pair }];
+});
+const panePartition = panePartitionProblems({ pairs: panePairs, ledger: PANE_TEXT_DIVERGENCES });
+failures.push(...panePartition.problems);
+
 if (failures.length > 0) {
     console.error(`check-website-adwaita-gallery: ${failures.length} gallery/storybook disagreement(s):\n`);
     for (const failure of failures) console.error(`  - ${failure}`);
@@ -831,4 +1279,19 @@ console.log(
         `of ${blocks.length} blocks provides, every fragment slot they write is one the component renders, ` +
         `${overriding.size} block(s) override the markup tab, all ledgered, and ${WINDOW_COMPONENT} mounts ` +
         'the live preview ahead of them.',
+);
+
+/** The ledger's own partition, by kind, so a run says what the remaining work IS. */
+const paneKindCounts = new Map([...PANE_DIVERGENCE_KINDS.keys()].map((kind) => [kind, 0]));
+for (const reason of Object.values(PANE_TEXT_DIVERGENCES)) {
+    if (reason === null) continue;
+    const kind = /^([a-z]+):/.exec(reason)?.[1];
+    if (paneKindCounts.has(kind)) paneKindCounts.set(kind, paneKindCounts.get(kind) + 1);
+}
+console.log(
+    `check-website-adwaita-gallery: ${panePairs.length} block(s) written twice — ` +
+        `${panePartition.identical} are the SAME TEXT after one normalisation (the widget-namespace import ` +
+        `lines), ${panePairs.length - panePartition.identical} ledgered [` +
+        [...paneKindCounts].map(([kind, count]) => `${kind} ${count}`).join(', ') +
+        `] — distance ${panePartition.distance} line(s) over all pairs.`,
 );

--- a/scripts/check-website-adwaita-gallery.mjs
+++ b/scripts/check-website-adwaita-gallery.mjs
@@ -527,8 +527,7 @@ const PANE_DIVERGENCE_KINDS = new Map([
 ]);
 
 /** The kinds and what each one MEANS, for the two failures that ask an author to pick one. */
-const paneKindMenu = () =>
-    [...PANE_DIVERGENCE_KINDS].map(([kind, means]) => `      ${kind}: ${means}`).join('\n');
+const paneKindMenu = () => [...PANE_DIVERGENCE_KINDS].map(([kind, means]) => `      ${kind}: ${means}`).join('\n');
 
 /**
  * Blocks whose two panes are NOT the same text, and why.
@@ -790,7 +789,10 @@ const PANE_NORMALISATION_VECTORS = [
         ["import Adw from 'gi://Adw?version=1';", "import Gtk from 'gi://Gtk?version=4.0';", 'x'],
         ['«widget vocabulary: Adw, Gtk»', 'x'],
     ],
-    [["import { Adw, Gtk } from '@gjsify/adwaita-nativescript';", 'x'], ['«widget vocabulary: Adw, Gtk»', 'x']],
+    [
+        ["import { Adw, Gtk } from '@gjsify/adwaita-nativescript';", 'x'],
+        ['«widget vocabulary: Adw, Gtk»', 'x'],
+    ],
     [["import { Adw } from '@gjsify/adwaita-nativescript';"], ['«widget vocabulary: Adw»']],
     // NOT normalised, each for its own reason: a glyph is a value the port needs and
     // libadwaita does not, `@nativescript/core` is a toolkit GJS has no counterpart

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -538,6 +538,60 @@ It also carries the correction this entry implies and § 9 does not: § 9 names 
 as the second renderer, and the corpus that exists pairs `gtk-host` with the NativeScript
 port, because those are the two the gallery authors from one source.
 
+### The gallery's two authored PANES are now measured too, and five of forty are one text
+
+The sibling fact to the entry above, one surface over. That one is about the gallery's two
+authored TREES — the data two generators emit. This one is about the two authored PANES a
+reader actually copies: the `gjs` fence and the `nativescript` fence of the same block.
+
+ADR 0034 § Amendment 12 said the `gi://` arms were *"the last of the two things keeping the
+website's Native TypeScript and NativeScript snippets from being the same text"*, and left
+the snippets alone. Stages 8 and 9 both landed on 2026-09-05 and neither was cashed in on the
+documentation surface for four days, because nothing MEASURED the distance: no arm read a
+`nativescript` fence against its `gjs` sibling, so "the two are now closer" was unfalsifiable.
+
+Arm 12 of `check-website-adwaita-gallery.mjs` is that measurement — this file and not
+`check-generated-website-data.mjs`, whose arm 11 holds the same claim over the two trees but
+never opens an `.mdx`. ONE declared normalisation: the lines that BIND the widget namespaces
+are read as the namespaces they bind, so `import { Adw, Gtk } from '@gjsify/adwaita-nativescript'`
+and the two `gi://` lines compare equal. That normalisation is what makes the number honest —
+without it this very change could have halved the printed distance by editing forty import
+lines and moving no program. It is held on its own output by vectors, because the partition
+vectors cannot see a widening that changes no verdict: measured, widening the specifier set to
+`@gjsify/*` left every partition vector green and moved only the distance.
+
+The numbers are PRINTED, never written here. What the change was measured against: 40 pairs,
+0 identical, distance 599 lines before; 5 identical after, and the remaining 35 ledgered by
+the KIND of work that would close each one — a rename, a glyph, renderer work, or a different
+program. Ledger entries are self-retiring, the shape arm 5b and arm 11 already have.
+
+**What is left, with its price.**
+
+- *The `glyph` entries are one renderer decision.* Every icon property on the port takes an
+  SVG SOURCE rather than a theme name, so those panes import a glyph from
+  `@gjsify/adwaita-icons` where the GJS pane writes `'folder-symbolic'`. Nothing on that
+  runtime resolves a theme name today; a resolver would close a whole kind at once.
+- *The `composition` entries split two ways.* Four are the `layout.mdx` blocks, where the
+  NativeScript window is an XML template plus a loader and the TypeScript pane is therefore a
+  `~/adw` barrel and a `Builder.load()` — not a widget construction at all, and not a
+  divergence a rename could close. The rest are blocks where the port has no counterpart
+  widget (`Gtk.Box`, `Gtk.Label`, `Adw.CarouselIndicatorDots`) and a `@nativescript/core`
+  layout stands in.
+- *The `property` entries are the renderer backlog*, and they overlap the `property` bucket of
+  the tree census above rather than repeating it: a pane can differ on a property the two
+  trees never carried.
+- *`Gtk` is the narrow half.* The arm answers `Adw` and `Gtk` and the NativeScript renderer
+  has 5 of 106 `Gtk` members, so every GTK widget a gjs pane reaches for outside
+  Button/DropDown/Entry/Image/MenuButton is a `property` entry by construction.
+
+**What this does NOT close, and it is the same limit as the entry above.** Two panes being one
+text is not two runtimes behaving the same. The panes are compared as TEXT; nothing here runs
+either of them. `check-doc-fences.mjs` holds every property a NativeScript pane writes —
+through an assignment or through the construct-props bag — against the port's own declared
+members, which is what makes a converged pane checkable rather than merely plausible, but that
+is a name check too. See *The doc fences that show no imports are unread, on purpose* for the
+API-shape gap that a tsc pass would close and this one does not.
+
 ### A property can agree on its NAME and disagree on its VALUE KIND
 
 `check-vocabulary-alignment.mjs` prints a property distance and calls a NativeScript
@@ -3987,6 +4041,22 @@ Attempted and NOT landed, with what was measured:
   arm reads TS2304 only and treats an unresolved module as none of its business.
 
 So it wants a different job and a different unit, not a wider regex on this one.
+
+**Where that leaves a `nativescript` fence, stated because those fences now carry more.** They
+are NOT typechecked in the API-shape sense above — the arm reads TS2304 only, and the port's
+`lib/types` are not built in this job. What holds them instead is `check-doc-fences.mjs`'s own
+NativeScript arm, which reads the port's SOURCE with no build and refuses a property a widget
+does not declare, through either door: `x.p = v` and `new Adw.Avatar({ p: v })`. The bag door
+is the one that TELLS the reader — an unknown assignment sticks as a dead own-property at exit
+0, an unknown bag key throws (ADR 0034 § Amendment 13) — and a getter with no setter is
+refused on both, because a bag refuses it by name and a bare assignment throws in strict mode,
+which every NativeScript bundle is. Both directions were A/B-proven on the real gallery.
+
+What that arm cannot see is a MISSING import: it resolves `Adw.StatusPage` through the port's
+own namespace barrels, never through the fence's import list. A fence that shows at least one
+import is covered anyway — the SNIPPETS arm reports the unbound `Adw` as TS2304 — so what is
+left uncovered is the import-LESS fence, which that arm passes over on purpose. Every
+`nativescript` fence in the gallery shows its imports today, and nothing holds that.
 
 One measurement discipline note, because the probe repeated the defect this PR is about:
 the throwaway script written to measure the class reported `0 diagnostics` twice while tsc

--- a/website/src/content/docs/adwaita/boxed-lists.mdx
+++ b/website/src/content/docs/adwaita/boxed-lists.mdx
@@ -26,7 +26,10 @@ Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
 [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web)
 and [`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita)
-follow its naming, and where one of them differs, its own window says so.
+follow its naming, and where one of them differs, its own window says so. Both ports answer
+`gi://Adw` and `gi://Gtk`, so a NativeScript snippet opens with the same import
+line as the Native TypeScript one beside it; `gjsify build --app nativescript
+--gi-renderer` is the opt-in that makes it resolve.
 
 :::note
 The previews run the browser port, so behaviour Libadwaita drives natively (an
@@ -109,21 +112,19 @@ preferences page.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
+    import Gtk from 'gi://Gtk?version=4.0';
 
-    const group = new Adw.PreferencesGroup();
-    group.title = 'Account';
-    group.description = 'Manage how this device signs in and syncs.';
+    const signOut = new Gtk.Button({ text: 'Sign out', styleClasses: 'flat' });
 
-    const name = new Adw.EntryRow();
-    name.title = 'Display name';
-    name.text = 'Grace Hopper';
-    group.addRow(name);
+    const group = new Adw.PreferencesGroup({
+        title: 'Account',
+        description: 'Manage how this device signs in and syncs.',
+        headerSuffix: signOut,
+    });
 
-    const sync = new Adw.SwitchRow();
-    sync.title = 'Sync over Wi-Fi only';
-    sync.active = true;
-    group.addRow(sync);
+    group.addRow(new Adw.EntryRow({ title: 'Display name', text: 'Grace Hopper' }));
+    group.addRow(new Adw.SwitchRow({ title: 'Sync over Wi-Fi only', active: true }));
     ```
   </Fragment>
 </AdwWidget>
@@ -192,21 +193,20 @@ row responds to a click, which is how you open a detail page.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw, Gtk } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
+    import Gtk from 'gi://Gtk?version=4.0';
     import { goNextSymbolic } from '@gjsify/adwaita-icons/actions';
     import { networkWirelessSymbolic } from '@gjsify/adwaita-icons/devices';
 
-    const row = new Adw.ActionRow();
-    row.title = 'Wi-Fi';
-    row.subtitle = 'Connected to Highgarden 5GHz';
+    const row = new Adw.ActionRow({
+        title: 'Wi-Fi',
+        subtitle: 'Connected to Highgarden 5GHz',
+    });
 
-    const icon = new Gtk.Image();
-    icon.iconName = networkWirelessSymbolic; // an Adwaita symbolic icon (SVG string)
-    row.setPrefix(icon);
-
-    const chevron = new Gtk.Image();
-    chevron.iconName = goNextSymbolic;
-    row.setSuffix(chevron);
+    // `iconName` takes the SVG SOURCE, not a theme name — nothing on this runtime
+    // resolves one, so the glyph is imported and handed in.
+    row.setPrefix(new Gtk.Image({ iconName: networkWirelessSymbolic }));
+    row.setSuffix(new Gtk.Image({ iconName: goNextSymbolic }));
     ```
   </Fragment>
 </AdwWidget>
@@ -251,12 +251,13 @@ the row you will use most in a preferences page.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
 
-    const row = new Adw.SwitchRow();
-    row.title = 'Automatic updates';
-    row.subtitle = 'Download and install updates without asking';
-    row.active = true;
+    const row = new Adw.SwitchRow({
+        title: 'Automatic updates',
+        subtitle: 'Download and install updates without asking',
+        active: true,
+    });
     ```
   </Fragment>
 </AdwWidget>
@@ -302,11 +303,13 @@ user types.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
 
-    const row = new Adw.EntryRow();
-    row.title = 'Display name';
-    row.text = 'Ada Lovelace';
+    const row = new Adw.EntryRow({
+        title: 'Display name',
+        text: 'Ada Lovelace',
+        showApplyButton: true,
+    });
     ```
   </Fragment>
 </AdwWidget>
@@ -349,11 +352,12 @@ to reveal it. Use it anywhere a password or key is edited inline.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
 
-    const row = new Adw.PasswordEntryRow();
-    row.title = 'Password';
-    row.text = 'correct-horse-battery';
+    const row = new Adw.PasswordEntryRow({
+        title: 'Password',
+        text: 'correct-horse-battery',
+    });
     ```
   </Fragment>
 </AdwWidget>
@@ -414,13 +418,14 @@ same array goes in the `model` attribute as JSON.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
 
-    const row = new Adw.ComboRow();
-    row.title = 'Accent colour';
-    row.subtitle = 'Used to highlight selected items';
-    row.model = ['Blue', 'Teal', 'Green', 'Orange', 'Purple'];
-    row.selected = 1;
+    const row = new Adw.ComboRow({
+        title: 'Accent colour',
+        subtitle: 'Used to highlight selected items',
+        model: ['Blue', 'Teal', 'Green', 'Orange', 'Purple'],
+        selected: 1,
+    });
     ```
   </Fragment>
 </AdwWidget>
@@ -508,12 +513,12 @@ size or a count.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
 
-    const row = new Adw.SpinRow();
-    row.title = 'Font size';
-    row.adjustment = { lower: 0, upper: 100, stepIncrement: 1 };
-    row.value = 16;
+    const row = new Adw.SpinRow({
+        title: 'Font size',
+        adjustment: { lower: 0, upper: 100, value: 16, stepIncrement: 1 },
+    });
     ```
   </Fragment>
 </AdwWidget>
@@ -574,21 +579,16 @@ whole section.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
 
-    const row = new Adw.ExpanderRow();
-    row.title = 'Proxy settings';
-    row.subtitle = 'Route traffic through a custom proxy';
-    row.expanded = true;
+    const row = new Adw.ExpanderRow({
+        title: 'Proxy settings',
+        subtitle: 'Route traffic through a custom proxy',
+        expanded: true,
+    });
 
-    const host = new Adw.EntryRow();
-    host.title = 'Host';
-    host.text = 'proxy.example.com';
-    row.addRow(host);
-
-    const auth = new Adw.SwitchRow();
-    auth.title = 'Use authentication';
-    row.addRow(auth);
+    row.addRow(new Adw.EntryRow({ title: 'Host', text: 'proxy.example.com' }));
+    row.addRow(new Adw.SwitchRow({ title: 'Use authentication', active: false }));
     ```
   </Fragment>
 </AdwWidget>
@@ -635,12 +635,14 @@ Adwaita style classes (`.suggested-action`, `.destructive-action`).
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
     import { listAddSymbolic } from '@gjsify/adwaita-icons/actions';
 
-    const row = new Adw.ButtonRow();
-    row.title = 'Add account';
-    row.startIconName = listAddSymbolic; // an Adwaita symbolic icon (SVG string)
+    const row = new Adw.ButtonRow({
+        title: 'Add account',
+        // `startIconName` takes the SVG SOURCE here, not a theme name.
+        startIconName: listAddSymbolic,
+    });
     row.className = 'adw-button-row suggested-action';
     ```
   </Fragment>

--- a/website/src/content/docs/adwaita/buttons.mdx
+++ b/website/src/content/docs/adwaita/buttons.mdx
@@ -30,7 +30,10 @@ Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
 [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web)
 and [`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita)
-follow its naming, and where one of them differs, its own window says so.
+follow its naming, and where one of them differs, its own window says so. Both ports answer
+`gi://Adw` and `gi://Gtk`, so a NativeScript snippet opens with the same import
+line as the Native TypeScript one beside it; `gjsify build --app nativescript
+--gi-renderer` is the opt-in that makes it resolve.
 
 :::note
 The previews run the browser port, so behaviour Libadwaita drives natively (a
@@ -86,14 +89,16 @@ short.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
     import { folderDownloadSymbolic } from '@gjsify/adwaita-icons/places';
     import { StackLayout } from '@nativescript/core';
 
-    const content = new Adw.ButtonContent();
-    content.iconColor = '#ffffff';
-    content.label = 'Download';
-    content.iconName = folderDownloadSymbolic; // an Adwaita symbolic icon (SVG string)
+    const content = new Adw.ButtonContent({
+        label: 'Download',
+        // `iconName` takes the SVG SOURCE here, not a theme name.
+        iconName: folderDownloadSymbolic,
+        iconColor: '#ffffff',
+    });
 
     // Gtk.Button is text-only, so a styled layout wraps the content.
     const button = new StackLayout();
@@ -170,12 +175,14 @@ header bar or toolbar, where a raised button looks too heavy.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
     import { documentSaveSymbolic } from '@gjsify/adwaita-icons/actions';
 
-    const button = new Adw.SplitButton();
-    button.menuModel = ['Save as…', 'Export', 'Print']; // or items, sections, submenus — ADR 0042
-    button.iconName = documentSaveSymbolic; // an Adwaita symbolic icon (SVG string)
+    const button = new Adw.SplitButton({
+        menuModel: ['Save as…', 'Export', 'Print'], // or items, sections, submenus — ADR 0042
+        // `iconName` takes the SVG SOURCE here, not a theme name.
+        iconName: documentSaveSymbolic,
+    });
     // With no icon set, the label drives the action half: button.label = 'Save';
     // button.className = 'adw-split-button flat'; // the header-bar / toolbar variant
     ```
@@ -256,7 +263,7 @@ once set", and the only setter is class-level.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
     import { viewGridSymbolic, viewListSymbolic, viewPagedSymbolic } from '@gjsify/adwaita-icons/actions';
 
     const group = new Adw.ToggleGroup();

--- a/website/src/content/docs/adwaita/feedback.mdx
+++ b/website/src/content/docs/adwaita/feedback.mdx
@@ -27,7 +27,10 @@ Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
 [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web)
 and [`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita)
-follow its naming, and where one of them differs, its own window says so.
+follow its naming, and where one of them differs, its own window says so. Both ports answer
+`gi://Adw` and `gi://Gtk`, so a NativeScript snippet opens with the same import
+line as the Native TypeScript one beside it; `gjsify build --app nativescript
+--gi-renderer` is the opt-in that makes it resolve.
 
 :::note
 The previews hold each dialog **open** and each toast **visible**, which is not
@@ -127,11 +130,12 @@ on the desktop.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
 
-    const content = new Adw.StatusPage();
-    content.title = 'Documents';
-    content.description = 'Drag files here to organise them.';
+    const content = new Adw.StatusPage({
+        title: 'Documents',
+        description: 'Drag files here to organise them.',
+    });
 
     const overlay = new Adw.ToastOverlay();
     overlay.setContent(content);
@@ -205,7 +209,7 @@ ID, and that ID is what reaches your code. Give one response a **destructive** o
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
 
     const dialog = new Adw.AlertDialog(
         'Delete Project?',
@@ -214,6 +218,9 @@ ID, and that ID is what reaches your code. Give one response a **destructive** o
 
     dialog.addResponse('cancel', 'Cancel');
     dialog.addResponse('delete', 'Delete');
+    // The appearance is the nick, not a constant: `@gjsify/adwaita-core` spells it
+    // 'default' | 'suggested' | 'destructive' on every surface.
+    dialog.setResponseAppearance('delete', 'destructive');
     dialog.defaultResponse = 'cancel';
     dialog.closeResponse = 'cancel';
 
@@ -290,17 +297,18 @@ Legal sub-pages you never lay out yourself.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
 
-    const dialog = new Adw.AboutDialog();
-    dialog.applicationName = 'Adwaita Storybook';
-    dialog.applicationIcon = '🗔';
-    dialog.version = '0.11.0';
-    // NS exposes only scalar fields: credits fold into the developer line.
-    dialog.developerName = 'A GJSify Project · Ada Lovelace, Grace Hopper';
-    dialog.comments = 'A live catalogue of native GTK and Adwaita widgets, rendered under GJS.';
-    dialog.website = 'https://github.com/gjsify/gjsify';
-    dialog.copyright = '© 2026 The GJSify Project';
+    const dialog = new Adw.AboutDialog({
+        applicationName: 'Adwaita Storybook',
+        applicationIcon: '🗔',
+        version: '0.11.0',
+        // NS exposes only scalar fields: credits fold into the developer line.
+        developerName: 'A GJSify Project · Ada Lovelace, Grace Hopper',
+        comments: 'A live catalogue of native GTK and Adwaita widgets, rendered under GJS.',
+        website: 'https://github.com/gjsify/gjsify',
+        copyright: '© 2026 The GJSify Project',
+    });
 
     dialog.present();
     ```
@@ -410,32 +418,32 @@ the web port renders them stacked instead.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
+    import { preferencesSystemSymbolic } from '@gjsify/adwaita-icons/categories';
 
-    const dialog = new Adw.PreferencesDialog();
-    dialog.title = 'Preferences';
+    const dialog = new Adw.PreferencesDialog({ title: 'Preferences' });
 
-    const page = new Adw.PreferencesPage();
-    const group = new Adw.PreferencesGroup();
-    group.title = 'Appearance';
+    const page = new Adw.PreferencesPage({
+        title: 'General',
+        // `iconName` takes the SVG SOURCE here, not a theme name.
+        iconName: preferencesSystemSymbolic,
+    });
 
-    const darkStyle = new Adw.SwitchRow();
-    darkStyle.title = 'Dark style';
-    darkStyle.subtitle = 'Use a dark colour scheme';
-    darkStyle.active = true;
-    group.addRow(darkStyle);
+    const group = new Adw.PreferencesGroup({
+        title: 'Appearance',
+        description: 'Control how the application looks and behaves.',
+    });
 
-    const accent = new Adw.ComboRow();
-    accent.title = 'Accent colour';
-    accent.model = ['Blue', 'Teal', 'Green', 'Orange', 'Purple'];
-    accent.selected = 0;
-    group.addRow(accent);
-
-    const fontSize = new Adw.SpinRow();
-    fontSize.title = 'Font size';
-    fontSize.adjustment = { lower: 8, upper: 24 };
-    fontSize.value = 12;
-    group.addRow(fontSize);
+    group.addRow(new Adw.SwitchRow({ title: 'Dark style', subtitle: 'Use a dark colour scheme', active: true }));
+    group.addRow(new Adw.ComboRow({
+        title: 'Accent colour',
+        model: ['Blue', 'Teal', 'Green', 'Orange', 'Purple'],
+        selected: 0,
+    }));
+    group.addRow(new Adw.SpinRow({
+        title: 'Font size',
+        adjustment: { lower: 8, upper: 24, value: 12, stepIncrement: 1 },
+    }));
 
     page.addGroup(group);
     dialog.add(page);

--- a/website/src/content/docs/adwaita/layout.mdx
+++ b/website/src/content/docs/adwaita/layout.mdx
@@ -59,7 +59,11 @@ Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
 [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web)
 and [`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita)
-follow its naming, and where one of them differs, its own window says so.
+follow its naming, and where one of them differs, its own window says so. Both ports answer
+`gi://Adw` and `gi://Gtk`, which is what lets a NativeScript snippet elsewhere on
+this site open with the same import line as the Native TypeScript one beside it.
+Not here: every widget on this page is a tree, so each NativeScript window is an XML
+template and the loader that mounts it.
 
 :::note
 The previews run the browser port, so behaviour Libadwaita drives natively (a

--- a/website/src/content/docs/adwaita/navigation.mdx
+++ b/website/src/content/docs/adwaita/navigation.mdx
@@ -27,7 +27,10 @@ Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
 [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web)
 and [`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita)
-follow its naming, and where one of them differs, its own window says so.
+follow its naming, and where one of them differs, its own window says so. Both ports answer
+`gi://Adw` and `gi://Gtk`, so a NativeScript snippet opens with the same import
+line as the Native TypeScript one beside it; `gjsify build --app nativescript
+--gi-renderer` is the opt-in that makes it resolve.
 
 :::note
 These are the widgets that lean hardest on Libadwaita: adaptive breakpoints,
@@ -174,7 +177,7 @@ the sidebar and the content each their own navigation page and header bar.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
     import { mailUnreadSymbolic } from '@gjsify/adwaita-icons/status';
 
     // Sidebar: the navigation list, not a boxed list. The NS surface takes a
@@ -183,21 +186,19 @@ the sidebar and the content each their own navigation page and header bar.
     sidebarList.setItems(['All Mail', 'Starred', 'Drafts', 'Archive']);
     sidebarList.selected = 0;
 
-    const sidebarHeader = new Adw.HeaderBar();
-    sidebarHeader.title = 'Mailboxes';
     const sidebar = new Adw.ToolbarView();
-    sidebar.addTopBar(sidebarHeader);
+    sidebar.addTopBar(new Adw.HeaderBar({ title: 'Mailboxes' }));
     sidebar.setContent(sidebarList);
 
     // Content: a status page inside a toolbar view.
-    const status = new Adw.StatusPage();
-    status.iconName = mailUnreadSymbolic;
-    status.title = 'All Mail';
-    status.description = 'Select a conversation from the list to read it here.';
-    const contentHeader = new Adw.HeaderBar();
-    contentHeader.title = 'All Mail';
+    const status = new Adw.StatusPage({
+        // `iconName` takes the SVG SOURCE here, not a theme name.
+        iconName: mailUnreadSymbolic,
+        title: 'All Mail',
+        description: 'Select a conversation from the list to read it here.',
+    });
     const content = new Adw.ToolbarView();
-    content.addTopBar(contentHeader);
+    content.addTopBar(new Adw.HeaderBar({ title: 'All Mail' }));
     content.setContent(status);
 
     const view = new Adw.NavigationSplitView();
@@ -331,23 +332,23 @@ navigation pane that should not push the main content aside on a narrow window.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
     import { folderMusicSymbolic } from '@gjsify/adwaita-icons/places';
 
     const sidebarList = new Adw.Sidebar();
     sidebarList.setItems(['Home', 'Discover', 'Library', 'Settings']);
     sidebarList.selected = 0;
 
-    const header = new Adw.HeaderBar();
-    header.styleClasses = 'flat';
     const sidebar = new Adw.ToolbarView();
-    sidebar.addTopBar(header);
+    sidebar.addTopBar(new Adw.HeaderBar({ styleClasses: 'flat' }));
     sidebar.setContent(sidebarList);
 
-    const status = new Adw.StatusPage();
-    status.iconName = folderMusicSymbolic;
-    status.title = 'Your Library';
-    status.description = 'Toggle the sidebar to browse sections. Collapse it to overlay the content.';
+    const status = new Adw.StatusPage({
+        // `iconName` takes the SVG SOURCE here, not a theme name.
+        iconName: folderMusicSymbolic,
+        title: 'Your Library',
+        description: 'Toggle the sidebar to browse sections. Collapse it to overlay the content.',
+    });
     const content = new Adw.ToolbarView();
     content.addTopBar(new Adw.HeaderBar());
     content.setContent(status);
@@ -480,31 +481,31 @@ the detail page and watch the back button appear.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw, Gtk } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
+    import Gtk from 'gi://Gtk?version=4.0';
     import { avatarDefaultSymbolic } from '@gjsify/adwaita-icons/status';
 
     const view = new Adw.NavigationView();
 
     // Detail page.
-    const detailHeader = new Adw.HeaderBar();
-    detailHeader.title = 'Ada Lovelace';
-    const detailStatus = new Adw.StatusPage();
-    detailStatus.iconName = avatarDefaultSymbolic;
-    detailStatus.title = 'Ada Lovelace';
-    detailStatus.description = 'Mathematician and writer, the first computer programmer.';
+    const detailStatus = new Adw.StatusPage({
+        // `iconName` takes the SVG SOURCE here, not a theme name.
+        iconName: avatarDefaultSymbolic,
+        title: 'Ada Lovelace',
+        description: 'Mathematician and writer, the first computer programmer.',
+    });
     const detail = new Adw.ToolbarView();
-    detail.addTopBar(detailHeader);
+    detail.addTopBar(new Adw.HeaderBar({ title: 'Ada Lovelace' }));
     detail.setContent(detailStatus);
 
     // Root page: a pill button that pushes the detail page by tag.
-    const rootHeader = new Adw.HeaderBar();
-    rootHeader.title = 'Contacts';
-    const open = new Gtk.Button();
-    open.text = 'Open contact';
-    open.styleClasses = 'pill';
+    const open = new Gtk.Button({
+        text: 'Open contact',
+        styleClasses: 'pill',
+    });
     open.addEventListener('tap', () => view.push('detail'));
     const root = new Adw.ToolbarView();
-    root.addTopBar(rootHeader);
+    root.addTopBar(new Adw.HeaderBar({ title: 'Contacts' }));
     root.setContent(open);
 
     view.add(root, 'root');
@@ -616,7 +617,10 @@ already knows how to be one.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw, NOTIFY_SIDEBAR_SELECTED } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
+    // `NOTIFY_SIDEBAR_SELECTED` is a signal NAME, not a widget, so it has no member in
+    // the `Adw` namespace and keeps the package import.
+    import { NOTIFY_SIDEBAR_SELECTED } from '@gjsify/adwaita-nativescript';
     import { mailUnreadSymbolic, starredSymbolic } from '@gjsify/adwaita-icons/status';
     import { mailSendSymbolic } from '@gjsify/adwaita-icons/actions';
     import { folderSymbolic } from '@gjsify/adwaita-icons/places';
@@ -630,10 +634,9 @@ already knows how to be one.
     ];
 
     // The NS surface takes a flat label list (no per-item subtitle/icon slot).
-    const sidebar = new Adw.Sidebar();
+    const sidebar = new Adw.Sidebar({ width: 220 });
     sidebar.setItems(items.map((it) => it.title));
     sidebar.selected = 0;
-    sidebar.width = 220;
 
     const status = new Adw.StatusPage();
     const syncContent = () => {
@@ -810,7 +813,8 @@ content pane, not to work.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw, Gtk } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
+    import Gtk from 'gi://Gtk?version=4.0';
     import { Label, StackLayout } from '@nativescript/core';
 
     const sheet = new Adw.BottomSheet();
@@ -819,9 +823,7 @@ content pane, not to work.
     const center = new StackLayout();
     center.horizontalAlignment = 'center';
     center.verticalAlignment = 'middle';
-    const toggle = new Gtk.Button();
-    toggle.text = 'Toggle sheet';
-    toggle.styleClasses = 'pill';
+    const toggle = new Gtk.Button({ text: 'Toggle sheet', styleClasses: 'pill' });
     toggle.addEventListener('tap', () => { sheet.open = !sheet.open; });
     center.addChild(toggle);
     sheet.setContent(center);
@@ -836,9 +838,7 @@ content pane, not to work.
 
     const group = new Adw.PreferencesGroup();
     for (const rowTitle of ['Copy link', 'Send to a friend', 'Add to playlist']) {
-        const row = new Adw.ActionRow();
-        row.title = rowTitle;
-        group.addRow(row);
+        group.addRow(new Adw.ActionRow({ title: rowTitle }));
     }
     box.addChild(group);
     sheet.setSheet(box);

--- a/website/src/content/docs/adwaita/presentation.mdx
+++ b/website/src/content/docs/adwaita/presentation.mdx
@@ -27,7 +27,10 @@ Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
 [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web)
 and [`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita)
-follow its naming, and where one of them differs, its own window says so.
+follow its naming, and where one of them differs, its own window says so. Both ports answer
+`gi://Adw` and `gi://Gtk`, so a NativeScript snippet opens with the same import
+line as the Native TypeScript one beside it; `gjsify build --app nativescript
+--gi-renderer` is the opt-in that makes it resolve.
 
 :::note
 The previews run the browser port, so behaviour Libadwaita drives natively (a
@@ -76,17 +79,18 @@ it from an inline list glyph up to a full profile header.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
     import { avatarDefaultSymbolic } from '@gjsify/adwaita-icons/status';
 
-    const avatar = new Adw.Avatar();
-    avatar.text = 'Ada Lovelace';
-    avatar.size = 96;
-    avatar.showInitials = true;
-    // `iconName` takes the SVG SOURCE, not a theme name — nothing on this runtime
-    // resolves one, so the fallback glyph is handed in. Left empty it is the same
-    // Adwaita person icon, and `showInitials = false` is what shows it.
-    avatar.iconName = avatarDefaultSymbolic;
+    const avatar = new Adw.Avatar({
+        size: 96,
+        text: 'Ada Lovelace',
+        showInitials: true,
+        // `iconName` takes the SVG SOURCE, not a theme name — nothing on this runtime
+        // resolves one, so the fallback glyph is handed in. Left empty it is the same
+        // Adwaita person icon, and `showInitials: false` is what shows it.
+        iconName: avatarDefaultSymbolic,
+    });
     ```
   </Fragment>
 </AdwWidget>
@@ -134,12 +138,13 @@ space while the message applies.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
 
-    const banner = new Adw.Banner();
-    banner.title = 'Metered connection: updates paused';
-    banner.buttonLabel = 'Resume';
-    banner.revealed = true;
+    const banner = new Adw.Banner({
+        title: 'Metered connection: updates paused',
+        buttonLabel: 'Resume',
+        revealed: true,
+    });
     // No `useMarkup`: the NS banner label is plain text (no rich-text subset).
     ```
   </Fragment>
@@ -217,13 +222,19 @@ shows the **disabled-text** placeholder instead.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
 
-    const shortcut = new Adw.ShortcutLabel();
-    // `disabledText` first: an empty accelerator renders the placeholder, so the
-    // placeholder has to be in place before the accelerator triggers the rebuild.
-    shortcut.disabledText = 'Disabled';
-    shortcut.accelerator = '<Control>C';
+    // Ctrl+C. The keycap order is GTK's, not the string's: `<Shift><Control>a`
+    // renders as Ctrl Shift A.
+    const shortcut = new Adw.ShortcutLabel({ accelerator: '<Control>C' });
+
+    // A space lists alternatives, `...` a range, `+` a sequence, `&` keys held together.
+    const alternatives = new Adw.ShortcutLabel({ accelerator: '<Shift>A Home' });
+    const range = new Adw.ShortcutLabel({ accelerator: '<Alt>1...9' });
+    const together = new Adw.ShortcutLabel({ accelerator: 'Control_L&Control_R' });
+
+    // With no accelerator the placeholder is shown instead.
+    const unset = new Adw.ShortcutLabel({ accelerator: '', disabledText: 'Disabled' });
     ```
   </Fragment>
 </AdwWidget>
@@ -267,10 +278,9 @@ instead.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
 
-    const spinner = new Adw.Spinner();
-    spinner.size = 48;
+    const spinner = new Adw.Spinner({ size: 48 });
     ```
   </Fragment>
 </AdwWidget>
@@ -329,18 +339,22 @@ give the user a way out, such as a button that creates their first document.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw, Gtk } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
+    import Gtk from 'gi://Gtk?version=4.0';
     import { folderSymbolic } from '@gjsify/adwaita-icons/places';
 
-    const button = new Gtk.Button();
-    button.text = 'New Document';
-    button.styleClasses = 'suggested-action';
+    const button = new Gtk.Button({
+        text: 'New Document',
+        styleClasses: 'pill suggested-action',
+    });
 
-    const page = new Adw.StatusPage();
-    page.iconName = folderSymbolic; // an Adwaita symbolic icon (SVG string)
-    page.title = 'No Documents';
-    page.description = 'Documents you create or open will appear here.';
-    page.setChild(button);
+    const statusPage = new Adw.StatusPage({
+        // `iconName` takes the SVG SOURCE here, not a theme name.
+        iconName: folderSymbolic,
+        title: 'No Documents',
+        description: 'Documents you create or open will appear here.',
+    });
+    statusPage.setChild(button);
     ```
   </Fragment>
 </AdwWidget>
@@ -380,11 +394,12 @@ so a single-line title stays vertically centred.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
 
-    const windowTitle = new Adw.WindowTitle();
-    windowTitle.title = 'Inbox';
-    windowTitle.subtitle = '3 unread messages';
+    const windowTitle = new Adw.WindowTitle({
+        title: 'Inbox',
+        subtitle: '3 unread messages',
+    });
     ```
   </Fragment>
 </AdwWidget>

--- a/website/src/content/docs/adwaita/view-switching.mdx
+++ b/website/src/content/docs/adwaita/view-switching.mdx
@@ -28,7 +28,10 @@ Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
 [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web)
 and [`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita)
-follow its naming, and where one of them differs, its own window says so.
+follow its naming, and where one of them differs, its own window says so. Both ports answer
+`gi://Adw` and `gi://Gtk`, so a NativeScript snippet opens with the same import
+line as the Native TypeScript one beside it; `gjsify build --app nativescript
+--gi-renderer` is the opt-in that makes it resolve.
 
 :::note
 The previews run the browser port, so gestures Libadwaita drives natively
@@ -149,17 +152,16 @@ swaps between the two on a breakpoint.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw, type AdwViewPage } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
+    // `AdwViewPage` is a TYPE and not a widget, so it has no member in the `Adw`
+    // namespace and keeps the package import.
+    import type { AdwViewPage } from '@gjsify/adwaita-nativescript';
     import { folderSymbolic } from '@gjsify/adwaita-icons/places';
     import { mailUnreadSymbolic, starredSymbolic } from '@gjsify/adwaita-icons/status';
 
-    const page = (icon: string, title: string, description: string): Adw.StatusPage => {
-        const status = new Adw.StatusPage();
-        status.iconName = icon; // a real Adwaita symbolic icon (SVG string)
-        status.title = title;
-        status.description = description;
-        return status;
-    };
+    // An icon here is the SVG SOURCE, not a theme name.
+    const page = (icon: string, title: string, description: string): Adw.StatusPage =>
+        new Adw.StatusPage({ iconName: icon, title, description });
 
     const switcher = new Adw.ViewSwitcher();
     // Each view carries a title + icon (shown on the switcher button) and its content.
@@ -280,7 +282,7 @@ does not appear.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
     import { folderSymbolic } from '@gjsify/adwaita-icons/places';
     import { mailUnreadSymbolic, starredSymbolic } from '@gjsify/adwaita-icons/status';
 
@@ -290,9 +292,8 @@ does not appear.
         { name: 'starred', title: 'Starred', icon: starredSymbolic },
         { name: 'archive', title: 'Archive', icon: folderSymbolic },
     ]) {
-        const status = new Adw.StatusPage();
-        status.iconName = page.icon; // an Adwaita symbolic icon (SVG string)
-        status.title = page.title;
+        // An icon here is the SVG SOURCE, not a theme name.
+        const status = new Adw.StatusPage({ iconName: page.icon, title: page.title });
         stack.add(status, page.name, page.title, page.icon);
     }
 
@@ -377,16 +378,15 @@ disappears once a single page is left, so a one-tab document looks chrome-free.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw, type AdwViewPage } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
+    // `AdwViewPage` is a TYPE and not a widget, so it has no member in the `Adw`
+    // namespace and keeps the package import.
+    import type { AdwViewPage } from '@gjsify/adwaita-nativescript';
     import { viewGridSymbolic } from '@gjsify/adwaita-icons/actions';
 
-    const page = (title: string, body: string): Adw.StatusPage => {
-        const status = new Adw.StatusPage();
-        status.iconName = viewGridSymbolic; // a real Adwaita symbolic icon (SVG string)
-        status.title = title;
-        status.description = body;
-        return status;
-    };
+    // `iconName` takes the SVG SOURCE, not a theme name.
+    const page = (title: string, body: string): Adw.StatusPage =>
+        new Adw.StatusPage({ iconName: viewGridSymbolic, title, description: body });
 
     const tabView = new Adw.TabView();
     tabView.setViews([
@@ -508,17 +508,16 @@ makes it fit a header bar or a tight toolbar.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw, type AdwViewPage } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
+    // `AdwViewPage` is a TYPE and not a widget, so it has no member in the `Adw`
+    // namespace and keeps the package import.
+    import type { AdwViewPage } from '@gjsify/adwaita-nativescript';
     import { documentEditSymbolic, viewGridSymbolic } from '@gjsify/adwaita-icons/actions';
     import { preferencesSystemSymbolic } from '@gjsify/adwaita-icons/categories';
 
-    const page = (icon: string, title: string, body: string): Adw.StatusPage => {
-        const status = new Adw.StatusPage();
-        status.iconName = icon; // a real Adwaita symbolic icon (SVG string)
-        status.title = title;
-        status.description = body;
-        return status;
-    };
+    // An icon here is the SVG SOURCE, not a theme name.
+    const page = (icon: string, title: string, body: string): Adw.StatusPage =>
+        new Adw.StatusPage({ iconName: icon, title, description: body });
 
     const switcher = new Adw.InlineViewSwitcher();
     // display mode "both": pass '' as the title for icons-only, omit icon for labels-only.
@@ -650,7 +649,7 @@ does.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
     import { Label, StackLayout, type View } from '@nativescript/core';
 
     const page = (title: string, accent: string): View => {
@@ -668,8 +667,7 @@ does.
         return card;
     };
 
-    const carousel = new Adw.Carousel();
-    carousel.pageWidth = 440;
+    const carousel = new Adw.Carousel({ pageWidth: 440 });
     carousel.addPage(page('Welcome', 'accent'));
     carousel.addPage(page('Discover', 'success'));
     carousel.addPage(page('Get started', 'warning'));

--- a/website/src/content/docs/gtk/buttons.mdx
+++ b/website/src/content/docs/gtk/buttons.mdx
@@ -32,7 +32,10 @@ spells both buttons the way the GIR does — `<gtk-button>` and `<gtk-menu-butto
 the same tags `@gjsify/gtk-host` uses — because a widget is named after the library
 that owns it and the Adwaita part of these two is the stylesheet. The NativeScript
 port names them by the same rule, `Gtk.Button` and `Gtk.MenuButton`. Where a port
-behaves differently, its own window says so.
+behaves differently, its own window says so. Both ports answer
+`gi://Adw` and `gi://Gtk`, so a NativeScript snippet opens with the same import
+line as the Native TypeScript one beside it; `gjsify build --app nativescript
+--gi-renderer` is the opt-in that makes it resolve.
 
 :::note
 The previews run the browser port, so behaviour the toolkits drive natively can
@@ -133,31 +136,17 @@ each other and mean the same thing everywhere in the toolkit, so a
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Adw, Gtk } from '@gjsify/adwaita-nativescript';
+    import Adw from 'gi://Adw?version=1';
+    import Gtk from 'gi://Gtk?version=4.0';
 
-    const box = new Adw.WrapBox();
-    box.childSpacing = 12;
-    box.lineSpacing = 12;
+    const box = new Adw.WrapBox({ childSpacing: 12, lineSpacing: 12 });
 
-    const pill = new Gtk.Button();
-    pill.text = 'Pill';
-    pill.styleClasses = 'pill';
-    box.add(pill);
-
-    const suggested = new Gtk.Button();
-    suggested.text = 'Suggested';
-    suggested.styleClasses = 'suggested-action';
-    box.add(suggested);
-
-    const destructive = new Gtk.Button();
-    destructive.text = 'Delete';
-    destructive.styleClasses = 'destructive-action';
-    box.add(destructive);
-
-    const flat = new Gtk.Button();
-    flat.text = 'Flat';
-    flat.styleClasses = 'flat';
-    box.add(flat);
+    // No circular variant here: this Gtk.Button is text-only, so an icon-only
+    // button is Adw.ButtonContent inside a styled layout — see Adwaita/Buttons.
+    box.add(new Gtk.Button({ text: 'Pill', styleClasses: 'pill' }));
+    box.add(new Gtk.Button({ text: 'Suggested', styleClasses: 'suggested-action' }));
+    box.add(new Gtk.Button({ text: 'Delete', styleClasses: 'destructive-action' }));
+    box.add(new Gtk.Button({ text: 'Flat', styleClasses: 'flat' }));
     ```
   </Fragment>
 </AdwWidget>
@@ -231,13 +220,15 @@ in the popover it opens. Libadwaita ships no menu button, so this is
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Gtk } from '@gjsify/adwaita-nativescript';
+    import Gtk from 'gi://Gtk?version=4.0';
     import { openMenuSymbolic } from '@gjsify/adwaita-icons/actions';
 
-    const button = new Gtk.MenuButton();
-    button.iconName = openMenuSymbolic; // an Adwaita symbolic icon (SVG string)
-    button.menuTitle = 'Document';
-    button.menuModel = [{ label: 'Save as…' }, { label: 'Export' }, { label: 'Print' }];
+    const button = new Gtk.MenuButton({
+        // `iconName` takes the SVG SOURCE here, not a theme name.
+        iconName: openMenuSymbolic,
+        menuModel: [{ label: 'Save as…' }, { label: 'Export' }, { label: 'Print' }],
+        menuTitle: 'Document',
+    });
     // NativeScript has no popover, so the menu opens as the platform action sheet.
     ```
   </Fragment>

--- a/website/src/content/docs/gtk/controls.mdx
+++ b/website/src/content/docs/gtk/controls.mdx
@@ -33,7 +33,10 @@ spells both controls the way the GIR does — `<gtk-entry>` and `<gtk-drop-down>
 the same tags `@gjsify/gtk-host` uses — because a widget is named after the library
 that owns it and the Adwaita part of these two is the stylesheet. The NativeScript
 port names them by the same rule, `Gtk.Entry` and `Gtk.DropDown`. Where a port behaves
-differently, its own window says so.
+differently, its own window says so. Both ports answer
+`gi://Adw` and `gi://Gtk`, so a NativeScript snippet opens with the same import
+line as the Native TypeScript one beside it; `gjsify build --app nativescript
+--gi-renderer` is the opt-in that makes it resolve.
 
 :::note
 The previews run the browser port, so behaviour the toolkits drive natively can
@@ -90,12 +93,14 @@ control in row presentation, and the label doubles as the row title.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Gtk } from '@gjsify/adwaita-nativescript';
+    import Gtk from 'gi://Gtk?version=4.0';
 
-    const entry = new Gtk.Entry();
-    entry.placeholderText = 'Search files…';
+    const entry = new Gtk.Entry({
+        placeholderText: 'Search files…',
+    });
+
     entry.text = 'notes.md';
-    entry.editable = false;
+    entry.editable = false; // read but do not change
     ```
   </Fragment>
 </AdwWidget>
@@ -148,11 +153,12 @@ the popover follows, and the rows that did not change keep their place.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { Gtk } from '@gjsify/adwaita-nativescript';
+    import Gtk from 'gi://Gtk?version=4.0';
 
-    const dropDown = new Gtk.DropDown();
-    dropDown.model = ['Automatic', 'Always', 'Never', 'When busy'];
-    dropDown.selected = 0;
+    const dropDown = new Gtk.DropDown({
+        model: ['Automatic', 'Always', 'Never', 'When busy'],
+        selected: 0,
+    });
     // The list opens as the platform action sheet, which has no search field —
     // so `enableSearch` has no NativeScript equivalent.
     ```


### PR DESCRIPTION
ADR 0034 § Amendment 12 said the `gi://` arms were *"the last of the two
things keeping the website's Native TypeScript and NativeScript snippets
from being the same text"*, and then left the snippets alone. Stages 8
(the construct-props bag, 46/46 widget classes) and 9 (the `gi://` arms
behind `--gi-renderer`) both landed on 2026-09-05. Nobody cashed them in.

The interesting half is not the rewrite. It is that until now nothing in
this repository could have told you whether those two stages had bought
anything on the surface they were argued for: no arm read a `nativescript`
fence against its `gjs` sibling, so "the two are closer now" was
unfalsifiable.

## What was measured first

Across every `<AdwWidget>` block under `website/src/content/docs/`, on
`origin/main`:

- 40 blocks carry both a `gjs` and a `nativescript` pane
- **0 of 40** used the construct-props bag; 36 used `new X(); x.a = …`
- every one imported `@gjsify/adwaita-nativescript`
- line distance between the two panes, after one normalisation: **599**

## What converged

Every pane that constructs widgets now opens with
`import Adw from 'gi://Adw?version=1'` and passes its properties as a bag.

**Five blocks are now byte-identical to their `gjs` sibling** — `SwitchRow`,
`EntryRow`, `PasswordEntryRow`, `ShortcutLabel`, `WindowTitle` — and the
distance over all 40 pairs is **491**, from 599.

Two panes were DRIFT rather than a gap, and the arm is how they surfaced.
`ShortcutLabel` showed one keycap where the preview and the `gjs` pane show
five, though the port parses the same accelerator grammar through
`@gjsify/adwaita-core`. `AlertDialog` never marked its Delete response
destructive, though `setResponseAppearance` is there — it takes the nick
rather than an `Adw.ResponseAppearance` constant.

## What stayed different, and under which declared reason

35 blocks are ledgered, each opening with the KIND of work closing it would
take — most expensive kind wins, or the cheapest word wins every argument:

- `property` 17 — one side sets what the other has no counterpart for. The
  port's `Gtk` namespace has 5 of 106 members, so any GTK widget outside
  Button/DropDown/Entry/Image/MenuButton lands here by construction.
- `composition` 10 — two different programs. Four are the `layout.mdx`
  blocks, where the NativeScript pane is a `~/adw` barrel and a
  `Builder.load()` rather than a construction at all; the rest are blocks
  where a `@nativescript/core` layout stands in for a widget the port does
  not ship.
- `glyph` 4 — the port's icon properties take an SVG SOURCE, so the pane
  imports its glyph. One renderer decision would close the whole bucket.
- `vocabulary` 4 — a rename away.

Four panes keep a `@gjsify/adwaita-nativescript` import and say why in the
fence: three bind the type `AdwViewPage`, one binds
`NOTIFY_SIDEBAR_SELECTED`. Neither is a widget, so neither has a namespace
member, and § 3's "never a rename" is why they are not given one.

## The mechanism

`check-website-adwaita-gallery.mjs` arm 12 partitions every block into
same-text or ledgered-with-a-reason, and PRINTS the partition and the
distance on every run — no count in a header, no count in prose.

**ONE declared normalisation**: the lines that BIND the widget namespaces
are read as the namespaces they bind, so the package barrel and the two
`gi://` lines compare equal. That is exactly the equivalence stage 9
established, and declaring it is what keeps the number honest — without it,
this very PR would have cut the printed distance by forty lines while moving
no program.

It lives in that file and not in `check-generated-website-data.mjs`, whose
arm 11 holds the same claim over the two authored TREES: that arm's corpus
is generated data and never opens an `.mdx`; this file's corpus is the
blocks, which its arm 5 already reads.

Ledger entries are **self-retiring**, the shape arm 5b and arm 11 already
have. Both directions A/B-proven on the real gallery: breaking an identical
pair reports it unledgered, closing a ledgered one reports the entry stale.

Vectors run before a page is read. The normalisation is asserted on its own
OUTPUT beside them, because the partition alone cannot see a widening that
changes no verdict — measured: widening the specifier set to `@gjsify/*`
left every partition vector green and moved only the distance. Both
widenings (the specifier set, dropping the names from the marker) now go red
in the self-test.

## Making a converged pane checkable, not just plausible

Stage 8's bag would have taken coverage away. `check-doc-fences.mjs`'s
NativeScript arm held every `x.p = v` against the port's declared members
and saw nothing of `new Adw.Avatar({ p: v })`, so moving the panes would
have moved their properties out of its sight.

The arm now reads both doors with the SAME predicate — they are the same
claim about the widget — and both refuse a getter with no setter, which a
bag rejects by name and a bare assignment throws on in strict mode. 143
property writes held before, 153 after. A/B-proven with an unknown key
(`showInitals`) and a read-only one (`Adw.StatusPage.child`).

Its bag reader carries its own vectors, and one found a real defect in the
first cut: the shared `matchingBrace` counts a `{` inside a string literal,
so `title: "a { b"` swallowed the whole bag and the reader returned nothing
— which would have passed every bag in the gallery.

## Deliberately not fixed

- **Nothing here runs either pane.** They are compared as TEXT and their
  properties are held against the port's SOURCE. That a converged pane
  renders the same tree on a phone is ADR 0027 § 9's question, still open.
- **A `nativescript` fence is not typechecked in the API-shape sense.** The
  SNIPPETS arm reads TS2304 only, per page, and cannot isolate a fence.
  Recorded in `open-todos` with what would close it. Verified locally with
  a typescript-only `node_modules`: 177 of 218 fences typechecked, zero
  TS2304 across the docs, so the rewritten panes add none.
- **The `--gi-renderer` flag is now load-bearing for a reader**, so each
  gallery page says so in the paragraph that already explains how the two
  ports follow libadwaita's naming. Nothing holds that sentence — arm 10
  holds window TITLES in prose, and this is not one.
- **The preview/blueprint surfaces are untouched.** `Adw.EntryRow`'s
  `showApplyButton` is on the `gjs` pane and not on the other two; that is
  the cross-surface gap `open-todos` already records, not this PR's.

Expect a rebase against `feat/portable-values-at-the-seam`: it edits the
`Adw.ComboRow` and `Gtk.DropDown` blocks, both of which are ledgered here.
The `open-todos` edit is one self-contained block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtCcG3LLsz9voXAG9DVjhD

