### PR TITLE
docs(website): lighter, reader-facing documentation

### DIFF
--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -1,6 +1,6 @@
 ---
 title: CLI Reference
-description: Every gjsify command, with the flags, defaults and examples you actually need.
+description: Every gjsify command, with its flags, defaults and examples.
 ---
 
 `gjsify` is the only binary a GJSify project needs. It scaffolds, builds, runs, tests, formats, packages and publishes.
@@ -22,9 +22,9 @@ deno run -A --reload --min-dep-age=0 npm:@gjsify/cli@latest <command>
 
 See [Install & Update](/gjsify/guides/install/) for the details.
 
-Keep the `@latest` tag. All three runners reuse a cached copy of an unpinned bin, so a plain `npx @gjsify/cli …` can go on serving a release from months ago, and Deno adds a second rule that refuses anything published in the last 24 hours. Neither one tells you it happened; [Which version do `npx`, `bunx` and `deno run` give you?](/gjsify/guides/install/#which-version-do-npx-bunx-and-deno-run-give-you) has the measurement. Every example below writes plain `gjsify`; swap in whichever launcher you use.
+Keep the `@latest` tag. All three runners reuse a cached copy of an unpinned bin, so a plain `npx @gjsify/cli …` can go on serving a release from months ago. Deno adds a second rule and refuses anything published in the last 24 hours. Neither one tells you it happened. [Which version do `npx`, `bunx` and `deno run` give you?](/gjsify/guides/install/#which-version-do-npx-bunx-and-deno-run-give-you) has the measurement. Every example below writes plain `gjsify`. Swap in whichever launcher you use.
 
-`gjsify --help` lists every command, and its last line tells you which runtime the CLI itself is on, for example `Running on GJS 1.88.1 (SpiderMonkey)` or `Running on Node.js v24.x.y`. Each command prints its own flags with `gjsify <command> --help`, except the two pass-through commands, `run` and `tsc`, which hand `--help` to the target they launch. That host runtime picks the default `--app` target for `gjsify build` and the default `--runtime` for `gjsify run` and `gjsify storybook`.
+`gjsify --help` lists every command, and its last line tells you which runtime the CLI itself is on, for example `Running on GJS 1.88.1 (SpiderMonkey)` or `Running on Node.js v24.x.y`. Each command prints its own flags with `gjsify <command> --help`. The two pass-through commands, `run` and `tsc`, hand `--help` to the target they launch instead. That host runtime picks the default `--app` target for `gjsify build` and the default `--runtime` for `gjsify run` and `gjsify storybook`.
 
 ## Commands at a glance
 
@@ -55,7 +55,7 @@ gjsify create my-app --template cli --package-manager pnpm --install
 gjsify create                       # pick template, runtime and manager interactively
 ```
 
-On a terminal it asks three questions in order (template, runtime, package manager), each narrowing the next. Every one can be answered by a flag instead, which is also how it is driven without a TTY. `npm create @gjsify/app` is the same scaffolder and takes the same flags.
+On a terminal it asks three questions in order (template, runtime, package manager), each narrowing the next. Every one can be answered by a flag instead, which is how you drive it without a TTY. `npm create @gjsify/app` is the same scaffolder and takes the same flags.
 
 | Option | Default | Description |
 |---|---|---|
@@ -66,7 +66,7 @@ On a terminal it asks three questions in order (template, runtime, package manag
 | `-f`, `--force` | `false` | Scaffold into a directory that already has files in it. |
 | `--install` | `false` | Run an install right after scaffolding. |
 
-An installer has to produce the module layout its runtime resolves against, so the runtime decides which managers are offered: `gjs` → `gjsify`; `node` → `npm`, `yarn`, `pnpm`, `gjsify`; `bun` → `bun`; `deno` → `deno`. Where a runtime offers exactly one, nothing is asked: it is used and announced. Passing `-p` without `-r` settles the runtime too, since a pinned manager already names one (`-p bun` sets the project up for Bun).
+An installer has to produce the module layout its runtime resolves against, so the runtime decides which managers are offered: `gjs` → `gjsify`; `node` → `npm`, `yarn`, `pnpm`, `gjsify`; `bun` → `bun`; `deno` → `deno`. Where a runtime offers exactly one, nothing is asked. gjsify uses it and says so. Passing `-p` without `-r` settles the runtime too, since a pinned manager already names one (`-p bun` sets the project up for Bun).
 
 The templates:
 
@@ -80,7 +80,7 @@ The templates:
 | `web-server-express` | HTTP server on Express. |
 | `web-server-hono` | HTTP server on Hono, fetch-style API. |
 
-Every template ships `src/`, a `tsconfig.json` and a `package.json` with `build`, `start`, `dev`, `check` and `clear` scripts. All seven declare `gjs`, `node`, `bun` and `deno` in `gjsify.example.runtimes` and build both bundles (`build:gjs` and `build:node`), so `-r` decides which start script the printed next steps name (`start` for gjs, `start:node`, `start:bun` or `start:deno` for the others), not what the project can do later. The GTK templates list `@gjsify/node-gi` as a dependency, which is what carries `gi://` on the three non-GJS runtimes. Scaffolding is done by [`@gjsify/create-app`](https://www.npmjs.com/package/@gjsify/create-app).
+Every template ships `src/`, a `tsconfig.json` and a `package.json` with `build`, `start`, `dev`, `check` and `clear` scripts. All seven declare `gjs`, `node`, `bun` and `deno` in `gjsify.example.runtimes` and build both bundles (`build:gjs` and `build:node`). So `-r` only decides which start script the printed next steps name: `start` for gjs, `start:node`, `start:bun` or `start:deno` for the others. It does not limit what the project can do later. The GTK templates list `@gjsify/node-gi` as a dependency, which is what carries `gi://` on the three non-GJS runtimes. Scaffolding is done by [`@gjsify/create-app`](https://www.npmjs.com/package/@gjsify/create-app).
 
 ## Build and run
 
@@ -103,7 +103,7 @@ gjsify build src/index.ts --watch                               # rebuild on cha
 | `--minify` | bool | `true` | Minify the output. Pass `--no-minify` for pretty-printed code. |
 | `--globals` | string | `auto` | Which globals to inject. See [Globals](#globals). |
 | `--dialect` | `react-native` | none | Build a React Native application for a desktop target. Aliases `react-native` to [`@gjsify/react-native`](/gjsify/frameworks/react-native/) so your files keep the import they already have, and fails the build on a name that layer does not implement, naming the file and the line. Opt-in only, on `--app gjs` and `--app node`; also readable as `gjsify.dialect` in `package.json`. |
-| `--gi-renderer` | bool | `false` | Resolve `gi://Ns?version=X` to the target's widget renderer instead of to an empty module, so `import Adw from 'gi://Adw?version=1'` is the same line on every target. `--app browser` answers `gi://Adw` and `gi://Gtk` out of [`@gjsify/adwaita-web`](/gjsify/widgets/), `--app nativescript` out of `@gjsify/adwaita-nativescript`; `@girs/adw-1` reaches the same namespace. A namespace with no renderer, and a `?version=` the renderer's vocabulary was not generated against, both FAIL the build by name, and reading a widget the renderer does not ship throws naming it. Opt-in only, on those two targets. |
+| `--gi-renderer` | bool | `false` | Resolve `gi://Ns?version=X` to the target's widget renderer instead of to an empty module, so `import Adw from 'gi://Adw?version=1'` is the same line on every target. `--app browser` answers `gi://Adw` and `gi://Gtk` out of [`@gjsify/adwaita-web`](/gjsify/adwaita/), `--app nativescript` out of `@gjsify/adwaita-nativescript`; `@girs/adw-1` reaches the same namespace. A namespace with no renderer, and a `?version=` the renderer's vocabulary was not generated against, both FAIL the build by name, and reading a widget the renderer does not ship throws naming it. Opt-in only, on those two targets. |
 | `--exclude-globals` | list | none | Identifiers to drop from the auto-detected set, for false positives out of dead compat code (`--exclude-globals fetch,XMLHttpRequest`). |
 | `--shebang` | bool | `false` | Prepend a target-appropriate shebang and `chmod 755` the output: `#!/usr/bin/env -S gjs -m` for `--app gjs`, `#!/usr/bin/env node` for `--app node`. Needs a single `--outfile`. |
 | `-w`, `--watch` | bool | `false` | Watch sources and rebuild on change, logging each rebuild with its duration. Ctrl-C stops it cleanly. Rejected with `--library`, and it needs the npm `rolldown` engine, so run it under Node. On GJS use [`gjsify dev`](#gjsify-dev), which needs no watcher API and relaunches the app too. |
@@ -126,7 +126,7 @@ gjsify build src/index.ts --watch                               # rebuild on cha
 
 For `--app gjs` the JS target is `firefox140` (SpiderMonkey 140), and `gi://*`, `cairo`, `system` and `gettext` stay external. For `--app node` the target is `node24`.
 
-**Native N-API addons on GJS.** A `--app gjs` build routes a compiled `.node` addon through [`@gjsify/napi`](/gjsify/projects/napi/)'s `loadAddon`, intercepting the addon's own `bindings` or `node-gyp-build` helper (or a direct `.node` import) and finding the binary with node-gyp-build's probe order. So `import Database from 'better-sqlite3'` works after `gjsify install @gjsify/napi`, with no config. It does nothing when no native addon is in the graph, and it never applies to `--app node`, `browser` or `nativescript`.
+**Native N-API addons on GJS.** A `--app gjs` build routes a compiled `.node` addon through [`@gjsify/napi`](/gjsify/projects/napi/)'s `loadAddon`. It intercepts the addon's own `bindings` or `node-gyp-build` helper, or a direct `.node` import, and finds the binary with node-gyp-build's probe order. So `import Database from 'better-sqlite3'` works after `gjsify install @gjsify/napi`, with no config. It does nothing when no native addon is in the graph, and it never applies to `--app node`, `browser` or `nativescript`.
 
 </details>
 
@@ -141,17 +141,17 @@ gjsify build src/app.tsx --app gjs --outfile dist/app.gjs.mjs
 - [`@gjsify/rolldown-plugin-solid`](/gjsify/frameworks/solid/) for SolidJS JSX
 - [`@gjsify/rolldown-plugin-vue`](/gjsify/frameworks/vue/) for Vue single-file components
 
-**`--app gjs` refuses a JSX entry that configures no transform**, and that refusal is the point. Left unset, the transformer applies its own default — the automatic React runtime — so the bundle imports `react/jsx-runtime`. GJS resolves no bare specifier, so the build would report the miss as a *warning*, exit 0, and the artifact would abort at load with `ImportError: Module not found: react/jsx-runtime`. On a project that does have React installed it is worse: the bundle builds React elements, which a GTK host does nothing with.
+**`--app gjs` refuses a JSX entry that configures no transform**, and that refusal is the point. Left unset, the transformer falls back to the automatic React runtime, so the bundle imports `react/jsx-runtime`. GJS resolves no bare specifier, so the build would report the miss as a *warning*, exit 0, and the artifact would abort at load with `ImportError: Module not found: react/jsx-runtime`. On a project that does have React installed it is worse: the bundle builds React elements, which a GTK host does nothing with.
 
 Answer the question one of three ways, and the error message lists all three:
 
 | Answer | How |
 |---|---|
 | Preserve the JSX for a framework compiler | `"jsx": "preserve"` in tsconfig or `gjsify.bundler.transform.jsx`, plus the plugin above. Pair with tsconfig `"jsxImportSource": "@gjsify/gtk-host"` for the types. |
-| Use an automatic runtime you actually have | `"jsx": "react-jsx"` + `"jsxImportSource": "<pkg exporting ./jsx-runtime>"`. **Not** `@gjsify/gtk-host` — its `/jsx-runtime` is a type surface and throws when called. |
+| Use an automatic runtime you actually have | `"jsx": "react-jsx"` + `"jsxImportSource": "<pkg exporting ./jsx-runtime>"`. **Not** `@gjsify/gtk-host`. Its `/jsx-runtime` is types only and throws when called. |
 | Say the entry holds no JSX | `"jsx": false`, and the transformer reports the JSX itself. |
 
-`--app node` and `--app browser` are unaffected: the React default is a legitimate answer there, and refusing would break builds for a mistake they did not make.
+`--app node` and `--app browser` are unaffected. The React default is a legitimate answer there, and refusing would break builds for a mistake they did not make.
 
 #### Bundle a third-party CLI that reads its own `package.json`
 
@@ -195,7 +195,7 @@ gjsify build src/index.ts -o dist/index.js --verbose
 #   AbortSignal, Buffer, HTMLElement, document, fetch, navigator, …
 ```
 
-The multi-pass machinery behind this is described in [How It Works](/gjsify/how-it-works/#automatic-globals-detection).
+[How It Works](/gjsify/how-it-works/#automatic-globals-detection) describes the multi-pass machinery.
 
 ### Known identifiers
 
@@ -309,7 +309,7 @@ These are deliberately not part of the coarse `dom` group. Injecting one require
 
 Identifiers outside this table are ignored. If you still hit `ReferenceError: X is not defined`, add `X` as an extra: `--globals auto,X`.
 
-The two GTK-backed groups are the ones an `--app node` build can also ask for. A plain `--globals auto` node build injects nothing, because Node, Bun and Deno bring their own `fetch`, streams, crypto and events. Name a group or an identifier explicitly and it injects the same register modules the `--app gjs` target would, reaching GTK through [`@gjsify/node-gi`](/gjsify/projects/node-gi/). That is what the Adwaita templates' `build:node` script does — `gtk-minimal` needs none of it, because plain GTK reaches no DOM API:
+The two GTK-backed groups are the ones an `--app node` build can also ask for. A plain `--globals auto` node build injects nothing, because Node, Bun and Deno bring their own `fetch`, streams, crypto and events. Name a group or an identifier explicitly and it injects the same register modules the `--app gjs` target would, reaching GTK through [`@gjsify/node-gi`](/gjsify/projects/node-gi/). That is what the Adwaita templates' `build:node` script does. `gtk-minimal` needs none of it, because plain GTK reaches no DOM API:
 
 ```bash
 gjsify build src/index.ts --app node --outfile dist/index.node.mjs --globals auto,dom
@@ -339,7 +339,7 @@ gjsify dev --build-only          # rebuild on every change, never launch
 
 **What gets built is not declared twice.** `gjsify dev` reads your own `build:gjs` / `build:node` script and layers its flags on top, so the dev loop and `gjsify run build` cannot drift into producing different bundles. Override one flag at a time with `--globals` or `--outfile`, pass a different entry as the positional argument, or point `--script` at another script to follow a different build entirely.
 
-**Why this is not `gjsify build --watch`.** That flag drives rolldown's watcher API, which only the npm engine exposes — on a Node-free GJS host it is not available at all. `gjsify dev` asks for no watcher API: it watches with `fs.watch` and rebuilds by re-entering the ordinary build command, so the same loop runs on gjs, node, bun and deno.
+**Why this is not `gjsify build --watch`.** That flag drives rolldown's watcher API, which only the npm engine exposes. On a Node-free GJS host it is not there at all. `gjsify dev` asks for no watcher API. It watches with `fs.watch` and rebuilds by re-entering the ordinary build command, so the same loop runs on gjs, node, bun and deno.
 
 ### `gjsify run`
 
@@ -355,7 +355,7 @@ gjsify run ./server.mjs -- --port 8080
 | Argument / Option | Description |
 |---|---|
 | `<target>` | A script name from the current `package.json`, or a path to a built bundle. |
-| `[args..]` | Extra arguments forwarded to the script or to the runtime. Use `--` before flags you do not want gjsify to parse. Everything after `--` reaches the target as you typed it, numbers included — `-- --port 8080` arrives as `--port 8080`, and `-- --scale 1.0` arrives as `1.0` rather than `1`. |
+| `[args..]` | Extra arguments forwarded to the script or to the runtime. Use `--` before flags you do not want gjsify to parse. Everything after `--` reaches the target as you typed it, numbers included: `-- --port 8080` arrives as `--port 8080`, and `-- --scale 1.0` arrives as `1.0` rather than `1`. |
 | `-w`, `--workspace <name>` | Run `<target>` as a script in the named workspace, like `npm run <script> -w <name>`. Matches the package name, the workspace-relative path, or the directory basename. |
 | `--runtime <gjs\|node\|bun\|deno>` | Launch a bundle **file** on this runtime. Forces file mode. |
 | `--node-script` | Treat `<target>` as an unbundled Node-style script that imports `node:` builtins, and run it on the host runtime. Under GJS the file is bundled `--app gjs` on the fly first, which is what lets a repo script run on a machine with no Node. Cannot be combined with `--runtime` or `--workspace`. |
@@ -366,7 +366,7 @@ For a bundle file, `gjsify run` also sets `GI_TYPELIB_PATH` plus the host's libr
 
 #### Run a bundle on gjs, node, bun or deno
 
-Without `--runtime`, a bundle file follows the host runtime the CLI is on, with one exception: a `--app gjs` bundle (it keeps `gi://` imports and a `gjs` shebang) always runs on `gjs`, because it has no node-gi shim. `gjs` runs it via `gjs -m`. `node`, `bun` and `deno` all run the **same** `--app node` bundle, since Node-API is their common ABI. `@gjsify/node-gi` is only needed when the bundle actually uses `gi://`.
+Without `--runtime`, a bundle file follows the host runtime the CLI is on. A `--app gjs` bundle is the exception and always runs on `gjs`, because it has no node-gi shim. gjsify recognises it by its `gi://` imports and its `gjs` shebang. `gjs` runs it via `gjs -m`. `node`, `bun` and `deno` all run the **same** `--app node` bundle, since Node-API is their common ABI. `@gjsify/node-gi` is only needed when the bundle actually uses `gi://`.
 
 ```bash
 gjsify build src/app.ts --app gjs  --outfile dist/app.gjs.mjs
@@ -418,7 +418,7 @@ gjsify test --rebuild           # rebuild even if bundles look fresh
 | `--build` | `true` | Build before running. `--no-build` skips it when bundles already exist. |
 | `--verbose` | `false` | Print the resolved entry and outdir plus per-step timing. |
 
-`gjs` and `node` are the only two runtimes this command drives: it builds the `--app gjs` and `--app node` bundles and runs each on its own runtime. Bun and Deno consume the same `--app node` bundle, so you can point them at it yourself with [`gjsify run --runtime`](#gjsify-run), but `gjsify test` does not drive them.
+`gjs` and `node` are the only two runtimes this command drives. It builds the `--app gjs` and `--app node` bundles and runs each on its own runtime. Bun and Deno consume the same `--app node` bundle, so you can point them at it yourself with [`gjsify run --runtime`](#gjsify-run), but `gjsify test` does not drive them.
 
 A runtime you did not ask for explicitly is skipped when its binary is not on `PATH`, with a line saying so. Set defaults in `package.json`:
 
@@ -508,7 +508,7 @@ Anything you would pass repeatedly on the command line can live in the `gjsify` 
 
 ### Where `define` goes
 
-`define` belongs under `bundler.transform.define`, not at the top level of `bundler`. Rolldown reads only the nested one. If you write `bundler.define`, GJSify moves it for you and warns at build time; move it yourself to silence the warning.
+`define` belongs under `bundler.transform.define`, not at the top level of `bundler`. Rolldown reads only the nested one. If you write `bundler.define`, GJSify moves it for you and warns at build time. Move it yourself to silence the warning.
 
 ```jsonc
 // works, but warns on every build
@@ -554,9 +554,9 @@ An unset variable with no `default` becomes the literal `undefined`, so you can 
 | `export` | `default` | Which export to call. It has to be a function returning a Rolldown plugin. |
 | `options` | `{}` | Passed to that function. |
 
-`plugins` is an array, and every entry is an object with those fields — a bare `"@gjsify/rolldown-plugin-solid"` string is not the same thing and is not accepted.
+`plugins` is an array, and every entry is an object with those fields. A bare `"@gjsify/rolldown-plugin-solid"` string is not the same thing and is not accepted.
 
-A named plugin must be a real dependency of the package that configures it — `dependencies`, `devDependencies` or `optionalDependencies`, any of the three. In a monorepo an undeclared one resolves anyway through the hoisted root `node_modules` and then stops resolving the moment the package is installed from npm, which is a declaration that is true in the tree and false everywhere else. `gjsify` conformance fails on it rather than letting it ship.
+A named plugin must be a real dependency of the package that configures it: `dependencies`, `devDependencies` or `optionalDependencies`, any of the three. In a monorepo an undeclared one resolves anyway through the hoisted root `node_modules`, then stops resolving the moment the package is installed from npm. That declaration is true in your tree and false everywhere else, so `gjsify` conformance fails on it rather than letting it ship.
 
 Plugins run in the order listed.
 
@@ -630,7 +630,7 @@ gjsify install -g @gjsify/cli   # global install under ~/.local/share/gjsify/glo
 | `--force` | `false` | Install a required dependency even when its `os` / `cpu` / `libc` excludes the target, instead of failing with `EBADPLATFORM`. Incompatible optional dependencies stay skipped. |
 | `--prune` | `true` | Afterwards, remove packages an earlier install left behind that this host cannot use, see [`gjsify prune`](#gjsify-prune). `--no-prune` disables. Skipped under `--immutable`, and whenever `--os`/`--cpu`/`--libc` is given. |
 
-The resolver follows npm v3 and later semantics, and honours npm-style `overrides` and yarn-style `resolutions` in `package.json`. The lockfile is `gjsify-lock.json`, a path-keyed `packages` map at `lockfileVersion` 4. There is more on how the tree is built in [How It Works](/gjsify/how-it-works/#how-gjsify-install-resolves-a-tree).
+The resolver follows npm v3 and later semantics, and honours npm-style `overrides` and yarn-style `resolutions` in `package.json`. The lockfile is `gjsify-lock.json`, a path-keyed `packages` map at `lockfileVersion` 4. [How It Works](/gjsify/how-it-works/#how-gjsify-install-resolves-a-tree) has more on how the tree is built.
 
 ### `gjsify uninstall`
 
@@ -662,7 +662,7 @@ gjsify prune                    # the same, for this project's node_modules
 gjsify prune -g --os=darwin     # what a darwin host could not use
 ```
 
-The decision is a **pure manifest read**: npm's own `os`, `cpu` and `libc`, through the same check the installer filters with, so a pruned prefix converges on what a fresh install would have placed. A package that declares **no** platform is never touched, however unusable it looks. Inferring that from a package *name* is how a prune starts deleting things it cannot justify.
+The decision is a **pure manifest read** of npm's own `os`, `cpu` and `libc`, through the same check the installer filters with. So a pruned prefix converges on what a fresh install would have placed. A package that declares **no** platform is never touched, however unusable it looks. Inferring that from a package *name* is how a prune starts deleting things it cannot justify.
 
 `install` and `self-update` run the same pass automatically, and `--no-prune` opts out. That pass uses the **measured** host and refuses outright when `--os`, `--cpu` or `--libc` is given, so an install can never delete against a target you typed. On this command those flags are honoured, because asking is not a side effect.
 
@@ -673,7 +673,7 @@ The decision is a **pure manifest read**: npm's own `os`, `cpu` and `libc`, thro
 | `--verbose` | `false` | List every package rather than the first few. |
 | `--os <name>` / `--cpu <arch>` / `--libc <name>` | this host | Decide as if the host were this target. |
 
-Removing nothing is a success, since this is idempotent housekeeping. It exits non-zero only when a removal you asked for failed. Sizes are **apparent**, summed from the files, so `du`, which counts allocated blocks, reports a slightly different number.
+Removing nothing is a success, since this is idempotent housekeeping. It exits non-zero only when a removal you asked for failed. Sizes are **apparent**, summed from the files, so `du`, which counts allocated blocks, reports a different number.
 
 ### `gjsify upgrade`
 
@@ -703,25 +703,25 @@ gjsify upgrade --align --exact --filter @girs    # fix that gate, offline
 | `--exclude-workspace <pattern>` | none | Skip workspaces, for ones with deliberate dependency drift such as integration tests pinned to a specific upstream. Repeatable. |
 | `--align` | `false` | Offline repair mode: find deps declared at several ranges and align them to the highest. With `--exact`, also drop the operator from declarations that already agree. No registry calls. |
 | `--check` | `false` | CI gate: exit non-zero when any dep is declared inconsistently across workspaces. Offline. `--align` with the same flags is the fix. |
-| `--exact` | `false` | Pin without a range operator. Writing, emits `1.2.3` instead of `^1.2.3`; with `--check`, fails on any matched dep that carries one; with `--align`, repairs exactly that. Pair with `--filter` — a repository-wide exactness run touches every ordinary caret dep by design. |
+| `--exact` | `false` | Pin without a range operator. Writing, emits `1.2.3` instead of `^1.2.3`; with `--check`, fails on any matched dep that carries one; with `--align`, repairs exactly that. Pair with `--filter`. A repository-wide exactness run touches every ordinary caret dep by design. |
 | `--dry-run` | `false` | Print the plan without writing. |
 | `-y`, `--yes` | `false` | In interactive mode, select everything without prompting. |
 | `--cwd <path>` | `process.cwd()` | Project directory. From inside a workspace it walks up to the monorepo root. |
 | `--verbose` | `false` | Print resolution details. |
 
-`workspace:`, `file:`, `link:`, `git:`, `git+`, `http(s):`, `npm:`, `*` and `latest` ranges are skipped, since none of them is an external npm dependency. The range prefix is preserved: `^1.2.3` becomes `^2.0.0`, `~0.4.0` becomes `~0.5.0` — unless `--exact` drops it. Lines the update does not touch are left byte-for-byte as they were, so a dependency bump never arrives as a diff over unrelated fields. The registry URL comes from `~/.npmrc`, then `<cwd>/.npmrc`, with `npm_config_registry` overriding both, and scope-specific registries and auth tokens are honoured.
+`workspace:`, `file:`, `link:`, `git:`, `git+`, `http(s):`, `npm:`, `*` and `latest` ranges are skipped, since none of them is an external npm dependency. The range prefix is preserved: `^1.2.3` becomes `^2.0.0` and `~0.4.0` becomes `~0.5.0`, unless `--exact` drops it. Lines the update does not touch are left byte-for-byte as they were, so a dependency bump never arrives as a diff over unrelated fields. The registry URL comes from `~/.npmrc`, then `<cwd>/.npmrc`, with `npm_config_registry` overriding both, and scope-specific registries and auth tokens are honoured.
 
 Output is a colour-coded table (red major, yellow minor, green patch, cyan prerelease). Run `gjsify install` afterwards to fetch the new versions.
 
 `@gjsify/*` packages ship as one release train, so upgrade them together: `gjsify upgrade --latest --filter @gjsify`. See [Versioning & Compatibility](/gjsify/versioning/).
 
-`--check` and `--align` answer the same two questions, so whatever the gate rejects the repair with the same flags fixes. Without `--exact` that question is consistency alone, and a tree where every manifest agrees on `^4.1.0` is done. `--exact` adds exactness, which consistency cannot answer — those same manifests all carry an operator — so `--align --exact` widens to every matched declaration that has one and rewrites it at its declared version, operator dropped. It never asks the registry: `^4.1.0` becomes `4.1.0`, not the newest 4.x. Use `--latest --exact` when you want the newest release instead. A range that names no single version (`^1.x`) cannot be pinned offline; `--align` names those deps and exits non-zero rather than reporting a repair the gate will still reject.
+`--check` and `--align` answer the same two questions, so whatever the gate rejects the repair with the same flags fixes. Without `--exact` the question is consistency alone, and a tree where every manifest agrees on `^4.1.0` is done. `--exact` adds exactness, which consistency cannot answer, because those same manifests all carry an operator. So `--align --exact` widens to every matched declaration that has one and rewrites it at its declared version, operator dropped. It never asks the registry: `^4.1.0` becomes `4.1.0`, not the newest 4.x. Use `--latest --exact` when you want the newest release instead. A range that names no single version (`^1.x`) cannot be pinned offline. `--align` names those deps and exits non-zero rather than reporting a repair the gate will still reject.
 
-`@girs/*` is pinned **exactly** in this repository, and a CI step holds it that way. Consistency is not the same question: every manifest agreeing on one caret is perfectly consistent and still resolves to whatever is newest, and a published package's declaration is what a consumer installs against with no lockfile of ours. Since `@gjsify/gtk-host` consumes the `@girs/<ns>/vocabulary` subpath, a minor release moving it under such an install is a real hazard — so the pin is the whole version.
+`@girs/*` is pinned **exactly** in this repository, and a CI step holds it that way. Consistency is not the same question. Every manifest agreeing on one caret is perfectly consistent and still resolves to whatever is newest, and a published package's declaration is what a consumer installs against with no lockfile of ours. Since `@gjsify/gtk-host` consumes the `@girs/<ns>/vocabulary` subpath, a minor release moving it under such an install is a real hazard. So the pin is the whole version.
 
 ### `gjsify dlx`
 
-Run the GJS bundle of a published package without adding it to your project, like `npx` or `yarn dlx`. It is strictly a GJS-bundle runner: it resolves the package's GJS entry and calls `gjs -m <bundle>`. A package with no GJS entry fails loudly.
+Run the GJS bundle of a published package without adding it to your project, like `npx` or `yarn dlx`. It is strictly a GJS-bundle runner. It resolves the package's GJS entry and calls `gjs -m <bundle>`. A package with no GJS entry fails loudly.
 
 ```bash
 gjsify dlx @gjsify/example-dom-canvas2d-fireworks
@@ -805,7 +805,7 @@ gjsify generate-installer \
 | `--output <file>` | `install.mjs` | Where to write it. |
 | `--force` | `false` | Overwrite an existing file. |
 
-The generated file is a copy of GJSify's own `install.mjs` with three constants substituted. Commit it. The full publication workflow is in [Distributing GJS apps](/gjsify/guides/distributing-gjs-apps/).
+The generated file is a copy of GJSify's own `install.mjs` with three constants substituted. Commit it. [Distributing GJS apps](/gjsify/guides/distributing-gjs-apps/) has the full publication workflow.
 
 ## Work in a monorepo
 
@@ -866,7 +866,7 @@ gjsify workspace @gjsify/website build -d      # build its deps first
 
 ### Build cache
 
-With `--cached` (or `GJSIFY_BUILD_CACHE=1`; an explicit `--no-cached` wins), `gjsify foreach <script>` and `gjsify workspace <name> <script>` skip workspaces whose inputs are unchanged and restore the stored outputs instead of re-running the script.
+`gjsify foreach <script>` and `gjsify workspace <name> <script>` can skip workspaces whose inputs are unchanged and restore the stored outputs instead of re-running the script. Turn that on with `--cached` or `GJSIFY_BUILD_CACHE=1`. An explicit `--no-cached` wins over both.
 
 ```bash
 gjsify foreach build -tp --cached          # rebuild only what changed
@@ -918,7 +918,7 @@ gjsify check --no-parallel --verbose      # sequential, full output
 | `-j`, `--jobs <n>` | `os.cpus().length` | Max workers when parallel. |
 | `--verbose` | `false` | Log each per-workspace command before spawning. |
 
-In a workspace root it walks every package that defines a `check` script and runs `npm run check` in each. Inside a single package it runs that package's `check` script directly. Exit code is 1 if any check fails. With `--no-parallel` you get the first non-zero code; in parallel mode you get a summary of the failures.
+In a workspace root it walks every package that defines a `check` script and runs `npm run check` in each. Inside a single package it runs that package's `check` script directly. Exit code is 1 if any check fails. With `--no-parallel` you get the first non-zero code. In parallel mode you get a summary of the failures.
 
 ### `gjsify tsc`
 
@@ -929,7 +929,7 @@ gjsify tsc --noEmit
 gjsify tsc -p tsconfig.build.json
 ```
 
-Two engines back it, picked by what is on the machine: the `@gjsify/tsc` bundle spawned as `gjs -m <bundle>` when that bundle resolves and `gjs` is on `PATH`, otherwise upstream npm `typescript` spawned on Node. If neither is there it says so and exits 1, naming both fixes. It is the same thing as the `gjsify-tsc` bin from `@gjsify/tsc`. Most templates wire it into their `check` script.
+Two engines back it, and the machine picks. The `@gjsify/tsc` bundle runs as `gjs -m <bundle>` when that bundle resolves and `gjs` is on `PATH`. Otherwise gjsify spawns upstream npm `typescript` on Node. If neither is there it says so and exits 1, naming both fixes. It is the same thing as the `gjsify-tsc` bin from `@gjsify/tsc`. Most templates wire it into their `check` script.
 
 ### `gjsify format`
 
@@ -952,11 +952,11 @@ gjsify format --no-write src/    # report drift locally without writing
 | `--force` | `false` | With `--init`, overwrite the existing config files. |
 | `--verbose` | `false` | Echo the resolved oxfmt launcher and args before spawning. |
 
-A bare `gjsify format` writes. There is no flagless report mode: `--check` is the read-only CI mode and `--no-write` the read-only local one.
+A bare `gjsify format` writes. There is no flagless report mode. `--check` is the read-only CI mode, `--no-write` the read-only local one.
 
 Under GJS, formatting runs in-process through the `@gjsify/oxfmt-native` bridge. Everywhere else the `oxfmt` npm launcher is resolved from `node_modules` and spawned with `node`. Set `GJSIFY_OXFMT=npm` to force the launcher, or `GJSIFY_OXFMT=native` to fail instead of falling back when the prebuild is missing. From inside a sub-workspace, resolution walks up to the workspace root, so a single `.oxfmtrc.json` there applies everywhere.
 
-oxfmt itself formats more than JS and TS — JSON, CSS and TOML among them — but the `.oxfmtrc.json` that `--init` writes ignores every one of those, so a GJSify project formats JS and TS only. Drop a pattern from `ignorePatterns` to widen it.
+oxfmt itself formats JSON, CSS and TOML as well as JS and TS. The `.oxfmtrc.json` that `--init` writes ignores every one of those, so a GJSify project formats JS and TS only. Drop a pattern from `ignorePatterns` to widen it.
 
 If oxfmt is missing you get `[gjsify oxc] oxfmt not found.` with `gjsify install -D oxfmt` as the hint, and exit 1.
 
@@ -964,7 +964,7 @@ If oxfmt is missing you get `[gjsify oxc] oxfmt not found.` with `gjsify install
 
 `.oxfmtrc.json`: 4-space indent, single quotes, semicolons, trailing commas everywhere, arrow parens always, print width 120, bracket spacing on. This matches the GJSify codebase and the GNOME Shell style guide. Generated artifacts are excluded (`dist`, `lib`, `cli.gjs.mjs`, `test.{gjs,node}.mjs`), along with Flatpak build directories, `refs/`, prebuilds and compiled `.metainfo.xml`.
 
-`.oxlintrc.json`: oxlint's `correctness` category as errors, plus `typescript/no-non-null-assertion` off (the `!` operator is needed on `@girs/*` surfaces), `typescript/no-explicit-any` and `typescript/consistent-type-imports` as warnings, `unicorn/prefer-node-protocol` as an error, and `eslint/no-unused-vars` as a warning. Same excludes as the formatter.
+`.oxlintrc.json`: oxlint's `correctness` category as errors, plus `typescript/no-non-null-assertion` off (the `!` operator is needed on `@girs/*` types), `typescript/no-explicit-any` and `typescript/consistent-type-imports` as warnings, `unicorn/prefer-node-protocol` as an error, and `eslint/no-unused-vars` as a warning. Same excludes as the formatter.
 
 ### `gjsify lint`
 
@@ -983,7 +983,7 @@ gjsify lint --fix        # apply safe fixes
 | `--config-path <path>` | nearest one | `.oxlintrc.json` override. |
 | `--verbose` | `false` | Echo the resolved oxlint launcher and args. |
 
-oxlint is spawned through its Node launcher so its JavaScript plugin host is available. That host is what runs GJSify's own plugin, `@gjsify/oxlint-plugin-gjsify`, wired in through `jsPlugins` in the workspace `.oxlintrc.json`. Its one rule, `gjsify/register-class-order`, catches static GObject metadata (`GTypeName`, `Properties`, `Signals`, `InternalChildren`, `Template`, `CssName` and their siblings) declared after a `static { GObject.registerClass(…) }` block, where `registerClass` runs before the field is assigned and the metadata is silently ignored, and autofixes it by hoisting the fields above the static block. Name the rule when you need to configure or silence it. [GObject classes](/gjsify/patterns/gobject-classes/) explains the trap and the forms that avoid it.
+oxlint is spawned through its Node launcher so its JavaScript plugin host is available. That host is what runs GJSify's own plugin, `@gjsify/oxlint-plugin-gjsify`, wired in through `jsPlugins` in the workspace `.oxlintrc.json`. Its one rule, `gjsify/register-class-order`, catches static GObject metadata (`GTypeName`, `Properties`, `Signals`, `InternalChildren`, `Template`, `CssName` and their siblings) declared after a `static { GObject.registerClass(…) }` block. There `registerClass` runs before the field is assigned, and the metadata is silently ignored. The rule autofixes it by hoisting the fields above the static block. Name the rule when you need to configure or silence it. [GObject classes](/gjsify/patterns/gobject-classes/) explains the trap and the forms that avoid it.
 
 Use [`gjsify fix`](#gjsify-fix) for format plus safe lint fixes in one pass.
 
@@ -1050,7 +1050,7 @@ This used to be called `gjsify check`. The bare name now runs the TypeScript che
 
 **Node.js** is reported but never required. The `install.mjs` bootstrap is run by `gjs`, so "not installed" is a legitimate answer here.
 
-**Build toolchain, optional.** `blueprint-compiler` for `.blp` templates — resolved the same way the build resolves it, so a project with no `.blp` never needs it and a Windows host keeping it off `PATH` under MSYS2 is not a miss. `ninja` and `vala` for the Vala bridges, `cargo` for the three Rust-backed engines (`@gjsify/rolldown-native`, `@gjsify/lightningcss-native`, `@gjsify/oxfmt-native`). You only need these if you rebuild a prebuild from source.
+**Build toolchain, optional.** `blueprint-compiler` for `.blp` templates, resolved the same way the build resolves it. A project with no `.blp` never needs it, and a Windows host keeping it off `PATH` under MSYS2 is not a miss. `ninja` and `vala` for the Vala bridges, `cargo` for the three Rust-backed engines (`@gjsify/rolldown-native`, `@gjsify/lightningcss-native`, `@gjsify/oxfmt-native`). You only need these if you rebuild a prebuild from source.
 
 **Library dependencies, optional.** Checked only when the matching `@gjsify/*` package is in your project:
 
@@ -1189,11 +1189,11 @@ gjsify gettext translations dist/applications \
 
 Needs `msgfmt` (the `gettext` package).
 
-`--format xml` and `--format desktop` **require** `--template`: `msgfmt` cannot produce either shape from `.po` files alone, and refuses with `--desktop requires a "--template template" specification`. The catalogues are merged one at a time with `msgfmt --locale=<lang>`, so no `LINGUAS` file is needed.
+`--format xml` and `--format desktop` **require** `--template`. `msgfmt` cannot produce either shape from `.po` files alone, and refuses with `--desktop requires a "--template template" specification`. The catalogues are merged one at a time with `msgfmt --locale=<lang>`, so no `LINGUAS` file is needed.
 
-For `--format xml`, the template's **filename** matters: `msgfmt --xml` finds its ITS rules by filename *pattern*, not by reading the document. gettext walks `/usr/share/gettext/its/*.loc`, and AppStream's rule there pairs `pattern="*.metainfo.xml"` with the root element `component` — so an AppStream template must be named `*.metainfo.xml` or `*.metainfo.xml.in`. Named `app.xml.in`, the same content fails with `cannot locate ITS rules for app.xml`. Both `metainfo.loc` and `metainfo.its` come from the `appstream` package.
+For `--format xml`, the template's **filename** matters. `msgfmt --xml` finds its ITS rules by filename *pattern*, not by reading the document. gettext walks `/usr/share/gettext/its/*.loc`, and AppStream's rule there pairs `pattern="*.metainfo.xml"` with the root element `component`. So an AppStream template must be named `*.metainfo.xml` or `*.metainfo.xml.in`. Named `app.xml.in`, the same content fails with `cannot locate ITS rules for app.xml`. Both `metainfo.loc` and `metainfo.its` come from the `appstream` package.
 
-There is no `--format json`: `msgfmt` has no JSON writer. Use `@gjsify/vite-plugin-gettext`'s `po2jsonPlugin`, which parses the catalogues directly.
+There is no `--format json`, because `msgfmt` has no JSON writer. Use `@gjsify/vite-plugin-gettext`'s `po2jsonPlugin`, which parses the catalogues directly.
 
 ## Explore
 
@@ -1274,7 +1274,7 @@ With `GJSIFY_DEVTOOLS=1` the storybook host also exposes the devtools control pl
 
 ### `gjsify debug`
 
-Launch an MCP bridge for a running, devtools-enabled GJSify app, talking to its `org.gjsify.Devtools` D-Bus control plane. An MCP client uses this as its server command: the bridge speaks JSON-RPC on stdio and translates each tool call to D-Bus. It comes from [`@gjsify/devtools-mcp`](https://www.npmjs.com/package/@gjsify/devtools-mcp).
+Launch an MCP bridge for a running, devtools-enabled GJSify app, talking to its `org.gjsify.Devtools` D-Bus control plane. An MCP client uses this as its server command. The bridge speaks JSON-RPC on stdio and translates each tool call to D-Bus. It comes from [`@gjsify/devtools-mcp`](https://www.npmjs.com/package/@gjsify/devtools-mcp).
 
 ```bash
 # In .mcp.json:
@@ -1294,11 +1294,11 @@ gjsify debug --build-only --out dist/bridge.gjs.mjs   # build once, point .mcp.j
 | `--out <path>` | `node_modules/.cache/gjsify-debug` | Output bundle path. |
 | `--build-only` | `false` | Build the bridge bundle without launching it. |
 
-`gjsify debug` logs to stderr only, because stdout is the JSON-RPC channel. The bridge resolves `@gjsify/devtools-mcp` from your project's `node_modules`. There is no `--runtime` here: the bridge bundle is always built `--app gjs` and launched with `gjs`, whichever runtime the CLI itself is on. The app it talks to can be on any of the four, since the two only ever meet over D-Bus. Full workflow: [Debugging and remote control](/gjsify/guides/devtools/).
+`gjsify debug` logs to stderr only, because stdout is the JSON-RPC channel. The bridge resolves `@gjsify/devtools-mcp` from your project's `node_modules`. There is no `--runtime` here. The bridge bundle is always built `--app gjs` and launched with `gjs`, whichever runtime the CLI itself is on. The app it talks to can be on any of the four, since the two only ever meet over D-Bus. Full workflow: [Debugging and remote control](/gjsify/guides/devtools/).
 
 ### `gjsify browse`
 
-Launch the minimal Adwaita web browser from [`@gjsify/devtools-browser`](https://www.npmjs.com/package/@gjsify/devtools-browser), optionally at a URL. With `--devtools` it exposes the same `org.gjsify.Devtools` control plane, so an agent can navigate, screenshot the rendered page, evaluate JS, inspect elements and read the DOM, network and accessibility trees over MCP. It is built for debugging web apps you built with gjsify.
+Launch the minimal Adwaita web browser from [`@gjsify/devtools-browser`](https://www.npmjs.com/package/@gjsify/devtools-browser), optionally at a URL. With `--devtools` it exposes the same `org.gjsify.Devtools` control plane, so an agent can navigate, screenshot the rendered page, evaluate JS, inspect elements and read the DOM, network and accessibility trees over MCP. It is meant for debugging web apps you wrote with gjsify.
 
 ```bash
 gjsify browse                                     # open page:welcome
@@ -1319,7 +1319,7 @@ gjsify browse https://localhost:8080 --screenshot shot.png
 | `--screenshot <path>` | none | One-shot: load the URL, capture a WebKit screenshot to this path, exit. Handy in CI. |
 | `--build-only` | `false` | Build the bundle without launching it. |
 
-The browser is built on [`@gjsify/iframe`](https://www.npmjs.com/package/@gjsify/iframe), a `WebKit.WebView` postMessage bridge, and it is always built `--app gjs` and launched with `gjs`, whichever runtime the CLI itself is on. With `--inspector-port` it also sets `WEBKIT_INSPECTOR_HTTP_SERVER` and exposes the [`@gjsify/devtools-cdp`](https://www.npmjs.com/package/@gjsify/devtools-cdp) methods (`CdpDiscoverTargets`, `CdpConnect`, `CdpSend`, `CdpDrainEvents`) over the control plane, which is the deep Runtime, DOM, CSS, Network, Console and Debugger protocol. Drive it with `gjsify debug --profile browser`, described in the [Debugging and remote control guide](/gjsify/guides/devtools/).
+The browser is built on [`@gjsify/iframe`](https://www.npmjs.com/package/@gjsify/iframe), a `WebKit.WebView` postMessage bridge. It is always built `--app gjs` and launched with `gjs`, whichever runtime the CLI itself is on. With `--inspector-port` it also sets `WEBKIT_INSPECTOR_HTTP_SERVER` and exposes the [`@gjsify/devtools-cdp`](https://www.npmjs.com/package/@gjsify/devtools-cdp) methods (`CdpDiscoverTargets`, `CdpConnect`, `CdpSend`, `CdpDrainEvents`) over the control plane. That is the full Runtime, DOM, CSS, Network, Console and Debugger protocol. Drive it with `gjsify debug --profile browser`, described in the [Debugging and remote control guide](/gjsify/guides/devtools/).
 
 ## Ship it
 
@@ -1383,7 +1383,7 @@ ship/out/              the artifacts
 | `windows-dir-zip` | win32 | yes | any host | `glib-compile-schemas` |
 | `msi` | win32 | no | linux or win32 | `wixl` from `msitools`, or WiX Toolset v3.14 |
 
-`.deb`, `.rpm` and both zips are written by `ship` itself, with no `dpkg-deb`, no `rpmbuild` and no `zip`. `glib-compile-schemas` is a tool rather than a host, so the formats that declare it still pack anywhere; a non-Linux layout has no install step, so the schemas are compiled while the tree is assembled.
+`.deb`, `.rpm` and both zips are written by `ship` itself, with no `dpkg-deb`, no `rpmbuild` and no `zip`. `glib-compile-schemas` is a tool rather than a host, so the formats that declare it still pack anywhere. A non-Linux layout has no install step, so the schemas are compiled while the tree is assembled.
 
 Ask for a format this host cannot finish and you get a refusal naming the two-phase way across, never a broken file:
 
@@ -1393,7 +1393,7 @@ gjsify ship --from-stage ./ship/stage \
             --target macos-app-dmg                  # there, on a Mac
 ```
 
-Name the format in the `--stage` run as well: phase one renders one licence overlay per format, and a stage that never saw a format is refused when that format is asked for. A missing tool is a separate message from the wrong host, because the fixes differ, and both fire before your `build` script runs.
+Name the format in the `--stage` run as well. Phase one renders one licence overlay per format, and a stage that never saw a format is refused when that format is asked for. A missing tool is a separate message from the wrong host, because the fixes differ, and both fire before your `build` script runs.
 
 #### What it works out for you
 
@@ -1403,7 +1403,7 @@ Name the format in the `--stage` run as well: phase one renders one licence over
 - **Localised metadata** is folded in from `gjsify.ship.localeDir`. The compiled `.mo` catalogues become `Name[xx]=` in the `.desktop` entry and `xml:lang` in the AppStream component.
 - **Metadata** falls back to `gjsify.flatpak`, so a project that already ships a Flatpak usually needs no `gjsify.ship` block at all.
 
-Packing the same build twice gives byte-identical files, which is explained in [How It Works](/gjsify/how-it-works/#reproducible-ship-artifacts).
+Packing the same build twice gives byte-identical files. [How It Works](/gjsify/how-it-works/#reproducible-ship-artifacts) explains how.
 
 #### Configure it
 
@@ -1445,7 +1445,7 @@ Packing the same build twice gives byte-identical files, which is explained in [
 | `typelibPackages` | `{}` | GI namespace to the package shipping its typelib. This is what unblocks an unknown namespace. |
 | `bundledTypelibs` | `[]` | Directories whose `*.typelib` and `*.so` the package carries itself, for GI libraries that arrive as npm prebuilds rather than distro packages. Staged into `lib/<name>/gi/`, with the launcher pointing `GI_TYPELIB_PATH` and `LD_LIBRARY_PATH` there. |
 | `localeDir` | none | Directory of COMPILED gettext catalogues in `<lang>/LC_MESSAGES/<domain>.mo` layout. Staged into `share/locale/`; the launcher exports `GJSIFY_LOCALE_DIR`. `.po` sources are refused, because `bindtextdomain` reads `.mo` only. |
-| `fonts` | none | Font files or a directory of them, staged into `share/fonts/<appId>/`. One payload path, three different readers: Linux gets a fontconfig directory, macOS an `ATSApplicationFontsPath` entry in the `Info.plist`, and **Windows only a handed-over directory** — the app must register them itself, see below. |
+| `fonts` | none | Font files or a directory of them, staged into `share/fonts/<appId>/`. One payload path, three different readers: Linux gets a fontconfig directory, macOS an `ATSApplicationFontsPath` entry in the `Info.plist`, and **Windows only a handed-over directory**. The app must register them itself, see below. |
 | `extraFiles` | `{}` | Extra payload entries: prefix-relative destination to project-relative source. |
 | `execArgs` | `[]` | Arguments the launcher appends before the user's own. |
 | `flatpak` | derived | The Flatpak half: `runtime` (`gnome`/`freedesktop`), `runtimeVersion`, `branch` (`stable`), `sdkExtensions`, `appendPath`, `finishArgs`, `cleanup`. |
@@ -1459,17 +1459,17 @@ Metadata keys (`name`, `summary`, `description`, `developer`, `license`, `catego
 What differs is who reads them, because the font backends differ rather than the
 packaging:
 
-- **Linux** — a fontconfig directory entry. `.deb`/`.rpm` get `<dir>/usr/share/fonts</dir>`;
-  every other prefix gets `<dir prefix="xdg">fonts</dir>`, which fontconfig also expands
-  over `XDG_DATA_DIRS` — the variable the launcher already exports. Nothing to call.
-  (That expansion is not in `fonts-conf(5)`; it is measured across eight independent
+- **Linux.** A fontconfig directory entry. `.deb`/`.rpm` get `<dir>/usr/share/fonts</dir>`,
+  every other prefix `<dir prefix="xdg">fonts</dir>`, which fontconfig also expands over
+  `XDG_DATA_DIRS`, the variable the launcher already exports. Nothing to call.
+  (That expansion is not in `fonts-conf(5)`. It is measured across eight independent
   fontconfig builds, 2.14.1 through 2.18.3.)
-- **macOS** — `ATSApplicationFontsPath` in the `Info.plist`. Declarative, and the
-  ordering is the argument: the CoreText font map has no re-scan path, and the OS
-  activates before any of your code runs. *Not verified end to end — nothing here
-  launches a real `.app` yet.*
-- **Windows** — nothing declarative exists. `pangocairo` selects the win32 backend and
-  populates from DirectWrite alone, so a fontconfig directory is inert: pointing
+- **macOS.** `ATSApplicationFontsPath` in the `Info.plist`. Declarative, and the ordering
+  is the argument. The CoreText font map has no re-scan path, and the OS activates the
+  faces before any of your code runs. *Not verified end to end. Nothing here launches a
+  real `.app` yet.*
+- **Windows.** Nothing declarative exists. `pangocairo` selects the win32 backend and
+  populates from DirectWrite alone, so a fontconfig directory is inert. Pointing
   `FONTCONFIG_FILE` at the staged directory moves the default font map by **zero**
   families, even when it is the only configuration present. Registering the face at
   runtime moves it by **one**, and the family then resolves for real rather than
@@ -1487,14 +1487,14 @@ const fonts = initFonts();
 ```
 
 Call it once at startup and **before any text is laid out**. That ordering is
-load-bearing rather than tidy: the fontconfig backend caches the fontset it resolved for
-a description and registering afterwards does not invalidate it, so a layout that
-measured the family first goes on measuring the fallback for the life of the process.
-`initFonts()` reads `GJSIFY_FONT_DIR` itself, does nothing when the app ships no faces,
-never throws, and returns which faces were registered, which the font map declined (macOS
-does, correctly — its bundle already activated them before your code ran) and which
-failed. Safe to call on all three operating systems, so there is no platform branch to
-write.
+load-bearing rather than tidy. The fontconfig backend caches the fontset it resolved for
+a description, and registering afterwards does not invalidate it. A layout that measured
+the family first goes on measuring the fallback for the life of the process.
+`initFonts()` reads `GJSIFY_FONT_DIR` itself, does nothing when the app ships no faces
+and never throws. It returns which faces were registered, which the font map declined
+and which failed. macOS declines correctly, because its bundle already activated them
+before your code ran. Safe to call on all three operating systems, so there is no
+platform branch to write.
 
 #### Signing
 
@@ -1513,13 +1513,13 @@ With no identity the run skips, prints why on stderr, and exits 0. `--sign` on t
 
 #### Where the interpreter comes from
 
-On **Linux** it is depended on, not shipped: `gjs (>= 1.86)`, or `nodejs (>= 24)` on deb and `nodejs(engine) >= 24` on rpm for an `--app node` bundle. Both floors exclude current Debian stable, and `gjsify ship` warns rather than lowering them; set `gjsify.ship.minGjsVersion` or `minNodeVersion` if your bundle genuinely runs on an older one.
+On **Linux** it is depended on, not shipped: `gjs (>= 1.86)`, or `nodejs (>= 24)` on deb and `nodejs(engine) >= 24` on rpm for an `--app node` bundle. Both floors exclude current Debian stable, and `gjsify ship` warns rather than lowering them. Set `gjsify.ship.minGjsVersion` or `minNodeVersion` if your bundle genuinely runs on an older one.
 
 On **macOS and Windows** there is no system interpreter to depend on, so the artifact carries its own from `@gjsify/node-runtime-<target>`, with the GTK closure from `@gjsify/gtk-runtime-<target>` and the addon from `@gjsify/node-gi`. You declare all three yourself in the project you package. They are resolved **by name** out of your own `node_modules` at ship time, so they have to be installed there. `GJSIFY_NODE_RUNTIME` and `GJSIFY_GTK_RUNTIME` override the first two with a directory. All six names are published, at the same version as the rest of the release train, and re-measured against the registry before every release. [macOS app bundles](/gjsify/ship/macos/) and [Windows artifacts](/gjsify/ship/windows/) carry the copy-pasteable blocks.
 
 That is also why the four macOS and Windows formats accept `node` only. There is no relocatable GJS to put inside a downloadable bundle, and there is no GJS host on Windows at all.
 
-Which runtime a target ships is `gjsify.ship.app.<os>` — keyed `linux`, `darwin`, `win32` — falling back to `gjsify.app`. It is per target because the answer is: a project can be GJS on Linux, where the distribution provides one, and Node where nothing does. One field for both questions meant that asking for a `.app` moved the Linux package's `Depends:` with it.
+Which runtime a target ships is `gjsify.ship.app.<os>`, keyed `linux`, `darwin` and `win32`, falling back to `gjsify.app`. It is per target because the answer changes with the OS: a project can be GJS on Linux, where the distribution provides one, and Node where nothing does. One field for both questions meant that asking for a `.app` moved the Linux package's `Depends:` with it.
 
 ### `gjsify flatpak`
 
@@ -1529,7 +1529,7 @@ The Flatpak toolchain, for shipping GJS apps and CLIs to Flathub.
 |---|---|
 | [`flatpak init`](#gjsify-flatpak-init) | Scaffold the Flathub asset set: manifest JSON, MetaInfo XML, `.desktop` (apps only), `flathub.json`. |
 | [`flatpak check`](#gjsify-flatpak-check) | Run `appstreamcli validate --strict` and `flatpak-builder-lint` locally. |
-| [`flatpak build`](#gjsify-flatpak-build) | Wrap `flatpak-builder` with sensible defaults. |
+| [`flatpak build`](#gjsify-flatpak-build) | Wrap `flatpak-builder`, with `--force-clean`, `--sandbox` and `--delete-build-dirs` on. |
 | [`flatpak deps`](#gjsify-flatpak-deps) | Wrap `flatpak-node-generator` to produce the offline npm cache. |
 | [`flatpak sources`](#gjsify-flatpak-sources) | Generate an offline `sources` array from any lockfile. |
 | [`flatpak ci`](#gjsify-flatpak-ci) | Scaffold `.github/workflows/flatpak.yml`. |
@@ -1566,7 +1566,7 @@ gjsify flatpak init --kind cli      # CLI tool: no .desktop, console-application
 | `--force` | `false` | Overwrite existing outputs. By default they are skipped and logged. |
 | `--verbose` | `false` | Print resolved fields before writing. |
 
-Each output is checked for existence on its own, so a hand-tuned `.desktop` does not block re-running `init` to refresh the others. Missing MetaInfo fields are reported with the exact `gjsify.flatpak.<key>` to set: the manifest still writes, and MetaInfo and `.desktop` wait until you fill the gaps.
+Each output is checked for existence on its own, so a hand-tuned `.desktop` does not block re-running `init` to refresh the others. Missing MetaInfo fields are reported with the exact `gjsify.flatpak.<key>` to set. The manifest still writes, and MetaInfo and `.desktop` wait until you fill the gaps.
 
 <details>
 <summary>Every gjsify.flatpak metadata key</summary>
@@ -1609,7 +1609,7 @@ Each output is checked for existence on its own, so a hand-tuned `.desktop` does
 | `modules` | optional | Replaces the module array outright, so neither `extraModules` nor the Meson default is emitted. This is what a plain JS CLI wants, since the Meson default does not apply to it. |
 | `flathubRepo` | optional | Overrides the `flathub/<app-id>` derivation for repos that do not follow the convention. |
 
-Every translatable string (`summary`, description paragraphs and list items, screenshot captions, release notes) takes a parallel `translatorHint` that becomes a `<!-- TRANSLATORS: ... -->` comment in the generated `.metainfo.xml.in`. `xgettext` and `msgfmt --xml --template` forward those to the `.po` files, so translators see the context. There is a worked example in [Ship a GTK app as a Flatpak](/gjsify/guides/flatpak-app/#rich-appstream-features-i18n-ready).
+Every translatable string (`summary`, description paragraphs and list items, screenshot captions, release notes) takes a parallel `translatorHint` that becomes a `<!-- TRANSLATORS: ... -->` comment in the generated `.metainfo.xml.in`. `xgettext` and `msgfmt --xml --template` forward those to the `.po` files, so translators see the context. [Ship a GTK app as a Flatpak](/gjsify/guides/flatpak-app/#rich-appstream-features-i18n-ready) has a worked example.
 
 </details>
 
@@ -1636,7 +1636,7 @@ Needs `appstreamcli` and `flatpak-builder-lint` on `PATH`. Both ship inside the 
 
 #### `gjsify flatpak build`
 
-Build the Flatpak with `flatpak-builder`, wrapping the usual install, export, bundle and tarball pipeline.
+Build the Flatpak with `flatpak-builder`, then install it, export it to a repo, bundle it or tar the build directory up.
 
 ```bash
 gjsify flatpak build
@@ -1726,7 +1726,7 @@ gjsify flatpak sync-flathub --version v0.6.6 --no-pr         # clone, commit, pu
 | `--dry-run` | `false` | Report the resolution, branch and commit, touching no files. |
 | `--verbose` | `false` | Echo every `git` and `gh` invocation. |
 
-It clones or updates `flathub/<app-id>` under `$XDG_CACHE_HOME/gjsify/flathub-sync/`, edits `modules[0].sources[<i>]` to set `tag` and `commit`, adds an `x-checker-data` block if missing so Flathub's update bot can pick up future releases, and preserves the manifest's original indentation and key order. Needs `git` always, and `gh` unless you pass `--no-pr`. Re-running with the same `--version` does nothing when the manifest is already pinned.
+It clones or updates `flathub/<app-id>` under `$XDG_CACHE_HOME/gjsify/flathub-sync/` and edits `modules[0].sources[<i>]` to set `tag` and `commit`. It adds an `x-checker-data` block if missing, so Flathub's update bot can pick up future releases, and it preserves the manifest's original indentation and key order. Needs `git` always, and `gh` unless you pass `--no-pr`. Re-running with the same `--version` does nothing when the manifest is already pinned.
 
 #### `gjsify flatpak diff`
 
@@ -1830,13 +1830,13 @@ Auth reads `process.env.NPM_CONFIG_USERCONFIG` first (where `actions/setup-node`
 
 **A 2xx from npm is an accepted write, not a durable one, so the upload is read back.** After the PUT
 succeeds, `gjsify publish` asks the registry for that exact `name@version` and prints
-`+ name@version` only once it is served. A 2xx that never resolves is its own outcome —
-`publish-unconfirmed`, exit 1 — and the message states what was PUT, what was asked and what came
+`+ name@version` only once it is served. A 2xx that never resolves is its own outcome,
+`publish-unconfirmed`, exit 1. The message then states what was PUT, what was asked and what came
 back. The retry window exists because npm's write really is eventually consistent: measured over
 the 199 packages of the v0.46.0 release, 90.5% were committed before the response arrived and 9.5%
 between 56 and 252 seconds after it, while one was never committed at all under a green job. A
-`409 already published` tolerated by `--tolerate-republish` is read back the same way — npm can
-refuse to overwrite a version seconds before it serves it — and the read-back GET carries the same
+`409 already published` tolerated by `--tolerate-republish` is read back the same way, because npm
+can refuse to overwrite a version seconds before it serves it. The read-back GET carries the same
 credential the upload did, so a registry that requires a token to read packuments does not turn a
 good publish into a red one. Set `--verify-timeout 0` for a registry with no packument read path.
 
@@ -1878,7 +1878,7 @@ gjsify login --username me --otp 123456
 | `--otp <code>` | prompted on demand | 2FA code. |
 | `--json` | `false` | Emit `{username, registry}` on success. |
 
-It prompts for the password with the input hidden. This is npm's legacy credentials flow; the web OAuth flow is not supported.
+It prompts for the password with the input hidden. This is npm's legacy credentials flow. The web OAuth flow is not supported.
 
 ### `gjsify logout`
 
@@ -1923,7 +1923,7 @@ gjsify trust --dry-run
 
 Make sure every publishable package in a monorepo is both published on npm and has a Trusted Publisher configured, doing only the missing work. It folds the whole manual first-publish and trust bootstrap into one idempotent sweep.
 
-Nothing about it is specific to a gjsify project. It works on any npm or yarn workspace out of the box, and `--packages` extends it to a monorepo that has no workspace manifest at all — a repo whose package directories simply sit next to each other.
+Nothing about it is specific to a gjsify project. It works on any npm or yarn workspace, and `--packages` extends it to a monorepo with no workspace manifest at all: a repo whose package directories sit next to each other.
 
 ```bash
 gjsify onboard                       # publish and trust whatever is missing
@@ -1947,7 +1947,7 @@ gjsify onboard --yes                 # non-interactive
 | `--build` / `--no-build` | `--build` | Run a to-be-published package's `build` script first. Turn it off for a repo whose packages are generated artifacts. |
 | `--registry <url>` | scope-aware `.npmrc` lookup | Registry override. |
 | `--otp <code>` | prompted once on demand | The initial shared 2FA code. |
-| `--concurrency <n>` | `4` | How many packages to read state for in parallel. Kept small so one token does not burst npm; the first read is always serial, to prompt for the shared code once. |
+| `--concurrency <n>` | `4` | How many packages to read state for in parallel. Kept small so one token does not burst npm. The first read is always serial, to prompt for the shared code once. |
 | `-v, --verbose` | `false` | List every package in the plan, not just the rows that need work. The counts always cover all of them. |
 | `--dry-run` | `false` | Report the plan without changing anything. |
 | `--json` | `false` | Emit a summary object as the final stdout line. |
@@ -1955,37 +1955,38 @@ gjsify onboard --yes                 # non-interactive
 
 What it does, in order: check the token is live (running the [`login`](#gjsify-login) flow only if it is not), enumerate the publishable packages, read each package's Trusted Publisher state concurrently, then act only on the gaps. One 2FA code is reused across every publish and trust operation, so a sweep of many packages usually asks you for a code once. Re-running when everything is already published and trusted does nothing and exits 0.
 
-The sweep reports progress through both phases: the state-read phase ticks (`read 600/703 — 590 to
-do, 10 already done`) and every write is numbered (`[123/662] trusted @acme/x`). Nothing else
-writes to the terminal while a 2FA prompt is open — such messages are held and flushed once you
-have answered, so a notice from a concurrent worker cannot land inside the digits you are typing.
+The sweep reports progress through both phases. The state-read phase ticks (`read 600/703`, then
+`590 to do, 10 already done`) and every write is numbered (`[123/662] trusted @acme/x`). Nothing
+else writes to the terminal while a 2FA prompt is open. Those messages are held and flushed once
+you have answered, so a notice from a concurrent worker cannot land inside the digits you are
+typing.
 
-One 2FA code covers the whole sweep, and it is asked for **once at a time** — concurrent probes
+One 2FA code covers the whole sweep, and it is asked for **once at a time**. Concurrent probes
 share the prompt rather than each opening their own. npm codes expire on their ~30-second window,
-so a long sweep may ask again later; each such expiry costs exactly one prompt.
+so a long sweep may ask again later. Each such expiry costs exactly one prompt.
 
 Trusted-Publisher **writes** run at `--write-concurrency` (default 4); **publishes** stay serial,
 because publish order is a correctness property. Raising the write concurrency buys fewer 2FA
-prompts rather than raw speed — measured against a 703-package repo, npm rate-limits the sweep at
+prompts rather than raw speed. Measured against a 703-package repo, npm rate-limits the sweep at
 serial pace already, so the registry sets the ceiling, not the loop. What serial cost was codes:
 one lives about 30 seconds, so the sweep crossed a code boundary roughly every 38 packages.
 
 An HTTP 429 is waited out, not reported. npm throttles a long sweep, and because it is cumulative
-it lands on the *tail* of the list — which reads as "these packages are special" when the truth is
-that the sweep asked too fast. A 429 **anywhere pauses everywhere**: retrying one throttled request in isolation leaves the rest
-of the sweep provoking the very limit that retry is waiting out, which is how a real run spent its
-retry budget and reported `trust failed (HTTP 429)`. Reads and writes share one cool-down, so the
+it lands on the *tail* of the list. That reads as "these packages are special" when the truth is
+that the sweep asked too fast. A 429 **anywhere pauses everywhere**. Retrying one throttled
+request in isolation leaves the rest of the sweep provoking the very limit that retry is waiting
+out, which is how a real run spent its retry budget and reported `trust failed (HTTP 429)`. Reads and writes share one cool-down, so the
 sweep self-paces down to whatever npm will serve. The wait is a TIME budget (5 minutes per request), not an
-attempt count: a fixed number of doubling retries is only ~30 seconds of patience, npm's window is
-longer than that, and a real 703-package sweep consequently failed its last 73 writes inside a
-single cooldown. Only throttling that outlasts the budget is reported — in the plan AND in the
-closing summary, since a write is throttled long after the plan has scrolled away and `73 failed`
-on its own reads as 73 broken packages.
+attempt count. A fixed number of doubling retries is only ~30 seconds of patience, and npm's
+window is longer than that: a real 703-package sweep failed its last 73 writes inside a single
+cooldown. Only throttling that outlasts the budget is reported, in the plan AND in the closing
+summary. A write is throttled long after the plan has scrolled away, and `73 failed` on its own
+reads as 73 broken packages.
 
-npm advertises no budget ahead of time — there are no `X-RateLimit-*` headers on ordinary
-responses — so the first 429 of a run prints what the registry actually said, including when it
-said nothing and the delay is the CLI's own. Re-running is safe: the sweep is idempotent and
-skips whatever already landed.
+npm advertises no budget ahead of time, and there are no `X-RateLimit-*` headers on ordinary
+responses. So the first 429 of a run prints what the registry actually said, including when it
+said nothing and the delay is the CLI's own. Re-running is safe, because the sweep is idempotent
+and skips whatever already landed.
 
 A package whose own `package.json` names a **different** `repository` than the one being
 configured is refused, with the foreign repo and the count. A workspace of a repo is not the same
@@ -1995,4 +1996,4 @@ that package's OIDC exchange at a workflow that never publishes it. Narrow the s
 `--exclude` / `--include`, or point `--repository` at the repo that does publish them. A package
 that declares no repository is not evidence of a mismatch, and passes.
 
-The first line of output names the repo root and every enumeration source with its count — `root=/src/types | packages(*)=703`. That is worth reading before you let a sweep write to npm: the package list is the whole blast radius, and a total on its own cannot tell the right tree from a plausible wrong one. `--json` carries the same three fields (`root`, `sources`, `discovered`) in its summary object.
+The first line of output names the repo root and every enumeration source with its count: `root=/src/types | packages(*)=703`. Read it before you let a sweep write to npm. The package list is the whole blast radius, and a total on its own cannot tell the right tree from a plausible wrong one. `--json` carries the same three fields (`root`, `sources`, `discovered`) in its summary object.

--- a/website/src/content/docs/contributing/architecture.md
+++ b/website/src/content/docs/contributing/architecture.md
@@ -5,7 +5,7 @@ description: Monorepo structure and GNOME library mappings
 
 GJSify is an npm-workspaces monorepo, bootstrapped by its own CLI. `gjsify install` is the supported install path (no Yarn, no Node-only npm CLI required; see [Development Setup](/gjsify/contributing/development-setup/)).
 
-## Monorepo Structure
+## Monorepo structure
 
 ```
 gjsify/
@@ -25,7 +25,7 @@ gjsify/
 └── website/         # This documentation site
 ```
 
-## Build System
+## Build system
 
 GJSify uses **Rolldown** (Vite 8's production bundler) with platform-specific plugins to produce different bundles from the same source:
 
@@ -36,7 +36,7 @@ GJSify uses **Rolldown** (Vite 8's production bundler) with platform-specific pl
 
 The alias table lives in `packages/infra/resolve-npm/lib/index.mjs`; the Rolldown plugins live in `packages/infra/rolldown-plugin-gjsify/`.
 
-## GNOME Library Mapping
+## GNOME library mapping
 
 Each `@gjsify/*` package maps Node.js or Web APIs to native GNOME libraries:
 
@@ -64,3 +64,38 @@ GJSify treats the **Node.js API**, the **Web API**, the **DOM API**, the **Frame
 - `packages/nativescript-bridge/`: the Adwaita widget set, storybook renderer and devtools agent as real Android and iOS views, plus the `node:fs` and platform bridges behind them
 
 The DOM-element ↔ GTK-widget pairings are documented in [Bridge Widgets](/gjsify/patterns/bridges/).
+
+## What the platform audit verifies
+
+The `<os>-<arch>` marks on [Platform Support](/gjsify/platform-support/) come from `scripts/audit-runtimes.mjs --check`, the same rule the CI gate runs. [How It Works](/gjsify/how-it-works/#what-the-platform-marks-prove) says what each mark means to someone installing a package; this section is the audit behind them.
+
+`✓` requires the binary to be committed in the bridge's per-target package (`@gjsify/<bridge>-<os>-<arch>`), not in the bridge's own tarball. Since that split the bridge itself carries no `prebuilds/` directory at all, so a cell that asked the bridge alone answered "declared and built" and printed `✓` for two bridges that commit nothing anywhere. The glyphs are now machine-checked against the directories on disk (`tests/e2e/ci-runner-arch`).
+
+Every `○` target is held to a `release.yml` job that builds, load-tests and uploads it, because a release cannot download another workflow's artifact and that tarball is the only route by which one reaches a consumer. Two packages are in that state:
+
+- **`@gjsify/napi`, both targets.** `napi.yml` rebuilds and gates on the linux-x64 prebuild, and its macOS job builds, load-tests and uploads the darwin-arm64 one. No job commits either back, and each per-target package says so in `package.json#gjsify.platformsUncommitted`, printed on every `--check` run. The linux-x64 directory used to be committed while its darwin sibling was exempt: one bridge running two policies, where every job that touched the path overwrote the checked-out bytes before reading them, and the declaration checks stayed green across a week of source drift. Deleting it made freshness real by removal, since the only linux-x64 artifact anyone can load is now the one CI produced in that same run.
+- **`@gjsify/node-gi`, every declared target.** It builds with node-gyp at install time, or installs a prebuild straight from a release artifact, so there is no committed directory anywhere and no exemption entry to key the cell on: the absence *is* the state. `release.yml` carries a prebuild leg per target, which is what the audit checks.
+
+The audit runs wherever CI runs it, today an `ubuntu-latest` x64 Node runner, and a prebuild for another architecture cannot be loaded there. Rather than skip those, it splits what it verifies and reports which half it did:
+
+- **Structurally, on every committed artifact regardless of target.** The image's own machine field must match the directory it sits in (an ELF/Mach-O/PE header read, no `readelf` or `otool`); every `libgjsify*` sibling it records must be staged beside it and reachable through `$ORIGIN` or `@loader_path`; and every library leaf the typelib records must be present, because that leaf is what GObject-Introspection hands to the loader the moment a consumer resolves a class. This half caught both a missing macOS sibling cdylib and an emulated prebuild leg that compiled **x86-64** and staged it into `prebuilds/linux-{ppc64,s390x,riscv64}/`: `uraimo/run-on-arch-action` ignores its `arch` input whenever a custom `base_image` is supplied, so every other check passed and the artifact even loaded on the runner. Only reading the machine field against the directory name catches that.
+- **Functionally, only for the checking host's own target.** The library is `dlopen`ed with every library-path environment variable stripped, which proves the self-relative sibling hop for real instead of inferring it from the headers. A bridge whose *system* dependencies the runner lacks (libsoup, GStreamer, libgda) is reported as not-load-tested, never as broken, because that would be a fact about the runner rather than the artifact.
+
+So `✓` means "declared, targeted by a CI job, and committed with a structurally sound artifact". It does not mean anyone has run that artifact on that architecture. The per-run summary states both numbers separately.
+
+Every column name is a real directory name, spelled the one way a running process can compute about itself, `${process.platform}-${process.arch}`, so `gjsify.platforms`, the committed `prebuilds/<target>/`, the CI job that builds it and the resolver that loads it all use the same string.
+
+## How the cross-runtime claims are checked
+
+A golden-diff conformance harness runs the same programs on `gjs`, `node`, `bun` and `deno` and requires **byte-identical output**. A diff needs one side to diff against, and that side is the `gjs` output, itself checked against a committed golden file wherever the scenario has one. That makes gjs the yardstick for the comparison, which is a fact about the test rig and not advice about which runtime to build on. The ported GNOME GIMarshallingTests currently stand at 370 passing and none failing.
+
+Linux is the CI baseline: the full suite (10,000+ cases across Node and GJS), every e2e suite and every integration suite run on Fedora. The other two operating systems are covered by named jobs rather than by a runtime-class claim:
+
+- **macOS** runs `@gjsify/node-gi`'s own CI (build, conformance, a real GTK/Adwaita window, the full Adwaita storybook), `@gjsify/napi`'s build and gates, and the native-bridge prebuild job. Two jobs run the `@gjsify/*` suites themselves: `main.yml`'s `macos` job executes a curated subset of `--app gjs` bundles on arm64 under Homebrew `gjs` 1.88, and `macos-suites.yml` runs the Node-pillar suites on both `test:node` and `test:gjs`, on darwin-arm64 and darwin-x64, on every pull request as well as on `main` and the nightly. macOS is the only one of the three where both legs can run at all, which is the point of running them: `test:node` says the spec is right, `test:gjs` says the port is.
+- **Windows** runs `@gjsify/node-gi`'s CI including a real GTK window and the storybook, using a bundled GTK runtime rather than a system install, plus the Node-pillar `@gjsify/*` suites in `windows-suites.yml`, on every pull request as well as on `main` and the nightly. Those run under **cmd.exe with the git-bash utilities stripped from `PATH`**, because Git for Windows supplies a real `rm`, `cp` and `sh` that npm's `%COMSPEC%` scripts do not have, and testing from git-bash reports false greens.
+
+The macOS `--app gjs` bundles are built on the Fedora leg and executed on macOS. That split is a cost decision rather than a capability one. `@gjsify/rolldown-native`, the bundler engine `gjsify build` uses under GJS, is built, staged and load-tested under Homebrew `gjs` on both darwin arches by `prebuilds.yml`, and its `darwin-arm64` and `darwin-x64` artifacts are committed. What no job does yet is drive `gjsify build` under GJS on macOS end to end, and standing that up would mean a full `gjsify install` on a runner billed at 10x. A `--app gjs` bundle is a single self-contained file whose only unbundled imports are `gi://GLib`, `gi://Gio` and `gi://GioUnix`, so building it on Linux and running it on macOS is sound. It verifies **runtime** behaviour on macOS, not the build toolchain there.
+
+Bun and Deno share the `node` runtime slot through the Node-API common ABI, and `main.yml`'s `cross-runtime` job tests that rather than assuming it: one engine-agnostic `--app node` bundle per package, run on all three runtimes. The selection rule matters. A spec that imports `node:path` gets the *host runtime's* builtin, because the `--app node` bundle externalises it, so such a leg would test Bun rather than the polyfill. Every covered package either imports its own package by name, imports a bare Web specifier that the alias table routes to the polyfill, or is infra code that is nobody's builtin.
+
+The four defects that first darwin run found are recorded in [ADR 0018](https://github.com/gjsify/gjsify/blob/main/docs/adr/0018-os-axis-declaration.md) § *darwin re-measured*. `macos-suites.yml` re-measures on every run the macOS loader fact that invalidates the obvious fix for a `dyld` problem: SIP strips every `DYLD_*` variable at the first `/bin/sh` boundary, so a wrapper cannot hand the loader a path ([ADR 0024](https://github.com/gjsify/gjsify/blob/main/docs/adr/0024-ship-installable-artifacts.md) § 3).

--- a/website/src/content/docs/contributing/tdd-workflow.md
+++ b/website/src/content/docs/contributing/tdd-workflow.md
@@ -7,7 +7,7 @@ GJSify welcomes contributions! This page describes how we port new Node.js or We
 
 If you have not set up the monorepo yet, start with [Development Setup](/gjsify/contributing/development-setup/).
 
-## TDD Workflow
+## TDD workflow
 
 GJSify follows a test-driven development approach:
 
@@ -18,7 +18,7 @@ GJSify follows a test-driven development approach:
 5. **Implement**: use `@girs/*` types, consult `refs/{deno,bun,quickjs,workerd}/` for reference
 6. **Iterate**: until both platforms pass
 
-## Testing Rules
+## Testing rules
 
 - Tests must pass on **both Node.js and GJS**
 - **Never weaken tests** to accommodate GJS limitations. Fix the implementation instead
@@ -27,7 +27,7 @@ GJSify follows a test-driven development approach:
 - Use `@gjsify/unit` as the test framework; shared matchers: `toBe`, `toEqual`, `toBeTruthy`, `toBeFalsy`, `toContain`, `toMatch`, `toThrow`
 - Platform-specific test logic belongs in a separate `*.gjs.spec.ts` file or inside an `on('Gjs', …)` block, not sprinkled through the shared spec
 
-## Full Validation
+## Full validation
 
 Before opening a pull request, run the full validation sequence:
 

--- a/website/src/content/docs/coverage.mdx
+++ b/website/src/content/docs/coverage.mdx
@@ -8,13 +8,19 @@ import NodeApiCoverage from '../../components/NodeApiCoverage.astro';
 import WebStandardsCoverage from '../../components/WebStandardsCoverage.astro';
 import IntegrationTests from '../../components/IntegrationTests.astro';
 
-Use this page to answer one question before you start building: **is the thing I need already there?**
+This page answers one question before you start building: is the thing I need already there?
 
-Expand a category to see every module or standard with its status. **Full** means the surface a normal app touches works. **Partial** means the core works and specific corners are named. **Stub** means it resolves so a dependency check passes, but does nothing. **Planned** means it is in scope and not built yet. **Out of scope** means it makes no sense in a desktop GTK app and will not be built.
+Expand a category to see every module or standard with its status.
 
-The pillar totals are regenerated from the project's own status data on every site build, so they cannot drift from it. The three inventories under them are curated by hand, and the real-world packages we run end to end are more numerous than the selection shown here, so read a missing entry as "not listed", never as "not supported".
+- **Full** means the part a normal app touches works.
+- **Partial** means the core works and the specific corners that do not are named in the entry.
+- **Stub** means it resolves so a dependency check passes, but does nothing.
+- **Planned** means it is in scope and not built yet.
+- **Out of scope** means it makes no sense in a desktop GTK app and will not be built.
 
-**What the numbers measure:** the APIs gjsify implements itself, on top of GNOME libraries. That surface is at its largest on GJS, which has no `node:fs`, no `fetch` and no `<canvas>` of its own. Node, Bun and Deno have those, so a `--app node` build takes them straight from the runtime and most of the Node and Web entries below never enter that bundle. A handful of entries are gjsify's own code on every runtime, because no JavaScript runtime ships them at all — `DOMParser`, `<canvas>` and WebGL among them — and the Adwaita, framework and tooling entries are runtime-independent to begin with.
+The pillar totals are regenerated from the project's own status data on every site build, so they cannot drift from it. The three inventories under them are curated by hand, and we run more real-world packages end to end than the selection shown here, so read a missing entry as "not listed", never as "not supported".
+
+What the numbers measure is the APIs gjsify implements itself, on top of GNOME libraries. There are most of them on GJS, which has no `node:fs`, no `fetch` and no `<canvas>` of its own. Node, Bun and Deno have all three, so a `--app node` build takes them straight from the runtime and most of the Node and Web entries below never enter that bundle. A few entries are gjsify's own code on every runtime, because no JavaScript runtime ships them at all, `DOMParser`, `<canvas>` and WebGL among them. The Adwaita, framework and tooling entries are runtime-independent to begin with.
 
 For what is validated on Node.js, Bun, Deno and in the browser, see [Runtimes](/gjsify/runtimes/); for which operating systems each native bridge reaches, see [Platform Support](/gjsify/platform-support/).
 

--- a/website/src/content/docs/experiments/effect.mdx
+++ b/website/src/content/docs/experiments/effect.mdx
@@ -1,6 +1,6 @@
 ---
 title: Effect
-description: An optional integration, not a recommended pattern. Effect's platform services over Gio.File and GLib - typed errors, cancellation that reaches GIO, and cleanup tied to a window. Most GNOME apps do not need it.
+description: An optional integration, not a recommended pattern. Effect's platform services over Gio.File and GLib: typed errors, cancellation that reaches GIO, and cleanup tied to a window. Most GNOME apps do not need it.
 ---
 
 import CommandTabs from '../../../components/CommandTabs.astro';
@@ -8,10 +8,10 @@ import CommandTabs from '../../../components/CommandTabs.astro';
 :::caution[Read this first]
 This is an **experiment**, not part of the recommended way to build a GJSify app. Effect is a
 whole programming style, not a feature: adopting it changes how every function in your codebase
-is written, and nothing else on this site assumes you have.
+is written, and nothing else on this site assumes you have adopted it.
 
 **Most GNOME apps should skip it.** If you are here because something on this page sounds
-useful, check the cheaper answer first — it usually exists.
+useful, check the cheaper answer first. It usually exists.
 :::
 
 ## Should you use this?
@@ -26,7 +26,7 @@ a paradigm, and the next person reading your code will already know the language
 written in.
 
 **Possibly yes, if** your app runs a lot of I/O that can fail in ways you have to tell apart,
-that can be cancelled, and that overlaps — several services being reconciled against each
+that can be cancelled, and that overlaps: several services being reconciled against each
 other, a long import that a user may abandon halfway, a pipeline where "which step failed and
 why" is itself part of the domain. That is where `Effect<A, E, R>` starts giving back more
 than it costs, because the failure channel and the dependency set stop being conventions and
@@ -35,7 +35,7 @@ become types the compiler checks.
 **In either case it stays optional.** `@gjsify/effect-platform` is a bridge, not a foundation:
 nothing else in GJSify depends on it, and no other page assumes it.
 
-## What the bridge actually provides
+## What the bridge provides
 
 If you have decided Effect is right for your app, three things about GNOME are otherwise
 awkward, and this is what the package answers:
@@ -56,8 +56,8 @@ window stays exactly what it was; Effect runs the work behind it. See
 
 ## Install
 
-Effect itself runs on GJS unchanged — it is an ordinary npm dependency and needs nothing from
-us.
+Effect itself runs on GJS unchanged. It is an ordinary npm dependency and needs nothing from
+gjsify.
 
 <CommandTabs title="Install" group="pm">
   <Fragment slot="gjsify">
@@ -138,7 +138,7 @@ const outcome = Effect.gen(function* () {
 );
 ```
 
-The tags are Effect's, not ours, which is the point: the same code works against
+The tags are Effect's own rather than gjsify's, which is the point: the same code works against
 `@effect/platform-node`'s layer if you ever run it off GNOME.
 
 :::note[Why the domain matters]
@@ -151,7 +151,7 @@ original message rather than a plausible near miss.
 ## Stop work when the window closes
 
 This is the part that has no equivalent in a plain GJS app. Give the window a scope, start
-work inside it, and closing the window interrupts everything it started — including the read
+work inside it, and closing the window interrupts everything it started, including the read
 in flight, because the interrupt reaches GIO's own `Gio.Cancellable`.
 
 ```ts
@@ -187,12 +187,12 @@ export class MyWindow extends Adw.ApplicationWindow {
 ```
 
 A promise cannot be cancelled, so a `readDirectory` started with `await` runs to completion no
-matter what the user does. A fiber can, and here the cancellation is not just bookkeeping: the
-GIO call stops.
+matter what the user does. A fiber can, and the cancellation is not bookkeeping: the GIO call
+stops.
 
 :::caution[`destroy` is not when the window closes]
 `GtkWidget::destroy` is emitted from *dispose*, and your application holds a reference to its
-own window — so `window.destroy()` emits `unrealize` and no `destroy` at all. A scope hooked to
+own window, so `window.destroy()` emits `unrealize` and no `destroy` at all. A scope hooked to
 `destroy` alone keeps a closed window's work running.
 
 That is why there are two functions. `windowScope(window)` closes on `close-request` **or**
@@ -203,9 +203,9 @@ which is the later, stricter boundary: after it, touching the widget is a GJS er
 ## A signal as a stream
 
 `propertyStream` turns a GObject property into a stream of its values, starting with the one
-it has now. From there the usual stream operators apply — and `switchMap` gives you something
-that is real work to write by hand: each new value **interrupts** the work the previous one
-started.
+it has now. From there the usual stream operators apply. `switchMap` in particular gives you
+something that is real work to write by hand: each new value **interrupts** the work the
+previous one started.
 
 ```ts
 import { Duration, Effect, Stream } from 'effect';
@@ -229,7 +229,7 @@ guessing between them would be wrong some of the time.
 ### One rule: handlers stay synchronous
 
 A GTK signal handler runs synchronously, and some of them return a value GTK reads
-immediately — `Gtk.EventControllerKey::key-pressed` returns a boolean that decides whether the
+immediately. `Gtk.EventControllerKey::key-pressed` returns a boolean that decides whether the
 key propagates. An `async` handler returns a Promise, which is truthy, so it would swallow
 every key it was asked about.
 
@@ -267,7 +267,7 @@ const parent = await Effect.runPromise(Effect.provide(parentOf('~/Documents/note
 ```
 
 `join` is `g_build_filenamev`, `resolve` is `g_canonicalize_filename`, and the file-URL pair is
-`g_filename_{from,to}_uri` — the same encoding GIO round-trips. Everything else follows Node's
+`g_filename_{from,to}_uri`, the same encoding GIO round-trips. Everything else follows Node's
 `path.posix` rules exactly, and there is a test that compares the two implementations operation
 by operation to keep it that way.
 
@@ -309,21 +309,21 @@ Three more are implemented but **not interruptible**, because their async forms 
 from GJS: `copy`, `copyFile` and `rename` block the fiber while they run. Everything else can
 be cancelled.
 
-`watch` maps GIO's file-monitor events onto Effect's three `WatchEvent` shapes; a rename inside
-the watched directory currently surfaces as nothing, because GIO reports it as one `RENAMED`
+`watch` maps GIO's file-monitor events onto Effect's three `WatchEvent` shapes. A rename inside
+the watched directory currently shows up as nothing, because GIO reports it as one `RENAMED`
 event that has no counterpart.
 
 ## What it costs
 
 Importing Effect and running one effect adds about **25 KB** to a GJS bundle and **2 ms** to
 cold start. A real GTK window using these layers lands in the same size class as comparable
-windows that use no Effect at all — tree-shaking works, and you pay for what you import.
+windows that use no Effect at all. Tree-shaking works, and you pay for what you import.
 
 ## Where to look next
 
-- [effect.website](https://effect.website) for Effect itself — this page assumes nothing about
+- [effect.website](https://effect.website) for Effect itself. This page assumes nothing about
   it beyond `Effect.gen`, `Effect.provide` and `Stream`.
 - The [`effect-adw-services` showcase](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/effect-adw-services)
   is a complete window built this way, and every snippet above is taken from it.
 - [UI Frameworks](/gjsify/frameworks/) for the rendering half, which Effect deliberately does
-  not touch — and which, unlike this page, is part of the recommended path.
+  not touch, and which, unlike this page, is part of the recommended path.

--- a/website/src/content/docs/experiments/effect.mdx
+++ b/website/src/content/docs/experiments/effect.mdx
@@ -1,6 +1,6 @@
 ---
 title: Effect
-description: An optional integration, not a recommended pattern. Effect's platform services over Gio.File and GLib: typed errors, cancellation that reaches GIO, and cleanup tied to a window. Most GNOME apps do not need it.
+description: "An optional integration, not a recommended pattern. Effect's platform services over Gio.File and GLib: typed errors, cancellation that reaches GIO, and cleanup tied to a window. Most GNOME apps do not need it."
 ---
 
 import CommandTabs from '../../../components/CommandTabs.astro';

--- a/website/src/content/docs/frameworks/index.mdx
+++ b/website/src/content/docs/frameworks/index.mdx
@@ -7,14 +7,14 @@ import CommandTabs from '../../../components/CommandTabs.astro';
 
 Write your GTK 4 window in Solid, Vue or React, and get real `Gtk` and `Adw` widgets.
 
-GTK can already describe a window rather than assemble it — that is what Blueprint is for, and
-it does property bindings too. What a template cannot do is change its own shape: a `.blp` is
+GTK can already describe a window rather than assemble it. That is what Blueprint is for, and
+it does property bindings too. What a template cannot do is change its own shape. A `.blp` is
 instantiated once, so anything that appears, disappears or reorders while the app runs goes
 back into imperative code.
 
-Keeping a tree in sync with your state is exactly what a UI framework is for. Solid, Vue and
-React can all render somewhere other than a browser — they just need an object model to build
-against, and GTK's is not the DOM.
+Keeping a tree in sync with your state is what a UI framework is for. Solid, Vue and React can
+all render somewhere other than a browser. They need an object model to build against, and
+GTK's is not the DOM.
 
 [`@gjsify/gtk-host`](https://www.npmjs.com/package/@gjsify/gtk-host) is that object model.
 Nothing is hidden: every tag names a real GTK class, and you mount into a window your
@@ -22,7 +22,7 @@ application already built.
 
 :::tip[Blueprint is not replaced]
 The two answer different questions and mix well. Blueprint is the better choice for a window
-whose shape is fixed — and it is the only one of the two that `xgettext` can translate. Reach
+whose shape is fixed, and it is the only one of the two that `xgettext` can translate. Reach
 for a framework where the shape follows the data.
 :::
 
@@ -70,31 +70,37 @@ Your framework is a peer dependency and stays yours: `solid-js`, `@vue/runtime-c
 |---|---|---|---|
 | Solid | `@gjsify/gtk-host/solid` | `solid-js/universal`, 10 methods | [`@gjsify/rolldown-plugin-solid`](/gjsify/frameworks/solid/) |
 | Vue | `@gjsify/gtk-host/vue` | `@vue/runtime-core`, 10 required + 4 optional | [`@gjsify/rolldown-plugin-vue`](/gjsify/frameworks/vue/) |
-| React | `@gjsify/gtk-host/react` | `react-reconciler` HostConfig | none — TypeScript's own automatic runtime |
+| React | `@gjsify/gtk-host/react` | `react-reconciler` HostConfig | none, TypeScript's own automatic runtime does it |
 
 Pick one and the rest of this page is the same for all three. All three speak GTK's own tag
 vocabulary: `<gtk-box orientation="vertical">`, GTK property names, `css-classes` as a string
 array.
+
+None of the code on this page names a runtime. The host is plain TypeScript over `gi://`, so
+every example here builds and runs on GJS, Node.js, Bun and Deno from one source.
+[Runtimes](/gjsify/runtimes/) has that story, along with the two further targets the same widget
+names reach: a browser build, and an experimental NativeScript one for Android and iOS.
 
 ## Bringing a React Native app instead
 
 `<View>`, `<Text>`, `<Pressable>` and `className="flex-1 items-center"` are a *different*
 vocabulary, and it renders over the same host rather than beside it:
 
-- [React Native](/gjsify/frameworks/react-native/) — React Native's export surface on GTK 4, the
-  package a bundler aliases `react-native` to. Every name it does not implement is still exported
-  and refuses with a status and a reason, so a divergence is something you read rather than
-  something you find in a window.
-- [Styling on GTK](/gjsify/frameworks/styling/) — `@gjsify/gtk-host/style`, the framework-agnostic
-  half of that. `class="flex-1"` in a Vue template is the same question as `className="flex-1"` on
-  a React element, which is why it is a subpath of the host and not part of the React Native
-  package. It also carries the traps that make GTK styling fail *silently*, each one measured.
+- [React Native](/gjsify/frameworks/react-native/) puts React Native's exports on GTK 4. It is
+  the package a bundler aliases `react-native` to. Every name it does not implement is still
+  exported and refuses with a status and a reason, so you read a divergence instead of finding
+  it in a window.
+- [Styling on GTK](/gjsify/frameworks/styling/) is `@gjsify/gtk-host/style`, the
+  framework-agnostic half of that. `class="flex-1"` in a Vue template is the same question as
+  `className="flex-1"` on a React element, which is why it is a subpath of the host rather than
+  part of the React Native package. That page also carries the traps that make GTK styling fail
+  *silently*, each one measured.
 
 ## Solid JSX
 
-`registerBuiltinWidgets()` loads the generated table; after that the tags are available.
-Build with [`@gjsify/rolldown-plugin-solid`](/gjsify/frameworks/solid/), which is what turns
-the JSX into calls against the host.
+`registerBuiltinWidgets()` loads the generated table, and after that the tags are available.
+Build with [`@gjsify/rolldown-plugin-solid`](/gjsify/frameworks/solid/), which turns the JSX
+into calls against the host.
 
 ```tsx
 import Adw from 'gi://Adw?version=1';
@@ -211,11 +217,11 @@ app.connect('activate', () => {
 await app.runAsync([]);
 ```
 
-The Vue adapter exports `render`, `createApp`, `mount`, `adopt` and `widgetOf`. You will reach
-for the last one less often here than in Solid or React: you already hold the window you
-mounted into, and a widget *inside* the tree is what a `ref` on the element gives you, as in
-any Vue app. `widgetOf` is there for the case where what you hold is a host node rather than a
-component instance.
+The Vue adapter exports `render`, `createApp`, `mount`, `adopt` and `widgetOf`. You reach for
+the last one less often here than in Solid or React. You already hold the window you mounted
+into, and a `ref` on an element gives you a widget *inside* the tree, as in any Vue app.
+`widgetOf` is for the case where what you hold is a host node rather than a component
+instance.
 
 Both tag spellings work in a template. `<GtkLabel>` and `<gtk-label>` resolve to the same
 widget and to the same type-check key, so pick one and stay with it. The build needs
@@ -224,7 +230,7 @@ has the recipe and the reason.
 
 ## React
 
-React needs no compile plugin — its JSX is a runtime, and the adapter ships the automatic
+React needs no compile plugin. Its JSX is a runtime, and the adapter ships the automatic
 runtime TypeScript expects. Point `jsxImportSource` at the subpath, not at `react`:
 
 ```jsonc
@@ -255,8 +261,9 @@ scheduler, so an unflushed first render would leave the container empty and say 
 
 Pointing `jsxImportSource` at the subpath rather than at `react` is what keeps every DOM tag
 `@types/react` pre-declares from type-checking clean against a GTK renderer. The build needs two
-flags instead of a plugin — `--define 'process.env.NODE_ENV="production"' --exclude-globals navigator`; the
-[React page](/gjsify/frameworks/react/) has both, with the reason each one exists.
+flags instead of a plugin, `--define 'process.env.NODE_ENV="production"'` and
+`--exclude-globals navigator`. The [React page](/gjsify/frameworks/react/) has both, with the
+reason each one exists.
 
 ## What the host refuses to do quietly
 
@@ -304,9 +311,9 @@ is measured per widget rather than inherited.
 ## A dialog is presented, not adopted
 
 One family of widgets takes none of the rules above, and the difference is not a degradation you
-can work around. An `Adw.Dialog` is **presented against** a parent and never parented by it, so
-its place in your tree and its place in the GTK tree are different places — a portal. Put one in
-a box and the process aborts.
+can work around. An `Adw.Dialog` is **presented against** a parent and never parented by it. Its
+place in your tree and its place in the GTK tree are two different places, a portal. Put one in a
+box and the process aborts.
 
 So a dialog declares that instead, and the host places it by calling `present()` on the dialog
 rather than an adder on the parent. Write it exactly where it belongs in your markup:
@@ -331,19 +338,19 @@ Three things follow, and they are the same in all three adapters because the rul
 
 - **the dialog is not a child of the box.** It takes no position in the box's child list, so the
   button above it is the box's only child and adding or removing the dialog never moves anything.
-- **rendering it opens it; unrendering it closes it.** There is no imperative `present` call to
-  make and no `close` to remember — the dialog is up for exactly as long as the element is in
-  your tree, and it is closed unconditionally when the element goes, whatever `can-close` says.
+- **rendering it opens it; unrendering it closes it.** You make no imperative `present` call and
+  remember no `close`. The dialog is up for exactly as long as the element is in your tree, and
+  it closes unconditionally when the element goes, whatever `can-close` says.
 - **it waits for a window.** Renderers build a subtree before they insert it, so at the moment
   your dialog is created its parent is usually not in a window yet. Presenting then would open a
   stray toplevel; the host waits until the tree is really inside one, and presents there.
 
 `AdwDialog`, `AdwAlertDialog`, `AdwAboutDialog`, `AdwPreferencesDialog` and `AdwShortcutsDialog`
 are placed this way. The four subclasses build their own contents from their own API
-(`add_response`, `add`) and inherit a `set_child` that would replace that, so each is a tag you
-can create, give properties and handlers, and present — while a child written **inside** one is
-refused by name rather than silently wiping the widget's own template. Put your own layout in an
-`<adw-dialog>`; fill a subclass through its API, off a `ref`.
+(`add_response`, `add`) and inherit a `set_child` that would replace that. So each one is a tag
+you can create, give properties and handlers, and present, while a child written **inside** one
+is refused by name rather than silently wiping the widget's own template. Put your own layout in
+an `<adw-dialog>`; fill a subclass through its API, off a `ref`.
 
 ## Long lists
 
@@ -454,25 +461,25 @@ another to the type checker:
 The spellings are measured, not chosen. A capitalised `JSX.IntrinsicElements` key is never
 consulted, because `<GtkBox/>` is `TS2304: Cannot find name 'GtkBox'`. Volar resolves a kebab
 template tag to either key spelling but a Pascal tag only to a Pascal key, so one GType key
-covers both — and that key is also the table key and the GtkBuilder XML key.
+covers both. That key is also the table key and the GtkBuilder XML key.
 
-`noImplicitAny: true` and `strictTemplates: true` are load-bearing in the same way: without
-them the checker accepts everything and you conclude the surface works. Each framework page
-names the exact trap for its pipeline.
+`noImplicitAny: true` and `strictTemplates: true` matter for the same reason. Without them the
+checker accepts everything and you conclude the types work. Each framework page names the exact
+trap for its pipeline.
 
 ## Read the source
 
 Four showcases build the same window four ways, and each asserts the resulting tree against
 the **real** widget tree on every launch:
 
-- [`adw-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/adw-host-counter)
-  — imperative, straight through the host ops
-- [`solid-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/solid-host-counter)
-  — the same window as Solid JSX
-- [`vue-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/vue-host-counter)
-  — the same window as a `.vue` single-file component
-- [`react-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/react-host-counter)
-  — the same window as React, with no compile plugin at all
+- [`adw-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/adw-host-counter):
+  imperative, straight through the host ops
+- [`solid-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/solid-host-counter):
+  the same window as Solid JSX
+- [`vue-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/vue-host-counter):
+  the same window as a `.vue` single-file component
+- [`react-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/react-host-counter):
+  the same window as React, with no compile plugin at all
 
 ## See also
 
@@ -483,9 +490,8 @@ the **real** widget tree on every launch:
 - [Native Adwaita Apps](/gjsify/guides/native-adwaita-app/) for the application shell you
   mount into
 - [GObject Classes](/gjsify/patterns/gobject-classes/) for the `registerClass` rules your own
-  widget subclasses follow — the host resolves a subclass through its nearest registered
-  ancestor
+  widget subclasses follow. The host resolves a subclass through its nearest registered ancestor
 - [Adwaita gallery](/gjsify/adwaita/) for the widgets themselves
-- [Effect](/gjsify/experiments/effect/) if you already write TypeScript in that style — an
-  optional, experimental integration for the non-rendering half. It is not part of the
-  recommended path and none of the above needs it
+- [Effect](/gjsify/experiments/effect/) if you already write TypeScript in that style. It is an
+  optional, experimental integration for the non-rendering half, it is not part of the
+  recommended path, and nothing above needs it

--- a/website/src/content/docs/frameworks/react-native.mdx
+++ b/website/src/content/docs/frameworks/react-native.mdx
@@ -11,8 +11,8 @@ without a rename per file.
 
 There is no bridge and no native module host. This renders in-process onto GTK, so
 `NativeModules`, `TurboModuleRegistry` and `findNodeHandle` are not available and say so when you
-import them. What you get instead is a checkable list of what works, and every gap named before
-you run the app rather than found in a window that looks plausible.
+import them. What you get instead is a list of what works, readable from your own code, and every
+gap named before you run the app rather than found in a window that looks plausible.
 
 ## Install
 
@@ -56,7 +56,7 @@ copies.
 ## Declare your tokens
 
 `className` works on every primitive, and the **values** behind those names are your project's.
-The layer ships a deliberately tiny default scale — `0` and `px`, and nothing between them — so
+The layer ships a deliberately tiny default scale, `0` and `px` and nothing between them, so
 that a class naming a token you have not declared is a named error rather than a wrong margin.
 Write the scales once:
 
@@ -79,9 +79,9 @@ import { tokens } from './tokens.js';
 configureStyle({ tokens });
 ```
 
-If your tokens are generated from a Tailwind v4 `@theme`, add the structural defaults
-your `@theme` has no reason to declare — measured, a real application's vocabulary
-loses `rounded-full` and `inset-0`/`top-0`/`left-0`/`right-0` without them:
+If your tokens are generated from a Tailwind v4 `@theme`, add the structural defaults your
+`@theme` has no reason to declare. Measured, a real application's vocabulary loses
+`rounded-full` and `inset-0`/`top-0`/`left-0`/`right-0` without them:
 
 ```tsx
 import { TAILWIND_DEFAULT_TOKENS, mergeTokens } from '@gjsify/gtk-host/style';
@@ -95,8 +95,8 @@ not carry.
 
 Every snippet on this page uses those two scales. **Skipping this step is not a styling
 difference, it is a blank window**: the first undeclared token throws out of the render, React
-unmounts the tree, and the process goes on to exit 0 with no GTK diagnostic at all — measured, and
-the reason [`shotEvidence`](https://github.com/gjsify/gjsify/blob/main/packages/framework/gtk-host/src/probe.ts)
+unmounts the tree, and the process goes on to exit 0 with no GTK diagnostic at all. Measured,
+and the reason [`shotEvidence`](https://github.com/gjsify/gjsify/blob/main/packages/framework/gtk-host/src/probe.ts)
 exists. The [styling page](/gjsify/frameworks/styling/) has the whole class vocabulary; the token
 names above are only what these examples need.
 
@@ -109,7 +109,7 @@ export function Counter({ count, onPress }: { count: number; onPress: () => void
     return (
         <View>
             {/* `flex-1` resolves against the PARENT's orientation, so it goes on a
-                child and not on the root of the tree — the root has no parent to
+                child and not on the root of the tree. The root has no parent to
                 resolve against, and the layer says so instead of guessing. Same rule
                 for `self-*` and `absolute`; see "Where a component refuses a prop". */}
             <View className="flex-1 items-center justify-center gap-m">
@@ -158,7 +158,7 @@ main();
 mid-teardown, and you get a core dump where you wanted an exit code.
 
 While it runs, `AppRegistry.getApplication()` and `AppRegistry.getWindow()` answer with the
-`Adw.Application` and its window — that is how you add an action, set a default size or connect
+`Adw.Application` and its window. That is how you add an action, set a default size or connect
 `close-request` from inside a component. Both answer `null` before the first render and again
 once the loop has ended, so an accessor never hands you a window that has closed.
 
@@ -252,7 +252,7 @@ import { SUPPORT_TABLE, isImportable, explainUnsupported } from '@gjsify/react-n
 
 ## A modal is a dialog, and `visible` is the whole of it
 
-`<Modal>` renders an `Adw.Dialog` — a sheet over the window it is in, with libadwaita's own dim
+`<Modal>` renders an `Adw.Dialog`, a sheet over the window it is in, with libadwaita's own dim
 behind it. It is the one component whose widget is not placed inside its parent: a dialog is
 *presented against* a parent, so the box you write it in never holds it and never shifts because
 of it. Write it where it belongs and drive it with `visible`:
@@ -289,18 +289,18 @@ control and a click on the backdrop all arrive at `onRequestClose`, and setting 
 false is what takes the sheet down. Leave the prop out and the user cannot dismiss it.
 
 `onShow` fires once, when the modal is actually on screen. Children go into a box inside the
-dialog, so several of them are fine — and `style` and `className` land on the **dialog**, which
+dialog, so several of them are fine. But `style` and `className` land on the **dialog**, which
 is not a box, so `items-*` and `gap-*` there are refused by name and belong on a `<View>` inside.
 
 Refused, each naming what to do instead: `animationType`, `transparent`, `backdropColor` and
 `presentationStyle` (libadwaita animates and dims the sheet itself, and picks the animation from
-`Adw.Dialog:presentation-mode` — reach it through a `ref` if you want a bottom sheet),
+`Adw.Dialog:presentation-mode`; reach it through a `ref` if you want a bottom sheet),
 `onDismiss` (the only thing that dismisses the dialog is the element being unrendered, so put
 that work in the effect cleanup of whatever renders the `<Modal>`), plus `allowSwipeDismissal`,
 `supportedOrientations`, `onOrientationChange` and `modalRef`.
 
-For a question with buttons and no layout of your own, `Alert.alert()` is the shorter answer —
-it is an `Adw.AlertDialog` and it needs no element at all.
+For a question with buttons and no layout of your own, `Alert.alert()` is the shorter answer:
+it is an `Adw.AlertDialog` and needs no element at all.
 
 ## Adwaita widgets
 
@@ -310,8 +310,8 @@ GTK, and React Native has no clamp, no header bar and no preferences group to ma
 
 You still get them, from the other side. `@gjsify/gtk-host` carries a
 [generated tag for every concrete widget](/gjsify/frameworks/#the-widget-table-and-the-type-surfaces)
-in Gtk and Adw, and pointing `jsxImportSource` at `@gjsify/gtk-host/react` — the same tsconfig a
-React app on GTK already uses — is what puts that tag list in scope. So an Adwaita container and
+in Gtk and Adw, and pointing `jsxImportSource` at `@gjsify/gtk-host/react`, the same tsconfig a
+React app on GTK already uses, is what puts that tag list in scope. So an Adwaita container and
 a React Native primitive live in one tree:
 
 ```tsx
@@ -341,11 +341,11 @@ export function Documents({ onAdd }: { onAdd: () => void }) {
 Three rules hold there, and the layer states each of them by refusing rather than by dropping:
 
 - **A React Native primitive goes in the container's default slot.** `slot` is not one of its
-  props, and an unlisted prop is refused by name — so a named slot (`top`, `bottom`, `title`,
+  props, and an unlisted prop is refused by name, so a named slot (`top`, `bottom`, `title`,
   `end`) takes a gtk-host tag instead. A toolbar view's default slot is its content; a header
   bar's is `start`.
 - **Layout that needs a parent needs a `<View>` above it.** `flex-1`, `self-*` and `absolute`
-  resolve against the parent's orientation, and an Adwaita container publishes none — so an
+  resolve against the parent's orientation, and an Adwaita container publishes none, so an
   element directly under one is the root of its React tree and is told so.
 - **The container needs a curated child policy.** gtk-host will not guess how a widget adopts a
   child: `add`, `append` and `set_child` all exist somewhere in GTK and the wrong one is a
@@ -356,23 +356,23 @@ Three rules hold there, and the layer states each of them by refusing rather tha
   three times.
 
 The [Layout page](/gjsify/adwaita/layout/) of the Adwaita gallery carries this as a **React
-Native on GTK** tab beside the GJS, Blueprint, web and NativeScript ones — on the clamp, the
+Native on GTK** tab beside the GJS, Blueprint, web and NativeScript ones: on the clamp, the
 header bar and the toolbar view, and not on the wrap box, whose policy is still missing.
 
 ### What this is not
 
 **This layer does not put Adwaita on a phone.** `<adw-toolbar-view>` above is
-`Adw.ToolbarView` — a GTK 4 widget, in a GTK 4 window, on a machine where libadwaita is
+`Adw.ToolbarView`: a GTK 4 widget, in a GTK 4 window, on a machine where libadwaita is
 installed. Nothing on this page runs on Android or iOS, and no tab in the gallery claims
 otherwise.
 
-That is the distinction worth keeping, and it is a direction rather than a boundary: this layer
-takes React Native's *components* to GTK. The opposite direction — Adwaita's *components* rebuilt
-on React Native's primitives — has been **started**, as
+The distinction is a direction rather than a boundary. This layer takes React Native's
+*components* to GTK. The opposite direction, Adwaita's *components* rebuilt on React Native's
+primitives, has been **started** as
 [`@gjsify/adwaita-react-native`](https://github.com/gjsify/gjsify/blob/main/packages/framework/adwaita-react-native/README.md),
 and it is a walking skeleton rather than a way to run an Adwaita app on a phone.
 
-Every widget it ships carries the whole vertical — both platform halves, the resolution
+Every widget it ships carries the whole vertical: both platform halves, the resolution
 mechanism, the manifest declaration, a gate and suites on each side. `Adw.Bin` and `Adw.Clamp`
 came first and proved that shape; the package's own README table is the live set, and
 `check-vocabulary-alignment.mjs` prints the count on every run. The halves fork at the
@@ -381,15 +381,16 @@ package's `exports` map on the `react-native` condition, never by file name. You
 libadwaita's own type name with its namespace prefix read back off it, and it is the only
 spelling the package root has.
 
-What it is honest about is more useful than what it claims. The phone half is not a `maxWidth`
-approximation — it runs `@gjsify/adwaita-core`'s port of `adw_clamp_layout_allocate`, libadwaita's
-own easing curve — but it **has never run on a device**: its numbers are asserted as instructions,
-not measured as pixels, because there is no Yoga and no phone in the loop. And its divergences
-are named in its README rather than smoothed over, the first of them on the very widget above:
-React Native has no measure pass, so `Adw.Clamp` passes the child's intrinsic minimum as `0`, and a
-child wider than the clamp is compressed there where GTK would widen the clamp instead.
+What it is honest about is more useful than what it claims. The phone half is no `maxWidth`
+approximation: it runs `@gjsify/adwaita-core`'s port of `adw_clamp_layout_allocate`, libadwaita's
+own easing curve. But it **has never run on a device**, so its numbers are asserted as
+instructions rather than measured as pixels, because there is no Yoga and no phone in the loop.
+Its divergences are named in its README rather than smoothed over, the first of them on the very
+widget above. React Native has no measure pass, so `Adw.Clamp` passes the child's intrinsic
+minimum as `0`, and a child wider than the clamp is compressed there where GTK would widen the
+clamp instead.
 
-It is on npm (since `0.44.0`), but no gallery tab renders it — so nothing you see on this site
+It is on npm (since `0.44.0`), but no gallery tab renders it, so nothing you see on this site
 is that package.
 
 ## Two defaults that are inverted
@@ -414,7 +415,7 @@ the code path runs.
 
 ## Routing
 
-`@gjsify/react-native/router` mirrors the `expo-router` surface name for name. Import from the
+`@gjsify/react-native/router` mirrors `expo-router` name for name. Import from the
 subpath: `--dialect react-native` rewrites `react-native` and nothing else, so an `expo-router`
 specifier stays an `expo-router` specifier. `router`, `usePathname`, `useLocalSearchParams`,
 `Stack` and `Tabs` are implemented.
@@ -457,8 +458,9 @@ Screen options are `title`, `headerShown` and `animation` on `<Stack.Screen>`, a
 `<Tabs.Screen>`. Anything else is refused by name.
 
 **Deep links land where you send them, including a tab that is not the first one.** A desktop
-application gets them the way a phone does — a URI handler, a notification, a restored session —
-so entering at `/settings` rather than at the index route is the ordinary path, not an edge case:
+application gets them the way a phone does, through a URI handler, a notification or a restored
+session. Entering at `/settings` rather than at the index route is the ordinary path, not an
+edge case:
 
 ```tsx
 import { router } from '@gjsify/react-native/router';
@@ -471,8 +473,8 @@ router.navigate(entryHref);
 ```
 
 The tab the URL names is the tab that is focused and the tab the switcher highlights. A
-`tabPress` event is emitted only for a real press, so a handler hung off it — "scroll to top on
-the second press" is the usual one — does not fire while the application is being entered.
+`tabPress` event is emitted only for a real press, so a handler hung off it, usually "scroll to
+top on the second press", does not fire while the application is being entered.
 
 Router errors carry a stable `code`, so a test can assert one instead of matching a message:
 `duplicate-route`, `param-without-name`, `unresolved-href`, `not-a-screen-child`,
@@ -515,10 +517,10 @@ a `Gtk.TextBuffer`, and press state is a CSS pseudo-class that never reaches Rea
 
 So a refusal points at the GTK object to reach through a `ref`, rather than at a to-do item.
 
-A `<TextInput>` ref is React Native's own imperative handle — `focus()`, `blur()`, `clear()`,
-`isFocused()`, `setSelection()` — plus `widget`, the `Gtk.Entry` or `Gtk.TextView` itself, which
-is where everything the handle does not answer lives. Every other primitive's ref is the
-`Gtk.Widget` directly.
+A `<TextInput>` ref is React Native's own imperative handle: `focus()`, `blur()`, `clear()`,
+`isFocused()` and `setSelection()`. It also carries `widget`, the `Gtk.Entry` or `Gtk.TextView`
+itself, which is where everything the handle does not answer lives. Every other primitive's ref
+is the `Gtk.Widget` directly.
 
 ```tsx
 import { useEffect, useRef } from 'react';
@@ -530,7 +532,7 @@ function Notes() {
 
     useEffect(() => {
         input.current?.focus();
-        // multiline text lives in the buffer, not in `value` — reach the widget for it
+        // multiline text lives in the buffer, not in `value`; reach the widget for it
         (input.current?.widget as Gtk.TextView | undefined)?.get_buffer().set_text('hello', -1);
     }, []);
 
@@ -541,14 +543,14 @@ function Notes() {
 ## Ask before you render
 
 A refused prop throws when the element renders, and a render-time throw with no error boundary
-above it takes the whole React tree with it — that is React's behaviour rather than this layer's,
+above it takes the whole React tree with it. That is React's behaviour rather than this layer's,
 and it has cost a real application every screen it had. So the prop answers are published too,
 and you can assert them in your own test suite before a window exists:
 
 ```ts
 import { acceptsProp, explainProp } from '@gjsify/react-native/prop-table';
 
-acceptsProp('Text', 'onPress'); // false — a Gtk.Label emits no `clicked`
+acceptsProp('Text', 'onPress'); // false: a Gtk.Label emits no `clicked`
 explainProp('Text', 'onPress'); // the exact sentence a render would have thrown
 acceptsProp('Pressable', 'onPress'); // true
 ```

--- a/website/src/content/docs/frameworks/react.mdx
+++ b/website/src/content/docs/frameworks/react.mdx
@@ -5,9 +5,9 @@ description: Render React into GTK 4 widgets with @gjsify/gtk-host/react. Instal
 
 import CommandTabs from '../../../components/CommandTabs.astro';
 
-Render React into real `Gtk` and `Adw` widgets. There is no compile plugin and no DOM, and
-`react-dom` is not involved. React's JSX is already a runtime, so two lines of `tsconfig.json`
-and two build flags are the whole setup.
+Render React into real `Gtk` and `Adw` widgets. There is no compile plugin, no DOM and no
+`react-dom`. React's JSX is already a runtime, so two lines of `tsconfig.json` and two build
+flags are the whole setup.
 
 You keep React. Components, hooks, context, error boundaries, `useState`, `useEffect` and
 Suspense behave the way they do anywhere else. What changes is the element vocabulary:
@@ -173,8 +173,8 @@ const root = createRoot(myWindow, {
 ```
 
 **Passing `onUncaughtError` turns the rethrow off.** That is the right trade for an application
-with its own error surface, but you then own reporting entirely. Pass it to take over reporting,
-not to add a log line.
+that reports its own errors, but you then own reporting entirely. Pass it to take over
+reporting, not to add a log line.
 
 ## Three differences from react-dom
 

--- a/website/src/content/docs/frameworks/solid.mdx
+++ b/website/src/content/docs/frameworks/solid.mdx
@@ -6,10 +6,10 @@ description: Compile SolidJS JSX for a GTK 4 build with @gjsify/rolldown-plugin-
 import CommandTabs from '../../../components/CommandTabs.astro';
 
 [`@gjsify/rolldown-plugin-solid`](https://www.npmjs.com/package/@gjsify/rolldown-plugin-solid)
-compiles SolidJS JSX during a gjsify build, in `universal` generate mode — the only mode whose
+compiles SolidJS JSX during a gjsify build, in `universal` generate mode, the only mode whose
 output contains no DOM. It targets the renderer in
-[`@gjsify/gtk-host/solid`](/gjsify/frameworks/), and it is the whole compile step: a
-`.tsx` entry plus this plugin is a GTK app.
+[`@gjsify/gtk-host/solid`](/gjsify/frameworks/), and it is the whole compile step: a `.tsx`
+entry plus this plugin is a GTK app.
 
 It is an ordinary Rolldown plugin, so it also loads under Rollup and Vite.
 
@@ -88,7 +88,7 @@ export default {
 | `generate` | `universal` | `babel-preset-solid` mode. `dom` emits `document.createElement`, which GJS does not have. |
 | `include` | `/\.(m\|c)?[jt]sx$/` | Which modules to compile. A `.ts` file cannot contain JSX, so widening this is a mistake. |
 
-## The TypeScript half, and both halves are required
+## The TypeScript half, which is not optional
 
 ```jsonc
 {
@@ -100,18 +100,18 @@ export default {
 }
 ```
 
-`jsx: "preserve"` is what this plugin needs — the JSX has to survive TypeScript so Babel can
+`jsx: "preserve"` is what this plugin needs. The JSX has to survive TypeScript so Babel can
 take it, and `"react"` is refused outright with `jsxImportSource` (TS5089).
 
-`noImplicitAny` — which `strict` turns on — is not optional either. With `jsx: "preserve"`, no
+`noImplicitAny`, which `strict` turns on, is not optional either. With `jsx: "preserve"`, no
 `jsxImportSource` and `noImplicitAny` off, **every JSX element is implicitly `any` and `tsc`
 exits 0 having checked nothing**. A project in that state watches a clean type check go by and
-concludes the type surface works.
+concludes its types hold.
 
-One gap the surface cannot close: TypeScript exempts every hyphen-containing JSX attribute
-from excess-property checking, so `<gtk-box no-such={1} />` is accepted. Both spellings are
-generated, so a declared `can-focus="yes"` still fails on its *value* — but prefer `canFocus`,
-which is checked both ways.
+One gap the types cannot close: TypeScript exempts every hyphen-containing JSX attribute from
+excess-property checking, so `<gtk-box no-such={1} />` is accepted. Both spellings are
+generated, so a declared `can-focus="yes"` still fails on its *value*. Prefer `canFocus`, which
+is checked both ways.
 
 ## Why Babel, in an oxc toolchain
 
@@ -119,16 +119,16 @@ Solid's JSX is a **compiler**, not a runtime. `babel-plugin-jsx-dom-expressions`
 into straight-line calls against a renderer, and no oxc or SWC port of it exists. Rolldown's
 own transformer cannot stand in.
 
-That matters because of what happens when nothing is configured. Pointed at a `.tsx` with no
-JSX policy, the transformer defaults to the automatic React runtime and emits
+It matters because of what happens when nothing is configured. Pointed at a `.tsx` with no JSX
+policy, the transformer defaults to the automatic React runtime and emits
 `import { jsx } from "react/jsx-runtime"`. GJS cannot resolve a bare specifier at all, so the
-build reports the miss as a **warning**, exits 0 — and the artifact dies at its first import
+build reports the miss as a **warning** and exits 0, then the artifact dies at its first import
 under `gjs`. Measured end to end: exit 0, then exit 1.
 
 `gjsify build --app gjs` now refuses that case up front. Give it a `.tsx` entry with no
 `gjsify.bundler.transform.jsx` and no tsconfig `compilerOptions.jsx`, and the build stops with
 an error naming the file and the three ways to answer the question. The refusal is scoped to
-`--app gjs`: on `--app node` and `--app browser` the React default is a legitimate answer for a
+`--app gjs`. On `--app node` and `--app browser` the React default is a legitimate answer for a
 project that has React installed.
 
 Babel is loaded on the first matching module, so a build with no JSX in it never pays for it.
@@ -144,16 +144,16 @@ _$insertNode(_el$, _el$2);
 _$setProp(_el$, "title", "solid-host counter");
 ```
 
-Three consequences, and each is a thing the host has to do rather than the adapter:
+Three consequences, and each one is the host's job rather than the adapter's:
 
 - **Children are inserted before properties are set**, and `createElement` never sees a prop.
-  A construct-only property such as `cssName` therefore only survives because the host defers
+  A construct-only property such as `cssName` only survives because the host defers
   materialisation and rebuilds when it has to.
 - **Handlers arrive through `setProp`** under their JSX spelling (`onClicked`), not through a
   separate op.
 - **The renderer op names are emitted literally.** They are the member names of Solid's
-  `Renderer<NodeType>` — `createElement`, `createTextNode`, `insertNode`, `insert`, `spread`,
-  `setProp`, `mergeProps`, `effect`, `memo`, `createComponent`, `render`, `use` — so
+  `Renderer<NodeType>`: `createElement`, `createTextNode`, `insertNode`, `insert`, `spread`,
+  `setProp`, `mergeProps`, `effect`, `memo`, `createComponent`, `render`, `use`. So
   `moduleName` must re-export all twelve under exactly those names. A renderer that exports
   eleven builds fine and fails with `MISSING_EXPORT` on the twelfth, only for the JSX that
   happens to need it.
@@ -163,16 +163,16 @@ Three consequences, and each is a thing the host has to do rather than the adapt
 `For`, `Index`, `Show` and `Dynamic` come from `@gjsify/gtk-host/solid`, never from
 `solid-js/web`. That package is Solid's DOM renderer: its components build DOM elements
 nothing here can place. Measured with `<Dynamic component="GtkLabel">` imported from
-`solid-js/web` into a GJS bundle — the box's children were just the static sibling, with no
+`solid-js/web` into a GJS bundle: the box's children were just the static sibling, with no
 throw, no GTK diagnostic and exit 0. Importing it also makes `--globals auto` inject
 `document`, `HTMLCanvasElement` and `Path2D`, and pull `gi://Gdk`, `GdkPixbuf`, `Pango` and
 `PangoCairo` into the bundle.
 
 ## What it does not do
 
-The plugin is the compile step and nothing else. No `<style>` or CSS handling — GTK styling is
-a `Gtk.CssProvider` concern. No dev or HMR mode. `generate: "dom"` and `"ssr"` are settable and
-untested, because nothing here has a DOM to render into.
+The plugin is the compile step and nothing else. No `<style>` or CSS handling, because GTK
+styling is a `Gtk.CssProvider` concern. No dev or HMR mode. `generate: "dom"` and `"ssr"` are
+settable and untested, since nothing here has a DOM to render into.
 
 ## Related
 

--- a/website/src/content/docs/frameworks/styling.mdx
+++ b/website/src/content/docs/frameworks/styling.mdx
@@ -1,21 +1,20 @@
 ---
 title: Styling on GTK
-description: How @gjsify/gtk-host/style turns utility classes and style objects into GTK CSS, widget properties and attach-time intents — with the measured traps behind that split, the worst of which fail with no diagnostic at all.
+description: How @gjsify/gtk-host/style turns utility classes and style objects into GTK CSS, widget properties and attach-time intents, plus the measured traps behind that split. The worst of them fail with no diagnostic at all.
 ---
 
 [`@gjsify/gtk-host/style`](https://www.npmjs.com/package/@gjsify/gtk-host) is the styling
 partition: a utility class (`flex-1`, `mt-2xs`, `bg-emphasis`) or a `style={{…}}` object goes in,
 and GTK-shaped output comes out.
 
-It is framework-agnostic by construction. `class="flex-1"` in a Vue template is the same question
-as `className="flex-1"` on a React element, and both are the same question as a style object — so
-the answer lives one level below any of them, in the host rather than beside it. Today the binding
-that consumes it is [`@gjsify/react-native`](/gjsify/frameworks/react-native/), on both its React
-and its Solid front ends.
+It is framework-agnostic by construction. `class="flex-1"` in a Vue template, `className="flex-1"`
+on a React element and a `style` object are all the same question, so the answer lives one level
+below all three, in the host rather than beside it. Today the binding that consumes it is
+[`@gjsify/react-native`](/gjsify/frameworks/react-native/), on both its React and its Solid front
+ends.
 
 **Everything on this page is a measurement against a real GTK, not a reading of a specification.**
-That matters here more than in most places, because GTK's failure mode for a styling mistake is
-*exit 0 and a window that looks nearly right*.
+GTK's failure mode for a styling mistake is *exit 0 and a window that looks nearly right*.
 
 ## Three destinations, and no fourth
 
@@ -34,26 +33,26 @@ class and does the same in both directions. Both carry a value alongside the nam
 this a property" and "does this value parse" are different questions and only the pair is
 testable.
 
-Anything the partition cannot answer is a **named error** — an unknown utility, a token missing
+Anything the partition cannot answer is a **named error**: an unknown utility, a token missing
 from a scale, or a combination GTK has no way to express. There is no silent drop, because a
 styling layer that quietly ignores part of its input is invisible in CI and obvious on screen.
 
 ## `text-align` is not GTK CSS
 
-It is the single most likely mistake in this whole area, because it reads like paint. Anyone
-reading a `text-*` vocabulary groups it with `color` and `font-size`, emits it as a CSS
-declaration, and **GTK's parser drops it in silence** — the text stays left-aligned with no
-diagnostic anywhere.
+This is the most likely mistake in the whole area, because `text-align` reads like paint. Anyone
+reading a `text-*` vocabulary groups it with `color` and `font-size` and emits it as a CSS
+declaration. **GTK's parser drops it in silence**: the text stays left-aligned, with no diagnostic
+anywhere.
 
 Text alignment on GTK is a **widget property**, and specifically `Gtk.Label`'s: `xalign` (a float)
-together with `justify` (an enum). Both are needed for one `text-*`, because `xalign` positions a
-line inside the label's allocation while `justify` positions the lines relative to each other — so
-a single-line label ignores `justify` and a wrapped one looks unaligned without `xalign`. Setting
-one of the two is the shape that passes the test and fails on the first paragraph.
+together with `justify` (an enum). One `text-*` needs both. `xalign` positions a line inside the
+label's allocation, `justify` positions the lines relative to each other, so a single-line label
+ignores `justify` and a wrapped one looks unaligned without `xalign`. Setting one of the two is the
+shape that passes the test and fails on the first paragraph.
 
-And `Gtk.Box` has neither, measured. So `text-center` on a `<View>` wrapping a `<Text>` — ordinary
-authoring — cannot be resolved where the class is written. It becomes an **intent**, and the value
-travels down to the first descendant that can take it.
+`Gtk.Box` has neither, measured. So `text-center` on a `<View>` wrapping a `<Text>`, which is
+ordinary authoring, cannot be resolved where the class is written. It becomes an **intent**, and
+the value travels down to the first descendant that can take it.
 
 There is no logical spelling to map onto, either: `Gtk.Label:xalign` is `0 = left` and
 `GtkJustification` has exactly `LEFT`, `RIGHT`, `CENTER` and `FILL`. `text-start` and `text-end`
@@ -61,28 +60,27 @@ are named refusals pointing at `text-left` / `text-right`.
 
 ## GTK CSS margins are physical; widget margins are logical
 
-This is the decisive measurement of the whole partition, and the one to keep if everything else is
-rewritten:
+This is the decisive measurement of the whole partition:
 
 - **GTK CSS** accepts `margin-left` and `margin-right`. It **refuses** `margin-start`,
   `margin-end`, `padding-start` and `padding-end`.
 - **`Gtk.Widget`** installs `margin-start` and `margin-end`. It installs **no** `margin-left` and
   **no** `margin-right`.
 
-The two mechanisms are therefore not two ways to spell one thing that a layer gets to choose
-between. Each is the **only** route for one half of the source vocabulary, which splits along the
-same line: `ml-*` / `mr-*` are physical, `ms-*` / `me-*` are logical.
+So the two mechanisms are not two spellings of one thing a layer gets to choose between. Each is
+the **only** route for one half of the source vocabulary, which splits along the same line:
+`ml-*` / `mr-*` are physical, `ms-*` / `me-*` are logical.
 
-So `ml-*` / `mr-*` go through CSS and `ms-*` / `me-*` go through the widget property — and that is
-what stays correct under RTL. Routing `ms-*` through CSS would produce a margin that does not flip
-for a reader of Arabic or Hebrew: a bug with no failing test and no visible symptom in the
+`ml-*` / `mr-*` therefore go through CSS and `ms-*` / `me-*` through the widget property, and that
+is what stays correct under RTL. Routing `ms-*` through CSS would produce a margin that does not
+flip for a reader of Arabic or Hebrew: a bug with no failing test and no visible symptom in the
 language it was written in.
 
 `mt-*` / `mb-*` have no logical-versus-physical distinction to preserve, so they join the widget
-channel. Which leaves `m-*` straddling both, because `m-*` is physical: its horizontal half is CSS
-and its vertical half is widget properties. That looks like an inconsistency and is the opposite —
-it is what keeps `m-4 mx-2` resolving by last-wins on one key instead of stacking a CSS margin on
-top of a widget margin.
+channel. That leaves `m-*` straddling both, because `m-*` is physical: its horizontal half is CSS
+and its vertical half is widget properties. The apparent inconsistency is the point. It is what
+keeps `m-4 mx-2` resolving by last-wins on one key instead of stacking a CSS margin on top of a
+widget margin.
 
 `m-4 ms-2` cannot be saved that way, so it is a **refusal by name**:
 
@@ -92,16 +90,16 @@ top of a widget margin.
 
 ### Padding has no second route at all
 
-No GTK class installs a `padding` property of any kind — not `Gtk.Widget`, not `Gtk.Box`. Every
-padding is CSS, and a **logical** padding (`ps-*`, `pe-*`) is therefore a named refusal rather than
-a physical approximation: `padding-start` is not a CSS property either, so there is nothing to
-approximate it with. Use `pl-*` / `pr-*`.
+No GTK class installs a `padding` property of any kind, not `Gtk.Widget` and not `Gtk.Box`. Every
+padding is CSS, so a **logical** padding (`ps-*`, `pe-*`) is a named refusal rather than a physical
+approximation: `padding-start` is not a CSS property either, so there is nothing to approximate it
+with. Use `pl-*` / `pr-*`.
 
-## `border-width` without `border-style` paints nothing — and occupies nothing
+## `border-width` without `border-style` paints nothing, and occupies nothing
 
 CSS's initial `border-style` is `none`, and `none` zeroes the width. Measured on GTK 4.22.4, on a
-`Gtk.Box` carrying the class and rooted in a `Gtk.Window` — and the box's **contents are part of
-the measurement**, because a box's minimum size is its children's, so the absolute numbers only
+`Gtk.Box` carrying the class and rooted in a `Gtk.Window`. The box's **contents are part of the
+measurement**, because a box's minimum size is its children's, so the absolute numbers only
 reproduce on the shape they were taken on:
 
 | Declarations | empty `Gtk.Box` | one holding `Label("x")` |
@@ -110,11 +108,11 @@ reproduce on the shape they were taken on:
 | `border-width: 4px` | 0 × 0 px | 9 × 18 px |
 | `border-width: 4px; border-style: solid` | 8 × 8 px | 17 × 26 px |
 
-The no-border row is what makes the point, which is why it is in the table rather than assumed: a
-width without a style measures **identical to no border at all**, on either shape, and adding the
-style adds 4 px per edge — 8 px on each axis — on both. So a `border` utility that emitted only a
-width would be a class that does absolutely nothing, silently: no paint, and no space taken
-either, which is why it does not even show up as a layout shift you might notice.
+The no-border row is in the table rather than assumed, because it is what makes the point: a width
+without a style measures **identical to no border at all** on either shape, and adding the style
+adds 4 px per edge, 8 px on each axis, on both. A `border` utility that emitted only a width would
+therefore do nothing whatsoever, silently. No paint, and no space taken either, so not even a
+layout shift you might notice.
 
 Tailwind solves this in its preflight, globally. There is no preflight here, because a generated
 class has to be self-sufficient. The style therefore travels with the width: `border-style: solid`
@@ -124,13 +122,13 @@ is appended whenever a rule sets a border width and nothing in the same rule has
 
 GTK's CSS parser recovers from a bad **declaration** by dropping it. It does not always recover
 from a malformed **construct**: one can end the document, and every rule that follows is then
-silently absent. The symptom is "the application lost its styling", with no error anywhere — and
-in the measured case (an unterminated string) **GTK reported no error at all**.
+silently absent. The symptom is "the application lost its styling", with no error anywhere. In the
+measured case, an unterminated string, **GTK reported no error at all**.
 
 That is why a generated rule is **probed before it joins the sheet**. Each new rule is loaded into
 a throwaway `Gtk.CssProvider` together with a sentinel rule, the provider is serialised back, and
-the rule is accepted only if the sentinel survived the round trip. A behavioural test against the
-real parser rather than a model of its grammar — the only kind that cannot drift against a GTK
+the rule is accepted only if the sentinel survived the round trip. That tests the real parser
+instead of a model of its grammar, which is the only kind of test that cannot drift against a GTK
 upgrade.
 
 The refusal says which of the two happened:
@@ -145,8 +143,8 @@ document, so it is refused:
 
 ## `orientation` and `spacing` belong to `Gtk.Box`, not to `Gtk.Widget`
 
-Measured: `orientation` and `spacing` are not on `Gtk.Widget`. They are `Gtk.Box`'s — `orientation`
-via `Gtk.Orientable` — and a `Gtk.Label` has neither. `Gtk.CenterBox` has `orientation` and no
+Measured: `orientation` and `spacing` are not on `Gtk.Widget`. They are `Gtk.Box`'s, `orientation`
+by way of `Gtk.Orientable`, and a `Gtk.Label` has neither. `Gtk.CenterBox` has `orientation` and no
 `spacing` at all.
 
 So `flex-row` and `gap-*` name properties the partition can identify but cannot legally *apply*
@@ -157,32 +155,31 @@ deliberately weaker than the per-class table: the strongest thing it can assert 
 
 `items-*` is missing two things at once. GTK has no `align-items`: the alignment lives on each
 child as `halign` / `valign`, so resolving it means walking children. And *which* of the two it is
-depends on the element's own orientation — where the defaults disagree, since a `Gtk.Box` is
+depends on the element's own orientation, where the defaults disagree, since a `Gtk.Box` is
 horizontal and a React Native `View` is a column. There is not even a safe fallback to guess with.
 
 ## Your `@theme` will still lean on Tailwind for `0` and `full`
 
-The values behind a class name are your project's — that is the rule the whole
-partition is built on, and the default scale it ships is *deliberately* tiny so that
-a token you never declared is a named error rather than a wrong margin.
+The values behind a class name are your project's. That is the rule the whole partition is built
+on, and the default scale it ships is *deliberately* tiny, so that a token you never declared is a
+named error rather than a wrong margin.
 
-Measured, and it is the highest-frequency finding of the whole exercise: a
-production-shaped application whose Tailwind v4 `@theme` declares its own scales
-**still relies on Tailwind's defaults** for a handful of utilities. Running its real
-class vocabulary — **87 distinct utilities, 826 occurrences** — through this partition
-with tokens generated mechanically from that `@theme` resolves **81 of 87 distinct and
-803 of 826 occurrences**. Five of the six failures are one thing:
+Measured, and the highest-frequency finding of the whole exercise: a production-shaped application
+whose Tailwind v4 `@theme` declares its own scales **still relies on Tailwind's defaults** for a
+handful of utilities. Its real class vocabulary is **87 distinct utilities, 826 occurrences**. Run
+through this partition with tokens generated mechanically from that `@theme`, it resolves **81 of
+87 distinct and 803 of 826 occurrences**. Five of the six failures are one thing:
 
 | Class | Uses | Missing from |
 |---|---:|---|
 | `rounded-full` | 11 | the project's `borderRadius` scale |
 | `inset-0`, `left-0`, `right-0`, `top-0` | 9 between them | the project's `spacing` scale |
 
-The scales have no `full` and no `0`, and there is no reason they should.
-**Neither is a design decision.** A token source emits the values a designer chose;
-`inset-0` means "flush" and `rounded-full` means "a pill". So a project can declare
-its entire palette and type scale and still lean on Tailwind for the *structural*
-tokens — and find that out one class at a time, in a window.
+The scales have no `full` and no `0`, and there is no reason they should. **Neither is a design
+decision.** A token source emits the values a designer chose; `inset-0` means "flush" and
+`rounded-full` means "a pill". So a project can declare its entire palette and type scale and
+still lean on Tailwind for the *structural* tokens, then find that out one class at a time, in a
+window.
 
 The answer is an **opt-in you can see in your own code**, not a wider default:
 
@@ -194,31 +191,28 @@ import { tokens } from './tokens.js';
 configureStyle({ tokens: mergeTokens(TAILWIND_DEFAULT_TOKENS, tokens) });
 ```
 
-**Use `mergeTokens`, not a spread.** `{ ...TAILWIND_DEFAULT_TOKENS, ...tokens }`
-replaces whole *scales*, so a project that declares any `spacing` at all loses `0`
-again — which is the exact bug the constant exists to answer. `mergeTokens` merges
-token by token, later sets winning, so your `px` overrides the default `px` without
-taking the rest of the scale with it.
+**Use `mergeTokens`, not a spread.** `{ ...TAILWIND_DEFAULT_TOKENS, ...tokens }` replaces whole
+*scales*, so a project that declares any `spacing` at all loses `0` again, which is the exact bug
+the constant exists to answer. `mergeTokens` merges token by token, later sets winning, so your
+`px` overrides the default `px` without taking the rest of the scale with it.
 
-`TAILWIND_DEFAULT_TOKENS` is **not** a copy of Tailwind's default theme, and the
-smallness of the built-in default is unchanged. It carries the structural tokens and
-the keyword sets — the ones a `@theme` has no reason to name — and no numeric ladder,
-because shipping `spacing-4` … `spacing-96` would be shipping a design decision your
-project has already made differently. Three divergences from Tailwind's own numbers,
-each forced:
+`TAILWIND_DEFAULT_TOKENS` is **not** a copy of Tailwind's default theme, and the built-in default
+stays as small as it was. It carries the structural tokens and the keyword sets, the ones a
+`@theme` has no reason to name, and no numeric ladder: shipping `spacing-4` … `spacing-96` would
+ship a design decision your project has already made differently. Three divergences from
+Tailwind's own numbers, each one forced:
 
-- **every length is px, not rem** — a `rem` token pads and cannot margin, since
-  `Gtk.Widget:margin-top` is a `gint` of device pixels with no unit conversion behind
-  it. A rem-faithful copy would trade "the token is missing" for "the token throws on
-  half the families";
-- **`full` is `9999px`**, not `calc(infinity * 1px)` — GTK's parser has no infinity,
-  and a radius larger than the box is clamped anyway;
-- **`inherit` is absent from the colours** — `color: inherit` parses, but
-  `alpha(inherit, 0.5)` does not (measured), so `bg-inherit/50` would be a refusal
-  rather than a colour. The other four keywords survive the modifier and are carried.
+- **every length is px, not rem.** A `rem` token pads and cannot margin, because
+  `Gtk.Widget:margin-top` is a `gint` of device pixels with no unit conversion behind it. A
+  rem-faithful copy would trade "the token is missing" for "the token throws on half the families".
+- **`full` is `9999px`**, not `calc(infinity * 1px)`. GTK's parser has no infinity, and a radius
+  larger than the box is clamped anyway.
+- **`inherit` is absent from the colours.** `color: inherit` parses, `alpha(inherit, 0.5)` does not
+  (measured), so `bg-inherit/50` would be a refusal rather than a colour. The other four keywords
+  survive the modifier and are carried.
 
-You do not have to find any of this out from a table. A scale miss whose token
-Tailwind's defaults *do* define says so in the error, with the value:
+You do not have to find any of this out from a table. A scale miss whose token Tailwind's defaults
+*do* define says so in the error, with the value:
 
 ```
 @gjsify/gtk-host/style: "rounded-full" — "full" is not in the borderRadius scale.
@@ -227,62 +221,59 @@ Known: l, m, s. Tailwind's own default scale defines "full" (9999px) — a proje
 tokens with mergeTokens() if you rely on it
 ```
 
-An ordinary typo gets no such sentence, deliberately: a remedy offered where it would
-not have helped sends a reader to add a dependency instead of to fix the spelling.
+An ordinary typo gets no such sentence, deliberately: a remedy offered where it would not have
+helped sends a reader to add a dependency instead of to fix the spelling.
 
 ## `flex-wrap` is a different widget, not a property
 
-A `Gtk.Box` lays its children on one line and installs nothing that gives it a
-second one. Wrapping on GTK is `Gtk.FlowBox` — another class, reached by swapping the
-widget rather than by setting anything — so `flex-wrap` is an **intent** for the same
-reason `justify-between` is: the partition answers for an element's properties and
-has no say in what the element becomes. The layer above swaps the tag, and
-`flex-nowrap` is *resolved* by there being nothing to do, since a box is already one
-line.
+A `Gtk.Box` lays its children on one line and installs nothing that gives it a second one.
+Wrapping on GTK is `Gtk.FlowBox`, another class, reached by swapping the widget rather than by
+setting anything. So `flex-wrap` is an **intent** for the same reason `justify-between` is: the
+partition answers for an element's properties and has no say in what the element becomes. The layer
+above swaps the tag, and `flex-nowrap` is *resolved* by there being nothing to do, since a box is
+already one line.
 
-`flex-wrap-reverse` stays a refusal. `Gtk.FlowBox` installs `orientation`,
-`homogeneous`, `row-spacing`, `column-spacing`, `min-children-per-line`,
-`max-children-per-line` and `selection-mode`, and nothing that reverses the line
-order — so reverse the children instead, which is what the tree is for.
+`flex-wrap-reverse` stays a refusal. `Gtk.FlowBox` installs `orientation`, `homogeneous`,
+`row-spacing`, `column-spacing`, `min-children-per-line`, `max-children-per-line` and
+`selection-mode`, and nothing that reverses the line order. Reverse the children instead, which is
+what the tree is for.
 
 Two `Gtk.FlowBox` defaults are corrected on the way in, and both are the silent kind:
 
 | Default | What it would do to a `flex-wrap` container |
 |---|---|
-| `max-children-per-line: 7` | seven children per line however much room is left — a layout that is plausible on screen and wrong |
+| `max-children-per-line: 7` | seven children per line however much room is left, a layout that is plausible on screen and wrong |
 | `selection-mode: SINGLE` | a click selects a child and draws a focus ring, which a flex container never does |
 
-There is **no "no limit" spelling** for the first. `0` is out of range for the
-`guint` — a `GLib-GObject-CRITICAL`, and the property keeps its old value — and
-writing `G_MAXUINT` stores **65535**, which is therefore GTK's own way to say "as
-many as fit". It costs nothing: the natural width tracks the child count, measured
-identical for twelve children at `12`, `1024` and `65535`.
+There is **no "no limit" spelling** for the first. `0` is out of range for the `guint`: you get a
+`GLib-GObject-CRITICAL` and the property keeps its old value. Writing `G_MAXUINT` stores **65535**,
+which is therefore GTK's own way to say "as many as fit". It costs nothing: the natural width
+tracks the child count, measured identical for twelve children at `12`, `1024` and `65535`.
 
-**A gap changes channel when an element wraps.** `Gtk.FlowBox` has *no* `spacing` at
-all; it has `row-spacing` and `column-spacing`, and both are real at once. So on a
-wrapping element `gap-*` becomes both spacings instead of the box's single one, and
-the axis-qualified spellings stop being an orientation question — `gap-x-*` is the
-gap between children in a line whichever way the lines run. That is also the one
-place the two-gap-spellings refusal lifts: `gap-4 gap-x-2` asks a `Gtk.Box` for two
-spacings it does not have, and asks a `Gtk.FlowBox` for exactly the two it does.
+**A gap changes channel when an element wraps.** `Gtk.FlowBox` has *no* `spacing` at all. It has
+`row-spacing` and `column-spacing`, and both are real at once. So on a wrapping element `gap-*`
+becomes both spacings instead of the box's single one, and the axis-qualified spellings stop being
+an orientation question: `gap-x-*` is the gap between children in a line whichever way the lines
+run. That is also the one place the two-gap-spellings refusal lifts. `gap-4 gap-x-2` asks a
+`Gtk.Box` for two spacings it does not have, and asks a `Gtk.FlowBox` for exactly the two it does.
 
-`orientation` needs no translation and keeps working across the swap, measured on
-both classes: `HORIZONTAL` fills along x and wraps into rows, `VERTICAL` fills along
-y and wraps into columns — the same meaning `flex-row` and `flex-col` already had.
+`orientation` needs no translation and keeps working across the swap, measured on both classes:
+`HORIZONTAL` fills along x and wraps into rows, `VERTICAL` fills along y and wraps into columns,
+the same meaning `flex-row` and `flex-col` already had.
 
 ## The generated stylesheet
 
 A widget takes `css-classes`, a string array. So something has to turn a set of declarations into
 a **name** and keep a document that defines it.
 
-- **Class names are content-addressed** — FNV-1a over the rule text. Two elements with the same
+- **Class names are content-addressed**, FNV-1a over the rule text. Two elements with the same
   declarations get the same class and the document holds one rule, not one per element. A
   per-element name is the shape that makes a long list re-parse the whole sheet on every row.
 - **Reload is coalesced.** Mounting a tree produces one rule per distinct style, and reloading the
   document per rule is quadratic. It is rebuilt once per microtask instead, with an explicit
   `flush()` for a test or for an application about to present a window.
 - **Variants become pseudo-classes** on the same generated name: `active:` → `:active`, and
-  likewise `hover:`, `focus:` and `disabled:`. That is what makes a pressed style free — GTK
+  likewise `hover:`, `focus:` and `disabled:`. That is what makes a pressed style free: GTK
   animates the state itself, and nothing has to reach the framework when a finger goes down. A
   variant with no pseudo-class equivalent is refused by name, listing the ones that work.
 
@@ -291,22 +282,22 @@ a **name** and keep a document that defines it.
 | You write | What happens |
 |---|---|
 | `justify-around`, `justify-evenly` | refused at the partition: GTK's box gives leftover main-axis space to the children that expand and has no per-gap distribution mode |
-| `justify-between` | deferred, then refused at attach time: the mapping is `Gtk.CenterBox`, a different **widget**, and two or three children pick it — this layer resolves properties for the widget it was handed and has no children to count. Spell the distribution with a spacer child (`flex-1`) or with `gap-*` |
+| `justify-between` | deferred, then refused at attach time: the mapping is `Gtk.CenterBox`, a different **widget**, and two or three children pick it, while this layer resolves properties for the widget it was handed and has no children to count. Spell the distribution with a spacer child (`flex-1`) or with `gap-*` |
 | `ps-*` / `pe-*` | refused: GTK has no logical padding in either mechanism |
 | `text-start` / `text-end` | refused: GTK aligns text physically |
 | `w-1/2` and other fractions | refused: a widget requests a *minimum* in pixels or expands to fill. `w-full` / `h-full` are the only fractions with an exact GTK meaning |
-| `overflow-scroll`, `overflow-auto` | refused: scrolling is a **widget** on GTK, not an overflow mode — wrap the element in a `Gtk.ScrolledWindow`. `Gtk.Overflow` has exactly `VISIBLE` and `HIDDEN` |
+| `overflow-scroll`, `overflow-auto` | refused: scrolling is a **widget** on GTK, not an overflow mode, so wrap the element in a `Gtk.ScrolledWindow`. `Gtk.Overflow` has exactly `VISIBLE` and `HIDDEN` |
 | `flex-2`, `grow-2`, `shrink-*`, `basis-*` | refused: GTK expresses main-axis growth as the boolean `hexpand` / `vexpand`, so there is no growth factor, shrink factor or flex basis to carry. `flex-1` is the only spelling with a GTK meaning |
 | `flex-wrap-reverse` | refused: `Gtk.FlowBox` runs its lines in one direction only and installs nothing that reverses them. Reverse the children |
 | `flex-wrap` on a `<Text>`, or on a `ScrollView`'s own class list | refused at attach time: there is no wrapping `Gtk.Label` and no wrapping `Gtk.ScrolledWindow` to swap in. On a `ScrollView` the box that holds the children is reached through `contentContainerClassName` |
-| a name no family claims | `UnknownUtilityError`, naming the utility — never a silent drop |
+| a name no family claims | `UnknownUtilityError`, naming the utility, never a silent drop |
 
-The first two rows refuse at different moments, and it is worth knowing why. **No child count
-makes `space-around` or `space-evenly` expressible**, so an attach-time answer could add nothing —
-refusing them where the class is read is the earliest and strongest place available. For
-`space-between` the child count *is* the whole question, so it travels as an intent and is answered
-where the children are known. Either way the message names the GTK mechanism that is missing, not
-the utility that is unsupported.
+The first two rows refuse at different moments, and the reason is worth knowing. **No child count
+makes `space-around` or `space-evenly` expressible**, so an attach-time answer could add nothing,
+and refusing them where the class is read is the earliest place available. For `space-between` the
+child count *is* the whole question, so it travels as an intent and is answered where the children
+are known. Either way the message names the GTK mechanism that is missing, not the utility that is
+unsupported.
 
 The pattern is the same throughout: a refusal costs a reader one sentence, and an approximation
 costs them an afternoon in a window where every widget is present and something is quietly in the
@@ -314,11 +305,10 @@ wrong place.
 
 ## Your own stylesheet, and Adwaita's named colours
 
-The generated sheet above is one of **two** documents an application has on its
-display. The other is the one you wrote — a GTK CSS file, plus the Adwaita named
-colours set from your design tokens — and it goes through a small registry rather
-than a setter, because the shape it has to fit is several named looks with one
-selected at runtime:
+The generated sheet above is one of **two** documents an application has on its display. The other
+is the one you wrote: a GTK CSS file, plus the Adwaita named colours set from your design tokens.
+It goes through a small registry rather than a setter, because what it has to fit is several named
+looks with one selected at runtime:
 
 ```ts
 import { NEUTRAL_THEME, ThemeRegistry } from '@gjsify/gtk-host/style';
@@ -337,53 +327,49 @@ themes
 themes.selectDefault(process.platform); // …or themes.select('ocean') from a settings row
 ```
 
-It is framework-agnostic, like the rest of this page: nothing about it is React's or
-Vue's, and the platform is a **parameter** rather than a `process.platform` read
-inside the package — which is also what lets a settings screen preview another
-desktop's look.
+It is framework-agnostic, like the rest of this page. Nothing about it is React's or Vue's, and the
+platform is a **parameter** rather than a `process.platform` read inside the package, which is also
+what lets a settings screen preview another desktop's look.
 
-`NEUTRAL_THEME` is the one theme shipped today, and its document is **empty**. That
-is a statement, not a placeholder: a GTK application should look like the desktop it
-is running on, and the accent belongs to whoever picked it in Settings. Selecting the
-neutral theme is how an application returns to Adwaita *exactly*, which is measurably
-true — reloading the provider to the empty string restores every named colour to
-libadwaita's own value.
+`NEUTRAL_THEME` is the one theme shipped today, and its document is **empty**. That is a statement,
+not a placeholder: a GTK application should look like the desktop it is running on, and the accent
+belongs to whoever picked it in Settings. Selecting the neutral theme is how an application returns
+to Adwaita *exactly*, and that is measurably true. Reloading the provider to the empty string
+restores every named colour to libadwaita's own value.
 
-It also declares `defaultOn: ['*']`, so `selectDefault(process.platform)` resolves on
-every platform GTK runs on and not only on the three this project targets — a theme
-with a dedicated `defaultOn` list still wins over it by being registered later.
-`selectDefault` refuses only when *nothing* registered declares a default, which is a
-question it should not guess at. `themes.dispose()` takes the document back off the
-display, for a shell that tears its theming down rather than exiting.
+It also declares `defaultOn: ['*']`, so `selectDefault(process.platform)` resolves on every
+platform GTK runs on and not only on the three this project targets. A theme with a dedicated
+`defaultOn` list still wins over it by being registered later. `selectDefault` refuses only when
+*nothing* registered declares a default, which is a question it should not guess at.
+`themes.dispose()` takes the document back off the display, for a shell that tears its theming down
+rather than exiting.
 
 ### The accent is a custom property, not `AdwStyleManager`
 
-**`AdwStyleManager:accent-color` cannot carry a design token's accent on any runtime,
-because it is an enum.** `AdwAccentColor` has nine members — BLUE, TEAL, GREEN,
-YELLOW, ORANGE, RED, PINK, PURPLE, SLATE — so `rgb(17 34 51)` has no representation
-in it. The accent is therefore a CSS custom property: `--accent-bg-color` and its 47
-siblings, redefined on `:root`, which is what Adwaita's own rules resolve against.
+**`AdwStyleManager:accent-color` cannot carry a design token's accent on any runtime, because it is
+an enum.** `AdwAccentColor` has nine members: BLUE, TEAL, GREEN, YELLOW, ORANGE, RED, PINK, PURPLE
+and SLATE. So `rgb(17 34 51)` has no representation in it. The accent is therefore a CSS custom
+property, `--accent-bg-color` and its 47 siblings, redefined on `:root`, which is what Adwaita's own
+rules resolve against.
 
-**That property is also read-only**, on every closure this suite has been measured
-on — Linux with libadwaita 1.9.3 and all three published runtime bundles — and
-libadwaita's own source installs the ParamSpec readable-only, read at 1.10.alpha.1.
-Assigning throws *Property AdwStyleManager.accent-color is not writable*.
+**That property is also read-only** on every closure this suite has been measured on: Linux with
+libadwaita 1.9.3 and all three published runtime bundles. libadwaita's own source installs the
+ParamSpec readable-only, read at 1.10.alpha.1, and assigning throws *Property
+AdwStyleManager.accent-color is not writable*.
 
-But that is deliberately **not** the reason given above, because "the property is
-locked" and "the property is the wrong shape" lead to different code. The first
-invites *just set the property* the moment a flag somewhere seems to allow it — which
-reaches nine colours at best and silently ignores the application's own accent token
-otherwise. The second holds on every runtime, whatever the flag says. The theme
-registry reads and writes that property nowhere, and branches on its writability
+But that is deliberately **not** the reason given above, because "the property is locked" and "the
+property is the wrong shape" lead to different code. The first invites *just set the property* the
+moment a flag somewhere seems to allow it, which reaches nine colours at best and silently ignores
+the application's own accent token otherwise. The second holds on every runtime, whatever the flag
+says. The theme registry reads and writes that property nowhere, and branches on its writability
 nowhere.
 
-48 named colours are measured to exist and are the set a theme may override. A name
-libadwaita does not define is refused: `--acccent-bg-color` is a perfectly valid
-custom property that nothing ever reads, so a theme setting it would silently do
-nothing. The **legacy** `@define-color accent_bg_color …` spelling also still works,
-and is deliberately not what this emits — mixing the two is how you get a definition
-nothing reads, which is why an underscored name is a refusal naming the hyphenated
-one.
+48 named colours are measured to exist and are the set a theme may override. A name libadwaita does
+not define is refused: `--acccent-bg-color` is a perfectly valid custom property that nothing ever
+reads, so a theme setting it would silently do nothing. The **legacy**
+`@define-color accent_bg_color …` spelling also still works, and is deliberately not what this
+emits. Mixing the two is how you get a definition nothing reads, which is why an underscored name is
+a refusal naming the hyphenated one.
 
 ### The provider priority is the whole design
 
@@ -391,33 +377,31 @@ Three measurements, and the plausible guess is wrong in all three:
 
 | Measured | Consequence |
 |---|---|
-| libadwaita's own stylesheet sits at **exactly** `STYLE_PROVIDER_PRIORITY_THEME` (200) — an override at 199 loses, at 201 wins, at 200 wins *only* by being added later | a theme document must be strictly above 200, or its effect depends on load order |
+| libadwaita's own stylesheet sits at **exactly** `STYLE_PROVIDER_PRIORITY_THEME` (200): an override at 199 loses, at 201 wins, at 200 wins *only* by being added later | a theme document must be strictly above 200, or its effect depends on load order |
 | the generated sheet is at `STYLE_PROVIDER_PRIORITY_APPLICATION` (600), and at equal priority the **later** provider wins | a theme at 600 installed after the sheet silently clobbers the utility class you wrote at the element |
-| priority is resolved **before** specificity — a low-specificity rule at 400 beats a high-specificity one at 200 | "make the theme selector more specific" is not a lever; the number is the only one |
+| priority is resolved **before** specificity: a low-specificity rule at 400 beats a high-specificity one at 200 | "make the theme selector more specific" is not a lever; the number is the only one |
 
-So a theme document is installed at `STYLE_PROVIDER_PRIORITY_SETTINGS` (400), GTK's
-own named value in the one gap that satisfies both constraints — and measured to do
-so **whichever document is installed first**. A utility class always beats the theme,
-the theme always beats Adwaita.
+So a theme document is installed at `STYLE_PROVIDER_PRIORITY_SETTINGS` (400), GTK's own named value
+in the one gap that satisfies both constraints, and measured to do so **whichever document is
+installed first**. A utility class always beats the theme, the theme always beats Adwaita.
 
-An application document goes through the **same containment probe** as a generated
-rule, and for a stronger reason: it is the document this package did not write. It is
-probed at *registration*, so a malformed rule names the line that declared the theme
-rather than the settings row that switched to it hours later.
+An application document goes through the **same containment probe** as a generated rule, and for a
+stronger reason: it is the document this package did not write. It is probed at *registration*, so
+a malformed rule names the line that declared the theme rather than the settings row that switched
+to it hours later.
 
-One provider is installed once and its **document is replaced** on a switch. Removing
-and re-adding also works, measured; replacing is chosen because a provider installed
-once can never end up at the wrong position relative to the generated sheet, however
-many times a user has changed theme.
+One provider is installed once and its **document is replaced** on a switch. Removing and
+re-adding also works, measured. Replacing is chosen because a provider installed once can never
+end up at the wrong position relative to the generated sheet, however many times a user has
+changed theme.
 
 ### Do not read a switch back from a pixel
 
-Sampling a `Gtk.WidgetPaintable` render node reports the **old** colour after a
-provider is removed — the paintable's node is cached and a removal does not
-invalidate it, while a subsequent add does. That reads exactly like "removing a
-provider does not work", and it is false; it cost a wrong conclusion before it was
-caught. Resolve `var(--name)` into a `color` and read `widget.get_color()`: the
-resolved value is the truth, the pixel is a picture of a cache.
+Sampling a `Gtk.WidgetPaintable` render node reports the **old** colour after a provider is removed.
+The paintable's node is cached and a removal does not invalidate it, while a subsequent add does.
+That reads exactly like "removing a provider does not work", and it is false; it cost a wrong
+conclusion before it was caught. Resolve `var(--name)` into a `color` and read
+`widget.get_color()`: the resolved value is the truth, the pixel is a picture of a cache.
 
 ## This is not the Adwaita web token contract
 
@@ -430,9 +414,8 @@ and nothing there applies here.
 
 - [React Native](/gjsify/frameworks/react-native/) for the primitive vocabulary that consumes this
   partition, and how `className` and `style={{…}}` reach it
-- [UI Frameworks](/gjsify/frameworks/) for the host layer, and for the *property-coercion*
-  refusals — enum nicks, read-only writes, misspelled properties — which are a different table
-  from this page's
+- [UI Frameworks](/gjsify/frameworks/) for the host layer, and for the *property-coercion* refusals
+  that are a different table from this page's: enum nicks, read-only writes, misspelled properties
 - [Adwaita theming](/gjsify/adwaita/theming/) for the web token contract
 - [ADR 0032](https://github.com/gjsify/gjsify/blob/main/docs/adr/0032-react-native-on-the-gtk-host.md)
   §§ 1–6 for the layer split, the one normalised property set, and why an intent exists at all

--- a/website/src/content/docs/frameworks/vue.mdx
+++ b/website/src/content/docs/frameworks/vue.mdx
@@ -93,13 +93,13 @@ export default {
 |---|---|---|
 | `isCustomElement` | `isGtkHostTag` | Which tags compile to an element vnode instead of a component lookup. |
 | `include` | `/\.vue$/` | Which modules to compile. |
-| `runtimeModuleName` | `@vue/runtime-core` | Module the generated code imports Vue's runtime from. `vue` — the compiler's own default — drags `@vue/runtime-dom` and the DOM renderer into a bundle with no DOM. |
+| `runtimeModuleName` | `@vue/runtime-core` | Module the generated code imports Vue's runtime from. `vue`, the compiler's own default, drags `@vue/runtime-dom` and the DOM renderer into a bundle with no DOM. |
 
 ## The tag predicate, and why it is only a prefix rule
 
 `isGtkHostTag` accepts `gtk-`/`adw-` kebab **and** `Gtk`/`Adw` followed by a capital. Both
 spellings are required: `isCustomElement` is consulted for PascalCase tags too, and one
-`GlobalComponents` key answers both spellings — so a kebab-only rule leaves `<GtkBox>`
+`GlobalComponents` key answers both spellings, so a kebab-only rule leaves `<GtkBox>`
 type-checking and then resolving as a missing component.
 
 It decides "element vnode or component lookup", never whether the widget exists. An unknown
@@ -110,13 +110,13 @@ first one to drift.
 
 Without the predicate the failure is silent in the direction that matters. Measured on one
 template: **7 of 7 tags compiled to `_resolveComponent(…)` and zero element vnodes were
-emitted.** Vue's resolver misses, warns once per tag — and that warning is `__DEV__`-only,
+emitted.** Vue's resolver misses and warns once per tag, and that warning is `__DEV__`-only,
 which the production defines above strip. With the predicate: 0 `resolveComponent`, 6
 `createElementVNode` plus the root `createElementBlock`.
 
 ## The build recipe
 
-`@vue/runtime-core` is DOM-free in fact — every `document`, `navigator` and `HTMLElement`
+`@vue/runtime-core` is DOM-free in fact. Every `document`, `navigator` and `HTMLElement`
 reference sits in a dev, HMR or devtools branch behind `__DEV__` or a `typeof window` guard.
 But `--globals auto` is a static scan: it injects a polyfill for each identifier it *sees*,
 which made the bundle require `gi://Gdk`, `GdkPixbuf`, `Pango` and `PangoCairo` at load. The
@@ -124,7 +124,7 @@ four defines let dead-code elimination remove those branches first.
 
 One import the recipe cannot save is `Suspense`. `SuspenseImpl` carries `hydrate:
 hydrateSuspense`, which contains a literal `document.createElement("div")` that no define
-eliminates — hydration is never called here, but the identifier is still there. Measured, same
+eliminates. Hydration is never called here, but the identifier is still there. Measured, same
 entry plus one named import, `--app gjs`:
 
 | Import | Bytes | Typelibs |
@@ -136,8 +136,7 @@ entry plus one named import, `--app gjs`:
 | `+ Suspense`, `--exclude-globals document` | 196 614 | `gi://GLib` |
 
 So `--exclude-globals document` is the escape if you need `Suspense`. `Transition` is not in
-the table because `@vue/runtime-core` does not export it at all — it belongs to
-`runtime-dom`.
+the table because `@vue/runtime-core` does not export it at all; it belongs to `runtime-dom`.
 
 ## The type check, and the trap that fakes a green one
 
@@ -159,8 +158,8 @@ behind it:
 - **`strictTemplates: true`.** Measured on `vue-tsc@3.3.11`: with it, an unknown prop, an
   unknown tag, an unknown event, a wrong value type and a bad enum nick all fail. Without it,
   the unknown prop, the unknown event and the unknown *tag* are silently accepted while wrong
-  value types still error — so a project without it sees type errors appear and concludes the
-  surface works.
+  value types still error. A project without it sees type errors appear and concludes that its
+  types hold.
 - **Set it in the base of your `extends` chain.** Measured, four cells, all four: the base
   tsconfig's value wins and the child's is ignored outright, in *both* directions. In a
   monorepo the shared base config therefore decides this for every package and a per-package
@@ -181,7 +180,7 @@ import '@gjsify/gtk-host/vue-components';
 
 ## What it refuses, and what it ignores
 
-**`<style>` is refused with a named error.** GTK styling is a `Gtk.CssProvider` concern —
+**`<style>` is refused with a named error.** GTK styling is a `Gtk.CssProvider` concern:
 there is no element a CSS rule could attach to, and `<style scoped>` compiles to an attribute
 selector GTK 4 CSS does not have. Load the CSS yourself with
 `Gtk.CssProvider.load_from_string()` plus `Gtk.StyleContext.add_provider_for_display()`, and
@@ -193,15 +192,15 @@ depend on the block's `lang`. Write JSX in a `.tsx` file and compile it with
 [`@gjsify/rolldown-plugin-solid`](/gjsify/frameworks/solid/) instead. A `<script>` with no
 `lang` is parsed as TypeScript.
 
-**A split SFC is refused as well** — `<template src>` and `<script src>`, and a
+**A split SFC is refused as well**, meaning `<template src>` and `<script src>`, and a
 `<template lang>` other than `html`. Measured, each compiled to something that looked like a
-component and was not: an external template became `return null`, an external script became an
+component and was not. An external template became `return null`, an external script became an
 empty object with the module never imported, and `lang="pug"` compiled to a render function
 returning the pug source as a text node. All three render blank or logic-less at exit 0.
 
 Out of scope and not attempted: HMR, asset-URL rewriting, custom blocks, SSR, `?query`
 suffixes on a `.vue` import, and watch-mode dependency registration. A custom block is the one
-thing neither compiled nor refused — the plugin reports it as a build warning naming the block
+thing neither compiled nor refused. The plugin reports it as a build warning naming the block
 and otherwise ignores it.
 
 ## Related

--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -5,13 +5,13 @@ description: Install the CLI, scaffold a project, and get a GTK 4 window running
 
 import CommandTabs from '../../components/CommandTabs.astro';
 
-Install the CLI, scaffold a project, run it: that is a GTK 4 window on screen
-running your own TypeScript, in about a minute.
+Install the CLI, scaffold a project, run it. About a minute later a GTK 4 window
+is on screen, running your own TypeScript.
 
-**First, pick your runtime.** gjsify targets four, and the command blocks on this
-page carry a tab per runtime: GJS, Node.js, Bun and Deno. Choose once and the rest
-of the page follows you, as does every other page on this site. If a step fails,
-jump to [If it did not start](#if-it-did-not-start).
+**First, pick your runtime.** gjsify targets four: GJS, Node.js, Bun and Deno.
+Every command block on this page has a tab per runtime, and the tab you pick
+follows you across the rest of the site. If a step fails, jump to
+[If it did not start](#if-it-did-not-start).
 
 ## What you need
 
@@ -25,11 +25,12 @@ One JavaScript runtime, and the GNOME libraries your app itself uses:
 | Deno | 2 | Linux, macOS, Windows |
 
 On Linux, GTK 4 and libadwaita come from your distribution and every runtime uses
-them; the package lists are [further down](#if-it-did-not-start). On macOS and
-Windows the Node, Bun and Deno route brings its own:
-`@gjsify/gtk-runtime-darwin-arm64`, `-darwin-x64` and `-win32-x64` carry GTK, and
+them. The package lists are [further down](#if-it-did-not-start).
+
+On macOS and Windows the Node, Bun and Deno route brings its own GTK.
+`@gjsify/gtk-runtime-darwin-arm64`, `-darwin-x64` and `-win32-x64` carry it, and
 `@gjsify/node-gi` loads `gi://` out of them, so there is nothing to install by
-hand. Windows has no `gjs` binary at all, so take Node, Bun or Deno there; macOS
+hand. Windows has no `gjs` binary at all, so take Node, Bun or Deno there. macOS
 has one from Homebrew, but nobody verifies the GJS route there end to end, which
 is why [Platform Support](/gjsify/platform-support/) calls that column partial.
 
@@ -59,11 +60,11 @@ is why [Platform Support](/gjsify/platform-support/) calls that column partial.
   </Fragment>
 </CommandTabs>
 
-You get the same `gjsify` command from all four, and the runtime you installed
-with becomes the one it builds for by default.
+All four give you the same `gjsify` command, and the runtime you installed with
+becomes the one it builds for by default.
 
 Each route puts the launcher somewhere different: `~/.local/bin` for the GJS
-bootstrap (which runs on stock `gjs` and involves no Node.js), your npm prefix,
+bootstrap (which runs on stock `gjs` and needs no Node.js), your npm prefix,
 `~/.bun/bin` for Bun, `~/.deno/bin` for Deno. If that directory is not on your
 `PATH` yet, add it:
 
@@ -120,32 +121,32 @@ A window titled `hello-gjsify` opens with a label in it. That window is your
 
 :::caution[Keep the `@latest`]
 `npm create`, `bunx` and `deno run` all reuse a cached copy of an unpinned
-package, so an unpinned `npm create @gjsify/app` can scaffold from a scaffolder
-you last used months ago — one whose templates predate `build:node` and the
-`start:node` script, which is a "missing script" error four commands later and no
-hint at all about where it came from. The tag forces a fresh resolve.
+package. So an unpinned `npm create @gjsify/app` can scaffold from a scaffolder
+you last used months ago, whose templates predate `build:node` and the
+`start:node` script. You find that out four commands later, as a "missing script"
+error with no hint about where it came from. The tag forces a fresh resolve.
 
-Deno applies a second rule on top: by default it refuses any version published in
-the last 24 hours and quietly takes the previous one, which is why its command
-carries `--reload --min-dep-age=0`. Both rules, and how to see which version you
-actually got, are on
+Deno applies a second rule on top: it refuses any version published in the last
+24 hours and takes the previous one instead, without saying so. That is why its
+command carries `--reload --min-dep-age=0`. Both rules, and how to see which
+version you actually got, are on
 [Which version do `npx`, `bunx` and `deno run` give you?](/gjsify/guides/install/#which-version-do-npx-bunx-and-deno-run-give-you)
 :::
 
 In a terminal the CLI asks which runtime to set the project up for, opening on the
 one it is running on, and then which package manager to install with. In a script
-it takes the same defaults and prints what it took. That answer changes no
+it takes the same defaults and prints what it took. Your answer changes no
 scaffolded byte: every template ships a bundle for every runtime, so it only
 decides which start script the printed next steps name. Set it outright with
 `--runtime gjs|node|bun|deno`.
 
 That is why the Bun and Deno commands above pass it. `bunx` and `deno run` fetch
 an npm bin and start it on Node, so the CLI's "which runtime am I on?" answers
-`node` and its next steps would name `npm` — correct about itself, and not what
+`node`, and its next steps would name `npm`. Correct about itself, and not what
 you asked for.
 
-Leave `--template` off and the CLI asks you which one you want too, but that one
-has no defensible default: in a script `--template` is required.
+Leave `--template` off and the CLI asks which one you want too. That one has no
+defensible default, so in a script `--template` is required.
 
 | Template | What you get |
 |---|---|
@@ -157,10 +158,10 @@ has no defensible default: in a script `--template` is required.
 | `web-server-hono` | HTTP server on Hono |
 | `web-server-express` | HTTP server on Express |
 
-All seven run on GJS, Node.js, Bun and Deno. Each declares that set in
-`gjsify.example.runtimes`, which is what `gjsify run --runtime <name>` checks
-against, so asking for a runtime a project has no bundle for fails with a message
-instead of crashing somewhere inside one.
+All seven run on GJS, Node.js, Bun and Deno. Each one declares that set in
+`gjsify.example.runtimes`, and `gjsify run --runtime <name>` checks against it.
+Asking for a runtime a project has no bundle for fails with a message instead of
+crashing somewhere inside one.
 
 ## What the CLI generated
 
@@ -190,17 +191,17 @@ The scripts are the whole build system:
 }
 ```
 
-Two bundles out of one `src/index.ts`. `dist/index.gjs.js` is what GJS runs, and
+Two bundles out of one `src/index.ts`. `dist/index.gjs.js` is what GJS runs.
 `dist/index.node.mjs` is shared by Node, Bun and Deno, because Node-API is their
 common ABI and none of them needs a target of its own. Both builds name `--app`
-explicitly so the target cannot silently follow whichever runtime invoked the
+explicitly, so the target cannot silently follow whichever runtime invoked the
 build.
 
-`dev` is the loop you will spend the most time in: it watches `src/`, rebuilds on
-every change and relaunches the app, with no separate watcher to install — see
-[`gjsify dev`](/gjsify/cli-reference/#gjsify-dev). Note that the scaffolded script
-names `--runtime gjs` outright, whichever runtime you set the project up for, so
-on Node, Bun or Deno run `gjsify dev --runtime node` (or `bun`, or `deno`)
+`dev` is the loop you will spend the most time in. It watches `src/`, rebuilds on
+every change and relaunches the app, with no separate watcher to install; see
+[`gjsify dev`](/gjsify/cli-reference/#gjsify-dev). One wrinkle: the scaffolded
+script names `--runtime gjs` outright, whichever runtime you set the project up
+for. On Node, Bun or Deno, run `gjsify dev --runtime node` (or `bun`, or `deno`)
 yourself, or edit the script once to say so.
 
 Run them with whichever toolchain you picked above:
@@ -241,14 +242,14 @@ Run them with whichever toolchain you picked above:
   </Fragment>
 </CommandTabs>
 
-`start` and `dev` name the GJS bundle; `start:node`, `start:bun` and `start:deno`
-name the shared one. That naming is the only difference between the four columns.
+`start` and `dev` name the GJS bundle. `start:node`, `start:bun` and `start:deno`
+name the shared one. That is the only difference between the four columns.
 
 Launch through `gjsify run` rather than calling `gjs`, `node`, `bun` or `deno`
-yourself: it sets `LD_LIBRARY_PATH` and `GI_TYPELIB_PATH` so the bundle finds any
-native packages (`@gjsify/webgl`, for instance). That is why every `start:*` script
-above goes through it. For a GJS bundle, `gjsify info` prints those paths if you
-want to export them by hand.
+yourself. It sets `LD_LIBRARY_PATH` and `GI_TYPELIB_PATH` so the bundle finds
+native packages such as `@gjsify/webgl`, which is why every `start:*` script above
+goes through it. For a GJS bundle, `gjsify info` prints those paths if you want to
+export them by hand.
 
 ## Add a button
 
@@ -265,10 +266,14 @@ const app = new Gtk.Application({
 });
 ```
 
+Nothing in that file names a runtime. The same bytes build for GJS, Node.js, Bun
+and Deno, and so does every TypeScript sample on this site, the
+[widget gallery](/gjsify/adwaita/) included.
+
 `applicationId` is the session-bus name your app claims, and every project needs
-its own. If you copy this file into a second project, change it there: when two
-running apps claim one name, GTK treats the second launch as a remote instance of
-the first, forwards its `activate` to that app's window and exits 0 with no window
+its own. Change it if you copy this file into a second project. When two running
+apps claim one name, GTK treats the second launch as a remote instance of the
+first, forwards its `activate` to that app's window, and exits 0 with no window
 and no error of its own.
 
 Inside the `activate` handler, next to the label the template already creates:
@@ -289,8 +294,8 @@ dialogs see [Native Adwaita Apps](/gjsify/guides/native-adwaita-app/).
 ## Use Node.js and Web APIs
 
 Write ordinary Node.js and Web code in the same file. The build resolves each
-`node:*` import and injects the globals your code touches, so there is no import
-list to maintain:
+`node:*` import and injects the globals your code touches, so you maintain no
+import list of your own:
 
 ```typescript
 import { readFileSync } from 'node:fs'
@@ -330,7 +335,7 @@ ws.addEventListener('message', (event) => console.log(event.data))
 <details>
 <summary>Global detection missed something?</summary>
 
-Rare, but it happens with libraries that reach `globalThis` through another
+It is rare, and it happens with libraries that reach `globalThis` through another
 object, which hides the access from static analysis. Keep `auto` on and name the
 identifier you need:
 
@@ -424,4 +429,4 @@ Three things that trip people up:
 - [Ship a Flatpak](/gjsify/guides/flatpak-app/): put your app on Flathub
 - [One-line installer](/gjsify/guides/distributing-gjs-apps/): let users install your app with `curl`
 - [CLI Reference](/gjsify/cli-reference/): every command and flag
-- [Packages](/gjsify/packages/overview/): the Node.js, Web and DOM surface
+- [Packages](/gjsify/packages/overview/): the Node.js, Web and DOM APIs gjsify implements

--- a/website/src/content/docs/guides/bundled-fonts.md
+++ b/website/src/content/docs/guides/bundled-fonts.md
@@ -7,10 +7,10 @@ Your app wants to render in a face nobody's machine has. Put the `.ttf` in the p
 `gjsify.ship.fonts`, then call `initFonts()` once before you build any UI.
 
 Two steps, because staging a file and having the toolkit *know about* it are different
-things — and the gap between them is the quietest failure in GTK. Pango does not report a
-missing family. `set_family('Brand')` against a font map that has never heard of `Brand`
-resolves to the default sans, the window draws, the process exits 0 and nothing anywhere
-says a word. Your app is just wearing the wrong typeface.
+things. The gap between them is the quietest failure in GTK: Pango does not report a missing
+family. `set_family('Brand')` against a font map that has never heard of `Brand` resolves to
+the default sans, the window draws, the process exits 0 and nothing anywhere says a word.
+Your app is just wearing the wrong typeface.
 
 ## 1. Stage the faces
 
@@ -26,25 +26,25 @@ says a word. Your app is just wearing the wrong typeface.
 
 `data/fonts` is also the default: leave the key out and a directory by that name is picked
 up if it exists. Every face lands at `share/fonts/<appId>/<basename>` in the payload, on all
-three layouts — the app id is in the path because `/usr/share/fonts` is shared with every
+three layouts. The app id is in the path because `/usr/share/fonts` is shared with every
 other package on the machine, and a `Regular.ttf` at the top of it belongs to whoever
 installed last.
 
 Ship the desktop formats: `.ttf`, `.otf`, `.ttc`, `.otc`. A `.woff`, `.woff2` or `.eot` is
-**refused by name**, not quietly skipped — whether FreeType can open one is a build option
-of the FreeType inside the *shipped* runtime, not the one on your packaging machine, so a
-web wrapper that works here is exactly the kind of thing that substitutes silently there.
+**refused by name**, not quietly skipped. Whether FreeType can open one is a build option of
+the FreeType inside the *shipped* runtime, not the one on your packaging machine, so a web
+wrapper that works here is exactly the kind of thing that substitutes silently there.
 
 Two other refusals, same reasoning: a configured path that holds no face at all, and two
-faces whose basenames collide (one of them would not ship, and a face that did not ship is
-a substituted typeface rather than an error).
+faces whose basenames collide. One of the two would not ship, and a face that did not ship
+is a substituted typeface rather than an error.
 
 ## 2. Register them at startup
 
-`gjsify ship`'s launcher exports **`GJSIFY_FONT_DIR`** at the staged directory — on every
-layout, because only the launcher knows whether your payload became `/usr`, a `--prefix`
-tree, `/app`, a bundle's `Contents/Resources` or `C:\Program Files\My App`. Reading it is
-your app's side of the handover, and `@gjsify/gtk-host` does it for you:
+`gjsify ship`'s launcher exports **`GJSIFY_FONT_DIR`** at the staged directory, on every
+layout. Only the launcher knows whether your payload became `/usr`, a `--prefix` tree,
+`/app`, a bundle's `Contents/Resources` or `C:\Program Files\My App`. Reading it is your
+app's side of the handover, and `@gjsify/gtk-host` does it for you:
 
 ```bash
 gjsify install @gjsify/gtk-host
@@ -65,7 +65,7 @@ interface InitFontsResult {
     dir: string | undefined;
     /** Faces now on the default font map. */
     registered: readonly string[];
-    /** Faces a font map that does no runtime registration refused — see below. */
+    /** Faces a font map that does no runtime registration refused. See below. */
     declined: readonly string[];
     /** Faces that failed for any other reason. Each one was also warned about on stderr. */
     failed: readonly { path: string; message: string }[];
@@ -88,7 +88,7 @@ empty arrays.
 
 ### Running from your source tree
 
-Before there is a payload there is no `GJSIFY_FONT_DIR`. Pass the directory instead — the
+Before there is a payload there is no `GJSIFY_FONT_DIR`. Pass the directory instead. The
 option wins over the environment, so one line covers both:
 
 ```ts
@@ -105,9 +105,9 @@ Run from a project whose `data/fonts` holds one face:
 dir=data/fonts registered=1 failed=0
 ```
 
-A relative path resolves against the working directory, which is what you want in a source
-tree and never what you want in a shipped app — where `GJSIFY_FONT_DIR` is absolute and
-takes over.
+A relative path resolves against the working directory. That is what you want in a source
+tree and never what you want in a shipped app, where `GJSIFY_FONT_DIR` is absolute and takes
+over.
 
 ## 3. Call it before you build any UI
 
@@ -116,8 +116,8 @@ This is a contract, not a style preference.
 **Registration is not retroactive.** The fontconfig-backed font map caches the *fontset* it
 resolved for a font description, and `add_font_file` does not invalidate that cache. So a
 `Pango.Layout` that measured your family before the call keeps measuring the fallback for
-the life of the process — even though `list_families()` now lists the family, and even
-though a context created afterwards loads the real face.
+the life of the process, even though `list_families()` now lists the family, and even though
+a context created afterwards loads the real face.
 
 Measured, on Linux, with one layout before the call and one after:
 
@@ -129,13 +129,13 @@ control (invented family): 87x63
 ```
 
 Read the last three lines together. `registered=1` succeeded. `listed=true` says the family
-is on the font map. And the text still measures `87x63` — byte for byte what a family that
+is on the font map. And the text still measures `87x63`, byte for byte what a family that
 does not exist measures. The symptom is not "no font"; it is a **stale measurement**, which
 from inside your app reads like "the font is installed and Pango is ignoring me".
 
 On Windows a late call recovers, because that backend clears the map's cache when you add a
-file. So registering early is free on the backend that recovers and unrecoverable on the
-one that does not — which is why the rule is stated flatly for both.
+file. So registering early is free on the backend that recovers and unrecoverable on the one
+that does not, which is why the rule is stated flatly for both.
 
 In an `Adw.Application`, the place that satisfies the rule is `startup`, before the first
 window exists:
@@ -159,7 +159,7 @@ class MyApplication extends Adw.Application {
 If you use [`runAdwaitaApp`](/gjsify/guides/native-adwaita-app/), the line above it is early
 enough: `createWindow` does not run until the first `activate`.
 
-## What each operating system actually does
+## What each operating system does
 
 One payload directory, three different readers. You write the same call everywhere; each
 operating system answers it differently, and all three answers are correct:
@@ -167,21 +167,21 @@ operating system answers it differently, and all three answers are correct:
 | Where it runs | What reaches the font map | What `initFonts()` reports |
 |---|---|---|
 | **Linux** (`.deb`, `.rpm`, Flatpak, a `--prefix` tree) | fontconfig finds the staged directory on its own, through the stock `fonts.conf` | the faces in `registered` |
-| **macOS** (`.app`) | `ATSApplicationFontsPath` in `Info.plist`: macOS activates the directory for your app before your code runs | the faces in `declined` — **expected, not a failure** |
+| **macOS** (`.app`) | `ATSApplicationFontsPath` in `Info.plist`: macOS activates the directory for your app before your code runs | the faces in `declined`. **Expected, not a failure** |
 | **Windows** (program directory, `.msi`) | **nothing.** This call is the mechanism | the faces in `registered` |
 
 Windows is the row that matters. GTK4 there is pangowin32, and that font map is populated
-from DirectWrite and from nothing else — no filesystem search path, no fontconfig. A
-fontconfig directory beside your app is inert: measured on Windows 11, a config naming your
+from DirectWrite and from nothing else: no filesystem search path, no fontconfig. A
+fontconfig directory beside your app is inert. Measured on Windows 11, a config naming your
 staged directory moves the default font map by zero families *even when it is the only
-configuration loaded*. `add_font_file` on that same map — the one a `Gtk.Label` renders
-through — is what puts the family there.
+configuration loaded*. What puts the family there is `add_font_file` on that same map, the
+one a `Gtk.Label` renders through.
 
 macOS goes the other way. Pango's CoreText font map implements no runtime registration at
 all, so the call answers `G_IO_ERROR_NOT_SUPPORTED` and `initFonts()` files the face under
 `declined` rather than `failed`. **Nothing is lost**: the bundle's `Info.plist` already had
 the OS activate the same directory at launch, earlier than any code of yours could have
-run. So `declined` on macOS is the correct outcome and needs no branch in your app — which
+run. So `declined` on macOS is the correct outcome and needs no branch in your app, which
 is why there is no `process.platform` check anywhere in this API. The decision is made from
 the error the font map returns, so it stays right whichever backend a host actually
 compiled in.
@@ -190,7 +190,7 @@ compiled in.
 
 Do not take `registered.length` as proof. It says the call did not fail; it does not say
 the family is renderable, and a substituted family looks identical to a resolved one from
-the outside. Measure instead — an invented family is your control:
+the outside. Measure instead, with an invented family as your control:
 
 ```ts
 import Pango from 'gi://Pango?version=1.0';
@@ -235,7 +235,7 @@ listed=true
 Round9x13=66x50 vs ZzzNoSuchFamily=87x63
 ```
 
-The same program with nothing staged — which is what a broken payload looks like from the
+The same program with nothing staged, which is what a broken payload looks like from the
 inside:
 
 ```text
@@ -249,11 +249,11 @@ Round9x13=87x63 vs ZzzNoSuchFamily=87x63
 and nothing about the run says so. That is why the control is in the check.
 
 On macOS the honest expectation is different again: `declined=1`, and the family absent
-from `list_families()` *at this point in the process* — with the text still correct on
-screen, because the OS activated the directory before your code ran. The check to run in a
-shipped `.app` is `PangoCairo.FontMap.get_default().list_families()` inside the running
-bundle, and `PANGOCAIRO_BACKEND=bogus ./YourApp` makes Pango print which backends it was
-actually built with.
+from `list_families()` *at this point in the process*, with the text still correct on screen
+because the OS activated the directory before your code ran. The check to run in a shipped
+`.app` is `PangoCairo.FontMap.get_default().list_families()` inside the running bundle, and
+`PANGOCAIRO_BACKEND=bogus ./YourApp` makes Pango print which backends it was actually built
+with.
 
 ## Who does what
 
@@ -264,27 +264,27 @@ actually built with.
 | `initFonts()` from `@gjsify/gtk-host/fonts` | reads the variable and registers what it finds |
 
 `gjsify ship` deliberately does not make the call for you. A packaging command that injected
-a startup step would be deciding your app's initialisation order, invisibly — and the
+a startup step would be deciding your app's initialisation order, invisibly, and the
 ordering above is exactly the thing that has to stay yours.
 
 ## When it does not work
 
 | What you see | What it means |
 |---|---|
-| `dir` is `undefined` in a shipped app | the payload staged no face — check `gjsify.ship.fonts` and re-run `gjsify ship` |
+| `dir` is `undefined` in a shipped app | the payload staged no face. Check `gjsify.ship.fonts` and re-run `gjsify ship` |
 | `declined` holds your faces, on macOS | correct. `ATSApplicationFontsPath` already did the work |
 | `declined` holds your faces, anywhere else | this process resolved a font map that does no runtime registration; check `PANGOCAIRO_BACKEND` |
-| `initFonts: … could not be read as an application font` | FreeType would not open that file — truncated, corrupt, or something wearing a face extension |
+| `initFonts: … could not be read as an application font` | FreeType would not open that file: truncated, corrupt, or something wearing a face extension |
 | the family is listed but text is unchanged | something laid out text before `initFonts()`. Move the call earlier |
 | `gjsify ship: … is a web-font wrapper` | replace the `.woff2` with the desktop face it was made from |
 | `gjsify ship: … holds no font face` | the configured directory has no `.ttf`/`.otf`/`.ttc`/`.otc` in it |
 
 ## Where to next
 
-- [Windows artifacts](/gjsify/ship/windows/) — the layout where this call is the only
+- [Windows artifacts](/gjsify/ship/windows/): the layout where this call is the only
   mechanism there is.
-- [macOS app bundles](/gjsify/ship/macos/) — where the `Info.plist` key does the work
+- [macOS app bundles](/gjsify/ship/macos/): where the `Info.plist` key does the work
   instead.
-- [Linux packages](/gjsify/ship/linux-packages/) — where fontconfig gets there on its own.
+- [Linux packages](/gjsify/ship/linux-packages/): where fontconfig gets there on its own.
 - [CLI Reference → `gjsify ship`](/gjsify/cli-reference/#gjsify-ship) lists every
   configuration key.

--- a/website/src/content/docs/guides/devtools.md
+++ b/website/src/content/docs/guides/devtools.md
@@ -78,8 +78,8 @@ await registerRootComponent(App, {
 });
 ```
 
-Everything in the rest of this page — `DumpTree`, `Screenshot`, `ActivateWidget` — then works
-against the rendered widget tree, not just against the application object.
+`DumpTree`, `Screenshot`, `ActivateWidget` and the rest of this page then work against the
+rendered widget tree, not only the application object.
 
 ### Options
 

--- a/website/src/content/docs/guides/flatpak-cli-tool.md
+++ b/website/src/content/docs/guides/flatpak-cli-tool.md
@@ -12,7 +12,7 @@ compared on [Ship your app](/gjsify/ship/); for a GTK app, use
 A `gjsify build` output is already one self-contained file, so Flatpak buys you
 three specific things: the pinned runtime, any build-time helpers you need
 (`glib-compile-resources`, `blueprint-compiler`) bundled once, and a sandbox
-that makes it easy to say which host paths the tool may touch.
+where you declare which host paths the tool may touch.
 
 ## Keep the GNOME runtime
 

--- a/website/src/content/docs/guides/install.mdx
+++ b/website/src/content/docs/guides/install.mdx
@@ -76,9 +76,10 @@ it as untested rather than promised.
   </Fragment>
 </CommandTabs>
 
-Node.js 20 or newer — the floor [`@gjsify/node-gi`](/gjsify/projects/node-gi/)
-declares, and the one the CLI and its builds hold to. Pick this route if you
-already manage your developer tools through npm.
+Node.js 20 or newer. That is the floor
+[`@gjsify/node-gi`](/gjsify/projects/node-gi/) declares, and the one the CLI and
+its builds hold to. Pick this route if you already manage your developer tools
+through npm.
 
 {/* No Yarn tab: Yarn 2+ dropped `global add` and offers no replacement that
     installs a persistent bin. A tab is a promise the command works. */}

--- a/website/src/content/docs/guides/native-adwaita-app.md
+++ b/website/src/content/docs/guides/native-adwaita-app.md
@@ -219,7 +219,7 @@ import {
     pickFile, saveFile,
 } from '@gjsify/adwaita-app';
 
-// The parent every one of these dialogs is modal to — your own window, not a
+// The parent every one of these dialogs is modal to: your own window, not a
 // browser `window`. GJS has no such global.
 const myWindow = new Adw.ApplicationWindow({ application: new Adw.Application({ applicationId: 'org.example.App' }) });
 
@@ -245,9 +245,9 @@ const target = await saveFile(myWindow, { title: 'Export', initialName: 'report.
 `pickFile` and `saveFile` resolve to `null` when the user cancels, so a cancel is a normal
 value and not an exception.
 
-Pair `destructive: true` with `defaultResponse: 'cancel'`. The reason to show a "really
-delete this?" dialog is the accidental gesture, and a confirm default hands the reflex of
-dismissing a dialog with Enter the deletion instead of the escape.
+Pair `destructive: true` with `defaultResponse: 'cancel'`. A "really delete this?" dialog
+exists to catch the accidental gesture. Make the confirm response the default and the reflex
+of pressing Enter to get rid of a dialog performs the deletion instead of escaping it.
 
 ## Jump straight to a view while developing
 
@@ -257,7 +257,7 @@ view you're working on instead of clicking there every time.
 ```ts
 import { readAppDevHooks, resolveInitialNavIndex } from '@gjsify/adwaita-app';
 
-// Whatever `MYAPP_FILE` should open — your own document store.
+// Whatever `MYAPP_FILE` should open: your own document store.
 const store = { load: (path: string): void => console.log('opening', path) };
 
 const hooks = readAppDevHooks({ prefix: 'MYAPP' });

--- a/website/src/content/docs/guides/storybook.md
+++ b/website/src/content/docs/guides/storybook.md
@@ -193,8 +193,8 @@ each variant. See [Devtools & MCP](/gjsify/guides/devtools/) for the whole loop.
 ## The rule of thumb
 
 Treat a story as part of the widget: **every custom widget ships a `*.story.ts` next to
-it.** It is the widget's living documentation and its visual regression surface. A widget
-without a story is a widget nobody can look at without running your whole app.
+it.** It is the widget's living documentation, and it is what a screenshot test can point
+at. A widget without a story is a widget nobody can look at without running your whole app.
 
 ## The packages behind it
 

--- a/website/src/content/docs/guides/vite-plugin.mdx
+++ b/website/src/content/docs/guides/vite-plugin.mdx
@@ -57,7 +57,7 @@ export default defineConfig({
 
 `gjsifyBrowser()` returns a plugin **array**, so spread it. Don't nest it.
 
-Here is what you get:
+The preset is four pieces:
 
 | Piece | What it does |
 |---|---|

--- a/website/src/content/docs/guides/web-views.md
+++ b/website/src/content/docs/guides/web-views.md
@@ -1,16 +1,15 @@
 ---
 title: Web Views
-description: Embed real web content in a native app with @gjsify/iframe — the same code on Linux, macOS and Windows, plus the Windows caveats you will hit.
+description: Embed real web content in a native app with @gjsify/iframe. The same code on Linux, macOS and Windows, plus the Windows caveats you will hit.
 ---
 
-`@gjsify/iframe` puts a real browser engine inside your app. You write against
-`HTMLIFrameElement` the way you would on a web page — `src`, `srcdoc`,
-`contentWindow.postMessage()`, `addEventListener('message')` — and what renders is a full
-web view with cookies, JavaScript, CSS and developer tools behind it. An HTML report, a
-help page, an OAuth flow, a third-party widget, a Markdown preview: this is the package for
-all of them.
+`@gjsify/iframe` puts a real browser engine inside your app: an HTML report, a help page,
+an OAuth flow, a third-party widget, a Markdown preview. It works on Linux, macOS and
+Windows, and **your source does not branch for any of them**.
 
-It works on Linux, macOS and Windows, and **your source does not branch for any of them**.
+You write against `HTMLIFrameElement` the way you would on a web page: `src`, `srcdoc`,
+`contentWindow.postMessage()`, `addEventListener('message')`. What renders is a full web
+view with cookies, JavaScript, CSS and developer tools behind it.
 
 ## Install
 
@@ -18,7 +17,7 @@ It works on Linux, macOS and Windows, and **your source does not branch for any 
 gjsify install @gjsify/iframe
 ```
 
-On Linux you also need WebKitGTK 6.0 from your distribution — `gjsify system-check` tells
+On Linux you also need WebKitGTK 6.0 from your distribution; `gjsify system-check` tells
 you whether it is there. On macOS and Windows the engine comes with the package, with one
 proviso on Windows: your users need the WebView2 runtime, which
 [has its own section](#the-webview2-runtime-has-to-be-on-the-users-machine) below.
@@ -26,8 +25,8 @@ proviso on Windows: your users need the WebView2 runtime, which
 
 ## A window with a web view
 
-`IFrameBridge` is a `Gtk.Widget` — it extends `WebKit.WebView` — so it goes wherever a
-widget goes. This is a complete program:
+`IFrameBridge` extends `WebKit.WebView`, so it is a `Gtk.Widget` and goes wherever a widget
+goes. This is a complete program:
 
 ```ts
 import Adw from 'gi://Adw?version=1';
@@ -102,11 +101,11 @@ Prefer `loadUri(url)` and `loadHtml(html, baseUri?)` over setting `src` and `src
 directly: they keep the engine and the iframe element's attributes in step.
 
 Two things to watch. `contentWindow` is `null` until the first navigation finishes, and
-`onReady()` is drained per load — so re-attach your message listener from `onReady()` after
-each load. (A browser `<iframe>` keeps `contentWindow` across navigations, so a browser
-build does not need this.) And `pageTitle` is still empty inside `onReady()`: the engine
-reports the document title a moment after the load finishes. If you mirror the title into a
-header bar, watch for it instead of reading it once:
+`onReady()` is drained per load, so re-attach your message listener from `onReady()` after
+each load. A browser `<iframe>` keeps `contentWindow` across navigations, so a browser build
+does not need this. And `pageTitle` is still empty inside `onReady()`: the engine reports
+the document title a moment after the load finishes. If you mirror the title into a header
+bar, watch for it instead of reading it once:
 
 ```ts
 view.connect('notify::title', () => {
@@ -115,30 +114,29 @@ view.connect('notify::title', () => {
 ```
 
 If your code calls `document.createElement('iframe')` or names `HTMLIFrameElement`
-directly, `gjsify build` sees the reference and wires up the DOM surface for you — that is
-what `--globals auto` (the default) does. `new IFrameBridge()` needs none of it and works
-under `--globals none`; when you want the global installed unconditionally, the bridge has
+directly, `gjsify build` sees the reference and wires up the DOM APIs for you. That is what
+`--globals auto`, the default, does. `new IFrameBridge()` needs none of it and works under
+`--globals none`; when you want the global installed unconditionally, the bridge has
 `installGlobals()`.
 
 ## Driving the page
 
-Beyond loading, the bridge is a small automation surface — the same calls whether the app
-is on screen or running headless in a test:
+These calls work the same whether the app is on screen or running headless in a test:
 
 | Call | What it does |
 |---|---|
 | `evaluateJavaScript(expr)` | Evaluate an *expression* in the page and get its value back. Wrap multi-statement logic in an IIFE that returns something. |
 | `queryDom(selector, limit?)` | Metadata for every element matching a CSS selector. |
 | `getLinks()` | Every `<a href>` on the page: resolved href, trimmed text, title. |
-| `clickElement(selectorOrText)` | Click the first match — a CSS selector, or an `<a>` matched by its exact text. |
+| `clickElement(selectorOrText)` | Click the first match: a CSS selector, or an `<a>` matched by its exact text. |
 | `waitForNavigation(timeoutMs?)` | Resolve on the next finished load. Register it *before* the click that triggers one. |
 | `takeScreenshot('full' \| 'visible')` | The rendered page as PNG bytes. |
 | `getConsoleLogs()` / `onConsole(cb)` | The page's own `console.*` output, with `new IFrameBridge({ captureConsole: true })`. |
 | `getViewportSize()` / `setViewportSize(w, h)` | Read the realised content size; request a different one. |
 
-Values from `evaluateJavaScript` round-trip through JSON, so anything that is not
-JSON-serialisable — a DOM node, a function, a circular object — comes back as `undefined`,
-and a thrown page error rejects the promise.
+Values from `evaluateJavaScript` round-trip through JSON. Anything that is not
+JSON-serialisable comes back as `undefined`: a DOM node, a function, a circular object. A
+thrown page error rejects the promise.
 
 ## One API, three engines
 
@@ -153,34 +151,34 @@ is on. Which engine answers to that name is decided by packaging:
 
 The Windows row is the interesting one. WebView2 is Chromium, and it is deliberately
 presented under the `WebKit-6.0` namespace anyway: the namespace names the API *shape*, not
-the engine. What that buys you is the whole point — **no backend seam, and no `if (os ===
-…)` anywhere in your code.** The same `new IFrameBridge()`, the same `loadUri()`, the same
+the engine. That is the whole point. **No backend seam, and no `if (os === …)` anywhere in
+your code.** The same `new IFrameBridge()`, the same `loadUri()`, the same
 `evaluateJavaScript()`, on all three.
 
 Both shims are ordinary dependencies of `@gjsify/iframe` and contain no JavaScript. Each
 one's binaries arrive through per-platform optional dependencies, which your package manager
-installs only on the matching platform and skips silently everywhere else — so a Linux
-install pulls in two empty packages and no binaries at all.
+installs only on the matching platform and skips silently everywhere else. A Linux install
+pulls in two empty packages and no binaries at all.
 
-Where the engines genuinely differ, the differences are below, and each one announces
-itself at the call site rather than failing quietly.
+Where the engines genuinely differ, the differences are below. Each one announces itself at
+the call site rather than failing quietly.
 
 ## Windows: the view is an overlay
 
 On Windows the web content is a child window the OS composites on top of your app. It is
-not a node in GTK's scene graph, which buys you input, focus and accessibility straight
-from the OS — and costs you clipping. An ancestor cannot cut the page to shape, nothing can
-be drawn over it, and opacity and transforms do not reach it.
+not a node in GTK's scene graph. That buys you input, focus and accessibility straight from
+the OS, and costs you clipping: an ancestor cannot cut the page to shape, nothing can be
+drawn over it, and opacity and transforms do not reach it.
 
 So these arrangements will not do what you expect:
 
-- **inside a `Gtk.ScrolledWindow` or `Gtk.Viewport`** — the scrolled window scrolls the
+- **inside a `Gtk.ScrolledWindow` or `Gtk.Viewport`**: the scrolled window scrolls the
   widget, not the page, and the content is not clipped to the viewport;
-- **as the main child of a `Gtk.Overlay`** — anything you overlay is drawn *under* the web
+- **as the main child of a `Gtk.Overlay`**: anything you overlay is drawn *under* the web
   content instead of over it;
-- **inside a `Gtk.Popover`** — the popover's rounded, clipped surface is not followed;
-- **with an opacity below 1**, on the view or on any ancestor — it is not applied to the
-  web content.
+- **inside a `Gtk.Popover`**: the popover's rounded, clipped surface is not followed;
+- **with an opacity below 1**, on the view or on any ancestor: it is not applied to the web
+  content.
 
 gjsify warns once per finding, naming the ancestor, rather than letting it look like a bug
 in your layout. The view also keeps the list:
@@ -190,12 +188,12 @@ view.get_hosting_mode();        // WebKit.HostingMode.OVERLAY
 view.get_overlay_constraints(); // the arrangements it cannot honour, as readable strings
 ```
 
-Those two names exist on the Windows backend only — they describe a condition Linux and
-macOS do not have — so guard the call or keep it to Windows-specific diagnostics.
+Those two names exist on the Windows backend only, because they describe a condition Linux
+and macOS do not have. Guard the call, or keep it to Windows-specific diagnostics.
 
-What the detector cannot see is a CSS `border-radius` that reaches the widget — that is not
-readable from GTK's public API — so treat the list as the arrangements that have been
-reported, not as proof there are no others.
+What the detector cannot see is a CSS `border-radius` that reaches the widget, which is not
+readable from GTK's public API. Treat the list as the arrangements that have been reported,
+not as proof there are no others.
 
 Design around it the same way you would around a video overlay: give the web view its own
 rectangle in the window. A full-page document under a header bar is the shape that works.
@@ -210,8 +208,8 @@ something else:
   a block list exists to prevent, so it narrows in the safe direction.
 - **Named script worlds are ignored.** There is no public isolated-world API to map them
   onto. `user_script_new_for_world()` still exists so your call site stays portable, and it
-  tells you what it did — worth knowing because macOS *does* honour the same argument, so
-  the identical call is isolated there and not here.
+  tells you what it did. Worth knowing, because macOS *does* honour the same argument: the
+  identical call is isolated there and not here.
 - **A full-document snapshot returns the viewport.** `takeScreenshot('full')` captures what
   is laid out, not the whole scrollable document. Snapshot options other than the default
   are ignored too.
@@ -222,8 +220,8 @@ something else:
   `evaluateJavaScript()` is unaffected: it already serialises inside the page.
 - **End-of-document script injection is approximated** by a document-start script that
   defers itself to `DOMContentLoaded`.
-- **Console forwarding to stdout is not honoured** — use the bridge's own
-  `captureConsole` option, which works on every platform.
+- **Console forwarding to stdout is not honoured.** Use the bridge's own `captureConsole`
+  option, which works on every platform.
 - **`allow-file-access-from-file-urls` is not offered as a setting**, because the
   equivalent is a process-wide switch rather than a per-view one. An absent property warns
   at the call; a present one that quietly did nothing would not.
@@ -232,10 +230,10 @@ something else:
 ### What else has to be on the machine
 
 The Windows backend links GTK, GLib and GObject, and Windows has no system copy of any of
-them, so install `@gjsify/gtk-runtime-win32-x64` alongside it — the same bundle every
-Windows gjsify app already uses to reach `gi://` at all. It is deliberately not pulled in
-for you: a second copy of those DLLs on the process's search path is a worse failure than
-the one it would solve.
+them. Install `@gjsify/gtk-runtime-win32-x64` alongside it, the same bundle every Windows
+gjsify app already uses to reach `gi://` at all. It is deliberately not pulled in for you: a
+second copy of those DLLs on the process's search path is a worse failure than the one it
+would solve.
 
 ### The WebView2 runtime has to be on the user's machine
 
@@ -253,8 +251,8 @@ have. The generated installer does not do this for you yet.
 Evergreen runtime's client key lives only under
 `HKLM\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\…`; the 64-bit view of the same path
 does not have it. A detector that checks only the 64-bit path reports "not installed" on a
-machine that has the runtime — a check that looks green everywhere it is tested and is
-wrong at the user. Read both views, or call
+machine that has the runtime: a check that looks green everywhere it is tested and is wrong
+at the user. Read both views, or call
 `GetAvailableCoreWebView2BrowserVersionString`, which is view-independent.
 
 ### What is proven on Windows, and what is not
@@ -267,7 +265,7 @@ texture, and the page's own `postMessage` arrives on the app side.
 What has not been verified is the same view re-parented under a real application window:
 tracking its bounds as the window moves and resizes, hiding when the widget is unmapped,
 and input and focus arriving from the OS. If you are deciding whether to depend on the
-Windows web view today, that is the line — the engine, the loading, the scripting and the
+Windows web view today, that is the line. The engine, the loading, the scripting and the
 snapshots are demonstrated; the widget-in-a-window behaviour is not yet.
 
 ## macOS notes
@@ -294,9 +292,9 @@ The minimum deployment target is macOS 11.
 
 ## Related
 
-- [Bridge Widgets](/gjsify/patterns/bridges/#embed-a-web-page) — where `IFrameBridge` sits
+- [Bridge Widgets](/gjsify/patterns/bridges/#embed-a-web-page): where `IFrameBridge` sits
   next to the canvas, WebGL and video bridges, and when to reach for each
-- [Minimalist Browser](/gjsify/showcases/minimalist-browser/) — a URL bar, history and
+- [Minimalist Browser](/gjsify/showcases/minimalist-browser/): a URL bar, history and
   `postMessage`, in one small app
-- [Platform Support](/gjsify/platform-support/) — what reaches your operating system
-- [Ship your app](/gjsify/ship/) — packaging for Linux, macOS and Windows
+- [Platform Support](/gjsify/platform-support/): what reaches your operating system
+- [Ship your app](/gjsify/ship/): packaging for Linux, macOS and Windows

--- a/website/src/content/docs/guides/webrtc.md
+++ b/website/src/content/docs/guides/webrtc.md
@@ -106,7 +106,7 @@ your source and injects the matching register module for you.
 would rather import them by hand.
 
 **It needs a running main loop, not a window.** WebRTC is driven by GLib main-context callbacks,
-so a headless `GLib.MainLoop` is enough — but without one the handshake never progresses.
+so a headless `GLib.MainLoop` is enough. Without one the handshake never progresses.
 
 **`addIceCandidate` returns a promise, and it rejects.** Server-reflexive candidates come back
 from a STUN server long after the local host candidates do, so on a short-lived connection they
@@ -149,16 +149,16 @@ apart exactly where you least want them to.
 `gstreamer1-plugins-good` puts `pulsesrc` on practically every Linux install, container images
 included, and `Gst.ElementFactory.make('pulsesrc')` succeeds there whether or not an audio
 daemon is listening. So on a headless server, inside a container, or in a sandboxed app without
-audio access, `getUserMedia` claimed a source that could never produce a buffer — and the
-synthetic fallback below it, the one source that *does* work on such a host, was unreachable
+audio access, `getUserMedia` claimed a source that could never produce a buffer. And the
+synthetic fallback below it, the one source that *does* work on such a host, was unreachable,
 because a broken `pulsesrc` was always claimed first.
 
 Nothing threw. You got a track, and the track was dead. The failure surfaced seconds later and
 somewhere else entirely: `addTrack` wired the dead source up, `webrtcbin` sent no RTP, and the
 remote peer's `track` event simply never fired. It reads as a WebRTC bug and it is not one.
 
-Now each candidate is started for real — in a throwaway `src ! <converter> ! fakesink`
-pipeline — and kept only if that does not fail. Candidates are tried in order:
+Now each candidate is started for real, in a throwaway `src ! <converter> ! fakesink`
+pipeline, and kept only if that does not fail. Candidates are tried in order:
 
 | Kind | Real sources, in order | Synthetic fallback |
 |---|---|---|
@@ -176,7 +176,7 @@ So colour bars instead of your face, or a sine tone instead of a room, is the pa
 that no real device opened. Treat it as a diagnosis. It is a far better one than silence, and
 `track.label` names the element that won.
 
-A source that is still starting up counts as a pass, not a failure — a live camera that has not
+A source that is still starting up counts as a pass, not a failure. A live camera that has not
 prerolled within half a second is slow, not broken.
 
 ### The probe runs once per process
@@ -215,17 +215,17 @@ const stream = await getUserMedia({
 ```
 
 `navigator.mediaDevices.getSupportedConstraints()` is the machine-readable version of that table.
-Everything it reports `false` for — `echoCancellation`, `noiseSuppression`, `autoGainControl`,
-`facingMode`, `aspectRatio`, `resizeMode`, `latency`, `groupId` — is accepted and ignored, the
-way a browser treats an unsupported non-required constraint. `deviceId` is accepted too, but it
-does not yet select the device: source selection is the probe order above, not your hint.
+Everything it reports `false` for is accepted and ignored, the way a browser treats an
+unsupported non-required constraint: `echoCancellation`, `noiseSuppression`, `autoGainControl`,
+`facingMode`, `aspectRatio`, `resizeMode`, `latency`, `groupId`. `deviceId` is accepted too, but
+it does not yet select the device: source selection is the probe order above, not your hint.
 
 ### enumerateDevices comes back empty in containers
 
 `navigator.mediaDevices.enumerateDevices()` returns an empty array when `CI` is set in the
 environment, or when neither `DISPLAY` nor `WAYLAND_DISPLAY` is. GStreamer's `DeviceMonitor` can
 crash inside native code on some GJS and GStreamer combinations in containers, and a native crash
-is not something a `try`/`catch` in JavaScript can rescue you from — so it is not attempted where
+is not something a `try`/`catch` in JavaScript can rescue you from, so it is not attempted where
 there are almost certainly no devices to find. Do not treat an empty list as "this machine has no
 microphone"; call `getUserMedia` and read `track.label`.
 
@@ -237,7 +237,7 @@ gap: capture once, and the following `enumerateDevices` fills the names in.
 
 ### Never send an empty string
 
-`channel.send('')` **closes the channel.** Not "drops the message" — closes it, and everything
+`channel.send('')` **closes the channel.** Not "drops the message": closes it, and everything
 you send afterwards is lost.
 
 It gives you no signal at the call site. `send` returns normally, throws nothing, and
@@ -252,12 +252,12 @@ readyState 1.5 s later:       closing
 ```
 
 That combination is what makes this so confusing in the field. Nothing fails where the mistake
-is, the data that vanishes is the data that came *after*, and the channel dies a beat later — so
+is, the data that vanishes is the data that came *after*, and the channel dies a beat later. So
 it reads as a race somewhere else in your protocol.
 
 This is an upstream defect in GStreamer 1.28.5, not something the package can work around.
 GStreamer's data channel builds a zero-length buffer for the empty-string path, where RFC 8831
-§ 6.6 requires one zero byte — SCTP cannot carry an empty user message at all, which is exactly
+§ 6.6 requires one zero byte. SCTP cannot carry an empty user message at all, which is exactly
 why the spec spends a byte on saying so.
 
 Guard the call site:
@@ -267,8 +267,8 @@ if (text.length > 0) channel.send(text);
 ```
 
 If an empty payload means something in your protocol, give it a one-byte encoding of its own
-rather than sending nothing — a single-character sentinel, or a JSON envelope such as
-`{"type":"ping"}`, both of which survive the trip.
+rather than sending nothing: a single-character sentinel, or a JSON envelope such as
+`{"type":"ping"}`. Both survive the trip.
 
 ### Large messages throw rather than vanish
 
@@ -284,7 +284,7 @@ max message size: 262144
 ```
 
 That value comes from the peer's `a=max-message-size` SDP attribute, and falls back to 262144
-bytes — as in the loopback above, where neither side advertises one. A `0` means unlimited.
+bytes, as in the loopback above, where neither side advertises one. A `0` means unlimited.
 Frame anything larger yourself.
 
 The throw is the feature. Before it existed an oversize `send` returned normally and the frame
@@ -297,12 +297,12 @@ to the browser's own native WebRTC, so one source file builds both ways and you 
 side by side and compare them line by line.
 
 There is no `--app node` build. The backend is a GStreamer pipeline reached through a typelib,
-which Node, Bun and Deno have no route to — so anything built on this package should declare
+which Node, Bun and Deno have no route to. So anything built on this package should declare
 `gjs` in its `gjsify.runtimes`, and a `--runtime node` request then fails with an explanation
 rather than a crash.
 
 ## Related
 
-- [WebRTC Loopback](/gjsify/showcases/webrtc-loopback/) — the data-channel handshake as a runnable showcase, in GJS and in the browser.
-- [WebRTC Video](/gjsify/showcases/webrtc-video/) — `getUserMedia` into a GTK 4 `Gtk.Picture` via `video.srcObject`.
-- [Web API packages](/gjsify/packages/web/) — what else `@gjsify/webrtc` covers and which GNOME libraries back it.
+- [WebRTC Loopback](/gjsify/showcases/webrtc-loopback/): the data-channel handshake as a runnable showcase, in GJS and in the browser.
+- [WebRTC Video](/gjsify/showcases/webrtc-video/): `getUserMedia` into a GTK 4 `Gtk.Picture` via `video.srcObject`.
+- [Web API packages](/gjsify/packages/web/): what else `@gjsify/webrtc` covers and which GNOME libraries back it.

--- a/website/src/content/docs/how-it-works.mdx
+++ b/website/src/content/docs/how-it-works.mdx
@@ -5,24 +5,24 @@ description: What gjsify build and gjsify run actually do, from import aliasing 
 
 import CommandTabs from '../../components/CommandTabs.astro';
 
-This page is optional. You can write, build and ship a gjsify app without reading a line of it, because everything described here happens on its own when you run `gjsify build` and `gjsify run`.
+This page is optional. `gjsify build` and `gjsify run` do everything described here on their own, so you can write and ship an app without reading a line of it.
 
-Read it when you want to know what those two commands actually did, or when a build behaves in a way the task guides don't explain. Each section stands on its own, so jump straight to the one you care about.
+Read it when a build behaved in a way the task guides don't explain, or when you want to know what those two commands did. Each section stands on its own, so jump to the one you need.
 
-For the short version of which target runs where, see [Runtimes](/gjsify/runtimes/). For every flag, see the [CLI Reference](/gjsify/cli-reference/).
+Which target runs where is in [Runtimes](/gjsify/runtimes/). Every flag is in the [CLI Reference](/gjsify/cli-reference/).
 
 ## Import aliasing
 
-The bundler plugin rewrites imports so that one source file builds for a runtime that does not ship them. Which imports get rewritten is decided by `--app`, and the two app targets rewrite in opposite directions:
+One source file has to build for runtimes that do not ship the imports it uses, so the bundler plugin rewrites them. `--app` decides which ones, and the two app targets rewrite in opposite directions:
 
 | Target | What it rewrites | Why |
 |---|---|---|
 | `--app gjs` | Node.js and Web API imports, to their `@gjsify/*` equivalents | GJS has no `node:` builtins and no DOM |
 | `--app node` | `gi://` imports, onto the [node-gi bridge](/gjsify/projects/node-gi/) | Node.js, Bun and Deno have no GObject Introspection |
 
-Each leaves the other side alone. `--app gjs` keeps `gi://*`, `cairo`, `system` and `gettext` untouched, because the GJS runtime resolves those itself. `--app node` keeps the `node:` imports untouched, because the host runtime already has them, and one such bundle runs on Node, Bun and Deno alike.
+Each target leaves the other side alone. `--app gjs` keeps `gi://*`, `cairo`, `system` and `gettext` untouched, because the GJS runtime resolves those itself. `--app node` keeps the `node:` imports untouched, because the host runtime already has them, and one such bundle runs on Node, Bun and Deno alike.
 
-Here is the `--app gjs` direction in full:
+The `--app gjs` direction in full:
 
 ```typescript
 // You write:
@@ -42,15 +42,15 @@ import { createServer } from '@gjsify/http'     // → Soup.Server
 
 The alias table lives in `@gjsify/resolve-npm` and covers every Node.js builtin and Web API gjsify implements. Current coverage is in the [Packages Overview](/gjsify/packages/overview/).
 
-Two things follow from this. First, the bare specifier is the canonical form: no gjsify-specific import ever appears in your source, so the same file type-checks against `@types/node` and builds for GJS or for Node depending on `--app`. Second, the `@gjsify/*` packages still have to be resolvable from your project. `gjsify create` puts the ones a template needs into `package.json`, and if you reach for a new API later you add the matching package like any other dependency.
+Two things follow. The bare specifier is the canonical form: no gjsify-specific import ever appears in your source, so one file type-checks against `@types/node` and builds for GJS or for Node depending on `--app`. And the `@gjsify/*` packages still have to be resolvable from your project. `gjsify create` puts the ones a template needs into `package.json`; reach for a new API later and you add its package like any other dependency.
 
 The GJS target compiles down to `firefox140`, which is SpiderMonkey 140, the engine in GJS 1.86.
 
 ## Automatic globals detection
 
-Most of what follows is the `--app gjs` story, because that is the target where the Node and Web surface has to be installed in the first place: Node, Bun and Deno already define `process`, `Buffer`, `fetch` and the rest. `--globals` is not inert on `--app node`, though. There the default `auto` looks for GJS's own ambient globals (`print`, `imports`, …) and side-effect imports `@gjsify/node-gi/globals` only when the bundled output references them, and naming globals explicitly (`--globals auto,dom`) requests the same `@gjsify/*` register bodies the GJS target gets, which is what a `gi://` source needs when it runs through the reverse bridge. `--app browser` uses the host's own globals and injects nothing.
-
 Aliasing handles imports. Plenty of npm code also reaches for globals with no import at all: `process.env.FOO`, `Buffer.from(data)`, `new URL('https://…')`, `await fetch(...)`. On GJS those don't exist until something registers them on `globalThis`.
+
+Most of this section is the `--app gjs` story, because that is the target where the Node and Web APIs have to be installed in the first place. Node, Bun and Deno already define `process`, `Buffer`, `fetch` and the rest. `--globals` is not inert there, though. On `--app node` the default `auto` looks for GJS's own ambient globals (`print`, `imports`, …) and side-effect imports `@gjsify/node-gi/globals` only when the bundled output references them. Naming globals explicitly (`--globals auto,dom`) requests the same `@gjsify/*` register bodies the GJS target gets, which is what a `gi://` source needs when it runs through the reverse bridge. `--app browser` uses the host's own globals and injects nothing.
 
 Every `@gjsify/*` package that provides a Node or Web global exposes one or more `/register` subpaths, for instance `@gjsify/fetch/register/fetch` and `@gjsify/node-globals/register/process`. Importing a subpath for its side effect runs the registration; importing only named exports from the package root stays tree-shakeable.
 
@@ -83,7 +83,7 @@ The default `--globals auto` works out which registers your project needs by ana
   </Fragment>
 </CommandTabs>
 
-Every tab above passes `--app gjs` explicitly, because `--app` defaults to the target of whichever runtime the CLI is on: `gjs` under gjs, `node` under node, bun and deno. Set `gjsify.app` in `package.json` to fix the target for a project and the flag becomes optional again.
+Every tab above passes `--app gjs` explicitly, because `--app` defaults to the target of the runtime the CLI is on: `gjs` under gjs, `node` under node, bun and deno. Set `gjsify.app` in `package.json` to fix the target for a project and the flag is optional again.
 
 ### What auto detection does
 
@@ -93,7 +93,7 @@ It is an iterative build:
 2. **Pass 2** rebuilds with those globals injected as small `register` stubs, seeded with the precomputed set of globals the registers themselves reference. Injected code can pull in more code, so the loop repeats until the detected set stops growing. Two passes is the normal case, five is the hard cap.
 3. The final build uses the converged set and writes to disk.
 
-Detection runs on the **bundled, tree-shaken** output rather than on your source tree, and that one choice is what makes it dependable. If an identifier survives dead-code elimination it is genuinely reachable, so an isomorphic dependency that guards `document` behind `typeof document !== 'undefined'` produces no false positive, and a file the bundler loaded and then shook away contributes nothing.
+Detection runs on the **bundled, tree-shaken** output rather than on your source tree, and that one choice is what makes it dependable. An identifier that survives dead-code elimination is genuinely reachable. So an isomorphic dependency that guards `document` behind `typeof document !== 'undefined'` produces no false positive, and a file the bundler loaded and then shook away contributes nothing.
 
 Use `--verbose` to watch it converge:
 
@@ -214,7 +214,7 @@ If `X` is not in the table, gjsify does not implement it yet. Check the [Package
 
 ## Native prebuilds and `gjsify run`
 
-Some gjsify packages need native code. `@gjsify/webgl`, for example, ships a Vala-built shared library plus a GIR typelib that bridges WebGL calls, through libepoxy, to whichever OpenGL the host offers: GLES where GDK provides it, desktop GL on macOS, whose backend goes through CGL and exposes no GLES profile at all.
+Some gjsify packages need native code. `@gjsify/webgl` ships a Vala-built shared library plus a GIR typelib that routes WebGL calls through libepoxy to whichever OpenGL the host offers: GLES where GDK provides it, desktop GL on macOS, whose backend goes through CGL and exposes no GLES profile at all.
 
 Those binaries do not sit in the main package. A native package declares the targets it promises in `"gjsify": { "platforms": [...] }` and lists one companion package per target as an `optionalDependency`, so an install only fetches the binary for the machine you are on. The companion carries the files under `prebuilds/<os>-<arch>/`:
 
@@ -225,7 +225,7 @@ node_modules/@gjsify/webgl-linux-x64/prebuilds/linux-x64/
   libgwebgl.so
 ```
 
-There is one spelling for that directory, the same one a running process can compute about itself: `linux-x64`, `linux-arm64`, `darwin-arm64`, `win32-x64`, plus a `-musl` suffix on Linux hosts whose C library needs it. Because the process derives its own name, locating the directory needs no translation step. A package that ships nothing for your platform is skipped in silence, since every native bridge is optional at runtime.
+There is one spelling for that directory, the same one a running process can compute about itself: `linux-x64`, `linux-arm64`, `darwin-arm64`, `win32-x64`, plus a `-musl` suffix on Linux hosts whose C library needs it. The process derives its own name, so locating the directory needs no translation step. A package that ships nothing for your platform is skipped in silence, because every native bridge is optional at runtime.
 
 ### The environment it sets
 
@@ -298,6 +298,8 @@ If you want to call `gjs` directly, from a systemd unit or inside a packaged Fla
 </CommandTabs>
 
 `gjsify info` without `--export` prints the same information for humans: every native package it detected and the exact variables needed to run the bundle.
+
+macOS adds a constraint. SIP strips every `DYLD_*` variable at the first `/bin/sh` boundary, so a wrapper script cannot hand the loader a path: the process that sets `DYLD_LIBRARY_PATH` has to be the one that launches the bundle. [ADR 0024](https://github.com/gjsify/gjsify/blob/main/docs/adr/0024-ship-installable-artifacts.md) § 3 has the measurement.
 
 ## The GLib main loop
 
@@ -406,49 +408,23 @@ The `<os>-<arch>` marks in the [Platform Support](/gjsify/platform-support/) tab
 
 The marks are read out of the workflow YAML, so "a CI job targets it" claims exactly that, never that a green run of that job exists. `○` in particular says nothing about whether the job currently succeeds.
 
-`✓` means the binary is committed in this repository, in the bridge's per-target package (`@gjsify/<bridge>-<os>-<arch>`, an `optionalDependencies` entry a package manager installs or silently skips), not in the bridge's own tarball. Since that split the bridge itself carries no `prebuilds/` directory at all, so a cell that asked the bridge alone answered "declared and built" and printed `✓` for two bridges that commit nothing anywhere. The glyphs are now machine-checked against the directories on disk (`tests/e2e/ci-runner-arch`).
+`✓` means the binary is committed in this repository, in the bridge's per-target package (`@gjsify/<bridge>-<os>-<arch>`, an `optionalDependencies` entry a package manager installs or silently skips), not in the bridge's own tarball. It does not mean anyone has run that artifact on that architecture. Read it as "declared, targeted by a CI job, and committed with a structurally sound artifact".
 
-`○` is the state to read carefully: CI produces the artifact, but this repository does not carry it, so a `git clone` has nothing to load and an `npm install` gets whatever the last publish shipped. It is never a gap the audit overlooked. Every `○` target is held to a `release.yml` job that builds, load-tests and uploads it, because a release cannot download another workflow's artifact and that tarball is the only route by which one reaches a consumer. Two packages are in that state:
-
-- **`@gjsify/napi`, both targets.** `napi.yml` rebuilds and gates on the linux-x64 prebuild, and its macOS job builds, load-tests and uploads the darwin-arm64 one. No job commits either back, and each per-target package says so in `package.json#gjsify.platformsUncommitted`, printed on every `--check` run. The linux-x64 directory used to be committed while its darwin sibling was exempt: one bridge running two policies, where every job that touched the path overwrote the checked-out bytes before reading them, and the declaration checks stayed green across a week of source drift. Deleting it made freshness real by removal, since the only linux-x64 artifact anyone can load is now the one CI produced in that same run.
-- **`@gjsify/node-gi`, every declared target.** It builds with node-gyp at install time, or installs a prebuild straight from a release artifact, so there is no committed directory anywhere and no exemption entry to key the cell on: the absence *is* the state. `release.yml` carries a prebuild leg per target, which is what the audit checks.
-
-### What the audit actually verifies
-
-It runs wherever CI runs it, today an `ubuntu-latest` x64 Node runner, and a prebuild for another architecture cannot be loaded there. Rather than skip those, the audit splits what it verifies and reports which half it did:
-
-- **Structurally, on every committed artifact regardless of target.** The image's own machine field must match the directory it sits in (an ELF/Mach-O/PE header read, no `readelf` or `otool`); every `libgjsify*` sibling it records must be staged beside it and reachable through `$ORIGIN` or `@loader_path`; and every library leaf the typelib records must be present, because that leaf is what GObject-Introspection hands to the loader the moment a consumer resolves a class. This half caught both a missing macOS sibling cdylib and an emulated prebuild leg that compiled **x86-64** and staged it into `prebuilds/linux-{ppc64,s390x,riscv64}/`: `uraimo/run-on-arch-action` ignores its `arch` input whenever a custom `base_image` is supplied, so every other check passed and the artifact even loaded on the runner. Only reading the machine field against the directory name catches that.
-- **Functionally, only for the checking host's own target.** The library is `dlopen`ed with every library-path environment variable stripped, which proves the self-relative sibling hop for real instead of inferring it from the headers. A bridge whose *system* dependencies the runner lacks (libsoup, GStreamer, libgda) is reported as not-load-tested, never as broken, because that would be a fact about the runner rather than the artifact.
-
-So `✓` means "declared, targeted by a CI job, and committed with a structurally sound artifact". It does not mean anyone has run that artifact on that architecture. The per-run summary states both numbers separately.
+`○` is the state to read carefully: CI produces the artifact, but this repository does not carry it, so a `git clone` has nothing to load and an `npm install` gets whatever the last publish shipped. It is never a gap the audit overlooked. Two packages are in that state, `@gjsify/napi` on both its targets and `@gjsify/node-gi` on every target it declares.
 
 Every column name is a real directory name. Targets are spelled the one way a running process can compute about itself, `${process.platform}-${process.arch}`, so `gjsify.platforms`, the committed `prebuilds/<target>/`, the CI job that builds it and the resolver that loads it all use the same string, with nothing to translate between them.
 
+How the audit arrives at those marks, what it checks structurally on every artifact and what it can only check functionally on its own architecture, is in [Architecture](/gjsify/contributing/architecture/#what-the-platform-audit-verifies).
+
 ## How the cross-runtime claims are checked
 
-A golden-diff conformance harness runs the same programs on `gjs`, `node`, `bun` and `deno` and requires **byte-identical output**. A diff needs one side to diff against, and that side is the `gjs` output, itself checked against a committed golden file wherever the scenario has one. That makes gjs the yardstick for the comparison, which is a fact about the test rig and not advice about which runtime to build on. The ported GNOME GIMarshallingTests currently stand at 370 passing and none failing.
+The same programs run on `gjs`, `node`, `bun` and `deno`, and their output has to match byte for byte. The conformance harness behind that claim, the Fedora CI baseline and the named macOS and Windows jobs are in [Architecture](/gjsify/contributing/architecture/#how-the-cross-runtime-claims-are-checked).
 
-Linux is the CI baseline: the full suite (10,000+ cases across Node and GJS), every e2e suite and every integration suite run on Fedora. The other two operating systems are covered by named jobs rather than by a runtime-class claim:
+## Windows traps that look like defects
 
-- **macOS** runs `@gjsify/node-gi`'s own CI (build, conformance, a real GTK/Adwaita window, the full Adwaita storybook), `@gjsify/napi`'s build and gates, and the native-bridge prebuild job. Two jobs run the `@gjsify/*` suites themselves: `main.yml`'s `macos` job executes a curated subset of `--app gjs` bundles on arm64 under Homebrew `gjs` 1.88, and `macos-suites.yml` runs the Node-pillar suites on both `test:node` and `test:gjs`, on darwin-arm64 and darwin-x64, on every pull request as well as on `main` and the nightly. macOS is the only one of the three where both legs can run at all, which is the point of running them: `test:node` says the spec is right, `test:gjs` says the port is.
-- **Windows** runs `@gjsify/node-gi`'s CI including a real GTK window and the storybook, using a bundled GTK runtime rather than a system install, plus the Node-pillar `@gjsify/*` suites in `windows-suites.yml`, on every pull request as well as on `main` and the nightly. Those run under **cmd.exe with the git-bash utilities stripped from `PATH`**, because Git for Windows supplies a real `rm`, `cp` and `sh` that npm's `%COMSPEC%` scripts do not have, and testing from git-bash reports false greens.
+Three host traps on Windows fail in ways that name the wrong culprit. The first two each cost a verification run an entire discarded pass.
 
-The macOS `--app gjs` bundles are built on the Fedora leg and executed on macOS. That split is a cost decision rather than a capability one. `@gjsify/rolldown-native`, the bundler engine `gjsify build` uses under GJS, is built, staged and load-tested under Homebrew `gjs` on both darwin arches by `prebuilds.yml`, and its `darwin-arm64` and `darwin-x64` artifacts are committed. What no job does yet is drive `gjsify build` under GJS on macOS end to end, and standing that up would mean a full `gjsify install` on a runner billed at 10x. A `--app gjs` bundle is a single self-contained file whose only unbundled imports are `gi://GLib`, `gi://Gio` and `gi://GioUnix`, so building it on Linux and running it on macOS is sound. It verifies **runtime** behaviour on macOS, not the build toolchain there.
-
-Bun and Deno share the `node` runtime slot through the Node-API common ABI, and `main.yml`'s `cross-runtime` job tests that rather than assuming it: one engine-agnostic `--app node` bundle per package, run on all three runtimes. The selection rule matters. A spec that imports `node:path` gets the *host runtime's* builtin, because the `--app node` bundle externalises it, so such a leg would test Bun rather than the polyfill. Every covered package either imports its own package by name, imports a bare Web specifier that the alias table routes to the polyfill, or is infra code that is nobody's builtin.
-
-The four defects that first darwin run found are recorded in
-[ADR 0018](https://github.com/gjsify/gjsify/blob/main/docs/adr/0018-os-axis-declaration.md) § *darwin re-measured*.
-The macOS loader fact that invalidates the obvious fix for a `dyld` problem — SIP strips every `DYLD_*` variable at
-the first `/bin/sh` boundary, so a wrapper cannot hand the loader a path — is
-[ADR 0024](https://github.com/gjsify/gjsify/blob/main/docs/adr/0024-ship-installable-artifacts.md) § 3, and
-`macos-suites.yml` re-measures it on every run.
-
-## Measuring gjsify on Windows
-
-Two traps cost a cross-platform verification run an entire discarded pass, so they are written down here.
-
-**Win32-OpenSSH puts its session in session 0, which has no desktop.** Every GTK showcase driven over SSH died with an `0xC0000005` access violation inside `gtk-4-1.dll`, a crash with a plausible stack and no hint of the real cause, which reads like a gjsify defect and is not one. Re-run as an interactive scheduled task in the logged-on session, the same commands render:
+**Win32-OpenSSH puts its session in session 0, which has no desktop.** Every GTK showcase driven over SSH died with an `0xC0000005` access violation inside `gtk-4-1.dll`, a crash with a plausible stack and no hint of the real cause. It reads like a gjsify defect and is not one. Re-run as an interactive scheduled task in the logged-on session, the same commands render:
 
 ```powershell
 schtasks /create /tn gjsifyTest /tr "%USERPROFILE%\test\run.cmd" `
@@ -460,7 +436,7 @@ Write output under `%USERPROFILE%`: an unelevated task may not write to `C:\`.
 
 **Check the CLI version before believing a Windows result.** A run reporting every WebGL showcase failing under deno with `Failed to require Gwebgl 0.1: Typelib file for namespace 'Gwebgl' (any version) not found` was measured against that box's npm-global gjsify 0.33.0. Re-measured on 0.37.0 in an interactive session, all four WebGL showcases reach the GL bridge under both deno and bun, and the error does not occur at all. `gjsify showcase` prints the version it is running as, so read that line first.
 
-One more, because it produces false greens: run commands the way npm does, through `cmd.exe`. A git-bash shell puts `C:\Program Files\Git\usr\bin` on `PATH`, so `chmod`, `cp`, `rm` and `which` resolve there and a script that cannot work for a normal user appears to.
+**Run commands the way npm does, through `cmd.exe`.** This one produces false greens. A git-bash shell puts `C:\Program Files\Git\usr\bin` on `PATH`, so `chmod`, `cp`, `rm` and `which` resolve there, and a script that cannot work for a normal user appears to work.
 
 ## Where to go next
 

--- a/website/src/content/docs/overview.mdx
+++ b/website/src/content/docs/overview.mdx
@@ -10,27 +10,27 @@ and you get a real GTK 4 / Adwaita application: one native process, no bundled
 browser engine, no second process behind the window. GTK and libadwaita stay
 exactly as they are, reached through `gi://` imports.
 
-Four JavaScript runtimes can execute that app, and the choice is yours: GJS,
-Node.js, Bun or Deno. What differs between them is where `gi://` comes from and
-how far the app travels. GJS is GNOME's own JavaScript runtime, so it resolves
-`gi://` itself with nothing in between; Linux distributions ship it and Homebrew
-builds it for macOS, but there is none for Windows. On Node, Bun and Deno the
-same imports resolve through [`@gjsify/node-gi`](/gjsify/projects/node-gi/), a
-Node-API addon, which is the route that reaches all three operating systems.
+Four JavaScript runtimes can run that app: GJS, Node.js, Bun and Deno. What
+differs between them is where `gi://` comes from. GJS is GNOME's own JavaScript
+runtime, so it resolves `gi://` itself with nothing in between. Linux
+distributions ship it and Homebrew builds it for macOS, but there is no GJS for
+Windows. On Node, Bun and Deno the same imports resolve through
+[`@gjsify/node-gi`](/gjsify/projects/node-gi/), a Node-API addon, and that is the
+route reaching all three operating systems.
 
 The code you write is the same either way. Where a runtime has no implementation
 of its own, gjsify supplies one: on GJS that means `node:fs`, `fetch`, `WebSocket`
 and `<canvas>`, backed by Gio, libsoup and Cairo, which is what lets a large slice
-of npm run there. Where the runtime already has the module, the runtime's own is
-used.
+of npm run there. Where the runtime already has the module, you get the runtime's
+own.
 
-**What you can build with it:** a desktop app with the full Adwaita widget set, a
-game rendering with WebGL into a real `Gtk.GLArea` or with Canvas 2D into a
-`Gtk.DrawingArea` (three.js and Excalibur.js run unmodified), a command-line tool,
-or an HTTP server on Express or Hono. `gjsify create` scaffolds a starter for each
-of those — a bare `Gtk.Window` if you want to begin from nothing — and every one
-of them builds for all four runtimes. The same source can also be built for the
-browser.
+**What you can build.** A desktop app with the full Adwaita widget set. A game
+rendering with WebGL into a real `Gtk.GLArea` or with Canvas 2D into a
+`Gtk.DrawingArea`, where three.js and Excalibur.js run unmodified. A command-line
+tool. An HTTP server on Express or Hono. `gjsify create` scaffolds a starter for
+each of those, and a bare `Gtk.Window` if you want to begin from nothing. Every
+one of them builds for all four runtimes, and the same source builds for the
+browser too.
 
 The CLI runs on all four runtimes as well, so you develop with the one you already
 have.
@@ -44,9 +44,10 @@ Where your code runs is a flag on the build, not a decision baked into your app:
 
 | `gjsify build --app` | Runs on | What that gives you |
 |---|---|---|
-| `gjs` | GJS, on Linux; macOS in part | GNOME's own interpreter resolves `gi://` directly, with nothing bridging into GTK. Linux distributions ship the runtime; on macOS it comes from Homebrew and only part of the surface is verified there; there is no `gjs` for Windows. |
+| `gjs` | GJS, on Linux; macOS in part | GNOME's own interpreter resolves `gi://` directly, with nothing bridging into GTK. Linux distributions ship the runtime. On macOS it comes from Homebrew and only part of it is verified there, and there is no `gjs` for Windows. |
 | `node` | Node.js, Bun and Deno, on Linux, macOS and Windows | One bundle for all three, because Node-API is their common ABI. `gi://` goes through `@gjsify/node-gi`, and `@gjsify/gtk-runtime-darwin-arm64`, `-darwin-x64` and `-win32-x64` carry GTK itself, so those two platforms need no system GTK. |
 | `browser` | any modern browser | No native code at all, so it is portable by construction. Adwaita comes over as Web Components through `@gjsify/adwaita-web`. |
+| `nativescript` | Android and iOS, experimental | Real native views, no webview. `@gjsify/adwaita-nativescript` carries the widget set. Try it; do not ship on it yet. See [Runtimes](/gjsify/runtimes/#mobile-with-nativescript-experimental). |
 
 The flag defaults to whatever runtime is running the CLI, so a CLI installed
 through the GJS bootstrap builds `gjs` bundles and one installed with npm, Bun or
@@ -63,7 +64,7 @@ operating-system question.
 - [Widget Gallery](/gjsify/adwaita/): every Adwaita component, with live previews and code
 - [UI Frameworks](/gjsify/frameworks/): render a GTK window from Solid, Vue, React or React Native
 - [Native Adwaita Apps](/gjsify/guides/native-adwaita-app/): the app shell, navigation, dialogs and toasts
-- [Runtimes](/gjsify/runtimes/): GJS, Node.js, Bun, Deno and the browser, and what runs where
+- [Runtimes](/gjsify/runtimes/): GJS, Node.js, Bun, Deno, the browser and mobile, and what runs where
 - [Packages](/gjsify/packages/overview/): the Node.js, Web and DOM APIs gjsify implements
 - [Showcases](/gjsify/showcases/): full apps that run natively and in your browser from one source
 - [CLI Reference](/gjsify/cli-reference/): every `gjsify` command and flag

--- a/website/src/content/docs/packages/dom.md
+++ b/website/src/content/docs/packages/dom.md
@@ -62,7 +62,7 @@ Same shape, different widget: `WebGLBridge` extends `Gtk.GLArea` and exposes Web
 
 `VideoBridge` takes a `MediaStream` through `srcObject` or a URL through `src`, and renders through GStreamer into a `Gtk.Picture`. `IFrameBridge` wraps a real `WebKit.WebView` and gives you `src`, `srcdoc`, navigation and `postMessage`. Both follow the same `onReady` pattern.
 
-For the full lifecycle, the resize behaviour and the traps worth knowing about ahead of time, read [Bridge Widgets](/gjsify/patterns/bridges/).
+For the full lifecycle, the resize behaviour and the traps worth knowing in advance, read [Bridge Widgets](/gjsify/patterns/bridges/).
 
 ## Which DOM element maps to which widget
 

--- a/website/src/content/docs/packages/node.mdx
+++ b/website/src/content/docs/packages/node.mdx
@@ -15,13 +15,13 @@ import { EventEmitter } from 'node:events';
 import path from 'node:path';
 ```
 
-In an `--app gjs` build each import is rewritten to its `@gjsify/*` implementation: `node:fs` to `Gio.File`, `node:http` to `Soup.Server`, `node:crypto` to `GLib.Checksum` and `GLib.Hmac`. Your source file stays portable either way, so the same file also builds for `--app node`, where the imports stay as written and Node, Bun and Deno answer them from their own builtins.
+In an `--app gjs` build each import is rewritten to its `@gjsify/*` implementation: `node:fs` to `Gio.File`, `node:http` to `Soup.Server`, `node:crypto` to `GLib.Checksum` and `GLib.Hmac`. The same file also builds for `--app node`, where the imports stay as written and Node, Bun and Deno answer them from their own builtins.
 
 The bare form works too. `import fs from 'fs'` resolves the same way, which is why dependencies written before the `node:` prefix existed keep working unchanged.
 
-## Globals come along for free
+## Globals need no import
 
-`process`, `Buffer`, `URL`, `structuredClone`, `queueMicrotask` and `setImmediate` need no import. An `--app gjs` build scans the bundled output, finds the ones you actually reach, and injects only those. An `--app node` build injects none of them, since Node, Bun and Deno already define them.
+`process`, `Buffer`, `URL`, `structuredClone`, `queueMicrotask` and `setImmediate` are there without one. An `--app gjs` build scans the bundled output, finds the ones you actually reach, and injects only those. An `--app node` build injects none of them, because Node, Bun and Deno already define them.
 
 ```typescript
 const port = Number(process.env.PORT ?? '8080');
@@ -30,7 +30,7 @@ const body = Buffer.from('hello', 'utf-8');
 
 ## Which modules are ready
 
-Three levels of completeness. **Full** means the surface a normal app touches is there. **Partial** means the core works and specific corners are missing (each one is named in the table). **Stub** means the module resolves so a dependency check passes, but does nothing useful.
+Three levels of completeness. **Full** means everything a normal app touches is there. **Partial** means the core works and specific corners are missing, each one named in the table. **Stub** means the module resolves so a dependency check passes, but does nothing useful.
 
 <NodeApiCoverage />
 

--- a/website/src/content/docs/packages/overview.mdx
+++ b/website/src/content/docs/packages/overview.mdx
@@ -19,11 +19,11 @@ app.get('/', (_req: Request, res: Response) => res.type('html').send(html));
 app.listen(8080);
 ```
 
-That file builds and runs on all four runtimes, and nothing in it mentions `@gjsify`. What changes is what the imports resolve to. An `--app gjs` build rewrites `node:fs` to `@gjsify/fs` (backed by `Gio.File`), and every `node:*` import inside `express` and its dependencies goes the same way. An `--app node` build leaves them alone, because Node, Bun and Deno ship those builtins themselves. The details are in [How It Works](/gjsify/how-it-works/).
+That file builds and runs on all four runtimes, and nothing in it mentions `@gjsify`. What changes is what the imports resolve to. An `--app gjs` build rewrites `node:fs` to `@gjsify/fs`, backed by `Gio.File`, and every `node:*` import inside `express` and its dependencies goes the same way. An `--app node` build leaves them alone, because Node, Bun and Deno ship those builtins themselves. [How It Works](/gjsify/how-it-works/) has the details.
 
 ## Install a package from npm
 
-Install it like any other dependency. Each of these installers writes the module layout its own runtime resolves against, so use the one your project is set up for.
+Install it like any other dependency. Each installer writes the module layout its own runtime resolves against, so use the one your project is set up for.
 
 <CommandTabs title="Install express">
   <Fragment slot="gjsify">
@@ -48,7 +48,7 @@ Install it like any other dependency. Each of these installers writes the module
   </Fragment>
 </CommandTabs>
 
-You do not add `@gjsify/fs`, `@gjsify/http` or any other polyfill by hand. `@gjsify/cli` depends on the two umbrella packages `@gjsify/node-polyfills` and `@gjsify/web-polyfills`, so once the CLI is a devDependency of your project (every scaffold from `gjsify create` has it), the whole polyfill set is already resolvable.
+You never add `@gjsify/fs`, `@gjsify/http` or any other polyfill by hand. `@gjsify/cli` depends on two umbrella packages, `@gjsify/node-polyfills` and `@gjsify/web-polyfills`. Once the CLI is a devDependency of your project, and every scaffold from `gjsify create` has it, the whole polyfill set is already resolvable.
 
 ## Import Node.js builtins
 
@@ -65,7 +65,7 @@ The bare form (`import fs from 'fs'`) resolves too, so dependencies written befo
 
 ## Use Web APIs without importing anything
 
-`fetch`, `WebSocket`, `crypto.subtle`, `ReadableStream` and friends are globals, not imports. An `--app gjs` build detects which ones your bundle actually reaches and registers only those. An `--app node` build injects none of them, since Node, Bun and Deno already have them:
+`fetch`, `WebSocket`, `crypto.subtle` and `ReadableStream` are globals, not imports. An `--app gjs` build detects which ones your bundle actually reaches and registers only those. An `--app node` build injects none of them, since Node, Bun and Deno already have them:
 
 ```typescript
 const response = await fetch('https://api.example.com/data');
@@ -122,16 +122,16 @@ These are the things that have no standard bare specifier:
 | Reverse bridge | 1 | [`@gjsify/node-gi`](/gjsify/projects/node-gi/), GObject-Introspection on Node.js, Bun and Deno |
 | Forward bridge | 1 | [`@gjsify/napi`](/gjsify/projects/napi/), native Node.js N-API `.node` addons in GJS |
 
-How much of each pillar is implemented is on [Coverage](/gjsify/coverage/), which renders it from generated data, module by module — one place, checked, rather than a percentage repeated here by hand. The three linked pages enumerate the modules and standards themselves, which is where a count belongs: a rendered list cannot disagree with itself, and a number typed beside it in another page has nothing holding it.
+[Coverage](/gjsify/coverage/) says how much of each row is implemented, module by module, rendered from generated data. No percentage is repeated here by hand: a rendered list cannot disagree with itself, and a number typed beside it on another page has nothing holding it.
 
 <BridgesGrid />
 
 ## Will my dependency work?
 
-The honest answer depends on what it reaches for. Two things help you decide before you try:
+It depends on what it reaches for, and two checks tell you before you try.
 
-- **Check the module list.** If your dependency only touches modules marked Full on the [Node.js](/gjsify/packages/node/) and [Web APIs](/gjsify/packages/web/) pages, it will almost certainly run.
-- **Check the integration suites.** Real npm packages whose own test suites run unmodified against `@gjsify/*` are listed on [Coverage](/gjsify/coverage/): `axios`, `socket.io`, `yargs`, `execa`, `fast-glob`, `cosmiconfig`, `webtorrent`, `acorn` and more. Express, three.js and Excalibur.js run as full [showcases](/gjsify/showcases/).
+- **The module list.** If your dependency only touches modules marked Full on the [Node.js](/gjsify/packages/node/) and [Web APIs](/gjsify/packages/web/) pages, it will almost certainly run.
+- **The integration suites.** [Coverage](/gjsify/coverage/) lists the real npm packages whose own test suites run unmodified against `@gjsify/*`: `axios`, `socket.io`, `yargs`, `execa`, `fast-glob`, `cosmiconfig`, `webtorrent`, `acorn` and more. Express, three.js and Excalibur.js run as full [showcases](/gjsify/showcases/).
 
 If a build fails on a missing global, the error names the identifier and [How It Works](/gjsify/how-it-works/) shows the one-flag fix.
 
@@ -141,4 +141,4 @@ If a build fails on a missing global, the error names the identifier and [How It
 - [Web APIs](/gjsify/packages/web/), the standards that work as globals
 - [DOM & Graphics](/gjsify/packages/dom/), canvas, WebGL, video and iframes inside GTK windows
 - [Versioning](/gjsify/versioning/), how to upgrade `@gjsify/*` safely
-- [Runtimes](/gjsify/runtimes/), the same source on GJS, Node.js, Bun, Deno and the browser
+- [Runtimes](/gjsify/runtimes/), the same source on GJS, Node.js, Bun, Deno, the browser and mobile

--- a/website/src/content/docs/packages/web.mdx
+++ b/website/src/content/docs/packages/web.mdx
@@ -61,7 +61,7 @@ Groups work too (`--globals auto,dom`). The full identifier and group list is in
 | `@gjsify/web-globals` | pure TS | Named re-exports of the common Web classes in one place. Its `/register` subpath sets them all on `globalThis` |
 | `@gjsify/webassembly` | pure TS | `WebAssembly.compile`, `instantiate`, `validate` and the streaming variants, wrapping SpiderMonkey's synchronous constructors |
 | `@gjsify/webaudio` | Gst 1.0, GstApp 1.0 | AudioContext over a GStreamer decodebin and playback chain, AudioBufferSourceNode, GainNode, AudioParam |
-| `@gjsify/webcrypto` | GLib, Gio | SubtleCrypto (AES, AES-KW, RSA-OAEP, RSA-PSS, ECDSA, HMAC, PBKDF2, HKDF, ECDH), CryptoKey, getRandomValues, randomUUID. The primitives come from `node:crypto`, entropy from `/dev/urandom` |
+| `@gjsify/webcrypto` | GLib, Gio | SubtleCrypto (AES, AES-KW, RSA-OAEP, RSA-PSS, ECDSA, HMAC, PBKDF2, HKDF, ECDH), CryptoKey, getRandomValues, randomUUID. The algorithms come from `node:crypto`, entropy from `/dev/urandom` |
 | `@gjsify/webrtc` | Gst 1.0, GstWebRTC 1.0, GstSDP 1.0 | RTCPeerConnection, RTCDataChannel, RTCRtpSender / Receiver / Transceiver, MediaStream, `getUserMedia`, RTCDTMFSender, RTCCertificate. [WebRTC & Media Capture](/gjsify/guides/webrtc/) walks through a data channel, how a capture device gets picked, and the limits worth knowing |
 | `@gjsify/webrtc-native` | Gst 1.0, GstWebRTC 1.0 | Prebuilt signal bridge that `@gjsify/webrtc` uses. You never import it directly |
 | `@gjsify/websocket` | Soup 3.0 | WebSocket, MessageEvent, CloseEvent, with NUL-safe text frames |

--- a/website/src/content/docs/patterns/bridges.mdx
+++ b/website/src/content/docs/patterns/bridges.mdx
@@ -8,8 +8,8 @@ import BridgesGrid from '../../../components/BridgesGrid.astro';
 A bridge is a GTK widget that also behaves like a DOM element. You get a real
 `HTMLCanvasElement` (or `<video>`, or `<iframe>`) whose drawing surface is a GTK widget you
 can mount in any container. Browser-shaped code like `canvas.getContext('webgl')` or
-`video.srcObject = stream` drives the GTK surface directly, with no `WebKit.WebView` wrapper
-and no separate renderer process.
+`video.srcObject = stream` draws straight into the GTK widget, with no `WebKit.WebView`
+wrapper and no separate renderer process.
 
 <BridgesGrid />
 
@@ -20,14 +20,13 @@ They follow the GTK layer rather than one runtime. Build `--app gjs` and the `gi
 below resolve in the `gjs` host itself; build `--app node` and the same source runs on Node,
 Bun and Deno with `gi://` going through [`@gjsify/node-gi`](/gjsify/projects/node-gi/).
 
-That is the shape. How far each bridge is *measured* is a separate question and the answer
-differs per package, so go by the numbers rather than the shape. The headless Canvas 2D core
-(`@gjsify/canvas2d-core`) is measured at 578/578 on Node, Bun and Deno; the GTK-backed
-`@gjsify/canvas2d` at 191/191 on Node. `@gjsify/webgl` and `@gjsify/iframe` run their suites
-on `gjs` and carry no node-family measurement, and `@gjsify/video` ships no suite at all, so
-off `gjs` treat those three as untested rather than promised. The iframe showcases say so in
-their own manifest: they declare `gjs` only, so `gjsify showcase <name> --runtime node`
-refuses them up front instead of crashing.
+How far each bridge is *measured* differs per package, so go by the numbers. The headless
+Canvas 2D core (`@gjsify/canvas2d-core`) is measured at 578/578 on Node, Bun and Deno, and
+the GTK-backed `@gjsify/canvas2d` at 191/191 on Node. `@gjsify/webgl` and `@gjsify/iframe`
+run their suites on `gjs` and carry no node-family measurement, and `@gjsify/video` ships no
+suite at all, so off `gjs` treat those three as untested rather than promised. The iframe
+showcases say so in their own manifest: they declare `gjs` only, so
+`gjsify showcase <name> --runtime node` refuses them up front instead of crashing.
 
 ## The shape of every bridge
 
@@ -167,8 +166,8 @@ bridge.onReady(() => {
 ```
 
 The bridge also warns on stderr once when it detects a software renderer. Treat the string as
-a report, not a capability check: if your app switches renderers, key that on a measured frame
-budget instead.
+a report rather than a capability check. If your app switches renderers, key that on a
+measured frame budget instead.
 
 ## Play video
 

--- a/website/src/content/docs/patterns/gobject-classes.md
+++ b/website/src/content/docs/patterns/gobject-classes.md
@@ -61,9 +61,10 @@ the code stays correct after a rename.
 
 ## Add a property
 
-Properties are GObject `ParamSpec`s, keyed by their kebab-case GObject name. Read and write
-them from JS with the camelCase or snake_case accessor the GObject layer generates for
-them. Both spellings exist on `gjs` and under node-gi, so pick one and stay with it.
+You declare each property as a `ParamSpec`, GObject's description of a property's type,
+range and default, keyed by the property's kebab-case GObject name. Read and write it from
+JS through the camelCase or snake_case accessor the GObject layer generates. Both spellings
+exist on `gjs` and under node-gi, so pick one and stay with it.
 
 ```ts
 class Counter extends GObject.Object {
@@ -96,7 +97,7 @@ Keep the bounds inside the C type. `ParamSpec.int` is a `gint`, so its maximum i
 `GLib-GObject-CRITICAL` on stderr to say why. The same holds for `uint`, `int64` and
 friends.
 
-The full `ParamSpec` surface (`boolean`, `double`, `enum`, `object`, `boxed`, `flags`, …)
+Every other `ParamSpec` kind (`boolean`, `double`, `enum`, `object`, `boxed`, `flags`, …)
 is exercised in
 [`examples/gobject-param-spec`](https://github.com/gjsify/ts-for-gir/tree/main/examples/gobject-param-spec).
 
@@ -122,8 +123,9 @@ this.connect('row-picked', (_self, id: string, index: number) => { /* … */ });
 
 ## Override a vfunc
 
-`vfunc_*` overrides are ordinary instance methods. They can sit anywhere in the class body,
-because they live on the prototype and are not affected by static evaluation order.
+A `vfunc_*` method overrides one of the C class's virtual functions, and it is an ordinary
+instance method. It can sit anywhere in the class body, because it lives on the prototype
+and static evaluation order does not touch it.
 
 ```ts
 class Initable extends GObject.Object {

--- a/website/src/content/docs/platform-support.mdx
+++ b/website/src/content/docs/platform-support.mdx
@@ -74,11 +74,11 @@ full Adwaita storybook against that bundle.
 
 Web views reach Windows too. `@gjsify/webview2-native` supplies a `WebKit-6.0`
 namespace backed by Microsoft's WebView2, so the code that embeds a page on Linux
-embeds one here unchanged. What decides whether you can build on it: the view is
-an overlay the OS composites on top of your window, so no ancestor can clip or
-scroll it; the WebView2 Evergreen runtime has to be present on the end user's
-machine, which is your installer's job to declare; and the view has been proven
-headlessly rather than re-parented under a real application window.
+embeds one here unchanged. Three things decide whether you can build on it. The
+view is an overlay the OS composites on top of your window, so no ancestor can
+clip or scroll it. The WebView2 Evergreen runtime has to be present on the end
+user's machine, which your installer has to declare. And the view has been proven
+headlessly, not re-parented under a real application window.
 [Web Views](/gjsify/guides/web-views/) has each of those in full.
 
 Two host settings are worth getting right before you start, because both fail in
@@ -102,14 +102,14 @@ skipped.
 `--app node` is fully supported: builds, conformance and a real GTK/Adwaita
 window are all exercised on Apple silicon, and `@gjsify/gtk-runtime-darwin-arm64`
 ships the GTK 4 / Adwaita closure so you do not need a Homebrew GTK. Intel Macs
-get the same treatment against `@gjsify/gtk-runtime-darwin-x64`: the same builds,
-the same display-free conformance and the same windowed GUI proof, each one a
-matrix leg beside its Apple-silicon twin rather than a reduced substitute.
+get the same against `@gjsify/gtk-runtime-darwin-x64`: the same builds, the same
+display-free conformance, the same windowed GUI proof, each one a matrix leg
+beside its Apple-silicon twin rather than a reduced substitute.
 
 Web views come with the package here. `@gjsify/webkit-native` puts Apple's WebKit
-behind the same `WebKit-6.0` namespace `@gjsify/iframe` uses on Linux, so there is
-no WebKitGTK to hunt for — upstream's GTK port is Linux-only by decision — and
-nothing in your code changes. The minimum deployment target is macOS 11, and a few
+behind the same `WebKit-6.0` namespace `@gjsify/iframe` uses on Linux, so nothing
+in your code changes and there is no WebKitGTK to hunt for. Upstream's GTK port is
+Linux-only by decision. The minimum deployment target is macOS 11, and a few
 page-level behaviours differ (document focus, the pointer cursor);
 [Web Views](/gjsify/guides/web-views/) names them.
 

--- a/website/src/content/docs/projects/napi.md
+++ b/website/src/content/docs/projects/napi.md
@@ -3,9 +3,9 @@ title: napi
 description: Load native Node.js N-API addons (.node) inside GJS, so a GJS app can use a database driver or codec straight from npm.
 ---
 
-[`@gjsify/napi`](https://github.com/gjsify/gjsify/tree/main/packages/napi/napi) lets a GJS app use native npm addons. A compiled `.node` file, the exact binary you would `require()` on Node, loads and runs unchanged under GJS.
+[`@gjsify/napi`](https://github.com/gjsify/gjsify/tree/main/packages/napi/napi) lets a GJS app use native npm addons. A compiled `.node` file, the exact binary you would `require()` on Node, loads and runs unchanged under GJS. It is experimental, and five real npm addons pass its golden-diff harness against Node today.
 
-You care about this if the library you need exists on npm as a native addon and you don't want to reimplement it in pure JavaScript. A database driver, a hashing library, a codec: install it, import it, and it works in a `gjsify build --app gjs` build with no wrapper on your side.
+You want it if the library you need exists on npm as a native addon and you would rather not reimplement it in pure JavaScript. A database driver, a hashing library, a codec: install it, import it, and it works in a `gjsify build --app gjs` build with no wrapper on your side.
 
 It is not a way to talk to GObject libraries. On GJS the native [`gi://`](/gjsify/patterns/gobject-classes/) binding stays the way to use GTK, GLib and everything else introspected, and you should always prefer it.
 
@@ -57,23 +57,23 @@ A golden-diff harness runs a deterministic workout of each addon on Node (the re
 | [`@node-rs/argon2`](https://github.com/napi-rs/node-rs) | Rust, napi-rs | synchronous | ✅ byte-identical |
 | [`node-sqlite3`](https://github.com/TryGhost/node-sqlite3) | C++, node-addon-api | **asynchronous** | ✅ byte-identical |
 
-Those are C, C++ and Rust addons emitted by three different N-API code generators, which is good evidence that an arbitrary *synchronous* addon runs unmodified. `node-sqlite3` additionally drives the async surface (`napi_async_work` plus threadsafe functions), so asynchronous `node-addon-api` packages are reachable too, not only the sync subset.
+Those are C, C++ and Rust addons emitted by three different N-API code generators, which is good evidence that an arbitrary *synchronous* addon runs unmodified. `node-sqlite3` also drives the async side (`napi_async_work` plus threadsafe functions), so asynchronous `node-addon-api` packages are reachable too, not only the sync subset.
 
 ### Scope
 
-The full synchronous N-API surface is implemented, plus the async and threadsafe-function group. `napi_async_work` runs each addon's `execute` callback on a `GThreadPool` worker (sized after `UV_THREADPOOL_SIZE`, as libuv does) and marshals `complete` back onto the GLib main context, so async addons get real concurrency.
+The whole synchronous N-API is implemented, plus the async and threadsafe-function group. `napi_async_work` runs each addon's `execute` callback on a `GThreadPool` worker (sized after `UV_THREADPOOL_SIZE`, as libuv does) and marshals `complete` back onto the GLib main context, so async addons get real concurrency.
 
-A few Node-specific corners stay stubbed because they have no engine-agnostic meaning on GJS, most notably `napi_get_uv_event_loop`: GJS has no libuv loop, the GLib main context is the loop.
+A few Node-specific corners stay stubbed because they have no engine-agnostic meaning on GJS. The clearest is `napi_get_uv_event_loop`: GJS has no libuv loop, the GLib main context is the loop.
 
 ### Platforms
 
 Prebuilt and CI-validated on **Linux x86_64** and **macOS arm64**, the same GJS and mozjs-140 pairing on both. Both prebuilds are rebuilt from the released source on every release and ship as optional dependencies (`@gjsify/napi-linux-x64`, `@gjsify/napi-darwin-arm64`), each carrying a `.so` or `.dylib` plus its `.gir` and `.typelib`.
 
-**Windows** is groundwork only. The loader and build wiring exist behind a manual CI job, but it is blocked upstream: the shim links GJS's SpiderMonkey, and no prebuilt `libgjs` for Windows exists yet. The [package README](https://github.com/gjsify/gjsify/tree/main/packages/napi/napi#readme) has the platform matrix.
+**Windows** is groundwork only. The loader and build wiring exist behind a manual CI job, but it is blocked upstream. The shim links GJS's SpiderMonkey, and no prebuilt `libgjs` for Windows exists yet. The [package README](https://github.com/gjsify/gjsify/tree/main/packages/napi/napi#readme) has the platform matrix.
 
 ## How it works
 
-Node-API is an engine-agnostic C ABI: the same `.node` binary already runs on Node, Deno and Bun. `@gjsify/napi` implements that ABI once more, over GJS's SpiderMonkey engine. The shim ships as a GObject-Introspection package (`.so` plus `.gir` plus `.typelib`), so GJS loads it through `imports.gi` like any other GI library, and it exposes `loadAddon(path)` to `dlopen` an addon and bind its `napi_*` symbols to the shim's implementation.
+Node-API is an engine-agnostic C ABI, which is why the same `.node` binary already runs on Node, Deno and Bun. `@gjsify/napi` implements that ABI once more, over GJS's SpiderMonkey engine. The shim ships as a GObject-Introspection package (`.so` plus `.gir` plus `.typelib`), so GJS loads it through `imports.gi` like any other GI library, and it exposes `loadAddon(path)` to `dlopen` an addon and bind its `napi_*` symbols to the shim's implementation.
 
 Your addon is built the normal way, with node-gyp or prebuilds. Nothing about it changes. The work is all on the shim side, and two pieces of it are worth knowing about:
 
@@ -82,7 +82,7 @@ Your addon is built the normal way, with node-gyp or prebuilds. Nothing about it
 
 ### How the import gets rewritten
 
-For `--app gjs` builds, a bundler plugin (`napiNodeAddonPlugin`) intercepts the addon's own acquisition helper and routes the compiled `.node` through `loadAddon`. It handles the four conventions a bundler can actually see: a direct `.node` import, `node-gyp-build`, `bindings`, and a napi-rs generated loader.
+For `--app gjs` builds, a bundler plugin (`napiNodeAddonPlugin`) intercepts the addon's own acquisition helper and routes the compiled `.node` through `loadAddon`. It handles the four conventions a bundler can see: a direct `.node` import, `node-gyp-build`, `bindings`, and a napi-rs generated loader.
 
 For the `node-gyp-build` and `bindings` cases it locates the binary with node-gyp-build's own probe order (`build/Release`, then `build/Debug`, then `prebuilds/`), so the GJS build loads the same file Node would. For a napi-rs package it replaces the generated loader module wholesale, because that module's `createRequire` body does not survive bundling. Detection is conservative and falls through to normal resolution when it isn't sure. The plugin is always on for `--app gjs` and does nothing when no native addon is in the graph.
 

--- a/website/src/content/docs/projects/node-gi.md
+++ b/website/src/content/docs/projects/node-gi.md
@@ -3,9 +3,9 @@ title: node-gi
 description: Run unchanged gi:// and GObject code on Node.js, Bun and Deno. The reverse bridge, so one source builds for GJS and for every Node-API runtime.
 ---
 
-[`@gjsify/node-gi`](https://github.com/gjsify/gjsify/tree/main/packages/node-gi/node-gi) runs the rest of gjsify backwards. Instead of bringing Node and Web APIs to GJS, it brings GObject Introspection to Node.js, Bun and Deno, so the same unchanged `gi://` source runs natively under GJS *and* on every Node-API runtime.
+[`@gjsify/node-gi`](https://github.com/gjsify/gjsify/tree/main/packages/node-gi/node-gi) runs the rest of gjsify backwards. Instead of bringing Node and Web APIs to GJS, it brings GObject Introspection to Node.js, Bun and Deno, so one unchanged `gi://` source runs natively under GJS *and* on every Node-API runtime. CI gates it on Linux, macOS and Windows, GUI apps included.
 
-You care about this if your GTK app, or a library that talks to GLib, should run on Node.js, Bun or Deno. Three common reasons: you already work in one of those runtimes and would rather stay in it; you are shipping to Windows, which has no GJS host at all ([Platform Support](/gjsify/platform-support/) explains why); or you want a test suite or a headless tool on the runtime your CI already has. If you build only for GJS you can skip this page, and nothing on the GJS side depends on node-gi at runtime.
+You want it if your GTK app, or a library that talks to GLib, should run on Node.js, Bun or Deno. Three common reasons: you already work in one of those runtimes and would rather stay in it; you are shipping to Windows, which has no GJS host at all ([Platform Support](/gjsify/platform-support/) explains why); or you want a test suite or a headless tool on the runtime your CI already has. Building only for GJS? Skip this page. Nothing on the GJS side depends on node-gi at runtime.
 
 :::note[Stability]
 node-gi is tested and released with every gjsify release, and real consumers exercise it. It is still a younger part of the framework than the GJS side, so a breaking change occasionally ships in a minor release, always with a changelog note. Details in the [stability model](/gjsify/versioning/#how-much-stability-to-expect).
@@ -18,7 +18,7 @@ gjsify build app.ts --app gjs    → gjs                dist/app.gjs.mjs   (nati
 gjsify build app.ts --app node   → node | bun | deno  dist/app.node.mjs  (@gjsify/node-gi)
 ```
 
-The bundler keeps `gi://` imports native for the GJS target and rewrites them onto the node-gi runtime for the Node target. Because node-gi is a Node-API addon, the *same* `--app node` bundle runs on Node, Bun and Deno: Node-API is their shared native ABI, so there is no separate `--app deno` or `--app bun` target and no second binding to maintain.
+The bundler keeps `gi://` imports native for the GJS target and rewrites them onto the node-gi runtime for the Node target. Because node-gi is a Node-API addon, the *same* `--app node` bundle runs on Node, Bun and Deno. Node-API is their shared native ABI, so there is no separate `--app deno` or `--app bun` target and no second binding to maintain.
 
 ```ts
 // The same file for gjs, node, bun and deno.
@@ -37,7 +37,7 @@ print(file.get_basename()); // "share"
 
 One Node-API binary loads on all three runtimes. `index.js` detects the runtime and prefers a shipped `prebuilds/<platform>-<arch>/` binary. Deno runs no postinstall build, so a prebuild is its only install path.
 
-GJS is the reference implementation, with native `gi://`. That is a statement about the test rig: the conformance harness runs each program on all four runtimes and diffs the other three against the GJS output byte for byte, so "reference" means "the expected answer here", not "the runtime to choose". Against it:
+GJS is the reference implementation, with native `gi://`. That is a statement about the test rig. The conformance harness runs each program on all four runtimes and diffs the other three against the GJS output byte for byte, so "reference" means "the expected answer here", not "the runtime to choose". Against it:
 
 | Capability | Node | Bun | Deno |
 |---|:--:|:--:|:--:|
@@ -51,7 +51,7 @@ GJS is the reference implementation, with native `gi://`. That is a statement ab
 | the runtime's own timers and I/O alive *during* a blocking GLib loop | ✅ | ✗ | ✗ |
 | GTK / Adwaita GUI apps | ✅ | ✅ | ✅ |
 
-The last gap is by design rather than unfinished. On Node, a libuv-to-GLib bridge nests the two loops, so a blocking GLib loop keeps Node's timers running. Bun and Deno have no usable libuv to hook, so they get a portable pump that iterates the default GLib context from a runtime timer. Either way you don't call anything: loading a namespace arms whichever mechanism the runtime needs, and `await`ing a Gio async call works with no explicit main loop.
+The last gap is by design rather than unfinished. On Node, a libuv-to-GLib bridge nests the two loops, so a blocking GLib loop keeps Node's timers running. Bun and Deno have no usable libuv to hook, so they get a portable pump that iterates the default GLib context from a runtime timer. Either way you call nothing. Loading a namespace arms whichever mechanism the runtime needs, and `await`ing a Gio async call works with no explicit main loop.
 
 GUI support is portable because a blocking `Gtk.Application.run()` is driven by GLib, not by the host's event loop. A real `Gtk.Application` builds an Adwaita window (`Adw.ToolbarView`, `Adw.HeaderBar`, `Adw.StatusPage`), applies a `Gtk.CssProvider` and exits 0 on gjs, node, bun and deno. CI gates that on all of them under xvfb, and the conformance oracle (a port of GJS's own `GIMarshallingTests`) runs byte-identical across the four.
 
@@ -64,10 +64,10 @@ A GTK app driven through node-gi intermittently logs `Gtk-CRITICAL **: gtk_event
 The operating system axis is separate from the runtime axis above, and `prebuilds/<platform>-<arch>/` carries a binary per platform *and* arch. What CI proves, named rather than generalised:
 
 - **Linux.** The full path: native `gi://` on GJS plus node-gi on Node, Bun and Deno, GTK and Adwaita GUIs, and the whole conformance suite against the system GTK.
-- **macOS, Apple silicon and Intel.** node-gi builds and passes the display-free conformance suite on Node, Bun and Deno, and the GTK GUI renders (render to texture, no visible desktop): an `Adw.ApplicationWindow` realizes, renders and reacts to input. [`@gjsify/gtk-runtime-darwin-arm64`](https://www.npmjs.com/package/@gjsify/gtk-runtime-darwin-arm64) and [`@gjsify/gtk-runtime-darwin-x64`](https://www.npmjs.com/package/@gjsify/gtk-runtime-darwin-x64) ship a prebuilt GTK 4 and Adwaita closure, so no system GTK and no Homebrew are required. CI proves that on runners where GTK was never installed.
+- **macOS, Apple silicon and Intel.** node-gi builds and passes the display-free conformance suite on Node, Bun and Deno, and the GTK GUI renders to texture with no visible desktop: an `Adw.ApplicationWindow` realizes, renders and reacts to input. [`@gjsify/gtk-runtime-darwin-arm64`](https://www.npmjs.com/package/@gjsify/gtk-runtime-darwin-arm64) and [`@gjsify/gtk-runtime-darwin-x64`](https://www.npmjs.com/package/@gjsify/gtk-runtime-darwin-x64) ship a prebuilt GTK 4 and Adwaita closure, so no system GTK and no Homebrew are required. CI proves that on runners where GTK was never installed.
 - **Windows, x64.** node-gi builds with MSVC and gvsbuild, and passes the display-free conformance suite on Node. Beyond that, the GTK GUI renders and the full Libadwaita Storybook renders, both proven in CI. [`@gjsify/gtk-runtime-win32-x64`](https://www.npmjs.com/package/@gjsify/gtk-runtime-win32-x64) ships the prebuilt GTK 4 and Adwaita closure, so no gvsbuild is needed to consume it.
 
-So the operating system decides how much choice you have. On Linux both paths are open: native `gi://` under GJS, and node-gi under Node, Bun and Deno. On macOS `--app node` is the supported path, and on Windows it is the only one, since there is no GJS host there. The per-package matrix is in [Platform Support](/gjsify/platform-support/).
+So the operating system decides how much choice you have. On Linux both paths are open, native `gi://` under GJS and node-gi under Node, Bun and Deno. On macOS `--app node` is the supported path, and on Windows it is the only one, since there is no GJS host there. The per-package matrix is in [Platform Support](/gjsify/platform-support/).
 
 ## Getting started
 
@@ -77,11 +77,11 @@ npm install @gjsify/node-gi
 
 To build the native addon you need a C++ toolchain (or the shipped prebuild for your platform) and the GLib 2.80 or newer development headers that expose `girepository-2.0`. At runtime you need the typelibs of the libraries you import, the same requirement `gi://` has under GJS. On macOS and Windows the `@gjsify/gtk-runtime-*` package covers that instead, bundling the GTK 4 and Adwaita closure so there is no system GTK to install.
 
-On Deno, run the bundle with `deno run -A --node-modules-dir=manual` so it uses the `node_modules` you already installed. Under `--node-modules-dir=auto` Deno re-resolves the whole build-time dependency tree, including platform binaries nothing at runtime imports, and that either hangs or needs registry access you may not have. The [package README](https://github.com/gjsify/gjsify/tree/main/packages/node-gi/node-gi#readme) covers requirements and install; the [GJS-compatible surface reference](https://github.com/gjsify/gjsify/blob/main/docs/node-gi-gjs-surface.md) has the full API, and the [platform notes](https://github.com/gjsify/gjsify/blob/main/docs/node-gi-platform-notes.md) the rest of the Deno notes.
+On Deno, run the bundle with `deno run -A --node-modules-dir=manual` so it uses the `node_modules` you already installed. Under `--node-modules-dir=auto` Deno re-resolves the whole build-time dependency tree, including platform binaries nothing at runtime imports, and that either hangs or needs registry access you may not have. The [package README](https://github.com/gjsify/gjsify/tree/main/packages/node-gi/node-gi#readme) covers requirements and install. The [GJS-compatibility reference](https://github.com/gjsify/gjsify/blob/main/docs/node-gi-gjs-surface.md) has the full API, and the [platform notes](https://github.com/gjsify/gjsify/blob/main/docs/node-gi-platform-notes.md) carry the rest of the Deno detail.
 
 ## How it works
 
-Two libuv-coupled subsystems were made portable so one binary spans every runtime:
+Two libuv-coupled subsystems had to become portable before one binary could span every runtime:
 
 - **The GC bridge.** The toggle-ref teardown drain uses a Node-API `napi_threadsafe_function` rather than a raw `uv_async_t`, because Deno exports no libuv symbols and Bun does not implement `uv_async_init`.
 - **The main loop.** Node keeps the uv-nesting bridge that co-pumps its event loop during a blocking GLib loop. Bun and Deno iterate the default GLib context from a runtime timer instead, so GIO async callbacks, GLib timeouts and DBus fire while the runtime's own loop stays live.
@@ -90,7 +90,7 @@ The native engine is derived from [node-gtk](https://github.com/romgrk/node-gtk)
 
 ## How it is tested
 
-The [example](https://github.com/gjsify/gjsify/tree/main/packages/node-gi/example) is the capstone: several deterministic `gi://` sources each build `--app gjs` and `--app node`, then run under GJS, Node, Bun and Deno, with the harness asserting byte-identical output on every one and GJS as the reference. The GJS output is not taken on trust either: where a scenario carries a committed golden file, GJS is diffed against that first, and only then do the other three get compared to it. It runs in CI on Fedora across all four.
+The [example](https://github.com/gjsify/gjsify/tree/main/packages/node-gi/example) is the capstone. Several deterministic `gi://` sources each build `--app gjs` and `--app node`, then run under GJS, Node, Bun and Deno, and the harness asserts byte-identical output on every one, with GJS as the reference. The GJS output is not taken on trust either: where a scenario carries a committed golden file, GJS is diffed against that first, and only then do the other three get compared to it. It runs in CI on Fedora across all four.
 
 Nine `@gjsify/*` packages also run their own test suites through node-gi in CI: `sqlite`, `http2`, `zlib`, `tls`, `ws`, `dom-elements`, `node-globals`, `crypto` and `string_decoder`. That is what keeps the bridge honest against real consumer code rather than against tests written for it.
 

--- a/website/src/content/docs/projects/ts-for-gir.md
+++ b/website/src/content/docs/projects/ts-for-gir.md
@@ -3,9 +3,9 @@ title: ts-for-gir
 description: The generator behind the @girs/* TypeScript types, so gi:// imports get autocomplete, jump-to-definition and type-checking across the GNOME stack.
 ---
 
-When you type `Gtk.Button` in a gjsify app and get autocomplete, a signal signature and jump-to-definition, that comes from [ts-for-gir](https://github.com/gjsify/ts-for-gir). It reads GObject Introspection `.gir` XML and emits `.d.ts` declarations for GLib, Gio, GTK, GStreamer, libadwaita, WebKit and around 700 other modules on the GNOME stack.
+When you type `Gtk.Button` in a gjsify app and get autocomplete, a signal signature and jump-to-definition, that comes from [ts-for-gir](https://github.com/gjsify/ts-for-gir). It reads GObject Introspection `.gir` XML and emits `.d.ts` declarations for GLib, Gio, GTK, GStreamer, libadwaita, WebKit and around 700 other modules on the GNOME stack. Most of the time you never run it: the declarations are published as the `@girs/*` npm packages, and `gjsify create` already puts the ones its templates need into your `package.json`.
 
-Most of the time you never run it. The declarations are published as the `@girs/*` npm packages, and `gjsify create` already puts the ones its templates need into your `package.json`. You come here for three reasons: the module you want has no published package, you are on a GNOME version the published types do not cover, or you want types generated from your own `.gir` files.
+You come here for three reasons: the module you want has no published package, you are on a GNOME version the published types do not cover, or you want types generated from your own `.gir` files.
 
 It is also usable on its own. Plenty of GJS projects that never touch gjsify install `@girs/*` for the types alone.
 
@@ -24,7 +24,7 @@ gjsify dlx @ts-for-gir/cli list
 gjsify dlx @ts-for-gir/cli generate Gtk-4.0
 ```
 
-`gjsify dlx` fetches the package into a content-addressed cache under `$XDG_CACHE_HOME/gjsify/dlx/`, runs its GJS bundle, and reuses the cache next time you ask for the same spec. The cache expires after seven days; pass `--cache-max-age 0` to force a refresh now.
+`gjsify dlx` fetches the package into a content-addressed cache under `$XDG_CACHE_HOME/gjsify/dlx/`, runs its GJS bundle, and reuses the cache next time you ask for the same spec. The cache expires after seven days. Pass `--cache-max-age 0` to force a refresh now.
 
 **Managed global install through the gjsify CLI:**
 
@@ -93,7 +93,7 @@ ts-for-gir analyze -f ./ts-for-gir-report.json
 ts-for-gir --help                            # the full surface
 ```
 
-`--reporter` writes a JSON file (`ts-for-gir-report.json` by default) listing every unresolved type, version conflict and skipped construct. `ts-for-gir analyze -f <report>` turns that into a readable summary, and it takes filters so you can narrow down:
+`--reporter` writes a JSON file (`ts-for-gir-report.json` by default) listing every unresolved type, version conflict and skipped construct. `ts-for-gir analyze -f <report>` turns that into a readable summary, and it takes filters:
 
 ```bash
 ts-for-gir analyze -f ./ts-for-gir-report.json --severity error critical
@@ -126,15 +126,15 @@ All of them are listed at [github.com/gjsify/types](https://github.com/gjsify/ty
 Two pages on this site document the idioms the generated declarations expect:
 
 - [GObject classes](/gjsify/patterns/gobject-classes/) covers the `GObject.registerClass()` forms, the static-block pattern, init-order rules, and the `static override $gtype` declaration that narrows the inherited `$gtype`.
-- [Bridge widgets](/gjsify/patterns/bridges/) covers how `Canvas2DBridge`, `WebGLBridge`, `IFrameBridge` and `VideoBridge` pair a polyfill DOM element with a real GTK widget, so browser-shaped code drives the GTK surface directly.
+- [Bridge widgets](/gjsify/patterns/bridges/) covers how `Canvas2DBridge`, `WebGLBridge`, `IFrameBridge` and `VideoBridge` pair a polyfill DOM element with a real GTK widget, so browser-shaped code drives the GTK widget directly.
 
 ## How the CLI itself is built
 
 `@ts-for-gir/cli` is built with gjsify, twice. `gjsify build --app node` produces the executable `bin/ts-for-gir` you get from npm, and `gjsify build --app gjs` produces `bin/ts-for-gir-gjs`, the GJS bundle that `gjsify dlx @ts-for-gir/cli` runs. That second bundle is why the Node-free install paths above work at all.
 
-The Node bundle keeps its heavier runtime dependencies (`typedoc`, `ejs`, `yargs`, `inquirer` and friends) external and installs them from npm as usual; the GJS bundle inlines everything, because there is no npm install step on that path.
+The Node bundle keeps its heavier runtime dependencies (`typedoc`, `ejs`, `yargs`, `inquirer` and friends) external and installs them from npm as usual. The GJS bundle inlines everything, because there is no npm install step on that path.
 
-Both are executable directly, with the shebang written by the build rather than by a wrapper script. If you are curious how a bundle keeps finding its own data files after a global install, that is covered in [How It Works](/gjsify/how-it-works/#location-independent-bundles).
+Both are executable directly, with the shebang written by the build rather than by a wrapper script. How a bundle keeps finding its own data files after a global install is covered in [How it works](/gjsify/how-it-works/#location-independent-bundles).
 
 ## What is in the repository
 

--- a/website/src/content/docs/runtimes.md
+++ b/website/src/content/docs/runtimes.md
@@ -15,6 +15,15 @@ gjsify build src/index.ts --app browser  # a web build of the same source
 Your source stays the same. What changes is which implementation each import
 resolves to.
 
+Every code sample on this site follows that rule, so read them as runtime-neutral
+even where they name one. The TypeScript in the [widget gallery](/gjsify/adwaita/)
+is written for GJS and runs unchanged on Node.js, Bun and Deno, because `gi://Adw`
+is the same import on all four. Two further targets answer those same `Adw.*` and
+`Gtk.*` names from a port instead of from libadwaita: `--app browser` through
+`@gjsify/adwaita-web`, and `--app nativescript` through
+`@gjsify/adwaita-nativescript`, on a phone. The widget you learn once keeps its
+name in all five places. What changes is the host around it.
+
 Start from the runtime you already have:
 
 | You run | Build target | `gi://` is resolved by | Operating systems |
@@ -46,7 +55,7 @@ is. [Platform Support](/gjsify/platform-support/) has that picture.
 
 GJS is GNOME's own JavaScript runtime, SpiderMonkey plus GObject introspection.
 It resolves `gi://Gtk?version=4.0` itself, so a GTK call from your code enters
-libgtk with nothing bridging in between, and GNOME ships GJS, so a GNOME desktop
+libgtk with nothing bridging in between. GNOME ships GJS, so a GNOME desktop
 already has the runtime installed.
 
 The build rewrites `node:*` imports and Web globals to gjsify's implementations,
@@ -58,14 +67,13 @@ gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js
 gjsify run dist/index.gjs.js
 ```
 
-You need `gjs` 1.86 or newer. Linux distributions ship it; on macOS it comes
-from Homebrew, where only part of the surface is verified; there is no GJS build
-for Windows.
-[Packages](/gjsify/packages/overview/) lists what is implemented.
+You need `gjs` 1.86 or newer. Linux distributions ship it. On macOS it comes
+from Homebrew, where only part of it is verified, and there is no GJS build for
+Windows. [Packages](/gjsify/packages/overview/) lists what is implemented.
 
 Two things are specific to this target. A `.deb` or `.rpm` built from a GJS app
 depends on the distribution's own `gjs (>= 1.86)` rather than carrying an
-interpreter, which is what keeps those packages small — see
+interpreter, which is what keeps those packages small; see
 [Ship your app](/gjsify/ship/). And a showcase's published artifact is its
 `--app gjs` bundle (`gjsify.main`), which is why `gjsify showcase` runs on GJS
 when a `gjs` binary is on PATH and follows the host runtime when there is none.
@@ -95,7 +103,7 @@ Homebrew GTK to install first.
 What differs between the three:
 
 - **Node.js** is the one with a declared engine floor: `@gjsify/node-gi` asks for
-  Node 20 or newer. It is also the widest tested of the three — on Linux it
+  Node 20 or newer. It is also the widest tested of the three. On Linux it
   carries the full GTK, Adwaita, windowing, widget, GtkSourceView and template
   checks.
 - **Bun** installs with `bun add` and writes its own module layout. Tracked at
@@ -134,7 +142,7 @@ there is no bridge and no engine floor to check. Every package declares what it
 provides here in its `gjsify.runtimes.browser` slot, the same way it declares its
 `gjs`, `node` and `nativescript` slots, and that declaration is held against what
 the source actually imports rather than taken on trust. The bundles themselves
-are driven on Firefox, which shares the SpiderMonkey engine with GJS; what that
+are driven on Firefox, which shares the SpiderMonkey engine with GJS. What that
 checks is our implementation claims against the real browser platform, not our
 GJS packages inside a browser.
 
@@ -143,22 +151,27 @@ GJS packages inside a browser.
 `gjsify build --app nativescript` produces bundles for the NativeScript
 toolchain, and `@gjsify/adwaita-nativescript` implements the Adwaita widget set,
 the storybook renderer and the devtools agent as real native Android and iOS
-views (not a WebView). The widget packages ship with every gjsify release; the
+views, not a WebView. The widget packages ship with every gjsify release. The
 runtime target itself is still experimental, so treat it as something to try
 rather than something to ship.
 
-## What keeps the four in step
+## What keeps the runtimes in step
 
 The same small `gi://` programs are run unchanged on gjs, node, bun and deno, and
 every runtime's output has to match GJS's byte for byte. GJS is the reference
 because it is the one implementation we did not write: a drift on either side
 fails the release, whether it came from the bridge or from a GJS change. Nothing
-is quietly excluded — the combinations known not to match are written down,
-by name, with the reason.
+is quietly excluded. The combinations known not to match are written down, by
+name, with the reason.
 
 Above that, each package's own test bundle is built once, engine-agnostic, and
 run as that same file on Node, Bun and Deno. The three cannot drift apart without
 the release stopping.
+
+The web and NativeScript ports are held a second way, because they are ports
+rather than the same code: they share one behaviour layer with each other, and
+both assert against the same recorded vectors, so a fix to a toast queue or a
+spin-button clamp lands in both at once.
 
 ## Pick a runtime for a single command
 
@@ -197,8 +210,8 @@ that usually decide it:
   and Deno it goes through `@gjsify/node-gi`, which means a native addon in your
   dependency tree and a prebuilt binary per platform.
 - **Distribution.** `gjsify ship` turns a built app into an installable artifact
-  with no packaging files in your repo — Linux packages from a GJS build, and
-  macOS and Windows artifacts from a `--app node` one, since those two carry
+  with no packaging files in your repo. Linux packages come from a GJS build, and
+  the macOS and Windows artifacts from a `--app node` one, since those two carry
   their own interpreter and GTK. [Ship your app](/gjsify/ship/) has the formats.
 - **The web.** `--app browser` drops native code entirely, which is what makes it
   portable and also what rules out the GNOME libraries: anything backed by GTK,
@@ -214,7 +227,7 @@ that usually decide it:
 
 - [Platform Support](/gjsify/platform-support/): Linux, macOS and Windows, per target
 - [Packages](/gjsify/packages/overview/): what is implemented on each runtime
-- [Coverage](/gjsify/coverage/): live dashboards of the implemented surface
+- [Coverage](/gjsify/coverage/): live dashboards of what is implemented
 - [node-gi](/gjsify/projects/node-gi/): the bridge that puts GObject on Node.js
 - [napi](/gjsify/projects/napi/): the other direction, native `.node` addons inside GJS
 - [How It Works](/gjsify/how-it-works/): the build pipeline behind the `--app` flag

--- a/website/src/content/docs/runtimes.md
+++ b/website/src/content/docs/runtimes.md
@@ -1,6 +1,6 @@
 ---
 title: Runtimes
-description: "Where your gjsify code can run: GJS, Node.js, Bun, Deno and the browser, and how to choose between them."
+description: "Where your gjsify code can run: GJS, Node.js, Bun, Deno, the browser and mobile, and how to choose between them."
 ---
 
 gjsify targets four JavaScript runtimes, and one flag decides which build you
@@ -17,12 +17,14 @@ resolves to.
 
 Every code sample on this site follows that rule, so read them as runtime-neutral
 even where they name one. The TypeScript in the [widget gallery](/gjsify/adwaita/)
-is written for GJS and runs unchanged on Node.js, Bun and Deno, because `gi://Adw`
-is the same import on all four. Two further targets answer those same `Adw.*` and
-`Gtk.*` names from a port instead of from libadwaita: `--app browser` through
-`@gjsify/adwaita-web`, and `--app nativescript` through
-`@gjsify/adwaita-nativescript`, on a phone. The widget you learn once keeps its
-name in all five places. What changes is the host around it.
+is written for GJS, and it runs unchanged on Node.js, Bun and Deno. `gi://Adw` is
+the same import on all four.
+
+Two further targets answer those same `Adw.*` and `Gtk.*` names from a port rather
+than from libadwaita. Add `--gi-renderer` to the build, and `--app browser`
+resolves `gi://Adw` out of `@gjsify/adwaita-web`, `--app nativescript` out of
+`@gjsify/adwaita-nativescript`, on a phone. So the widget you learn once keeps its
+name in five places. What changes is the host around it.
 
 Start from the runtime you already have:
 

--- a/website/src/content/docs/ship/index.mdx
+++ b/website/src/content/docs/ship/index.mdx
@@ -37,9 +37,9 @@ one payload under `ship/stage/`, and wraps that payload once per format into
 
 ## One command per operating system
 
-`gjsify ship <os>` names whose layout to assemble. A bare `gjsify ship`
-assembles the layout of the host you are sitting at, so name the operating
-system whenever you want one you are not on.
+`gjsify ship <os>` says which layout to assemble. A bare `gjsify ship` assembles
+the layout of the host you are on, so name the operating system when you want a
+different one.
 
 | Command | What lands in `ship/out/` | That target runs |
 |---|---|---|
@@ -47,15 +47,14 @@ system whenever you want one you are not on.
 | `gjsify ship darwin` | `My App.app`, `my-app-1.2.3-1.arm64.zip` | `node` |
 | `gjsify ship windows` | `My App/`, `my-app-1.2.3-1.x64.zip` | `node` |
 
-Each target's runtime is its own: `gjsify.ship.app.<os>`, keyed `linux`,
-`darwin`, `win32`, falling back to `gjsify.app`. So one project can be GJS on
-Linux and Node where no GJS exists, and stating the second half does not restate
-the first — before that key, asking for a `.app` moved the Linux package's
-`Depends:` with it.
+Each target picks its own runtime from `gjsify.ship.app.<os>`, keyed `linux`,
+`darwin` and `win32`, falling back to `gjsify.app`. So one project can be GJS on
+Linux and Node where no GJS exists. Before that key existed, asking for a `.app`
+moved the Linux package's `Depends:` with it.
 
 Assembling is never host-bound, so one workstation produces all three artifact
-sets. Packing is a different question, and two formats out of nine answer it
-differently. See [where each format can be packed](#where-each-format-can-be-packed).
+sets. Packing is another matter: two of the nine formats need a particular host.
+See [where each format can be packed](#where-each-format-can-be-packed).
 
 A Linux package declares its interpreter and its GTK libraries as dependencies
 and takes them from the distribution. The macOS bundle and the Windows program
@@ -145,12 +144,12 @@ gjsify ship darwin --stage --target macos-app,macos-app-zip,macos-app-dmg
 gjsify ship --from-stage ./stage --target macos-app-dmg
 ```
 
-`--stage` writes the payload and stops, plus `ship/stage/.gjsify-ship-stage.json`
-beside it. That file records the file modes, the pre-rendered licence overlays,
-the GI namespaces read out of your bundle and the build stamp, so a packing host
-needs nothing else. `--from-stage` reads no project at all. No `package.json`,
-no config, no built bundle. That is what lets one CI job assemble and another
-finish.
+`--stage` writes the payload and stops, leaving
+`ship/stage/.gjsify-ship-stage.json` beside it. That file records the file modes,
+the pre-rendered licence overlays, the GI namespaces read out of your bundle and
+the build stamp, so a packing host needs nothing else. `--from-stage` reads no
+project at all. No `package.json`, no config, no built bundle. That is what lets
+one CI job assemble and another finish.
 
 Name every format you intend to pack in the `--stage` run. Phase one renders one
 licence overlay per format, and a format the stage never saw is refused on the
@@ -211,10 +210,10 @@ feeds all of them.
 | No installation at all, run it straight from npm | publish a `dlx`-friendly package | [Run via dlx](/gjsify/guides/dlx-packaging/) |
 
 Choose `gjsify ship` when you want a user to install once and forget about it.
-Choose `gjsify flatpak init` on top of it when you are submitting to Flathub,
-which wants the manifest and the AppStream files committed in your repository.
-Choose the one-line installer while you are still iterating and your users are
-early adopters. Choose dlx for a tool nobody wants permanently installed.
+Add `gjsify flatpak init` on top when you are submitting to Flathub, which wants
+the manifest and the AppStream files committed in your repository. The one-line
+installer suits early adopters while you are still iterating, and dlx suits a
+tool nobody wants permanently installed.
 
 There is no AppImage target. The nearest thing that exists is the Flatpak
 bundle, which is also one file, needs no repository and works offline.

--- a/website/src/content/docs/ship/linux-packages.md
+++ b/website/src/content/docs/ship/linux-packages.md
@@ -107,12 +107,12 @@ what you inspect is what a user installs.
 Every `.deb` carries `/usr/share/doc/<pkg>/changelog.Debian.gz`. Debian Policy
 § 4.4 makes it mandatory, `lintian` reports a missing one as an error
 (`E: no-changelog`), and neither `dpkg -i` nor `apt install` says a word about
-it — so a package without one installs perfectly and fails review.
+it. So a package without one installs perfectly and fails review.
 
 You write nothing for it. `gjsify ship` looks for your project's own
 `CHANGELOG.md` (then `CHANGELOG`, `CHANGELOG.txt`, `NEWS.md`, `NEWS`), beside
-the project and then up to the root of its repository — the same search the
-licence file gets, so one changelog at the top of a monorepo covers every
+the project and then up to the root of its repository. That is the same search
+the licence file gets, so one changelog at the top of a monorepo covers every
 package under it. Point `gjsify.ship.changelogFile` at another file to override
 it.
 
@@ -130,9 +130,9 @@ my-app (1.2.3-1) unstable; urgency=medium
 The bullets are the `*`/`-` lines your changelog lists under that version's
 heading, with Markdown links flattened to their text and long lines wrapped.
 The `## [1.2.3](…) (2026-09-03)` heading `release-it` and
-`conventional-changelog` write is understood, as is a bare `## 1.2.3`. If
-nothing there names this version — or you ship no changelog at all — the entry
-is one line naming the version and your `homepage`, which satisfies the policy
+`conventional-changelog` write is understood, as is a bare `## 1.2.3`. When
+nothing there names this version, or you ship no changelog at all, the entry is
+one line naming the version and your `homepage`, which satisfies the policy
 without inventing history.
 
 Two things are deliberate. It is ONE entry, not your whole history: this file
@@ -146,7 +146,7 @@ Debian archive to close its ITP bug, which a package built here never has, and
 `changelog-not-compressed-with-max-compression` asks for `gzip -9`, which the
 compression API available under GJS cannot request yet.
 
-### Two more details worth knowing
+### The bundle directory and the launcher
 
 **The whole bundle directory is staged.** `gjsify.main: "dist/gjs.js"` stages
 all of `dist/` into `lib/my-app/`. Keep build leftovers out of that directory,
@@ -230,22 +230,22 @@ catalogues are staged into `share/locale/` and the launcher exports
 
 ## Ship a brand typeface
 
-`gjsify.ship.fonts` — a directory of faces, or one face, defaulting to `data/fonts`
-when that exists — stages them at `share/fonts/<appId>/`.
+`gjsify.ship.fonts` takes a directory of faces or a single face, defaults to
+`data/fonts` when that exists, and stages what it finds at `share/fonts/<appId>/`.
 
 ```jsonc
 "gjsify": { "ship": { "fonts": "data/fonts" } }
 ```
 
-On Linux the toolkit gets there without you: the stock `fonts.conf` names
+On Linux the toolkit gets there without you. The stock `fonts.conf` names
 `/usr/share/fonts` unconditionally, which covers the `.deb` and the `.rpm`, and it
-expands `<dir prefix="xdg">fonts</dir>` over `XDG_DATA_DIRS` — which the launcher
+expands `<dir prefix="xdg">fonts</dir>` over `XDG_DATA_DIRS`, which the launcher
 already sets at the staged `share/` on every prefix, including Flatpak's `/app`.
 There is no `fc-cache` step; the cache is built lazily on first use.
 
-Neither macOS nor Windows gets there that way, so if your project also ships those,
-read [Ship your own fonts](/gjsify/guides/bundled-fonts/) — the one call it adds to
-your startup is redundant here and the only mechanism there is on Windows.
+Neither macOS nor Windows gets there that way. If your project also ships those,
+read [Ship your own fonts](/gjsify/guides/bundled-fonts/). The one call it adds to
+your startup is redundant here, and on Windows it is the only mechanism there is.
 
 ## The Flatpak bundle
 
@@ -421,13 +421,14 @@ Requires: nodejs(engine) >= 24   # rpm
 ```
 
 `gjsify ship` picks the interpreter from `gjsify.ship.app.linux`, falling back to
-`gjsify.app` — the same field your build already uses — and the launcher it writes
-execs that one and no other. A package therefore declares exactly one interpreter,
-and ship refuses to build one whose launcher and dependency disagree.
+`gjsify.app`, the same field your build already uses. The launcher it writes execs
+that one and no other, so a package declares exactly one interpreter, and ship
+refuses to build one whose launcher and dependency disagree.
 
 The per-target key is what keeps this section INDEPENDENT of the other two OSes.
-A macOS or Windows artifact has to run Node, and before that key existed saying so
-moved this dependency too: a working GJS `.deb` became one apt refuses everywhere.
+A macOS or Windows artifact has to run Node, and before that key existed, saying
+so moved this dependency too: a working GJS `.deb` became one apt refuses
+everywhere.
 
 The `>= 24` default excludes every current Debian stable and Ubuntu LTS:
 

--- a/website/src/content/docs/ship/macos.md
+++ b/website/src/content/docs/ship/macos.md
@@ -45,7 +45,7 @@ project on GJS:
 ```jsonc
 {
   "gjsify": {
-    "app": "gjs",                        // the project default — Linux keeps it
+    "app": "gjs",                        // the project default, Linux keeps it
     "ship": { "app": { "darwin": "node" } }  // and macOS does not
   }
 }
@@ -136,11 +136,10 @@ is why the darwin formats need `glib-compile-schemas` on the packaging host. A
 `.app` has no install step to compile them later, and GSettings aborts on a
 schema directory that holds only sources.
 
-Some of what a Linux package relies on its install step for has no macOS
-equivalent. The `.desktop` entry, the AppStream component and the shared MIME
-type document are carried and never read, because macOS reads none of them.
-`gjsify ship` lists every such file on each run, so the payload holds no
-surprise.
+Some of what a Linux package needs its install step for has no macOS equivalent.
+The `.desktop` entry, the AppStream component and the shared MIME type document
+are carried and never read, because macOS reads none of them. `gjsify ship` lists
+every such file on each run, so the payload holds no surprise.
 
 **Your icon does not become the bundle icon.** The `Info.plist` carries no
 `CFBundleIconFile`, so the Finder and the Dock show the generic application
@@ -151,19 +150,19 @@ GTK finds it for in-app use.
 
 `gjsify.ship.fonts` stages your faces into the bundle and adds an
 `ATSApplicationFontsPath` entry to `Contents/Info.plist`, so macOS activates them
-before any of your code runs. That is the reason for choosing the declarative route
-over a call: the CoreText font map has no re-scan path, and the OS gets there first.
+before any of your code runs. That is why the declarative route beats a call here:
+the CoreText font map has no re-scan path, and the OS gets there first.
 
-Two honest limits. The key is emitted from Apple's own documentation of it, and **no
-CI leg here starts an `.app`** — so that macOS then resolves the family is not
-something this project has measured, unlike the Linux and Windows halves. And a
-`.app` is the only macOS layout that carries fonts; there is no `.pkg` path.
+Two honest limits. The key is emitted from Apple's own documentation of it, and
+**no CI leg here starts an `.app`**, so whether macOS then resolves the family is
+not something this project has measured, unlike the Linux and Windows halves. And
+a `.app` is the only macOS layout that carries fonts; there is no `.pkg` path.
 
 The `initFonts()` call the [Windows](/gjsify/ship/windows/) row needs is still safe
 to leave in a shared codebase. Pango's CoreText font map implements no runtime
-registration, so the call answers `G_IO_ERROR_NOT_SUPPORTED`, the faces come back
-under `declined` rather than `failed`, and nothing is lost — the `Info.plist` key
-already activated the same directory before your code ran. So you need no
+registration, so the call answers `G_IO_ERROR_NOT_SUPPORTED` and the faces come
+back under `declined` rather than `failed`. Nothing is lost: the `Info.plist` key
+already activated the same directory before your code ran. You need no
 `process.platform` branch. [Ship your own fonts](/gjsify/guides/bundled-fonts/) has
 the detail, including what to check inside a running bundle.
 

--- a/website/src/content/docs/ship/windows.md
+++ b/website/src/content/docs/ship/windows.md
@@ -37,16 +37,16 @@ on GJS:
 ```jsonc
 {
   "gjsify": {
-    "app": "gjs",                       // the project default — Linux keeps it
+    "app": "gjs",                       // the project default, Linux keeps it
     "ship": { "app": { "win32": "node" } }  // and Windows does not
   }
 }
 ```
 
-The key is `win32`, the `process.platform` spelling — not `windows`, the
-spelling the command positional takes. A key nothing reads would leave the
-target on the project default with nothing to say so, so `gjsify ship` and the
-manifest audit both refuse it by name.
+The key is `win32`, the `process.platform` spelling, not `windows`, which is what
+the command positional takes. A key nothing reads would leave the target on the
+project default with nothing to say so, so `gjsify ship` and the manifest audit
+both refuse it by name.
 
 Setting `gjsify.app` to `"node"` works too and moves every target with it,
 including the Linux `.deb`'s `Depends:`.
@@ -74,7 +74,6 @@ machine that runs it.
   }
 }
 ```
-
 
 `GJSIFY_GTK_RUNTIME` overrides the GTK lookup with a directory holding `bin/`
 and `girepository-1.0/`. When either package is missing, ship names it and still
@@ -133,7 +132,7 @@ That produces `ship/out/my-app-1.2.3-1.x64.msi` beside the other two artifacts.
 The installed tree is the tree the zip expands to. Nothing about the payload
 changes.
 
-What the installer adds is the three things a directory cannot do on its own:
+The installer adds three things a directory cannot do on its own:
 
 - It lays the program directory under `%ProgramFiles%\My App`, which
   `msiexec INSTALLDIR=…` overrides.
@@ -186,7 +185,7 @@ targets for prerelease builds.
 `gjsify.ship.fonts` stages your faces into `share/fonts/<appId>/` and the launcher
 exports `GJSIFY_FONT_DIR` pointing at it. On Windows that is where the command's job
 ends: `pangocairo` selects the win32 backend, which populates from DirectWrite alone,
-so a fontconfig directory is inert here. Measured — a config naming your staged
+so a fontconfig directory is inert here. Measured: a config naming your staged
 directory moves the default font map by zero families even when it is the only one
 loaded.
 
@@ -201,21 +200,21 @@ initFonts();
 
 It reads `GJSIFY_FONT_DIR` itself, hands every face it finds to
 `PangoCairo.FontMap.get_default().add_font_file()`, never throws, and does nothing
-when the payload carries no font — so the same line goes in your Linux and macOS
+when the payload carries no font. So the same line goes in your Linux and macOS
 builds with no OS branch around it. Skip it on Windows and Pango falls back to a
-system face, silently: the app merely looks wrong, with no error and no exit code,
+system face silently: the app merely looks wrong, with no error and no exit code,
 which is why this section exists rather than a warning at build time.
 
 [Ship your own fonts](/gjsify/guides/bundled-fonts/) has the staging key, where in
 `startup` the call belongs, and a check that tells a registered family apart from a
 substituted one.
 
-## One thing to know before you hand it to a user
+## The console window stays open
 
 `node.exe` is a console-subsystem program and the Node release ships no windowed
-variant, so starting the app leaves a console window open behind it. That
-applies to the `.cmd` launcher and to the shortcut the `.msi` writes. Nothing
-here hides it.
+variant, so starting the app leaves a console window open behind it. That applies
+to the `.cmd` launcher and to the shortcut the `.msi` writes. Nothing here hides
+it.
 
 ## Signing is optional here in a way it is not on macOS
 
@@ -246,9 +245,9 @@ gjsify ship windows \
 ```
 
 Step 1 is a `devDependency` because the packaging host needs those two, not the
-shipped app. To point the lookup somewhere else -- a patched interpreter, or a
-build you produced yourself -- set `GJSIFY_NODE_RUNTIME` to a directory holding
-`node.exe` and its `LICENSE`.
+shipped app. To point the lookup at a patched interpreter, or at a build you
+produced yourself, set `GJSIFY_NODE_RUNTIME` to a directory holding `node.exe`
+and its `LICENSE`.
 
 To split the work instead, assemble here and pack on Windows:
 

--- a/website/src/content/docs/showcases/adwaita-storybook.mdx
+++ b/website/src/content/docs/showcases/adwaita-storybook.mdx
@@ -7,7 +7,7 @@ import ShowcaseEmbed from '../../../components/ShowcaseEmbed.astro';
 
 A component browser for the Libadwaita widget set: a sidebar of stories, a live preview, and a controls panel wired to each story's arguments. The stories are grouped into nine categories, from Buttons and Boxed Lists to Navigation and View Switching.
 
-Two things to take from it. It is the fastest way to see what a Libadwaita widget looks like and how its properties behave before you commit to it. And it shows the story format gjsify uses: you describe a component once, in a file that imports no renderer, and get a native GTK preview and a browser preview from it.
+It is the fastest way to see what a Libadwaita widget looks like and how its properties behave before you commit to it. It also demonstrates gjsify's story format: describe a component once, in a file that imports no renderer, and you get a native GTK preview and a browser preview from it.
 
 ## Live demo
 
@@ -17,7 +17,7 @@ Pick a widget in the sidebar, change its controls, watch it update. This is the 
 
 ## Run it
 
-This showcase declares all four runtimes, so pick the one you already have:
+It declares all four runtimes, so pick the one you have:
 
 ```bash
 gjsify showcase adwaita-storybook --runtime gjs
@@ -28,7 +28,7 @@ gjsify showcase adwaita-storybook --runtime deno
 
 A native GTK 4 window opens with real `Adw.*` widgets: an `Adw.NavigationSplitView` for the sidebar, and an `Adw.Breakpoint` that folds it into single-pane navigation when the window gets narrow. The window is the same on all four.
 
-Under `gjs` the widgets come from GJS's native `gi://`. Under `node`, `bun` and `deno` they come through the [node-gi](/gjsify/projects/node-gi/) bridge, and one `--app node` bundle serves all three, so there is no per-runtime build and no third copy of a story. [Choose the runtime](/gjsify/showcases/#choose-the-runtime) covers what the CLI does when you leave the flag off.
+Under `gjs` the widgets come from GJS's native `gi://`. Under `node`, `bun` and `deno` they come through the [node-gi](/gjsify/projects/node-gi/) bridge, and one `--app node` bundle serves all three, so there is no per-runtime build and no third copy of a story. Leave the flag off and [Choose the runtime](/gjsify/showcases/#choose-the-runtime) says what the CLI picks.
 
 From a checkout of the showcase, `gjsify storybook` does the same thing, and `gjsify storybook --watch` rebuilds and relaunches when you edit a story. It takes the same `--runtime` flag, and because it builds the bundle itself rather than fetching a published one, its default is whichever runtime the CLI is running on.
 
@@ -44,7 +44,7 @@ mount(document.getElementById('app')!, { title: 'Adwaita Storybook' });
 
 ## Add your own story
 
-A story is two small files plus one optional third, and the split is what lets one description drive several renderers.
+A story is two small files plus one optional third. That split is what lets one description drive several renderers.
 
 - `src/<category>/<name>.meta.ts` holds the `StoryMeta`: title, category, and the controls that drive it. It imports no renderer, and it is the single source of truth.
 - `src/<category>/<name>.story.ts` is the GTK twin. It spreads the meta and names the widget: `{ ...meta, component: Adw.X.$gtype }`.
@@ -52,7 +52,7 @@ A story is two small files plus one optional third, and the split is what lets o
 
 Because the controls are declared once, both targets expose the same knobs, and a native screenshot lines up with a browser screenshot. `src/browser/stories.ts` is the shared list that `main.ts` (standalone) and `embed.ts` (`mount()`) both read.
 
-`gjsify storybook` finds every `*.story.ts` on its own. There is no storybook app to maintain: the settings it needs (application id, window title, story directory) live in the `gjsify.storybook` block of `package.json`.
+`gjsify storybook` finds every `*.story.ts` on its own. There is no storybook app to maintain. The settings it needs (application id, window title, story directory) live in the `gjsify.storybook` block of `package.json`.
 
 ## What it uses
 

--- a/website/src/content/docs/showcases/canvas2d-fireworks.mdx
+++ b/website/src/content/docs/showcases/canvas2d-fireworks.mdx
@@ -5,7 +5,7 @@ description: Particle fireworks drawn with the Canvas 2D API, running in a GTK 4
 
 import ShowcaseEmbed from '../../../components/ShowcaseEmbed.astro';
 
-Animated particle fireworks drawn with the plain Canvas 2D API. Click anywhere to fire one. The demo shows that `<canvas>` code you already know draws into a native GTK 4 window without a single gjsify import in the drawing code, so a browser animation you like can become a desktop app as-is.
+Animated particle fireworks drawn with the plain Canvas 2D API. Click anywhere to fire one. The drawing code names no GTK type and imports no gjsify package, and it still paints into a native GTK 4 window, so a browser animation you like becomes a desktop app as-is.
 
 Adapted from [a CodePen by @juliangarnier](https://codepen.io/juliangarnier/pen/gmOwJX).
 
@@ -15,7 +15,7 @@ Adapted from [a CodePen by @juliangarnier](https://codepen.io/juliangarnier/pen/
 
 ## Run it
 
-This showcase declares all four runtimes, so pick the one you already have:
+It declares all four runtimes, so pick the one you have:
 
 ```bash
 gjsify showcase canvas2d-fireworks --runtime gjs
@@ -28,9 +28,9 @@ A GTK 4 window opens with the canvas on the right and an Adwaita sidebar on the 
 
 The animation ticks on the GTK frame clock, so `requestAnimationFrame` lands on vsync exactly as it does in a browser.
 
-Under `gjs` this runs the `--app gjs` bundle against GJS's native `gi://`. Under `node`, `bun` and `deno` it runs the `--app node` bundle, where `gi://` goes through the [node-gi](/gjsify/projects/node-gi/) bridge. Drop the flag and the CLI runs the `--app gjs` bundle when `gjs` is on PATH, otherwise the `--app node` bundle on the runtime it is already on.
+`--runtime gjs` runs the `--app gjs` bundle against GJS's native `gi://`. The other three run the `--app node` bundle, where `gi://` goes through the [node-gi](/gjsify/projects/node-gi/) bridge. Drop the flag and the CLI runs the `--app gjs` bundle when `gjs` is on PATH, otherwise the `--app node` bundle on the runtime it is already on.
 
-This is also the showcase to reach for when you want to see [devtools](/gjsify/guides/devtools/) at work. Start it with `GJSIFY_DEVTOOLS=1` and you get the same `GetStatus`, `DumpTree` and `Screenshot` D-Bus calls on all four runtimes.
+It is also the showcase to reach for when trying [devtools](/gjsify/guides/devtools/): start it with `GJSIFY_DEVTOOLS=1` and the same `GetStatus`, `DumpTree` and `Screenshot` D-Bus calls answer on all four runtimes.
 
 ## Run it in the browser
 
@@ -46,7 +46,7 @@ Same code, except the `<canvas>` is a real browser canvas rather than a GTK widg
 
 ## What it uses
 
-| Package | Surface used |
+| Package | What it provides |
 |---|---|
 | [`@gjsify/canvas2d`](https://github.com/gjsify/gjsify/tree/main/packages/framework/canvas2d) | `Canvas2DBridge`, a `Gtk.DrawingArea` that draws with Cairo and PangoCairo |
 | [`@gjsify/dom-elements`](https://github.com/gjsify/gjsify/tree/main/packages/dom/dom-elements) | `HTMLCanvasElement`, `getBoundingClientRect()`, `requestAnimationFrame` |

--- a/website/src/content/docs/showcases/excalibur-jelly-jumper.mdx
+++ b/website/src/content/docs/showcases/excalibur-jelly-jumper.mdx
@@ -7,7 +7,7 @@ import ShowcaseEmbed from '../../../components/ShowcaseEmbed.astro';
 
 A 2D platformer built with [Excalibur.js](https://excaliburjs.com/) 0.32 and [Tiled](https://www.mapeditor.org/) tilemaps. The engine comes straight from npm with no fork and no patch.
 
-That is the thing to take away: a game engine written for the browser, reaching for WebGL2, `<canvas>`, `XMLHttpRequest`, `DOMParser`, `ResizeObserver`, `requestAnimationFrame` and WebAudio, runs inside a native Adwaita window. If gjsify can carry Excalibur, it can carry the npm library you had in mind.
+A game engine written for the browser, reaching for WebGL2, `<canvas>`, `XMLHttpRequest`, `DOMParser`, `ResizeObserver`, `requestAnimationFrame` and WebAudio, runs inside a native Adwaita window. If gjsify can carry Excalibur, it can carry the npm library you had in mind.
 
 Based on [sample-jelly-jumper](https://github.com/excaliburjs/sample-jelly-jumper) by the Excalibur team.
 
@@ -17,7 +17,7 @@ Based on [sample-jelly-jumper](https://github.com/excaliburjs/sample-jelly-jumpe
 
 ## Run it
 
-This showcase declares all four runtimes, so pick the one you already have:
+It declares all four runtimes, so pick the one you have:
 
 ```bash
 gjsify showcase excalibur-jelly-jumper --runtime gjs
@@ -37,7 +37,7 @@ A GTK 4 window opens with the game filling it and pause and mute buttons in the 
 
 The engine renders through WebGL2 on `Gtk.GLArea`. If no GL2 context is available it falls back to Canvas 2D over Cairo, the same fallback the browser build takes.
 
-Under `gjs` the game runs the `--app gjs` bundle against GJS's native `gi://`. Under `node`, `bun` and `deno` it runs one shared `--app node` bundle, where `gi://` goes through the [node-gi](/gjsify/projects/node-gi/) bridge. [Choose the runtime](/gjsify/showcases/#choose-the-runtime) covers what the CLI does when you leave the flag off.
+`--runtime gjs` runs the `--app gjs` bundle against GJS's native `gi://`. The other three share one `--app node` bundle, where `gi://` goes through the [node-gi](/gjsify/projects/node-gi/) bridge. Leave the flag off and [Choose the runtime](/gjsify/showcases/#choose-the-runtime) says what the CLI picks.
 
 ## Run it in the browser
 
@@ -53,7 +53,7 @@ handle.unmute();
 handle.pause();
 ```
 
-`assetBase` is what makes one resource table serve both targets: the game's `/res/...` paths are rewritten against it at load time. The handle also exposes `resume()`, `mute()`, `isPaused` and `isMuted`.
+`assetBase` is what makes one resource table serve both targets. The game's `/res/...` paths are rewritten against it at load time. The handle also exposes `resume()`, `mute()`, `isPaused` and `isMuted`.
 
 Tilemaps and spritesheets ship with the package under `@gjsify/example-dom-excalibur-jelly-jumper/assets/*`.
 
@@ -73,7 +73,7 @@ Tilemaps and spritesheets ship with the package under `@gjsify/example-dom-excal
 
 [`showcases/dom/excalibur-jelly-jumper/`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/excalibur-jelly-jumper)
 
-Every target enters the same `startGame(canvas, options)` in `src/game.ts`. The scenes, actors, physics, components, state and UI all sit at the top level of `src/` and never mention a platform. Only the shell differs: `src/gjs/gjs.ts` builds the `Adw.Application` and its window, `src/browser/browser.ts` exports `mount()`, and `src/browser/browser-main.ts` runs it full-page.
+Every target enters the same `startGame(canvas, options)` in `src/game.ts`. The scenes, actors, physics, components, state and UI all sit at the top level of `src/` and never mention a platform. Only the shell differs. `src/gjs/gjs.ts` builds the `Adw.Application` and its window, `src/browser/browser.ts` exports `mount()`, and `src/browser/browser-main.ts` runs it full-page.
 
 Per-target tuning goes through options on that one function (`pixelRatio`, `fixedUpdateFps`, `enablePerf`) rather than through forked code.
 

--- a/website/src/content/docs/showcases/express-webserver.mdx
+++ b/website/src/content/docs/showcases/express-webserver.mdx
@@ -5,11 +5,11 @@ description: An unmodified Express 5 blog app serving HTTP and JSON, with one so
 
 A small Express 5 blog: a JSON API, server-rendered article pages, and a static frontend. Express comes straight from npm with no fork and no shim in your code.
 
-The demo shows one `src/index.ts` serving on all four runtimes with no branch anywhere in it, GJS included. If you already have an Express service, this is what porting it looks like: nothing.
+One `src/index.ts` serves on all four runtimes with no branch anywhere in it, GJS included. If you already have an Express service, this is what porting it looks like: nothing.
 
 ## Run it
 
-This showcase declares all four runtimes, so pick the one you already have:
+It declares all four runtimes, so pick the one you have:
 
 ```bash
 gjsify showcase express-webserver --runtime gjs
@@ -33,7 +33,7 @@ curl http://localhost:3000/api/runtime
 
 Set `PORT` to listen somewhere else.
 
-`/api/runtime` is the interesting one: it reports which JavaScript engine is serving the request, from `runtimeName` in `@gjsify/runtime`. Run the same source on another runtime and that one field changes. Nothing else does, including the routes, the rendered pages and the JSON.
+`/api/runtime` is the interesting one. It reports which JavaScript engine is serving the request, from `runtimeName` in `@gjsify/runtime`. Run the same source on another runtime and that one field changes. Nothing else does, including the routes, the rendered pages and the JSON.
 
 From `showcases/node/express-webserver/` in a checkout you can build both bundles and run them side by side:
 
@@ -47,13 +47,13 @@ Same `src/index.ts`, two bundles: `dist/index.gjs.js` and `dist/index.node.mjs`.
 
 ## What it uses
 
-Which server implementation Express lands on is decided by the build target, and this is the one place the four runtimes genuinely diverge.
+The build target decides which server implementation Express lands on, and this is the one place the four runtimes genuinely diverge.
 
 Under `--app node` the `node:` imports stay as they are, so Express gets the host runtime's own `http`, `stream`, `events` and `url`. Under `--app gjs` there are no such builtins, so `gjsify build` rewrites each import to a GNOME-backed package:
 
 | Package | What Express needs it for |
 |---|---|
-| [`@gjsify/http`](https://github.com/gjsify/gjsify/tree/main/packages/node/http) | `http.createServer()`, `Server.listen()`, and the `IncomingMessage` and `ServerResponse` surface |
+| [`@gjsify/http`](https://github.com/gjsify/gjsify/tree/main/packages/node/http) | `http.createServer()`, `Server.listen()`, `IncomingMessage` and `ServerResponse` |
 | [`@gjsify/stream`](https://github.com/gjsify/gjsify/tree/main/packages/node/stream) | `req.pipe(res)` and body parsing |
 | [`@gjsify/events`](https://github.com/gjsify/gjsify/tree/main/packages/node/events) | `EventEmitter`, which Express and its middleware lean on throughout |
 | [`@gjsify/url`](https://github.com/gjsify/gjsify/tree/main/packages/node/url) | URL parsing in the route matcher |
@@ -69,7 +69,7 @@ You install none of them, and you import none of them. [How it works](/gjsify/ho
 - `src/data/posts.ts` holds the in-memory post fixtures the API and the pages both read.
 - `src/public/` is the static frontend, served with `express.static()`.
 
-Compared with the GTK showcases there is no shell to write, because a server has no UI. Build it, run it, and the only per-target file is the bundle.
+There is no shell to write here, because a server has no UI. The only per-target file is the bundle.
 
 ## Related
 

--- a/website/src/content/docs/showcases/index.mdx
+++ b/website/src/content/docs/showcases/index.mdx
@@ -3,18 +3,18 @@ title: Showcases
 description: Complete demo apps you can start with one command, each showing a slice of what gjsify can build on GTK 4.
 ---
 
-Showcases are finished, runnable apps. Each one starts with a single command, opens a real GTK 4 window, and is written in ordinary web code: `<canvas>`, WebGL, `fetch`, `XMLHttpRequest`, `RTCPeerConnection`, Express. They are the quickest way to find out whether gjsify can carry the kind of app you want to build, and the source of each one is a working template you can copy from.
+Showcases are finished, runnable apps. One command starts one and a real GTK 4 window opens. Behind that window is ordinary web code: `<canvas>`, WebGL, `fetch`, `XMLHttpRequest`, `RTCPeerConnection`, Express. Run a few to find out whether gjsify can carry the app you have in mind. Each one is also a working template you can copy from.
 
 ## Run one
 
-You need the `gjsify` CLI and at least one of `gjs`, `node`, `bun` and `deno`; two of the ten below declare `gjs` only, and the table says which. There is nothing to clone:
+You need the `gjsify` CLI and at least one of `gjs`, `node`, `bun` and `deno`. Two of the ten below declare `gjs` only, and the table says which. Nothing to clone:
 
 ```bash
 gjsify showcase                          # list every showcase
 gjsify showcase canvas2d-fireworks       # run one, opens a GTK 4 window
 ```
 
-The CLI fetches the showcase's npm package on demand, sets up the native typelibs it needs, and launches it. If a system library is missing, `gjsify system-check` names it. Add `--runtime` to say which of the four runs it, or leave it off and let the CLI resolve one: [Choose the runtime](#choose-the-runtime) below spells out both.
+The CLI fetches the showcase's npm package on demand, sets up the native typelibs it needs, and launches it. If a system library is missing, `gjsify system-check` names it. Add `--runtime` to say which of the four runs it, or leave it off and let the CLI resolve one. [Choose the runtime](#choose-the-runtime) below covers both.
 
 On Linux the GTK 4 stack comes from your distribution on every runtime. On macOS and Windows the `node`, `bun` and `deno` route pulls a prebuilt GTK 4 and Adwaita closure (`@gjsify/gtk-runtime-<os>-<arch>`) into the same cache, so there is no system GTK to install either.
 
@@ -46,13 +46,13 @@ gjsify showcase canvas2d-fireworks --runtime bun
 gjsify showcase canvas2d-fireworks --runtime deno
 ```
 
-Same window, same code, and here is what actually differs underneath:
+Same window, same code. What differs is underneath:
 
 - `--runtime gjs` runs the showcase's `--app gjs` bundle. GJS is GNOME's own JavaScript runtime, so `gi://Gtk` is native and nothing bridges into GTK.
 - `--runtime node`, `bun` and `deno` run its `--app node` bundle, where `gi://` goes through the [node-gi](/gjsify/projects/node-gi/) bridge. One bundle serves all three, because Node-API is their shared native ABI.
 - GJS is packaged for Linux and, partially, macOS; there is no GJS host on Windows. Node, Bun and Deno reach all three operating systems. [Platform Support](/gjsify/platform-support/) has the per-OS state.
 
-With no `--runtime` flag, the CLI runs the `--app gjs` bundle when `gjs` is on PATH, and otherwise the `--app node` bundle on whichever runtime the CLI itself is running on. That default follows from packaging rather than from a preference: a showcase's canonical build is its `--app gjs` bundle, declared as `gjsify.main`, and every showcase ships one, while not every showcase ships an `--app node` bundle.
+With no `--runtime` flag, the CLI runs the `--app gjs` bundle when `gjs` is on PATH, and otherwise the `--app node` bundle on whichever runtime the CLI itself is running on. That default is packaging, not preference. A showcase's canonical build is its `--app gjs` bundle, declared as `gjsify.main`. Every showcase ships one, and not every showcase ships an `--app node` bundle.
 
 Each showcase declares the runtimes it supports in `package.json` under `gjsify.example.runtimes`. Ask for one it does not declare and you get a clear error rather than a crash deep in the bundle. `minimalist-browser` and `webrtc-loopback` declare `["gjs"]`, because their native side is a WebKit view and a GStreamer pipeline reached through a typelib, so neither ships an `--app node` bundle. Their browser builds are unaffected: those run on the browser's own WebKit and WebRTC.
 
@@ -74,7 +74,7 @@ The package name follows the pattern `@gjsify/example-<category>-<name>`, so `ad
 
 ## Read the source
 
-Every showcase lives under [`showcases/`](https://github.com/gjsify/gjsify/tree/main/showcases) in the gjsify repo. They share one layout: a platform-agnostic module holds the app itself, and a thin shell per target wraps it. `src/gjs/` is the GTK shell, `src/browser/` is the DOM shell, and the file in between imports nothing platform-specific.
+Every showcase lives under [`showcases/`](https://github.com/gjsify/gjsify/tree/main/showcases) in the gjsify repo. They share one layout. A platform-agnostic module holds the app itself, and a thin shell per target wraps it. `src/gjs/` is the GTK shell, `src/browser/` is the DOM shell, and the file in between imports nothing platform-specific.
 
 That split is what you want to copy. Keep your app logic free of `@gjsify/*` imports, write against the standard APIs, and the same file runs on GTK and in a browser.
 

--- a/website/src/content/docs/showcases/minimalist-browser.mdx
+++ b/website/src/content/docs/showcases/minimalist-browser.mdx
@@ -7,7 +7,7 @@ import ShowcaseEmbed from '../../../components/ShowcaseEmbed.astro';
 
 A small browser shell: URL bar, back, forward and reload, and an `<iframe>` filling the rest of the window.
 
-The demo shows how to embed web content inside a GTK app. Write against `HTMLIFrameElement` the way you would on a web page, and on GJS you get a full `WebKit.WebView` behind it, with cookies, JavaScript, CSS and `postMessage` all working. Reports, help pages, OAuth flows, third-party widgets: this is the pattern for all of them.
+This is how you embed web content inside a GTK app. Write against `HTMLIFrameElement` the way you would on a web page, and on GJS you get a full `WebKit.WebView` behind it, with cookies, JavaScript, CSS and `postMessage` all working. Reports, help pages, OAuth flows, third-party widgets: same pattern for all of them.
 
 ## Live demo
 
@@ -58,19 +58,19 @@ The same input and button handlers, wrapped around a real `<iframe>`.
 
 ## Pick the right iframe API
 
-`IFrameBridge` gives you two surfaces and you can use either.
+`IFrameBridge` gives you two APIs, and either is fine.
 
 The standard one is `iframe.src`, `iframe.srcdoc`, `iframe.contentWindow.postMessage()` and `addEventListener('message')`. Use it when you want code that also runs in a browser, which is what this showcase does.
 
 The WebKit one is on the bridge itself: `loadUri()`, `loadHtml()`, `postMessage()`, `goBack()`, `goForward()`, `canGoBack`, `canGoForward`, and `reload()` inherited from `WebKit.WebView`. Use it when you want WebKit's own back and forward list rather than one you track yourself.
 
-One thing to watch on GJS: `contentWindow` is null until the first navigation finishes. Re-attach your message listener from `onReady()` after each load, the way `src/gjs/gjs.ts` does. A real `<iframe>` keeps `contentWindow` across navigations, so the browser build does not need this.
+On GJS, `contentWindow` is null until the first navigation finishes. Re-attach your message listener from `onReady()` after each load, the way `src/gjs/gjs.ts` does. A real `<iframe>` keeps `contentWindow` across navigations, so the browser build does not need this.
 
 ## Copy the structure
 
 [`showcases/dom/minimalist-browser/`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/minimalist-browser)
 
-- `src/browser-demo.ts` holds `BrowserCore`: the history stack, the `postMessage` wiring and the built-in `page:<name>` library. It runs unchanged in both targets because it talks to a duck-typed `IFrameHandle`, and both a real `<iframe>` and `IFrameBridge.iframeElement` satisfy it.
+- `src/browser-demo.ts` holds `BrowserCore`: the history stack, the `postMessage` wiring and the built-in `page:<name>` library. It runs unchanged in both targets because it talks to a duck-typed `IFrameHandle`, which both a real `<iframe>` and `IFrameBridge.iframeElement` satisfy.
 - `src/gjs/gjs.ts` is the `Adw.Application` shell driving `IFrameBridge`.
 - `src/browser/browser.ts` exports `mount()`; `browser-main.ts` runs it full-page.
 

--- a/website/src/content/docs/showcases/three-geometry-teapot.mdx
+++ b/website/src/content/docs/showcases/three-geometry-teapot.mdx
@@ -7,7 +7,7 @@ import ShowcaseEmbed from '../../../components/ShowcaseEmbed.astro';
 
 The Utah teapot rendered by [Three.js](https://threejs.org/), with an Adwaita sidebar that changes the geometry and the material while it spins.
 
-Two things to take from it. Three.js runs unmodified: `THREE.WebGLRenderer`, `TeapotGeometry` and `OrbitControls` come straight from npm and draw into a `Gtk.GLArea`. And the controls are real GTK widgets bound to the scene, so you can wrap a web renderer in a native GNOME interface instead of rebuilding one in HTML.
+Three.js runs unmodified: `THREE.WebGLRenderer`, `TeapotGeometry` and `OrbitControls` come straight from npm and draw into a `Gtk.GLArea`. The controls beside it are real GTK widgets bound to the scene, so you can wrap a web renderer in a native GNOME interface instead of rebuilding one in HTML.
 
 Ported from the upstream [`webgl_geometry_teapot`](https://threejs.org/examples/#webgl_geometry_teapot) example.
 
@@ -17,7 +17,7 @@ Ported from the upstream [`webgl_geometry_teapot`](https://threejs.org/examples/
 
 ## Run it
 
-This showcase declares all four runtimes, so pick the one you already have:
+It declares all four runtimes, so pick the one you have:
 
 ```bash
 gjsify showcase three-geometry-teapot --runtime gjs
@@ -26,11 +26,11 @@ gjsify showcase three-geometry-teapot --runtime bun
 gjsify showcase three-geometry-teapot --runtime deno
 ```
 
-A GTK 4 window opens as an `Adw.OverlaySplitView`: the sidebar holds the controls, the canvas fills the rest. Drag to orbit the camera, scroll to zoom. Same window and same scene on all four.
+A GTK 4 window opens as an `Adw.OverlaySplitView`. The sidebar holds the controls, the canvas fills the rest. Drag to orbit the camera, scroll to zoom. Same window and same scene on all four.
 
 The sidebar has two groups. **Geometry** sets the tessellation level (an `Adw.ComboRow` stepping 2, 3, 4, 5, 6, 8, 10, 15, 20, 30, 40, 50) and toggles Display Lid, Display Body, Display Bottom, Snug Lid and Original Scale. **Material** switches the shading between wireframe, flat, smooth, glossy, textured and reflective.
 
-Under `gjs` this runs the `--app gjs` bundle against GJS's native `gi://`. Under `node`, `bun` and `deno` it runs one shared `--app node` bundle, where `gi://` goes through the [node-gi](/gjsify/projects/node-gi/) bridge. [Choose the runtime](/gjsify/showcases/#choose-the-runtime) covers what the CLI does when you leave the flag off.
+`--runtime gjs` runs the `--app gjs` bundle against GJS's native `gi://`. The other three share one `--app node` bundle, where `gi://` goes through the [node-gi](/gjsify/projects/node-gi/) bridge. Leave the flag off and [Choose the runtime](/gjsify/showcases/#choose-the-runtime) says what the CLI picks.
 
 ## Run it in the browser
 
@@ -51,13 +51,13 @@ The browser build rebuilds the same sidebar out of `@gjsify/adwaita-web` custom 
 
 | Package | What Three.js needs it for |
 |---|---|
-| [`@gjsify/webgl`](https://github.com/gjsify/gjsify/tree/main/packages/framework/webgl) | The full WebGL 2.0 surface: vertex array objects, uniform buffer objects, `texStorage2D`, `drawElementsInstanced` |
+| [`@gjsify/webgl`](https://github.com/gjsify/gjsify/tree/main/packages/framework/webgl) | The whole WebGL 2.0 API: vertex array objects, uniform buffer objects, `texStorage2D`, `drawElementsInstanced` |
 | [`@gjsify/dom-elements`](https://github.com/gjsify/gjsify/tree/main/packages/dom/dom-elements) | `HTMLCanvasElement` and `requestAnimationFrame` |
 | [`@gjsify/event-bridge`](https://github.com/gjsify/gjsify/tree/main/packages/framework/event-bridge) | Mouse drag and scroll feeding `OrbitControls` |
 | `@gjsify/adwaita-web` | The sidebar in the browser build |
 | Libadwaita | `Adw.OverlaySplitView`, `Adw.ComboRow` and `Adw.SwitchRow` in the GTK build |
 
-`@gjsify/webgl` maps WebGL calls onto the platform's own GL through a Vala bridge, which is GLES 3.2 on Linux. Three.js targets desktop WebGL and does not know about that difference, and does not have to. [Bridge widgets](/gjsify/patterns/bridges/) has the detail.
+`@gjsify/webgl` maps WebGL calls onto the platform's own GL through a Vala bridge, which is GLES 3.2 on Linux. Three.js targets desktop WebGL, does not know about that difference, and does not have to. [Bridge widgets](/gjsify/patterns/bridges/) has the detail.
 
 ## Copy the structure
 

--- a/website/src/content/docs/showcases/three-loader-ldraw.mdx
+++ b/website/src/content/docs/showcases/three-loader-ldraw.mdx
@@ -17,7 +17,7 @@ Ported from the upstream [`webgl_loader_ldraw`](https://threejs.org/examples/#we
 
 ## Run it
 
-This showcase declares all four runtimes, so pick the one you already have:
+It declares all four runtimes, so pick the one you have:
 
 ```bash
 gjsify showcase three-loader-ldraw --runtime gjs
@@ -32,7 +32,7 @@ A GTK 4 window opens with an Adwaita sidebar next to the canvas. Drag to orbit, 
 - **Rendering** toggles Flat Colors, Merge Model and Smooth Normals.
 - **Display** steps through **Building Step**, and toggles the two edge layers `LDrawLoader` builds alongside the geometry: **Display Lines** and **Conditional Lines**.
 
-Under `gjs` this runs the `--app gjs` bundle against GJS's native `gi://`. Under `node`, `bun` and `deno` it runs one shared `--app node` bundle, where `gi://` goes through the [node-gi](/gjsify/projects/node-gi/) bridge. [Choose the runtime](/gjsify/showcases/#choose-the-runtime) covers what the CLI does when you leave the flag off.
+`--runtime gjs` runs the `--app gjs` bundle against GJS's native `gi://`. The other three share one `--app node` bundle, where `gi://` goes through the [node-gi](/gjsify/projects/node-gi/) bridge. Leave the flag off and [Choose the runtime](/gjsify/showcases/#choose-the-runtime) says what the CLI picks.
 
 ## Run it in the browser
 
@@ -56,7 +56,7 @@ The models ship with the package under `./assets/*`, so point `assetBase` at whe
 | [`@gjsify/fetch`](https://github.com/gjsify/gjsify/tree/main/packages/web/fetch) | `fetch` over `file://`, `Request`, `Headers`, `AbortSignal.any`, and a `Response.body` the loader can re-wrap |
 | [`@gjsify/web-streams`](https://github.com/gjsify/gjsify/tree/main/packages/web/streams) | `ReadableStream`, so the loader can report download progress |
 | [`@gjsify/dom-events`](https://github.com/gjsify/gjsify/tree/main/packages/web/dom-events) | `ProgressEvent`, dispatched per chunk while a model downloads |
-| [`@gjsify/webgl`](https://github.com/gjsify/gjsify/tree/main/packages/framework/webgl) | The full WebGL 2.0 surface, including `drawElementsInstanced` and sized internal formats |
+| [`@gjsify/webgl`](https://github.com/gjsify/gjsify/tree/main/packages/framework/webgl) | The whole WebGL 2.0 API, including `drawElementsInstanced` and sized internal formats |
 | [`@gjsify/dom-elements`](https://github.com/gjsify/gjsify/tree/main/packages/dom/dom-elements) | `HTMLCanvasElement` and `requestAnimationFrame` |
 | `@gjsify/adwaita-web` | The sidebar in the browser build |
 | Libadwaita | `Adw.ComboRow`, `Adw.SwitchRow` and `Adw.SpinRow` in the GTK build |

--- a/website/src/content/docs/showcases/three-postprocessing-pixel.mdx
+++ b/website/src/content/docs/showcases/three-postprocessing-pixel.mdx
@@ -17,7 +17,7 @@ Ported from the upstream [`webgl_postprocessing_pixel`](https://threejs.org/exam
 
 ## Run it
 
-This showcase declares all four runtimes, so pick the one you already have:
+It declares all four runtimes, so pick the one you have:
 
 ```bash
 gjsify showcase three-postprocessing-pixel --runtime gjs
@@ -28,7 +28,7 @@ gjsify showcase three-postprocessing-pixel --runtime deno
 
 A GTK 4 window opens as an `Adw.OverlaySplitView` with the controls in the sidebar. **Pixel Size** crushes the resolution into bigger cells. **Normal Edge** and **Depth Edge** set how strongly the shader outlines geometry. **Pixel-Aligned Panning** snaps camera movement to the pixel grid so the image stops shimmering as it moves. Same window and same pipeline on all four.
 
-Under `gjs` this runs the `--app gjs` bundle against GJS's native `gi://`. Under `node`, `bun` and `deno` it runs one shared `--app node` bundle, where `gi://` goes through the [node-gi](/gjsify/projects/node-gi/) bridge. [Choose the runtime](/gjsify/showcases/#choose-the-runtime) covers what the CLI does when you leave the flag off.
+`--runtime gjs` runs the `--app gjs` bundle against GJS's native `gi://`. The other three share one `--app node` bundle, where `gi://` goes through the [node-gi](/gjsify/projects/node-gi/) bridge. Leave the flag off and [Choose the runtime](/gjsify/showcases/#choose-the-runtime) says what the CLI picks.
 
 ## Run it in the browser
 
@@ -47,7 +47,7 @@ The browser build rebuilds the same sidebar from `@gjsify/adwaita-web` custom el
 
 ## What the pipeline does
 
-The composer chain is the standard Three.js one, and nothing in it is modified for the GTK window:
+The composer chain is the standard Three.js one, and nothing in it changes for the GTK window:
 
 1. `EffectComposer` wraps the renderer and owns the off-screen targets.
 2. `RenderPixelatedPass` renders the scene at a reduced resolution and applies the edge detection, with its own GLSL compiled at runtime.

--- a/website/src/content/docs/showcases/webrtc-loopback.mdx
+++ b/website/src/content/docs/showcases/webrtc-loopback.mdx
@@ -7,7 +7,7 @@ import ShowcaseEmbed from '../../../components/ShowcaseEmbed.astro';
 
 Two `RTCPeerConnection` instances in a single process exchange an SDP offer and answer, trickle ICE candidates at each other, open an `RTCDataChannel`, and echo a string and an `ArrayBuffer` back and forth. No signaling server and no remote peer.
 
-The demo shows that the W3C WebRTC API works on GJS, backed by GStreamer's `webrtcbin`. If your app needs peer-to-peer data or media, you write the same code you would write for a browser.
+The W3C WebRTC API works on GJS, backed by GStreamer's `webrtcbin`. If your app needs peer-to-peer data or media, you write the code you would write for a browser.
 
 ## Live demo
 
@@ -43,7 +43,7 @@ This is one of two showcases that declare `["gjs"]` rather than all four runtime
 gjsify showcase webrtc-loopback
 ```
 
-This one is a console program, not a window. It prints the handshake as it happens and exits when the round trip completes:
+This one is a console program rather than a window. It prints the handshake as it happens and exits when the round trip completes:
 
 ```
 [A] createOffer

--- a/website/src/content/docs/showcases/webrtc-video.mdx
+++ b/website/src/content/docs/showcases/webrtc-video.mdx
@@ -5,7 +5,7 @@ description: A webcam preview where video.srcObject = stream drives a real brows
 
 A live webcam preview built on `navigator.mediaDevices.getUserMedia({ video: true })`, with the resulting `MediaStream` assigned to a `<video>` element's `srcObject`.
 
-That single assignment is the whole cross-platform surface. In a browser it lights up a real `<video>`. On GJS it flows through [`@gjsify/video`](https://github.com/gjsify/gjsify/tree/main/packages/framework/video)'s `VideoBridge` into a GTK 4 `Gtk.Picture` fed by GStreamer's `gtk4paintablesink`. The demo shows that live media handles cross from capture to display without your code knowing which platform it is on.
+That single assignment is all the platform-specific code there is. In a browser it lights up a real `<video>`. On GJS it flows through [`@gjsify/video`](https://github.com/gjsify/gjsify/tree/main/packages/framework/video)'s `VideoBridge` into a GTK 4 `Gtk.Picture` fed by GStreamer's `gtk4paintablesink`. Live media crosses from capture to display without your code knowing which platform it is on.
 
 The shared module is about ten lines:
 
@@ -34,7 +34,7 @@ You need:
 
 ## Run it on GJS
 
-It builds two bundles, `--app gjs` and `--app browser`, and no `--app node` one: the capture side is a GStreamer pipeline reached through a typelib. From `showcases/dom/webrtc-video/`:
+It builds two bundles, `--app gjs` and `--app browser`, and no `--app node` one, because the capture side is a GStreamer pipeline reached through a typelib. From `showcases/dom/webrtc-video/`:
 
 ```bash
 gjsify run build     # gjs + browser bundles and the assets
@@ -53,7 +53,7 @@ gjsify run start:browser    # serves dist/ on localhost:8080
 
 The browser build uses the browser's own `getUserMedia` and a real `<video>` element.
 
-To embed it in a page of your own, import `mount()` from `src/browser/browser.ts`. The package is private and not published to npm, so there is no `@gjsify/example-dom-webrtc-video/browser` specifier to import; copy the file or point at your checkout.
+To embed it in a page of your own, import `mount()` from `src/browser/browser.ts`. The package is private and not published to npm, so there is no `@gjsify/example-dom-webrtc-video/browser` specifier to import. Copy the file, or point at your checkout.
 
 ```ts
 const handle = mount(container, { title: 'Webcam' });

--- a/website/src/content/docs/versioning.md
+++ b/website/src/content/docs/versioning.md
@@ -3,7 +3,7 @@ title: Versioning
 description: How to upgrade @gjsify/* safely, which versions work together, and how much stability each package promises.
 ---
 
-**Upgrade all your `@gjsify/*` dependencies together, to the same version.** That is the whole rule.
+**Upgrade all your `@gjsify/*` dependencies together, to the same version.** That is the whole rule. Nearly every package you import is tier 1, and no tier-1 release ships with a known break. A minor can break a tier-2 package (the Adwaita packages, storybook, the native app shell) with a changelog note. Tier 3 promises nothing.
 
 Every release publishes the entire package set at one version, and the packages are tested against each other at exactly that version. Mixing them (`@gjsify/fetch@0.46.x` with `@gjsify/http@0.45.x`, say) is untested and unsupported.
 
@@ -23,7 +23,7 @@ Preview first with `--dry-run`, and restrict the sweep with `--workspace <patter
 
 ## Repair a monorepo that has drifted apart
 
-In a workspace, different packages can end up declaring the same dependency at different ranges. `--align` fixes that offline, with no registry calls: it finds every dependency declared at more than one range and pulls them all up to the highest.
+In a workspace, different packages can end up declaring the same dependency at different ranges. `--align` fixes that offline, with no registry calls. It finds every dependency declared at more than one range and pulls them all up to the highest.
 
 ```bash
 gjsify upgrade --align
@@ -39,7 +39,7 @@ gjsify upgrade --check
 
 ## Pin without a range operator
 
-Consistency is not exactness. A tree where every manifest agrees on `^4.1.0` passes `--check` and still lets a minor release move under a consumer's lockfile-less install, so a package whose subpaths you depend on wants the whole version declared. `--exact` is that question, on both sides of the pair: `--check --exact` is the gate, and `--align --exact` is the repair — offline, keeping each declared version and dropping only the operator.
+Consistency is not exactness. A tree where every manifest agrees on `^4.1.0` passes `--check`, and still lets a minor release move under a consumer's lockfile-less install. So a package whose subpaths you depend on wants the whole version declared. `--exact` is that question, on both sides of the pair. `--check --exact` is the gate. `--align --exact` is the repair, offline, keeping each declared version and dropping only the operator.
 
 ```bash
 gjsify upgrade --check --exact --filter @girs   # gate
@@ -51,7 +51,7 @@ Pair `--exact` with `--filter`. Without one it reaches every dependency you decl
 
 ## What moves together, and what does not
 
-**Moves together:** every published `@gjsify/*` package. The Node.js modules, the Web APIs, the DOM bridges, the native prebuilds, the CLI and the build tooling all carry the same version number.
+**Moves together.** Every published `@gjsify/*` package: the Node.js modules, the Web APIs, the DOM bridges, the native prebuilds, the CLI and the build tooling all carry the same version number.
 
 **Keeps its own schedule:**
 
@@ -62,11 +62,11 @@ Pair `--exact` with `--filter`. Without one it reaches every dependency you decl
 
 Every package declares a tier in its own manifest, and the declaration is checked rather than taken on trust.
 
-**Tier 1, core.** Its whole test suite runs on both GJS and Node before every release, and no release ships with a known break in it. This is the Node.js, Web and DOM pillars, the GTK bridge widgets and the build tooling, which is nearly every package you will ever import.
+**Tier 1, core.** The whole test suite runs on both GJS and Node before every release, and no release ships with a known break in it. This is the Node.js, Web and DOM pillars, the GTK bridge widgets and the build tooling, which is nearly every package you will ever import.
 
 **Tier 2, product.** Tested and released on the same train, but a breaking change can arrive in a minor version with a changelog note. This covers the Adwaita packages, storybook, devtools, the native app shell, the published showcase apps and [node-gi](/gjsify/projects/node-gi/).
 
-**Tier 3, experimental.** No promise at all. New directions start here: today that is [`@gjsify/napi`](/gjsify/projects/napi/) with its shim prebuilds, the browser and CDP devtools adapters, the prebuilt GTK and Node runtime bundles that let a macOS or Windows artifact carry its own, the [GTK host](/gjsify/frameworks/) and the [React Native layer](/gjsify/frameworks/react-native/) over it. Each package's own `gjsify.tier` field is the authority — this list is what those fields say.
+**Tier 3, experimental.** No promise at all. New directions start here: today that is [`@gjsify/napi`](/gjsify/projects/napi/) with its shim prebuilds, the browser and CDP devtools adapters, the prebuilt GTK and Node runtime bundles that let a macOS or Windows artifact carry its own, the [GTK host](/gjsify/frameworks/) and the [React Native layer](/gjsify/frameworks/react-native/) over it. Each package's own `gjsify.tier` field is the authority, and this list is what those fields say.
 
 A package's runtime dependencies may only point at its own tier or a lower one, so nothing experimental can end up underneath something core.
 


### PR DESCRIPTION
The docs were written for people who already know gjsify. This rewrites them for someone
deciding whether to adopt it: fewer words per fact, no em dashes, one idea per sentence,
active voice, and no sentence that would read the same in another project's docs.

45 of the 57 in-scope pages changed. The 12 widget-gallery pages under `adwaita/` and
`gtk/` are untouched, because a sibling PR owns them.

**Lighter means fewer words per fact, never fewer facts.** Every measured claim, version
floor, CI leg name, distro package list and named gap is still there. The pages that grew
did so on purpose: `patterns/gobject-classes` now glosses `ParamSpec` and `vfunc_*` on
first use, `versioning` states the tier answer in paragraph one, and `runtimes` carries
the runtime claim below.

## Where the runtime claim landed

Every gallery page used to repeat "the `@girs` program that runs unchanged on GJS, Node,
Bun and Deno", because the gallery's window title would not name a runtime. The sibling PR
renames that window to GJS and drops the repetition, so the claim now lives in three
places a reader is already asking the question it answers:

- `getting-started`, right under the first `src/index.ts`: nothing in that file names a
  runtime, and the same bytes build for all four.
- `runtimes`, at the top: the gallery TypeScript is written for GJS and runs unchanged on
  Node, Bun and Deno. `--gi-renderer` then answers the same `Adw.*` and `Gtk.*` names out
  of `@gjsify/adwaita-web` on `--app browser` and `@gjsify/adwaita-nativescript` on
  `--app nativescript`, so the widget keeps its name in five places.
- `frameworks/index`, under the adapter table: the host is plain TypeScript over `gi://`,
  so every example on the page runs on all four.

NativeScript is now named as an experimental target on `overview` and `runtimes`, since the
port runs the same widget names on a phone. `packages/overview` already carried its own
version of the claim and keeps it; `how-it-works` did not need a fourth copy.

## What moved to contributing/

`how-it-works.mdx` drifted between two audiences. It drops from 36 KB to 29.7 KB, with the
contributor half moved into `contributing/architecture.md` under two new headings and a
one-line link left at each spot:

- **What the platform audit verifies** holds the `✓`-glyph incident after the per-target
  package split, the structural-vs-functional split of the audit, the `uraimo`
  `run-on-arch-action` leg that compiled x86-64 into `prebuilds/linux-ppc64/`, and both
  `○` packages with their reasons.
- **How the cross-runtime claims are checked** holds the golden-diff harness, gjs as the
  yardstick, 370 GIMarshallingTests, the per-OS job names, and the
  build-on-Fedora/run-on-macOS cost decision.

What a user needs in order to predict their own build stayed: the auto-globals iteration
loop, two-pass convergence, the five-pass cap, `firefox140`, and the Windows traps that
look like defects. The macOS SIP fact moved into "Running gjs yourself", where someone
wrapping `gjsify run` in a script needs it. Nothing else moved; several agents proposed
moves that were really support-level claims an adopter acts on, and those stayed put.

## Two em dashes stay, deliberately

`frameworks/styling.mdx` quotes `UnknownUtilityError`'s real message inside a ```text
fence, and `packages/framework/gtk-host/src/style/{errors,tokens}.ts` build that message
with em dashes. `ship/signing.md` quotes a `gjsify ship` stderr line whose wording
`tests/e2e/ship-signing/run.mjs:219` pins byte for byte. Rewriting either quote would
misquote the binary, and the source strings are out of scope here. Worth a follow-up in
the CLI if the rule should hold end to end.

## Also fixed

`cli-reference.md` linked to `/gjsify/widgets/`, which is not a page. It now points at the
Adwaita gallery. `experiments/effect.mdx`'s description gained an unquoted colon during
the rewrite, which broke the YAML frontmatter and the content sync; it is quoted now.

## Verification

- `node scripts/check-doc-fences.mjs` is OK across 14 sources, as it was before.
- `check-website-adwaita-gallery`, `check-website-package-names`,
  `check-website-preview-not-content`, `check-website-attr-samples`,
  `check-generated-website-data` and `check-doc-revert` are all clean.
- Every code fence audited against `origin/main`: byte-identical except six prose comment
  lines whose em dashes had to go, plus the two quoted error strings restored above.
- All 69 frontmatter blocks parse as YAML; `astro build` completes content sync and type
  generation over all of them.
- Every `/gjsify/...` link and `#anchor` in the tree resolves: 69 pages, 0 unresolved.
- Zero em dashes left in scope, apart from the two quoted strings named above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
