### PR TITLE
docs(website): one React, two element vocabularies

### DIFF
--- a/docs/code-anti-patterns.md
+++ b/docs/code-anti-patterns.md
@@ -308,3 +308,41 @@ emitted CSS — a selector matching nothing, on a pane that still rendered, so t
 page looked unstyled rather than broken and nothing in the build said a word.
 Astro strips `:global()` only in a SCOPED style block, where it is the escape
 hatch; in a global one there is nothing to escape from.
+
+## A rule whose premise died and whose conclusion did not
+
+**Rule: when a recorded reason says "X, SO Y" and X stops being true, RE-DERIVE Y in
+writing. Deleting the reason keeps a rule nobody can defend; deleting the rule
+because its premise expired throws away a conclusion that may still hold on other
+grounds. Either way the next reader "simplifies" the rule back into the bug.**
+
+Measured on the website's Adwaita gallery. Its React Native pane was labelled
+"React Native on GTK" rather than "React Native", and the label's recorded reason
+was: *there is no Adwaita widget set built out of React Native primitives, SO
+nothing under this window runs on a phone*. The qualifier existed so a reader
+meeting that pane beside the NativeScript one would not take it for the port that
+runs on a device.
+
+#1380 landed `@gjsify/adwaita-react-native`, which is exactly such a widget set.
+The premise was gone, and the `so` says it was load-bearing as written, so nothing
+in the note carried the label any more. The conclusion survived anyway, on a
+different ground: what is at stake is what THAT PANE renders, and it renders
+`@gjsify/react-native`, which takes React Native's components to GTK 4 in-process.
+A package running the other direction, elsewhere in the tree, does not put a phone
+in a pane. Had the reason simply been deleted, the qualifier would have read as
+decoration at the next edit; had the qualifier been dropped with its premise, the
+pane would have claimed a device it cannot reach.
+
+The pane itself is gone now, for an unrelated and smaller reason: it was filled on
+3 of 40 blocks, all on one page, against 28 blocks carrying a `react` snippet, so it
+was a footnote holding a window pane. The claim outlived it, which is the point.
+`website/src/content/docs/adwaita/layout.mdx` says in prose what those three
+snippets showed, and
+`website/src/content/docs/frameworks/react-native.mdx` § "What this is not" carries
+the direction argument for readers who need it.
+
+ADR 0034's stage 1 is the same shape and was resolved the same way: the stage was
+ordered first because adopting the vocabulary clauses on
+`@gjsify/adwaita-react-native` was free before its first publish, the package then
+published at 0.44.0, and the row is left as written because deleting the premise
+deletes the ordering argument. Two instances make it a class, not a one-off.

--- a/scripts/check-doc-fences.mjs
+++ b/scripts/check-doc-fences.mjs
@@ -288,18 +288,35 @@ function readStyledClasses() {
  *
  * The fences on these pages are INDENTED, inside `<Fragment slot="…">`, so an
  * anchored `^```` finds 10 of the 340 that are there.
+ *
+ * THE META IS READ, and it is read because not reading it did not skip one fence, it
+ * shifted the whole page. A `txt title="hello-gjsify"` opener matched nothing, so it was
+ * dropped and its CLOSING fence became the next opener: from there every fence on the
+ * page was off by one, and the one swallowed as the phantom's body was a fence no arm
+ * then read. Measured on `getting-started.mdx`, the one page in the tree with a fence
+ * attribute: 54 markers, 27 fences, and this reader came back with 26 plus a phantom of
+ * no language. At exit 0, because no arm reads a language it cannot name, which is this
+ * whole file's own failure mode one layer down.
+ *
+ * {@link fenceParseProblem} is the floor under that: markers and fences are held
+ * against each other per source, so the next shape this reader cannot parse is reported
+ * rather than absorbed.
  */
 function fences(text) {
     const lines = text.split('\n');
     const out = [];
     let open = null;
     for (let i = 0; i < lines.length; i++) {
-        const m = lines[i].match(/^(\s*)```(\w*)\s*$/);
+        const m = lines[i].match(/^(\s*)```([\w-]*)(.*)$/);
         if (!m) {
             if (open) open.body.push(lines[i]);
             continue;
         }
-        if (open && m[1].length === open.indent && m[2] === '') {
+        // A CLOSER is a bare fence: no language and nothing after it. An opener carrying
+        // meta and no language would read as one, and the count guard is where that
+        // would surface instead of shifting the page.
+        const bare = m[2] === '' && m[3].trim() === '';
+        if (open && m[1].length === open.indent && bare) {
             out.push({ lang: open.lang, line: open.line, body: open.body.join('\n') });
             open = null;
         } else if (!open) {
@@ -309,6 +326,24 @@ function fences(text) {
         }
     }
     return out;
+}
+
+/**
+ * A source whose fence MARKERS and fence BLOCKS disagree.
+ *
+ * Every fence is two markers and no page in this tree nests one, so `markers / 2` is
+ * what a correct read returns. An off-by-one here is the shape described above: some
+ * opener was not recognised, and from there the page is read shifted, silently.
+ */
+function fenceParseProblem(text, blocks) {
+    const markers = text.split('\n').filter((line) => /^\s*```/.test(line)).length;
+    if (markers === 2 * blocks.length) return null;
+    return (
+        `${markers} fence marker(s) on this page and ${blocks.length} fence(s) read, so ${markers / 2} were ` +
+        'there. An opener this reader cannot classify is not skipped: its closing fence becomes the next ' +
+        'opener, every fence after it is off by one, and a real one is swallowed as the body of a phantom ' +
+        'whose language no arm reads. Teach `fences()` the shape, or unnest the fence.'
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -913,6 +948,8 @@ try {
         }
         const text = readFileSync(abs, 'utf8');
         const list = fences(text);
+        const parse = fenceParseProblem(text, list);
+        if (parse !== null) fail(rel, parse);
         const slots = slotAtLine(text.split('\n'));
         for (const fence of list) {
             if (fence.lang !== 'ts') continue;
@@ -1253,9 +1290,12 @@ if (!existsSync(TSC_ENTRY)) {
             .split(sep)
             .join('/');
         const text = readFileSync(abs, 'utf8');
+        const pageFences = fences(text);
+        const parse = fenceParseProblem(text, pageFences);
+        if (parse !== null) fail(rel, parse);
         const page = [];
         let anyTsx = false;
-        for (const fence of fences(text)) {
+        for (const fence of pageFences) {
             const lang = fence.lang.toLowerCase();
             if (!SNIPPET_LANGS.has(lang)) continue;
             snippetFences += 1;

--- a/scripts/check-website-adwaita-gallery.mjs
+++ b/scripts/check-website-adwaita-gallery.mjs
@@ -122,6 +122,17 @@
 //      cannot outlive what it was recorded for. The partition and the DISTANCE are
 //      PRINTED on every run and written down nowhere: a count in a header is the
 //      drift this gallery has already paid for twice.
+//  13. Every TAB slot is filled on every block, or it is ledgered in
+//      {@link PARTIAL_TAB_SLOTS} with the reason it stays per-page. Arms 5 and 6 are
+//      each satisfied by ONE block writing a slot, so a tab on 3 of 40 blocks and a tab
+//      on all 40 are the same shape to them — and that shape has now got in three
+//      times: the `nativescript` XML template as a slot on 4 of 40 until #1502, the
+//      hand-written attribute pane (110 of its attributes named on their page, 54 not),
+//      and the `react-native` tab on 3 of 40, all three on one page. A port that cannot
+//      express every widget has a home that says so on every block, which is a data
+//      GROUP with a refusal pane; the ledger is for a tab that is genuinely per-page,
+//      and it is empty. The coverage is PRINTED, because each of the three had to be
+//      measured by hand before anyone could see it.
 //   9. The reader meets the RUNNING WIDGET before any source, and the markup that
 //      paints it is shown. Read out of both component files, because the claim now
 //      spans them: the live pane and the markup tab are ONE source (the pane mounts the
@@ -420,6 +431,19 @@ const MARKUP_OVERRIDE_LEDGER = {
     'Adw.Toast':
         "`<adw-toast-overlay>` has no declarative toast child — `addToast()` is the whole API — so the markup that PAINTS a toast in a static preview is the overlay's own internal DOM (`.adw-toast.visible` and friends), which is the one thing a reader must not copy. The preview depicts the result; the tab teaches the call.",
 };
+
+/**
+ * TAB slots filled on SOME blocks and not all, with the reason each one may stay a
+ * tab — arm 13's input, and empty, which is the state it is meant to keep.
+ *
+ * A tab is a per-page fence: forty pages have to write it, and the ones that do not
+ * are silent. Arms 5 and 6 are both satisfied by ONE block writing it, so a footnote
+ * and a port look identical to them, which is how the same shape got in three times
+ * (see arm 13). A port that genuinely cannot express every widget already has a home
+ * that says so on every block: a data GROUP with a refusal pane ({@link PaneGroup}).
+ * That is the fix an entry here is competing with, and it is why the bar is high.
+ */
+const PARTIAL_TAB_SLOTS = {};
 
 /**
  * The window model `AdwWidget` renders: each window's id, title, tab slots, data
@@ -1167,6 +1191,8 @@ if (blocks.length === 0) {
 }
 
 const provided = new Set();
+/** slot → the blocks that write it, by title. Arm 13 reads the SIZES. */
+const providedBy = new Map();
 /** Every slot ANY block writes, rendered or not — the corpus half of arm 6 reads this. */
 const authored = new Set();
 /** The blocks that override the preview window's markup tab — arm 8's input. */
@@ -1176,6 +1202,8 @@ for (const block of blocks) {
         authored.add(slot);
         if (ports.has(slot)) {
             provided.add(slot);
+            if (!providedBy.has(slot)) providedBy.set(slot, new Set());
+            providedBy.get(slot).add(`${block.page} ${block.title}`);
             continue;
         }
         if (slot === override) {
@@ -1252,6 +1280,64 @@ for (const window of windows) {
         `${WIDGET_COMPONENT} declares the window "${window.id}" (${window.slots.join(', ')}), and no\n` +
             `    <AdwWidget> block under ${GALLERY} provides any of its tabs. The window renders nowhere:\n` +
             '    a kind of implementation announced to every reader of the component and shown to none.',
+    );
+}
+
+// --- arm 13: a TAB is a pane on EVERY block, or the ledger says why not ---
+//
+// THE INCIDENT, three times, which is what makes it a class rather than a habit. A tab
+// is a fence forty pages have to write, and the pages that do not write it say nothing.
+//
+//   · the `nativescript` XML template was a SLOT until #1502, filled on 4 blocks of 40
+//   · the attribute pane was written by hand once per page: of the attributes its
+//     elements observe, 110 were named somewhere on their page and 54 were not
+//   · the `react-native` tab was filled on 3 blocks of 40, all three on `layout.mdx`,
+//     against 28 blocks carrying a `react` snippet
+//
+// Nothing said so in any of the three cases, and arms 5 and 6 cannot: 5 refuses a page
+// naming a slot the component has not got, 6 refuses a component naming a slot NO page
+// has got, and ONE page is enough for both. A footnote and a port are the same shape to
+// them. So the coverage is held here and PRINTED on every run, which is the half that
+// stops the next one needing to be noticed by hand.
+//
+// The remedy an entry here competes with is not "write 37 more fences". A port that
+// cannot express every widget gets a data GROUP with a refusal pane, which puts a pane
+// on every block and says WHY where there is no snippet — see {@link PaneGroup}, and
+// see the two groups the frameworks window already carries. The ledger is for a tab
+// that is genuinely per-page, and it is empty.
+//
+// SELF-RETIRING, like arm 12's: an entry naming a slot that has since reached every
+// block fails here, so a reason cannot outlive what it was recorded for.
+
+for (const [slot, blocksWithIt] of providedBy) {
+    const reason = PARTIAL_TAB_SLOTS[slot];
+    if (blocksWithIt.size === blocks.length) {
+        if (reason === undefined) continue;
+        failures.push(
+            `${slot}: ledgered in PARTIAL_TAB_SLOTS as a tab that cannot be filled everywhere, and it is\n` +
+                `    now on all ${blocks.length} blocks. A stale exemption reads as considered when it is merely\n` +
+                '    forgotten, and this one would license the next three-block tab. Delete the entry.',
+        );
+        continue;
+    }
+    if (reason !== undefined) continue;
+    failures.push(
+        `${WIDGET_COMPONENT} renders the tab "${slot}", and only ${blocksWithIt.size} of ${blocks.length}\n` +
+            `    <AdwWidget> blocks under ${GALLERY} write that fragment. The other ` +
+            `${blocks.length - blocksWithIt.size} draw the\n` +
+            '    window without it and say nothing, which is how a footnote comes to hold a window pane —\n' +
+            '    three times so far. Fill it everywhere, give the port a data GROUP with a refusal pane so\n' +
+            `    every block carries one, or add "${slot}" to PARTIAL_TAB_SLOTS in this script with the reason\n` +
+            '    it has to stay per-page.',
+    );
+}
+
+for (const slot of Object.keys(PARTIAL_TAB_SLOTS)) {
+    if (providedBy.has(slot)) continue;
+    failures.push(
+        `${slot}: ledgered in PARTIAL_TAB_SLOTS, and no window of ${WIDGET_COMPONENT} renders a tab of\n` +
+            '    that name on any block. Arm 13 polices nothing for it, so the entry is a reason recorded\n' +
+            '    against a tab that is not there.',
     );
 }
 
@@ -1535,6 +1621,16 @@ console.log(
             ', ',
         )}), ${overriding.size} block(s) override the markup tab, all ledgered, and the widget is mounted ` +
         `once, outside ${WINDOW_COMPONENT}'s tab view, ahead of the window that shows its markup.`,
+);
+
+// Arm 13, printed rather than counted by hand every few months: three panes have now
+// been written per page and left unwritten on most of them, and each time the coverage
+// was a thing somebody had to go and measure.
+const tabSlots = windows.flatMap((window) => window.slots);
+console.log(
+    `check-website-adwaita-gallery: ${tabSlots.length} tab slot(s) — ` +
+        tabSlots.map((slot) => `${slot} ${providedBy.get(slot)?.size ?? 0}/${blocks.length}`).join(', ') +
+        ` — each on every block or ledgered as per-page, ${Object.keys(PARTIAL_TAB_SLOTS).length} ledgered.`,
 );
 
 /** The ledger's own partition, by kind, so a run says what the remaining work IS. */

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -12,8 +12,7 @@
 //      declaration: two FILES of one program, against the REAL libadwaita widget.
 //   3. UI FRAMEWORKS — the same widget reached through an ELEMENT MODEL instead of
 //      the GObject API: the markup the first window is painted from, the three
-//      `@gjsify/gtk-host` dialects, React Native on GTK, and the NativeScript XML
-//      template.
+//      `@gjsify/gtk-host` dialects, and the NativeScript XML template.
 //
 // It used to be ONE window with all of those as sibling tabs, and siblings cannot
 // say any of it: `gjs`/`blueprint` ARE libadwaita, `preview` and `nativescript` are
@@ -46,24 +45,31 @@
 // scanner it fed still runs: `check-website-attr-samples.mjs` holds every preview
 // fence against the element it names.
 //
-// TWO CLAIMS THE CHROME NO LONGER MAKES, both load-bearing, both still said:
+// ONE CLAIM THE CHROME NO LONGER MAKES, load-bearing, still said. The GJS window's
+// tab was once labelled "GJS · Node · Bun · Deno" and its window "Native TypeScript",
+// both to avoid naming one runtime: naming GJS made the pane read as "the GJS
+// variant", i.e. as if the other three needed a different program. They do not, and
+// that is the claim the whole site rests on. It is now made ONCE, on the pages that
+// are about runtimes (getting-started, runtimes, the frameworks index), instead of in
+// an intro paragraph under all 40 blocks and again in a window subtitle. So the window
+// can be titled for what it runs, which is the shortest true name it has.
 //
-//   · The GJS window's tab was once labelled "GJS · Node · Bun · Deno" and its
-//     window "Native TypeScript", both to avoid naming one runtime: naming GJS made
-//     the pane read as "the GJS variant", i.e. as if the other three needed a
-//     different program. They do not, and that is the claim the whole site rests on.
-//     It is now made ONCE, on the pages that are about runtimes (getting-started,
-//     runtimes, the frameworks index), instead of in an intro paragraph under all 40
-//     blocks and again in a window subtitle. So the window can be titled for what it
-//     runs, which is the shortest true name it has.
-//   · "React Native on GTK" carried its qualifier in the tab LABEL, because a plain
-//     "React Native" standing beside NativeScript would have read as the port that
-//     runs on a phone — which is not what that pane renders. (That reason once read
-//     "code it has not written"; `@gjsify/adwaita-react-native` was written in #1380,
-//     and the qualifier survives it, because what is at stake is what THIS pane
-//     shows, not what exists elsewhere in the tree.) The qualifier is now the page's:
-//     `layout.mdx`, the only page with that pane, says it renders a GTK window and
-//     not a phone screen.
+// THE `react-native` TAB IS GONE AND ITS REASONING IS NOT. It was filled on 3 blocks
+// of 40, all on `layout.mdx`, against 28 blocks carrying a `react` snippet: a footnote
+// holding a window pane. What those three showed — an Adwaita element with React
+// Native children, and the token step the children need — `layout.mdx` now says once
+// in prose, and `frameworks/react-native.mdx` shows in full.
+//
+// Its LABEL carried a qualifier ("React Native on GTK") because a plain "React Native"
+// standing beside NativeScript reads as the port that runs on a phone, which is not
+// what that pane rendered. That reason once rested on there being no Adwaita widget
+// set built out of React Native primitives; #1380 wrote one
+// (`@gjsify/adwaita-react-native`) and the conclusion survived on other grounds, since
+// what was at stake is what THAT PANE showed and not what exists elsewhere in the
+// tree. Both halves are written down where a reader meets them: the direction argument
+// in `frameworks/react-native.mdx` § "What this is not", the general shape in
+// docs/code-anti-patterns.md § "A rule whose premise died and whose conclusion did
+// not". Read those before putting the tab back.
 //
 // So the header bar carries a title and nothing else. Whatever a header bar sits on
 // is what the reader takes the window to be about: it once held the widget TITLE over
@@ -376,21 +382,14 @@ const WINDOWS: readonly {
     {
         id: 'frameworks',
         // Every rendering of this widget that goes through an ELEMENT MODEL rather
-        // than through the GObject API: markup, three host dialects, React Native,
-        // and the XML template.
+        // than through the GObject API: markup, three host dialects, and the XML
+        // template.
         //
-        // `@gjsify/react-native` renders React Native components onto GTK 4
-        // IN-PROCESS, so that pane does not run on a phone, and `layout.mdx` — the
-        // only page that fills it — says it renders a GTK window and not a phone
-        // screen. This note used to give a different reason ("there is no Adwaita
-        // widget set built out of React Native primitives, SO nothing under this
-        // window runs on a phone") and that premise died with
-        // `@gjsify/adwaita-react-native` (#1380), which is exactly such a set. The
-        // `so` means the absence really was load-bearing as written; what survives
-        // is the CONCLUSION, on other grounds. What fills that pane is direction A,
-        // and a direction-B package existing elsewhere in the tree does not put a
-        // phone in it. It would take a PANE that renders one — which the XML
-        // template beside it now is, and which is why it is labelled for the port.
+        // A `react-native` tab stood here until it was measured: 3 blocks of 40, all
+        // on one page. See the header for what it claimed and where that claim
+        // lives now, and read that before adding it back. The XML template is the
+        // only pane under this title that runs on a phone, which is why it is
+        // labelled for the port.
         title: 'UI frameworks',
         tabs: [
             // The markup the FIRST window is painted from, shown here because a
@@ -398,7 +397,6 @@ const WINDOWS: readonly {
             // fence is read for the mount whether or not this tab renders, so arm 9
             // holds that the fence a reader can copy is actually shown somewhere.
             { slot: MARKUP_SLOT, label: 'HTML Web Components' },
-            { slot: 'react-native', label: 'React Native' },
         ],
         // Filled on all 40 blocks, snippet or recorded reason — see {@link PaneGroup}.
         groups: [FRAMEWORK_GROUP, NATIVESCRIPT_GROUP],

--- a/website/src/content/docs/adwaita/layout.mdx
+++ b/website/src/content/docs/adwaita/layout.mdx
@@ -1,6 +1,6 @@
 ---
 title: Layout
-description: "Adwaita layout containers: Clamp, HeaderBar, ToolbarView and WrapBox. A live preview with its markup, plus the TypeScript, Blueprint, React Native on GTK and NativeScript code."
+description: "Adwaita layout containers: Clamp, HeaderBar, ToolbarView and WrapBox. A live preview with its markup, plus the TypeScript, Blueprint and NativeScript code."
 ---
 
 import AdwWidget from '../../../components/AdwWidget.astro';
@@ -40,12 +40,6 @@ is added to the layout anyway.
 
 The Solid, Vue and React tabs go through
 [`@gjsify/gtk-host`](https://github.com/gjsify/gjsify/tree/main/packages/framework/gtk-host).
-The clamp, the header bar and the toolbar view carry a
-[`@gjsify/react-native`](/gjsify/frameworks/react-native/) tab as well, the only three
-blocks on the site that do. That tab renders a GTK window, not a phone screen, which
-is why it is not the NativeScript one; the [React Native
-page](/gjsify/frameworks/react-native/#adwaita-widgets) says what does and does not
-exist there.
 
 The wrap box only recently joined them. `@gjsify/gtk-host` had no child policy for
 `AdwWrapBox`, so a child placed in one was refused by name. That was deliberate: a
@@ -53,12 +47,17 @@ renderer guessing the policy would call `add`, `append` or `set_child` and be wr
 exit 0. The policy is now curated against libadwaita, so the block has a tree like the
 other three.
 
-Two of the three host dialects style with `className`, and both configure their token
-scales on the way in. That line is not decoration. The values behind a class name come
-from the project, the layer's default scales are deliberately small (spacing holds `0`
-and `px` alone), and a class naming an undeclared token throws out of the render,
-leaving an empty window at exit 0 with nothing in the log. The header bar's snippet
-names no class and needs no such line.
+React Native primitives go inside these containers too, through
+[`@gjsify/react-native`](/gjsify/frameworks/react-native/). The Adwaita element is the
+same one the React tab shows, and a `<View>` or `<Text>` sits in its default slot. The
+clamp, the header bar and the toolbar view carried a tab for that pairing, and they were
+the only three blocks on the site with one, so the [React Native
+page](/gjsify/frameworks/react-native/#adwaita-widgets) carries it in full instead. Two
+facts from there are worth having before you try it. The primitives need their token
+scales installed with `configureStyle({ tokens })` before the first render, because a
+class naming a token you have not declared throws out of the render and leaves an empty
+window at exit 0 with nothing in the log. And such a tree is a GTK window rather than a
+phone screen, which is why it was never the NativeScript tab.
 
 Libadwaita is the reference, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
@@ -133,29 +132,6 @@ at a comfortable measure on a large display without wasting room on a small one.
 
         styles ["card"]
       };
-    }
-    ```
-  </Fragment>
-  <Fragment slot="react-native">
-    ```tsx
-    import { Text, View } from 'react-native';
-    import { configureStyle } from '@gjsify/react-native';
-
-    // The class VALUES are the project's. The layer's default spacing scale holds `0`
-    // and `px` only, so a class naming a token you have not declared throws out of the
-    // render — the window is then empty at exit 0, with no GTK diagnostic.
-    configureStyle({ tokens: { spacing: { m: '12px' }, fontSize: { title: '18px' } } });
-
-    export function ReadingColumn() {
-        return (
-            <adw-clamp maximumSize={400} tighteningThreshold={300}>
-                {/* One child: `AdwClamp`'s policy is `set_child`, measured. */}
-                <View className="flex-col gap-m p-m">
-                    <Text className="text-title">Clamped</Text>
-                    <Text>It stops growing past the maximum size and stays centred.</Text>
-                </View>
-            </adw-clamp>
-        );
     }
     ```
   </Fragment>
@@ -240,26 +216,6 @@ the trailing one.
 
         styles ["flat"]
       }
-    }
-    ```
-  </Fragment>
-  <Fragment slot="react-native">
-    ```tsx
-    import { Pressable, Text } from 'react-native';
-
-    export function EditorHeader({ onBack }: { onBack: () => void }) {
-        return (
-            <adw-header-bar>
-                {/* A header bar's default slot is `start`, and a React Native
-                    primitive can only go in a default slot: `slot` is not one of
-                    its props, and an unlisted prop is refused by name. */}
-                <Pressable onPress={onBack}>
-                    <Text>Back</Text>
-                </Pressable>
-                <adw-window-title slot="title" title="Text Editor" subtitle="notes.md" />
-                <gtk-button slot="end" iconName="open-menu-symbolic" cssClasses={['flat']} />
-            </adw-header-bar>
-        );
     }
     ```
   </Fragment>
@@ -395,44 +351,6 @@ the view moves.
           styles ["flat"]
         }
       }
-    }
-    ```
-  </Fragment>
-  <Fragment slot="react-native">
-    ```tsx
-    import { Pressable, Text, View } from 'react-native';
-    import { configureStyle } from '@gjsify/react-native';
-
-    // Before the first render, and not optional: `gap-s`, `p-xl`, `text-title` and
-    // `text-caption` are this project's names. Without the scales the first one
-    // throws, React unmounts the tree, and the window is empty at exit 0.
-    configureStyle({
-        tokens: { spacing: { s: '8px', xl: '24px' }, fontSize: { caption: '11px', title: '18px' } },
-    });
-
-    export function Documents({ onAdd }: { onAdd: () => void }) {
-        return (
-            <adw-toolbar-view>
-                <adw-header-bar slot="top">
-                    <adw-window-title slot="title" title="Documents" subtitle="12 items" />
-                </adw-header-bar>
-
-                {/* The default slot is the content, and the content is React Native's. */}
-                <View className="flex-col items-center justify-center gap-s p-xl">
-                    <Text className="text-title">Your library</Text>
-                    <Text className="text-caption">Content sits between the toolbars.</Text>
-                </View>
-
-                {/* A box with the `toolbar` style class, not a Gtk.ActionBar: the
-                    action bar is in gtk-host's generated table, which knows the tag
-                    but not how it adopts a child, so it refuses one. */}
-                <gtk-box slot="bottom" cssClasses={['toolbar']}>
-                    <Pressable onPress={onAdd}>
-                        <Text>Add</Text>
-                    </Pressable>
-                </gtk-box>
-            </adw-toolbar-view>
-        );
     }
     ```
   </Fragment>

--- a/website/src/content/docs/frameworks/index.mdx
+++ b/website/src/content/docs/frameworks/index.mdx
@@ -76,6 +76,10 @@ Pick one and the rest of this page is the same for all three. All three speak GT
 vocabulary: `<gtk-box orientation="vertical">`, GTK property names, `css-classes` as a string
 array.
 
+React reaches this host through two element vocabularies rather than one, the GTK tags above and
+React Native's primitives. The [React page](/gjsify/frameworks/react/) puts the two side by side
+and says how to pick; the section below is the short version.
+
 None of the code on this page names a runtime. The host is plain TypeScript over `gi://`, so
 every example here builds and runs on GJS, Node.js, Bun and Deno from one source.
 [Runtimes](/gjsify/runtimes/) has that story, along with the two further targets the same widget
@@ -84,7 +88,9 @@ names reach: a browser build, and an experimental NativeScript one for Android a
 ## Bringing a React Native app instead
 
 `<View>`, `<Text>`, `<Pressable>` and `className="flex-1 items-center"` are a *different*
-vocabulary, and it renders over the same host rather than beside it:
+vocabulary, and it renders over the same host rather than beside it. It is not a fourth adapter.
+React Native code goes through the React adapter above, with different leaves and a different
+layout model:
 
 - [React Native](/gjsify/frameworks/react-native/) puts React Native's exports on GTK 4. It is
   the package a bundler aliases `react-native` to. Every name it does not implement is still
@@ -486,7 +492,9 @@ the **real** widget tree on every launch:
 - [Solid JSX](/gjsify/frameworks/solid/) for the compile step a `.tsx` entry needs
 - [Vue SFCs](/gjsify/frameworks/vue/) for the compile step a `.vue` entry needs
 - [React](/gjsify/frameworks/react/) for the `jsxImportSource` and build defines a `.tsx` entry
-  needs instead of a compile step
+  needs instead of a compile step, and for the choice between its two element vocabularies
+- [React Native on GTK](/gjsify/frameworks/react-native/) for the second of those, if you are
+  porting an app rather than starting one
 - [Native Adwaita Apps](/gjsify/guides/native-adwaita-app/) for the application shell you
   mount into
 - [GObject Classes](/gjsify/patterns/gobject-classes/) for the `registerClass` rules your own

--- a/website/src/content/docs/frameworks/react-native.mdx
+++ b/website/src/content/docs/frameworks/react-native.mdx
@@ -355,9 +355,10 @@ Three rules hold there, and the layer states each of them by refusing rather tha
   `tableProvenance()` from `@gjsify/gtk-host` for the live figure; this count has now drifted
   three times.
 
-The [Layout page](/gjsify/adwaita/layout/) of the Adwaita gallery carries this as a **React
-Native on GTK** tab beside the GJS, Blueprint, web and NativeScript ones: on the clamp, the
-header bar and the toolbar view, and not on the wrap box, whose policy is still missing.
+The [Layout page](/gjsify/adwaita/layout/) of the Adwaita gallery shows the clamp, the header
+bar and the toolbar view from every other angle: the live widget, its markup, the GJS program,
+the Blueprint declaration and the NativeScript template. It carried a tab for this pairing too,
+on those three blocks and nowhere else, which is why the pairing is documented here instead.
 
 ### What this is not
 

--- a/website/src/content/docs/frameworks/react-native.mdx
+++ b/website/src/content/docs/frameworks/react-native.mdx
@@ -1,13 +1,18 @@
 ---
-title: React Native
-description: Run React Native components on GTK 4. Primitives, lists, routing, styling, Adwaita containers, and the one build flag that turns it on.
+title: React Native on GTK
+description: Bring an existing React Native or Expo view layer onto GTK 4. Primitives, lists, routing, styling, Adwaita containers, and the one build flag that turns it on.
 ---
 
 import CommandTabs from '../../../components/CommandTabs.astro';
 
-Write `<View>`, `<Text>` and `<Pressable>` and get real GTK widgets. If you already have an
-Expo or React Native app, its view layer is the part that ports, and the aim is that it ports
-without a rename per file.
+Write `<View>`, `<Text>` and `<Pressable>` and get real GTK widgets. `@gjsify/react-native` is
+the package a bundler aliases `react-native` to, so an Expo or React Native app keeps the
+imports its files were written with. Its view layer is the part that ports, and the aim is that
+it ports without a rename per file.
+
+This page is for code you already have. If you are writing a GTK app from scratch, the
+[React page](/gjsify/frameworks/react/) carries the other element vocabulary and the comparison
+between the two.
 
 There is no bridge and no native module host. This renders in-process onto GTK, so
 `NativeModules`, `TurboModuleRegistry` and `findNodeHandle` are not available and say so when you
@@ -364,8 +369,16 @@ on those three blocks and nowhere else, which is why the pairing is documented h
 
 **This layer does not put Adwaita on a phone.** `<adw-toolbar-view>` above is
 `Adw.ToolbarView`: a GTK 4 widget, in a GTK 4 window, on a machine where libadwaita is
-installed. Nothing on this page runs on Android or iOS, and no tab in the gallery claims
-otherwise.
+installed. Nothing on this page runs on Android or iOS.
+
+The gallery used to make that claim in a tab label, which read **React Native on GTK** rather
+than **React Native**, because a plain one beside the NativeScript tab would have been taken for
+the port that runs on a device. The tab is gone and the qualifier is this page's title now,
+because the label went and its reason did not. Worth knowing what that reason is not: it was
+once written down as *there is no Adwaita widget set built out of React Native primitives, so
+nothing here runs on a phone*, and #1380 wrote exactly such a set. The premise died and the
+conclusion held, because what settles it is the direction below and not what exists elsewhere in
+the tree.
 
 The distinction is a direction rather than a boundary. This layer takes React Native's
 *components* to GTK. The opposite direction, Adwaita's *components* rebuilt on React Native's
@@ -577,7 +590,8 @@ reasons under the row they belong to.
 ## Related
 
 - [Getting started](/gjsify/getting-started/) if you do not have a gjsify project yet
-- [React](/gjsify/frameworks/react/) for the adapter underneath, and the build flags in full
+- [React](/gjsify/frameworks/react/) for the choice between the two element vocabularies, the
+  adapter underneath, and the build flags in full
 - [Styling on GTK](/gjsify/frameworks/styling/) for the class families and token scales
 - [Package README](https://github.com/gjsify/gjsify/blob/main/packages/framework/react-native/README.md)
   for the generated per-name support listing

--- a/website/src/content/docs/frameworks/react.mdx
+++ b/website/src/content/docs/frameworks/react.mdx
@@ -36,8 +36,7 @@ of wrong at exit 0, with every widget present and every row a column.
 `Adw.Clamp` holds long-form content at a readable width. The Adwaita element is identical on
 both paths, down to the property names:
 
-```tsx
-// @gjsify/gtk-host/react
+```tsx title="@gjsify/gtk-host/react"
 export function ReadingColumn() {
     return (
         <adw-clamp maximumSize={400} tighteningThreshold={300}>
@@ -52,8 +51,7 @@ export function ReadingColumn() {
 }
 ```
 
-```tsx
-// @gjsify/react-native
+```tsx title="@gjsify/react-native"
 import { Text, View } from 'react-native';
 
 import { configureStyle } from '@gjsify/react-native';

--- a/website/src/content/docs/frameworks/react.mdx
+++ b/website/src/content/docs/frameworks/react.mdx
@@ -1,6 +1,6 @@
 ---
 title: React
-description: Render React into GTK 4 widgets with @gjsify/gtk-host/react. Install, configure, render, build.
+description: One React on GTK 4, two element vocabularies. Pick between @gjsify/gtk-host/react and @gjsify/react-native, then install, configure, render, build.
 ---
 
 import CommandTabs from '../../../components/CommandTabs.astro';
@@ -10,8 +10,94 @@ Render React into real `Gtk` and `Adw` widgets. There is no compile plugin, no D
 flags are the whole setup.
 
 You keep React. Components, hooks, context, error boundaries, `useState`, `useEffect` and
-Suspense behave the way they do anywhere else. What changes is the element vocabulary:
-`<gtk-box>` instead of `<div>`.
+Suspense behave the way they do anywhere else. What changes is the element vocabulary, and
+gjsify has two of them.
+
+## Two vocabularies, one React
+
+Both packages run the same React 19 reconciler against the same host layer, and both produce
+real GTK widgets in the same window. They differ in what you type for leaves and for layout.
+
+| | [`@gjsify/gtk-host/react`](#install) | [`@gjsify/react-native`](/gjsify/frameworks/react-native/) |
+|---|---|---|
+| Leaves | `<gtk-label>`, `<gtk-button>`, one tag per GTK class | `<Text>`, `<Pressable>`, React Native's own props |
+| Layout | GTK containers, so `<gtk-box orientation="vertical">` | `<View>` and Yoga flexbox |
+| Styling | `cssClasses={['card']}` and GTK CSS | `className="flex-col gap-m"` over token scales you declare |
+| Adwaita widgets | 168 generated tags, 63 of them `Adw` | the same tags, in the same tree |
+| Reach for it | when the GTK window is the app you are writing | when you are bringing React Native or Expo code to the desktop |
+
+The two element sets stay in separate packages, and separate is the right answer. A `Gtk.Box`
+with no orientation is horizontal and a React Native `View` is a column, so one name over both
+would have to pick a default that is wrong for half of what it renders. GTK reports that kind
+of wrong at exit 0, with every widget present and every row a column.
+
+## The same window, written both ways
+
+`Adw.Clamp` holds long-form content at a readable width. The Adwaita element is identical on
+both paths, down to the property names:
+
+```tsx
+// @gjsify/gtk-host/react
+export function ReadingColumn() {
+    return (
+        <adw-clamp maximumSize={400} tighteningThreshold={300}>
+            <gtk-label
+                label="It stops growing past the maximum size and stays centred."
+                wrap
+                xalign={0}
+                cssClasses={['card']}
+            />
+        </adw-clamp>
+    );
+}
+```
+
+```tsx
+// @gjsify/react-native
+import { Text, View } from 'react-native';
+
+import { configureStyle } from '@gjsify/react-native';
+
+// The class VALUES are your project's. The layer's default spacing scale holds `0` and `px`
+// only, so a class naming a token you have not declared throws out of the render. React
+// unmounts the tree, the window is empty, and the process exits 0 with no GTK diagnostic.
+configureStyle({ tokens: { spacing: { m: '12px' }, fontSize: { title: '18px' } } });
+
+export function ReadingColumn() {
+    return (
+        <adw-clamp maximumSize={400} tighteningThreshold={300}>
+            <View className="flex-col gap-m p-m">
+                <Text className="text-title">Clamped</Text>
+                <Text>It stops growing past the maximum size and stays centred.</Text>
+            </View>
+        </adw-clamp>
+    );
+}
+```
+
+Two things follow from that pair. The Adwaita and GTK tags are available on both paths, because
+both point `jsxImportSource` at `@gjsify/gtk-host/react`, so a React Native tree reaches a
+clamp, a header bar or a toolbar view without leaving React Native. And the token step is the
+one line the second path adds that has no counterpart on the first. Style your GTK tags with
+`cssClasses` and there is nothing to declare up front.
+
+## Which one to pick
+
+**Have React Native or Expo code already?** Take
+[`@gjsify/react-native`](/gjsify/frameworks/react-native/). It is the package a bundler aliases
+`react-native` to, so your files keep the imports they have, and every name it does not
+implement is still exported and refuses with a status and a reason. That page carries the
+per-name support answers, the routing, and the prop table you can assert against before a
+window exists.
+
+**Starting fresh on GTK?** Take `@gjsify/gtk-host/react`, which is the rest of this page. One
+tag per GTK class, GTK property names, no style system to configure, and a type error rather
+than a runtime refusal when you name something that does not exist.
+
+**Neither of them runs on a phone.** Both render in-process onto GTK 4, so both need libadwaita
+on the machine. The opposite direction, Adwaita's widgets rebuilt on React Native's primitives,
+is [`@gjsify/adwaita-react-native`](https://github.com/gjsify/gjsify/blob/main/packages/framework/adwaita-react-native/README.md),
+and it is a walking skeleton that has never run on a device.
 
 ## Install
 
@@ -205,8 +291,8 @@ Here that reaches your tree only and never touches chrome your application put t
 
 - [Getting started](/gjsify/getting-started/) if you do not have a gjsify project yet
 - [UI Frameworks](/gjsify/frameworks/) for the host, the widget table and the placement rules
-- [React Native](/gjsify/frameworks/react-native/) if your components are written with `View`
-  and `Text` rather than `<gtk-box>`
+- [React Native](/gjsify/frameworks/react-native/) for the other vocabulary, if you are bringing
+  code written with `View` and `Text`
 - [Styling on GTK](/gjsify/frameworks/styling/) for class names and token scales
 - [`react-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/react-host-counter)
   for a complete window that asserts its own widget tree on every launch

--- a/website/src/content/docs/overview.mdx
+++ b/website/src/content/docs/overview.mdx
@@ -62,7 +62,7 @@ operating-system question.
 
 - [Getting Started](/gjsify/getting-started/): scaffold a project, get a window on screen
 - [Widget Gallery](/gjsify/adwaita/): every Adwaita component, with live previews and code
-- [UI Frameworks](/gjsify/frameworks/): render a GTK window from Solid, Vue, React or React Native
+- [UI Frameworks](/gjsify/frameworks/): render a GTK window from Solid, Vue or React, or bring React Native code to it
 - [Native Adwaita Apps](/gjsify/guides/native-adwaita-app/): the app shell, navigation, dialogs and toasts
 - [Runtimes](/gjsify/runtimes/): GJS, Node.js, Bun, Deno, the browser and mobile, and what runs where
 - [Packages](/gjsify/packages/overview/): the Node.js, Web and DOM APIs gjsify implements


### PR DESCRIPTION
One React, two element vocabularies. The gallery stops pretending they are two
frameworks, and the frameworks docs start saying which is which.

## The gallery window model

Three windows, unchanged in kind. The frameworks window loses one tab:

- **the widget** — the running component, alone, no tab bar
- **GJS** — `TypeScript` | `Blueprint`
- **UI frameworks** — `HTML Web Components` | `Solid` | `Vue` | `React` |
  `NativeScript`, plus the two refusal panes

The `react-native` slot was filled on 3 blocks of 40, all three on
`adwaita/layout.mdx`, against 28 blocks carrying a `react` snippet. Three
blocks on one page is a footnote holding a window pane.

`layout.mdx` now says once in prose what those three snippets showed: the
Adwaita element is the one the React tab already shows, the React Native
children go in its default slot, `configureStyle({ tokens })` is not optional,
and the result is a GTK window rather than a phone screen.

## What moved where

The `AdwWidget.astro` header passage about the tab's "on GTK" qualifier is not
deleted. It is split between the two places a reader meets it:

- **the direction argument** → `frameworks/react-native.mdx` § "What this is
  not", where the claim already lived. It now also records that the qualifier's
  original premise (no Adwaita widget set built out of React Native
  primitives) was written over by #1380 while the conclusion held.
- **the general shape** → `docs/code-anti-patterns.md` § "A rule whose premise
  died and whose conclusion did not". ADR 0034's stage 1 is the second
  instance, resolved the same way.

The component's header keeps a short record and points at both.

## The frameworks pages

`frameworks/react.mdx` leads with the choice. A comparison table, the
`Adw.Clamp` pair written both ways (the Adwaita element is byte-identical, the
children are not), and the decision as a question: bringing React Native or
Expo code, or starting fresh on GTK. It also says the two things a reader
otherwise has to infer: both paths point `jsxImportSource` at
`@gjsify/gtk-host/react`, so both reach the 168 generated tags; and neither
runs on a phone.

`frameworks/react-native.mdx` is reframed, not gutted. Title, description and
opening now say it is the path for code you already have. The primitives, the
lists, the routing, the styling, the prop table and the Adwaita rules all
stand. Its title carries the qualifier the tab label used to.

The packages stay separate, and the reason is measured: a `Gtk.Box` with no
orientation is horizontal and a React Native `View` is a column, so one name
over both would default wrong for half of what it renders, at exit 0.

`frameworks/index.mdx` stops implying a fourth adapter; `overview.mdx` stops
listing four peers where there are three plus a port.

## Two mechanisms, because this shape has now got in three times

**Arm 13 of `check-website-adwaita-gallery.mjs`** holds what a tab covers. A
tab is a fence 40 pages have to write, and arms 5 and 6 are each satisfied by
ONE block writing a slot, so a tab on 3 of 40 and a tab on all 40 are the same
shape to them. Three instances: the `nativescript` XML template as a slot on 4
of 40 until #1502, the hand-written attribute pane (110 of its attributes named
on their page, 54 not), and this one. Each had to be measured by hand first.
The coverage is now printed on every run, and a short tab fails unless
`PARTIAL_TAB_SLOTS` says why. The ledger is empty and a stale entry fails.

**`check-doc-fences.mjs` reads a fence attribute.** Its opener regex matched
```` ```<lang> ```` and nothing else, so a fence carrying an attribute matched
nothing: the dropped opener's closing fence became the next opener and every
fence after it on the page was off by one, with a real one swallowed as the
body of a phantom whose language no arm reads. Measured on
`getting-started.mdx`, the only page in the tree with one: 54 markers, 27
fences, 26 read. The swallowed fence there is `bash`, which no arm reads
either, so nothing was mischecked; a `ts` fence in that position would have
been. `fenceParseProblem` is the floor: markers against fences, per source.
The two comparison fences on the React page are its first consumer.

## Gates

Run before and after, all green: `check-website-adwaita-gallery`,
`check-generated-website-data`, `check-doc-fences`,
`check-website-attr-samples`, `check-nativescript-icon-names`,
`check-agent-context-size --check`, `gjsify format --check`, `oxlint scripts/`.
Site built and the three pages checked in a browser.

Arm 12's line is unmoved: `40 block(s) written twice — 7 are the SAME TEXT
after one normalisation … [vocabulary 6, glyph 0, property 22, composition 5]
— distance 357 line(s) over all pairs.`

`check-doc-fences` moves as expected: 6 → 5 className-bearing gallery fences
and 218 → 217 js/ts fences (three RN fences out of `layout.mdx`, two new ones
on `react.mdx`).

## Mutation tests

Eleven breaks, each confirmed red and reverted: arms 5, 6, 7, 9 and 10 of the
gallery gate, three on the new arm 13, two on the fence reader, and one on the
token arm. The table with what each one said is in a comment below.

## On the four reasons this PR was asked to preserve

All four hold, with one refinement worth knowing. The class-and-token style
system is `@gjsify/gtk-host/style`, framework-agnostic by construction, and
`styling.mdx` records that the only binding consuming it today is
`@gjsify/react-native`. So "the React path has no counterpart to that failure
mode" is true as of today rather than by design: give the host a `className`
binding and the empty-window-at-exit-0 failure reaches `gtk-host/react` too.
Nothing in this PR depends on that staying true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
