### PR TITLE
feat(adwaita-core): one authored tree, rendered

### DIFF
--- a/docs/adr/0051-one-authored-tree-rendered.md
+++ b/docs/adr/0051-one-authored-tree-rendered.md
@@ -1,6 +1,8 @@
 # 51. One authored tree, rendered: ADR 0027 § 9's criterion becomes a suite
 
-- Status: **Proposed**
+- Status: **Accepted** (2026-09-10) — amended, see § Amendment 1: the second driver is
+  `adwaita-web` and not the NativeScript port, because the port has no widget an
+  off-device suite can build. What was actually built is § What landed.
 - Date: 2026-09-09
 - Deciders: Pascal Garber
 - Related: [ADR 0004 (headless Adwaita core)](0004-headless-adwaita-core.md), [ADR 0027 (GTK host layer)](0027-gtk-host-layer.md), [ADR 0028 (widget table provenance)](0028-widget-table-provenance.md), [ADR 0030 (one corpus, GJS as oracle)](0030-one-corpus-gjs-as-oracle.md), [ADR 0034 (widget vocabulary convergence)](0034-widget-vocabulary-convergence.md)
@@ -216,7 +218,7 @@ Each stage is independently useful and breaks nothing that ships.
 | # | stage | what goes red if it is wrong |
 |---|---|---|
 | 1 | A tree driver for `gtk-host`: build `gtkHostTree(widget)` for each corpus block into real widgets, with `installDiagnosticsGate()` on, and assert the `adwaita-core` vectors the tree reaches. | a block that cannot be built; a GTK diagnostic during a build; a vector that disagrees; a block reaching no vector and not declared |
-| 2 | The same for the NativeScript port over `nativeScriptTree(widget)`, off-device against the port's own classes, the way the port's specs already run on GJS and Node. | the same four, plus a block whose two drivers disagree — which is the finding the whole ADR exists to produce |
+| 2 | ~~The same for the NativeScript port over `nativeScriptTree(widget)`~~ — **withdrawn, see § Amendment 1.** The port's widget classes extend `@nativescript/core` bases that no runtime here has, so there is no off-device tree to build. The second driver is `adwaita-web`, over the same corpus. | the same four, plus a block whose two drivers disagree — which is the finding the whole ADR exists to produce |
 | 3 | Teach `check-adwaita-conformance-drivers.mjs` the tree driver, so a table driven only from a tree is not read as undriven, and a tree claiming a table it does not reach fails. | a false coverage claim — the exact class that gate's three incidents are about |
 | 4 | Print the distance: blocks in the corpus, blocks reaching a vector, blocks declared, per renderer. Derived every run; no count in a header or in prose. | any figure that is written down rather than derived |
 | 5 | Put `adwaita-web` on the corpus: emit the gallery `preview` fence from `ADWAITA_GALLERY_SHARED_TREES` instead of authoring it per block, then drive it in `tests/browser`. This is the stage that closes § 9 in its own words. | a preview fence that is not what the shared tree emits; a web tree that fails a vector its two siblings pass |
@@ -226,3 +228,100 @@ touches the website's authored fences, and it is last because the two stages bef
 what make its result readable.
 
 Follow-up is tracked in `status/open-todos.md` per governance; this ADR records the *why*.
+
+## Amendment 1 — the second driver is `adwaita-web`, and stage 2 as written cannot exist
+
+Stage 2 asked for the NativeScript port "off-device against the port's own classes, the way
+the port's specs already run on GJS and Node". The measurement says the second half of that
+sentence is not what the port's specs do, and the first half is not available at all.
+
+Every widget module under `packages/nativescript-bridge/adwaita/src/widgets/` opens with a
+bare `@nativescript/core` import at module scope (`import { Button, GridLayout, ItemSpec,
+Label } from '@nativescript/core'` in `adw-banner.ts`, and the same shape in each sibling),
+because each class EXTENDS an NS view. `@nativescript/core` is an OPTIONAL peer dependency
+and the workspace install does not bring it in — `node_modules/@nativescript` holds
+`types`, `types-android` and `types-ios` and nothing else — so the specifier is
+unresolvable on GJS and on Node. The port's own suites say so in their headers and act on
+it: *"this file must NOT import `./widgets/adw-banner.js` (nor the package root) … the
+behaviour is exercised through `./widgets/chrome.js`, the pure sibling the widget
+composes"*. So what runs off-device is the port's PURE derivations, never its widgets, and a
+"tree driver" over those would build no tree at all — it would compare data to data, which
+is arm 11 and is precisely what this ADR exists to go past.
+
+A device would not repair that. An Android emulator can host the real classes, but a driver
+that needs one is not a CI guard: it cannot be the check that fails a PR, which is the only
+thing this rung is for. So the second driver is `adwaita-web` — the renderer § 9 named
+before this ADR re-aimed it — and the § "One correction to § 9's own wording" above is
+withdrawn. The correction it made is still true about the CORPUS: `gtk-host` and the
+NativeScript port are the two the gallery authors from one source. It was wrong to carry
+that fact over into the choice of DRIVER, because who authors a gallery block and who can
+build a tree in a test are two different questions.
+
+Stage 5's remaining half — emitting the gallery `preview` fence from
+`ADWAITA_GALLERY_SHARED_TREES` — is untouched and stays open: this amendment moves
+`adwaita-web` into the DRIVER position, not the website's authored fences.
+
+## What landed
+
+- **The corpus is read, never transcribed.** Both drivers import
+  `ADWAITA_GALLERY_SHARED_TREES` from `scripts/adwaita-gallery-shared-trees.mjs` itself. A
+  hand-written `scripts/adwaita-gallery-shared-trees.d.mts` beside it is what lets a
+  TypeScript spec do that without the corpus moving: `tsc` resolves the declaration and
+  never puts the `.mjs` in its program, so no package's `rootDir` is crossed, and each test
+  bundler inlines the module like any other relative import. The corpus stays where its two
+  plain-Node generators can reach it in a CI job with no `node_modules`.
+- **The join is renderer-free** — `packages/web/adwaita-core/src/conformance/shared-trees.ts`,
+  exported from `@gjsify/adwaita-core/conformance`. `sharedTreeExpectations(root)` returns
+  the vector ROWS an authored node instantiates, by matching the authored value against the
+  row's own input. It writes no expected value, which is decision 3 made structural rather
+  than promised.
+- **Two drivers.** `packages/framework/gtk-host/src/shared-trees.spec.ts` builds each block
+  through `createElement`/`setProp`/`insert` with `installDiagnosticsGate()` on;
+  `packages/web/adwaita-web/src/shared-trees.spec.ts` builds it out of custom elements in
+  Firefox. Each asserts, on the REAL tree its renderer produced, that the authored nodes
+  appear in the authored order — the libadwaita revealers and listboxes between them are the
+  renderer's business, the nesting is not — and then reads the reached rows off them.
+- **Each driver has exactly ONE seam**, a `read(expectation, node)` over a closed observable
+  vocabulary. Everything above it is shared; the per-surface transforms are `hostTagOf` on
+  both sides plus a camelCase→kebab ATTRIBUTE rule on the web, both total over the corpus.
+  There is no per-block branch on either side, which is the half of § 9's criterion that a
+  reviewer has to be able to see rather than be told.
+- **The gate learned the tree driver** (stage 3). `check-adwaita-conformance-drivers.mjs`
+  reads the join's table list out of its CODE, refuses a listed table no import backs and an
+  imported table left off the list, refuses a driver spec no entry hands to `run({…})`, and
+  refuses a binding no live suite drives. The one half it cannot decide statically — a
+  listed table no corpus node REACHES — the drivers assert themselves against
+  `reachedTables`, derived from the trees.
+- **The distance is printed and not written down** (stage 4): the gate reports the live tree
+  drivers and the joined tables, arm 11 still reports the partition, and the drivers name
+  every block that reaches no row.
+
+## What the drivers measured, that nothing else had
+
+Three limits are structural, and each is a fact about the criterion rather than a backlog
+item. They are in the binding's header where a reader of it will look; here is why they
+matter to the decision.
+
+- **A `GParamSpec` default is not a constructed default, and a tree driver reads the second
+  one.** `BANNER_DEFAULT_VECTORS` states that `AdwBanner:use-markup` defaults to TRUE, and
+  the pspec agrees: `Adw.Banner.find_property('use-markup').get_default_value()` is `true`
+  on libadwaita 1.9.3. A freshly constructed `Adw.Banner` answers FALSE — `get_use_markup()`
+  and `get_property('use-markup')` agree with each other. `gtk-host`'s README already names
+  that class (construction and the pspec disagree in a hundred-odd places) and the host's own
+  contract sides with construction. Both Adwaita ports implement the pspec default, so the
+  same authored banner is markup-on in the browser and markup-off in GTK. A tree driver
+  therefore cannot read a pspec-default table off a built widget, and the divergence it
+  exposes belongs to the ports rather than to this suite.
+- **A localized rendering is a fact about the runner.** `SHORTCUT_LABEL_VECTORS` spells
+  `<Control>C` as `[Ctrl][C]`; `Adw.ShortcutLabel` draws `gtk_accelerator_get_label`, which
+  is translated — measured as `["Strg","C"]` on this de_DE host and `["Ctrl","C"]` under
+  `LC_ALL=C`. The locale cannot be moved from inside the process: `GLib.setenv('LANGUAGE')`
+  and `GLib.setenv('LC_ALL')` after `Gtk.init` change neither. So the GTK renderer cannot be
+  held to that table by a tree driver at all, which is why `Adw.ShortcutLabel` is a declared
+  block rather than a passing one.
+- **A notify table's `emitted` half has nowhere to come from.** An authored tree writes a
+  property; it cannot attach a listener before the write. Only the END STATE of such a row is
+  reachable, and the binding takes only that.
+
+The consequence for decision 4 is the one worth keeping: two of the seven blocks reach no row
+at all, and the reason each reaches none is a measurement rather than an omission.

--- a/docs/adr/0051-one-authored-tree-rendered.md
+++ b/docs/adr/0051-one-authored-tree-rendered.md
@@ -248,9 +248,20 @@ composes"*. So what runs off-device is the port's PURE derivations, never its wi
 "tree driver" over those would build no tree at all — it would compare data to data, which
 is arm 11 and is precisely what this ADR exists to go past.
 
-A device would not repair that. An Android emulator can host the real classes, but a driver
-that needs one is not a CI guard: it cannot be the check that fails a PR, which is the only
-thing this rung is for. So the second driver is `adwaita-web` — the renderer § 9 named
+**Installing the peer would not repair it either, and that is the part worth writing down:
+the absence is structural, not a state of this checkout.** `@nativescript/core` ships no
+platform-neutral module for a widget class at all. In 9.1.1, `ui/label/`, `ui/core/view/`
+and `ui/layouts/grid-layout/` each hold `index.android.js`, `index.ios.js` and a
+`*-common.js` — and no `index.js`. Choosing between the two flavours is NativeScript's own
+platform-aware module resolution, not Node's and not a bundler's; a plain
+`import('@nativescript/core/ui/label/index.js')` fails with `Cannot find module`, and the
+package root fails one step earlier still, on a directory specifier ESM does not resolve.
+So `class AdwBanner extends GridLayout` has no base class to extend in any runtime that is
+not a device, whatever the manifest says. Adding the devDependency buys nothing.
+
+A device would not repair it from the other side. An Android emulator can host the real
+classes, but a driver that needs one is not a CI guard: it cannot be the check that fails a
+PR, which is the only thing this rung is for. So the second driver is `adwaita-web` — the renderer § 9 named
 before this ADR re-aimed it — and the § "One correction to § 9's own wording" above is
 withdrawn. The correction it made is still true about the CORPUS: `gtk-host` and the
 NativeScript port are the two the gallery authors from one source. It was wrong to carry

--- a/docs/adr/0051-one-authored-tree-rendered.md
+++ b/docs/adr/0051-one-authored-tree-rendered.md
@@ -306,12 +306,16 @@ matter to the decision.
   one.** `BANNER_DEFAULT_VECTORS` states that `AdwBanner:use-markup` defaults to TRUE, and
   the pspec agrees: `Adw.Banner.find_property('use-markup').get_default_value()` is `true`
   on libadwaita 1.9.3. A freshly constructed `Adw.Banner` answers FALSE — `get_use_markup()`
-  and `get_property('use-markup')` agree with each other. `gtk-host`'s README already names
-  that class (construction and the pspec disagree in a hundred-odd places) and the host's own
-  contract sides with construction. Both Adwaita ports implement the pspec default, so the
-  same authored banner is markup-on in the browser and markup-off in GTK. A tree driver
-  therefore cannot read a pspec-default table off a built widget, and the divergence it
-  exposes belongs to the ports rather than to this suite.
+  and `get_property('use-markup')` agree with each other — and the MECHANISM is measured, not
+  guessed: the banner's getter reads its template `GtkLabel`, whose own `use-markup` default
+  is FALSE and which nothing writes the banner's pspec default into. Setting that internal
+  label's property directly moves what the banner reports, which is what identifies the
+  getter as a delegation. `gtk-host`'s README already names the class (construction and the
+  pspec disagree in a hundred-odd places) and the host's own contract sides with
+  construction. Both Adwaita ports implement the pspec default, so the same authored banner
+  is markup-on in the browser and markup-off in GTK. A tree driver therefore cannot read a
+  pspec-default table off a built widget; what the ports should do about the divergence is a
+  rendering change with its own blast radius and is tracked in `status/open-todos.md`.
 - **A localized rendering is a fact about the runner.** `SHORTCUT_LABEL_VECTORS` spells
   `<Control>C` as `[Ctrl][C]`; `Adw.ShortcutLabel` draws `gtk_accelerator_get_label`, which
   is translated — measured as `["Strg","C"]` on this de_DE host and `["Ctrl","C"]` under

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -71,7 +71,7 @@ the TODO records the *what's left*.
 | [0048](0048-page-selection-by-identity.md) | A selection takes the shape its counterpart gives it: a name, a page, or an ordinal | Proposed |
 | [0049](0049-style-classes-are-a-list.md) | A look is a style class, and a widget carries a LIST of them | Proposed |
 | [0050](0050-effect-platform-services-for-gnome.md) | Effect's platform services for GNOME are a platform package, not a renderer | Accepted |
-| [0051](0051-one-authored-tree-rendered.md) | One authored tree, rendered: ADR 0027 § 9's criterion becomes a suite | Proposed |
+| [0051](0051-one-authored-tree-rendered.md) | One authored tree, rendered: ADR 0027 § 9's criterion becomes a suite | Accepted |
 | [0052](0052-attribute-meaning-in-the-fence.md) | An attribute's meaning is a generated comment in the fence a reader copies | Proposed |
 
 Source review: [docs/reports/2026-07-01-architecture-review.md](../reports/2026-07-01-architecture-review.md)

--- a/docs/release-notes/next.md
+++ b/docs/release-notes/next.md
@@ -132,6 +132,28 @@ A recurring theme, and this release closes another set of them:
 - On Windows, `C:\images\logo.png` was refused as a URI: a drive letter satisfies RFC 3986's
   scheme grammar exactly, and the only OS with drive letters is the one that failed.
 
+### One authored widget tree, built by two renderers
+
+The gallery has widget trees that are written once and drawn by more than one renderer. Until
+now two generators compared them as DATA — the same tags, the same properties — which says
+nothing about the two renderers BEHAVING the same on them. They are now BUILT: the GTK host
+turns each tree into real libadwaita widgets under a diagnostics gate, `@gjsify/adwaita-web`
+turns the same tree into custom elements in Firefox, and both are held to the
+`@gjsify/adwaita-core` conformance rows the tree's own authored values instantiate. Neither
+driver writes an expected value of its own, so a red test names the renderer rather than the
+assertion.
+
+It found what a per-widget suite structurally cannot. Breaking the DECLARATIVE path of
+`<adw-switch-row>` — the attribute read that runs when an element is built from markup, as
+opposed to the property set the existing suite drives — failed exactly the two tree tests
+and left the other 1 670 browser tests green.
+
+Two facts came out of the GTK side and are worth knowing if you write Adwaita for more than
+one surface. A `GParamSpec` default is not a constructed default: `AdwBanner:use-markup`
+declares `TRUE` and a freshly constructed banner answers `FALSE`, so the same authored banner
+is markup-on in the browser and markup-off in GTK. And `Adw.ShortcutLabel` draws TRANSLATED
+keycaps, so a shortcut rendering can only be asserted where nothing translates.
+
 ### Also in this release
 
 `@gjsify/vite-plugin-gettext` refuses to gut a catalog rather than writing an empty one;

--- a/docs/release-notes/next.md
+++ b/docs/release-notes/next.md
@@ -146,7 +146,7 @@ assertion.
 It found what a per-widget suite structurally cannot. Breaking the DECLARATIVE path of
 `<adw-switch-row>` — the attribute read that runs when an element is built from markup, as
 opposed to the property set the existing suite drives — failed exactly the two tree tests
-and left the other 1 670 browser tests green.
+and left every other browser test in the package green.
 
 Two facts came out of the GTK side and are worth knowing if you write Adwaita for more than
 one surface. A `GParamSpec` default is not a constructed default: `AdwBanner:use-markup`

--- a/packages/framework/gtk-host/src/shared-trees.spec.ts
+++ b/packages/framework/gtk-host/src/shared-trees.spec.ts
@@ -36,8 +36,9 @@ import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 
 import {
-    authoredNodes,
+    authoredTags,
     sharedTreeExpectations,
+    subjectIndexOf,
     type SharedTreeExpectation,
     type SharedTreeNode,
 } from '@gjsify/adwaita-core/conformance';
@@ -60,12 +61,15 @@ import type { HostElement } from './types.js';
  */
 function build(node: SharedTreeNode): HostElement {
     const el = createElement(node.tag, node.props as Record<string, unknown> | undefined);
+    // Before the children: `insert` parents a REALISED widget, and a construct-only
+    // property that never arrives reaches `g_error()` rather than failing a test.
     materialize(el);
     for (const child of node.children ?? []) insert(build(child), el);
     return el;
 }
 
-const widgetOf = (el: HostElement) => materialize(el) as unknown as Gtk.Widget;
+/** `build` has materialised every node on the way down, so the widget is already there. */
+const widgetOf = (el: HostElement) => el.widget as unknown as Gtk.Widget;
 const typeName = (widget: Gtk.Widget) =>
     GObject.type_name((widget as unknown as { constructor: { $gtype: GObject.GType } }).constructor.$gtype) ?? '';
 
@@ -111,49 +115,47 @@ export default async () => {
         // while GTK prints a critical, which is the entire class this driver exists to see.
         const diagnostics = installDiagnosticsGate();
 
-        const blocks = ADWAITA_GALLERY_SHARED_TREES.map((tree) => gtkHostTree(tree.widget));
-        // Authored GIR names, because the shape assertion below reads GTypes off the real
-        // tree; `gtkHostTree` has already turned the tags into this renderer's spelling.
-        const authored = ADWAITA_GALLERY_SHARED_TREES.map((tree) => tree.root);
+        const blocks = ADWAITA_GALLERY_SHARED_TREES.map((tree) => ({
+            widget: tree.widget,
+            // `gtkHostTree` has already turned the tags into this renderer's spelling; the
+            // AUTHORED tree keeps the GIR names, which is what the walks below compare
+            // against because they read GTypes off the real tree.
+            host: gtkHostTree(tree.widget).root,
+            authored: tree.root,
+        }));
+
+        /**
+         * Depth-first over the real tree, filtered to the authored classes: the libadwaita
+         * internals between them (a revealer, a listbox, a gizmo) are not the renderer's
+         * promise, the ORDER and the NESTING of what was authored is. Exact type names, so a
+         * subclass cannot stand in.
+         */
+        const realised = (root: Gtk.Widget, wanted: readonly string[]) => {
+            const set = new Set(wanted);
+            return descendants(root).filter((candidate) => set.has(typeName(candidate)));
+        };
 
         await gated(diagnostics, 'the shared corpus builds through gtk-host', async () => {
-            for (const [index, block] of blocks.entries()) {
-                const widget = ADWAITA_GALLERY_SHARED_TREES[index]!.widget;
+            for (const block of blocks) {
+                await it(`${block.widget} builds, and the REAL tree carries the authored nodes in order`, () => {
+                    const root = widgetOf(build(block.host));
+                    const wanted = authoredTags(block.authored);
 
-                await it(`${widget} builds, and the REAL tree carries the authored nodes in order`, () => {
-                    const root = widgetOf(build(block.root));
-
-                    // The authored GTypes, in the order the authored tree names them.
-                    const wanted = authoredNodes(authored[index]!).map(({ node }) => node.tag);
-                    const set = new Set(wanted);
-                    // Depth-first over the real tree, filtered to the authored classes: the
-                    // libadwaita internals between them (a revealer, a listbox, a gizmo) are
-                    // not the renderer's promise, the ORDER and the NESTING of what was
-                    // authored is. Exact type names, so a subclass cannot stand in.
-                    const built = descendants(root)
-                        .map(typeName)
-                        .filter((name) => set.has(name));
-
-                    expect(built).toStrictEqual(wanted);
+                    expect(realised(root, wanted).map(typeName)).toStrictEqual(wanted);
                 });
             }
         });
 
         await gated(diagnostics, 'the shared corpus against the adwaita-core vectors it reaches', async () => {
-            for (const [index, block] of blocks.entries()) {
-                const widget = ADWAITA_GALLERY_SHARED_TREES[index]!.widget;
-                const expectations = sharedTreeExpectations(authored[index]!);
-
-                for (const expectation of expectations) {
-                    await it(`${widget} — ${expectation.path}: ${expectation.table} — ${expectation.rule}`, () => {
-                        const root = widgetOf(build(block.root));
-                        const nodes = authoredNodes(authored[index]!);
+            for (const block of blocks) {
+                for (const expectation of sharedTreeExpectations(block.authored)) {
+                    await it(`${block.widget} — ${expectation.path}: ${expectation.table} — ${expectation.rule}`, () => {
+                        const root = widgetOf(build(block.host));
                         // The SAME filtered walk the shape test asserts, so the widget an
                         // expectation is read off is the one at the authored ADDRESS rather
                         // than the first of its class the tree happens to contain.
-                        const set = new Set(nodes.map(({ node }) => node.tag));
-                        const built = descendants(root).filter((candidate) => set.has(typeName(candidate)));
-                        const subject = built[nodes.findIndex(({ path }) => path === expectation.path)]!;
+                        const built = realised(root, authoredTags(block.authored));
+                        const subject = built[subjectIndexOf(block.authored, expectation.path)]!;
                         expect(typeName(subject)).toBe(expectation.gtype);
 
                         expect(read(expectation, subject)).toBe(expectation.expected);

--- a/packages/framework/gtk-host/src/shared-trees.spec.ts
+++ b/packages/framework/gtk-host/src/shared-trees.spec.ts
@@ -19,6 +19,12 @@
 // makes a failure attributable to the renderer. What a tree driver structurally cannot
 // reach, and why, is in that module's header.
 //
+// EVERYTHING THAT IS NOT ABOUT THIS RENDERER IS ELSEWHERE. Which tables the corpus reaches,
+// which block is declared to reach none, and whether an expectation's address exists at all
+// are facts about the CORPUS: they are asserted once, in `adwaita-core`'s own suite, which
+// runs on Node as well. Asserting them here too would be the same claim in three places,
+// two of which need a display.
+//
 // THE READERS GO THROUGH THE REAL GTK TREE (`descendants`, `findDescendant`), never the
 // host's shadow links: a renderer asserting against its own bookkeeping agrees with itself
 // while the window is wrong.
@@ -30,10 +36,7 @@ import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 
 import {
-    SHARED_TREE_BLOCKS_WITHOUT_EXPECTATIONS,
-    SHARED_TREE_TABLES,
     authoredNodes,
-    reachedTables,
     sharedTreeExpectations,
     type SharedTreeExpectation,
     type SharedTreeNode,
@@ -156,32 +159,7 @@ export default async () => {
                         expect(read(expectation, subject)).toBe(expectation.expected);
                     });
                 }
-
-                const declared = SHARED_TREE_BLOCKS_WITHOUT_EXPECTATIONS[widget] !== undefined;
-                if (expectations.length === 0) {
-                    // ADR 0051 § 4: a block that proves nothing has to SAY so, or the pass
-                    // count above reads as coverage this corpus does not have.
-                    await it(`${widget} reaches no vector, and says why`, () => {
-                        expect(declared).toBe(true);
-                    });
-                } else if (declared) {
-                    // Self-retiring, the shape arm 11 already uses for a converged
-                    // divergence: a declaration that has stopped being true fails.
-                    await it(`${widget} is declared vector-free, and is not`, () => {
-                        expect(expectations.map((one) => one.table)).toStrictEqual([]);
-                    });
-                }
             }
-        });
-
-        await it('every table the tree driver claims is one the corpus reaches', () => {
-            // The counterweight to `SHARED_TREE_TABLES`, which
-            // `check-adwaita-conformance-drivers.mjs` reads as this driver's coverage. A
-            // table listed there and reached by no corpus node would be a coverage claim
-            // with nothing behind it — the exact class that gate's three incidents are.
-            expect(reachedTables(ADWAITA_GALLERY_SHARED_TREES.map((tree) => tree.root))).toStrictEqual([
-                ...SHARED_TREE_TABLES,
-            ]);
         });
     });
 };

--- a/packages/framework/gtk-host/src/shared-trees.spec.ts
+++ b/packages/framework/gtk-host/src/shared-trees.spec.ts
@@ -1,0 +1,186 @@
+// ONE AUTHORED TREE, BUILT BY THIS RENDERER — ADR 0051, the GTK half of ADR 0027 § 9.
+//
+// The corpus is `scripts/adwaita-gallery-shared-trees.mjs`, read here rather than copied:
+// the same file the two gallery generators emit from, so a block cannot be tested in one
+// shape and shipped in another. The only transform on the way in is `gtkHostTree`, which is
+// this package's own `tagOf` — one deterministic case rule, no alias table, and no per-block
+// branch anywhere below.
+//
+// What this asserts that the per-widget specs cannot. Every other spec in this package
+// constructs its subject itself, so it proves the host can drive a widget somebody wrote a
+// test for. Here the widget arrives out of a tree NEITHER renderer authored: it is created
+// by tag, propertied by authored name, parented by the descriptor's own child policy, and
+// only then read. A mis-parenting, a property name that resolves to the wrong GObject
+// property, or a placement that silently replaces a template child fails here on a tree the
+// website ships.
+//
+// The expectations are `@gjsify/adwaita-core`'s, joined to the tree by
+// `sharedTreeExpectations` — this file writes NO expected value of its own, which is what
+// makes a failure attributable to the renderer. What a tree driver structurally cannot
+// reach, and why, is in that module's header.
+//
+// THE READERS GO THROUGH THE REAL GTK TREE (`descendants`, `findDescendant`), never the
+// host's shadow links: a renderer asserting against its own bookkeeping agrees with itself
+// while the window is wrong.
+
+import { expect, it, on } from '@gjsify/unit';
+
+import type Adw from '@girs/adw-1';
+import GObject from 'gi://GObject?version=2.0';
+import Gtk from 'gi://Gtk?version=4.0';
+
+import {
+    SHARED_TREE_BLOCKS_WITHOUT_VECTORS,
+    SHARED_TREE_TABLES,
+    authoredNodes,
+    reachedTables,
+    sharedTreeExpectations,
+    type SharedTreeExpectation,
+    type SharedTreeNode,
+} from '@gjsify/adwaita-core/conformance';
+
+import { ADWAITA_GALLERY_SHARED_TREES, gtkHostTree } from '../../../../scripts/adwaita-gallery-shared-trees.mjs';
+import { descendants, findDescendant, installDiagnosticsGate } from './conformance/index.js';
+import { registerBuiltinWidgets } from './descriptors/index.js';
+import { createElement, insert, materialize } from './host.js';
+import { GTK_HOSTS, gated } from './testing/gate.mjs';
+import type { HostElement } from './types.js';
+
+/**
+ * The whole renderer-specific half of this driver: a tag, its authored properties, its
+ * children, in that order.
+ *
+ * Recursive and total — no tag list, no property list, no per-block case. The authored
+ * property NAMES go to `setProp` verbatim (through `createElement`), which is the point:
+ * `buttonLabel` reaching `button-label` is the host's own coercion, and a driver spelling
+ * the GObject name itself would be testing its own translation table.
+ */
+function build(node: SharedTreeNode): HostElement {
+    const el = createElement(node.tag, node.props as Record<string, unknown> | undefined);
+    materialize(el);
+    for (const child of node.children ?? []) insert(build(child), el);
+    return el;
+}
+
+const widgetOf = (el: HostElement) => materialize(el) as unknown as Gtk.Widget;
+const typeName = (widget: Gtk.Widget) => GObject.type_name(widget.constructor.$gtype) ?? '';
+
+/**
+ * Read one observable off the widget this renderer built.
+ *
+ * The ONE seam between the shared expectations and this renderer — `StoryViewBase<TNode>`'s
+ * shape, applied to a read instead of a chrome. Everything above it is renderer-free and
+ * everything below it is GTK; a `switch` that grew a block name would be the per-surface
+ * branch ADR 0027 § 9 forbids.
+ */
+function read(expectation: SharedTreeExpectation, widget: Gtk.Widget): string | number | boolean {
+    switch (expectation.observable) {
+        case 'entry-text-length':
+            return (widget as unknown as Adw.EntryRow).textLength;
+        case 'switch-row-active':
+            return (widget as unknown as Adw.SwitchRow).active;
+        case 'banner-button-visible':
+            return bannerButton(widget)?.visible ?? false;
+        case 'banner-button-text':
+            // `get_text()` and not `label`: the banner template pins the button to
+            // `use-underline=True`, so `label` still carries the mnemonic marker while
+            // `get_text()` is what is painted — which is what the vector states.
+            return bannerLabel(widget)?.get_text() ?? '';
+    }
+}
+
+/** The banner's action button, reached through the REAL tree — it is a template child. */
+const bannerButton = (banner: Gtk.Widget): Gtk.Widget | null =>
+    findDescendant(banner, (widget) => widget instanceof Gtk.Button);
+
+const bannerLabel = (banner: Gtk.Widget): Gtk.Label | null => {
+    const button = bannerButton(banner);
+    return button ? (findDescendant(button, (widget) => widget instanceof Gtk.Label) as Gtk.Label | null) : null;
+};
+
+export default async () => {
+    await on(GTK_HOSTS, async () => {
+        Gtk.init();
+        registerBuiltinWidgets();
+
+        // GTK's failure mode is exit 0. Without this a block that mis-parents reports ✔
+        // while GTK prints a critical, which is the entire class this driver exists to see.
+        const diagnostics = installDiagnosticsGate();
+
+        const blocks = ADWAITA_GALLERY_SHARED_TREES.map((tree) => gtkHostTree(tree.widget));
+        // Authored GIR names, because the shape assertion below reads GTypes off the real
+        // tree; `gtkHostTree` has already turned the tags into this renderer's spelling.
+        const authored = ADWAITA_GALLERY_SHARED_TREES.map((tree) => tree.root);
+
+        await gated(diagnostics, 'the shared corpus builds through gtk-host', async () => {
+            for (const [index, block] of blocks.entries()) {
+                const widget = ADWAITA_GALLERY_SHARED_TREES[index]!.widget;
+
+                await it(`${widget} builds, and the REAL tree carries the authored nodes in order`, () => {
+                    const root = widgetOf(build(block.root));
+
+                    // The authored GTypes, in the order the authored tree names them.
+                    const wanted = authoredNodes(authored[index]!).map(({ node }) => node.tag);
+                    const set = new Set(wanted);
+                    // Depth-first over the real tree, filtered to the authored classes: the
+                    // libadwaita internals between them (a revealer, a listbox, a gizmo) are
+                    // not the renderer's promise, the ORDER and the NESTING of what was
+                    // authored is. Exact type names, so a subclass cannot stand in.
+                    const built = descendants(root)
+                        .map(typeName)
+                        .filter((name) => set.has(name));
+
+                    expect(built).toStrictEqual(wanted);
+                });
+            }
+        });
+
+        await gated(diagnostics, 'the shared corpus against the adwaita-core vectors it reaches', async () => {
+            for (const [index, block] of blocks.entries()) {
+                const widget = ADWAITA_GALLERY_SHARED_TREES[index]!.widget;
+                const expectations = sharedTreeExpectations(authored[index]!);
+
+                for (const expectation of expectations) {
+                    await it(`${widget} — ${expectation.path}: ${expectation.table} — ${expectation.rule}`, () => {
+                        const root = widgetOf(build(block.root));
+                        const nodes = authoredNodes(authored[index]!);
+                        // The SAME filtered walk the shape test asserts, so the widget an
+                        // expectation is read off is the one at the authored ADDRESS rather
+                        // than the first of its class the tree happens to contain.
+                        const set = new Set(nodes.map(({ node }) => node.tag));
+                        const built = descendants(root).filter((candidate) => set.has(typeName(candidate)));
+                        const subject = built[nodes.findIndex(({ path }) => path === expectation.path)]!;
+                        expect(typeName(subject)).toBe(expectation.gtype);
+
+                        expect(read(expectation, subject)).toBe(expectation.expected);
+                    });
+                }
+
+                const declared = Object.hasOwn(SHARED_TREE_BLOCKS_WITHOUT_VECTORS, widget);
+                if (expectations.length === 0) {
+                    // ADR 0051 § 4: a block that proves nothing has to SAY so, or the pass
+                    // count above reads as coverage this corpus does not have.
+                    await it(`${widget} reaches no vector, and says why`, () => {
+                        expect(declared).toBe(true);
+                    });
+                } else if (declared) {
+                    // Self-retiring, the shape arm 11 already uses for a converged
+                    // divergence: a declaration that has stopped being true fails.
+                    await it(`${widget} is declared vector-free, and is not`, () => {
+                        expect(expectations.map((one) => one.table)).toStrictEqual([]);
+                    });
+                }
+            }
+        });
+
+        await it('every table the tree driver claims is one the corpus reaches', () => {
+            // The counterweight to `SHARED_TREE_TABLES`, which
+            // `check-adwaita-conformance-drivers.mjs` reads as this driver's coverage. A
+            // table listed there and reached by no corpus node would be a coverage claim
+            // with nothing behind it — the exact class that gate's three incidents are.
+            expect(reachedTables(ADWAITA_GALLERY_SHARED_TREES.map((tree) => tree.root))).toStrictEqual([
+                ...SHARED_TREE_TABLES,
+            ]);
+        });
+    });
+};

--- a/packages/framework/gtk-host/src/shared-trees.spec.ts
+++ b/packages/framework/gtk-host/src/shared-trees.spec.ts
@@ -30,7 +30,7 @@ import GObject from 'gi://GObject?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 
 import {
-    SHARED_TREE_BLOCKS_WITHOUT_VECTORS,
+    SHARED_TREE_BLOCKS_WITHOUT_EXPECTATIONS,
     SHARED_TREE_TABLES,
     authoredNodes,
     reachedTables,
@@ -63,7 +63,8 @@ function build(node: SharedTreeNode): HostElement {
 }
 
 const widgetOf = (el: HostElement) => materialize(el) as unknown as Gtk.Widget;
-const typeName = (widget: Gtk.Widget) => GObject.type_name(widget.constructor.$gtype) ?? '';
+const typeName = (widget: Gtk.Widget) =>
+    GObject.type_name((widget as unknown as { constructor: { $gtype: GObject.GType } }).constructor.$gtype) ?? '';
 
 /**
  * Read one observable off the widget this renderer built.
@@ -156,7 +157,7 @@ export default async () => {
                     });
                 }
 
-                const declared = Object.hasOwn(SHARED_TREE_BLOCKS_WITHOUT_VECTORS, widget);
+                const declared = SHARED_TREE_BLOCKS_WITHOUT_EXPECTATIONS[widget] !== undefined;
                 if (expectations.length === 0) {
                     // ADR 0051 § 4: a block that proves nothing has to SAY so, or the pass
                     // count above reads as coverage this corpus does not have.

--- a/packages/framework/gtk-host/src/test.mts
+++ b/packages/framework/gtk-host/src/test.mts
@@ -15,6 +15,7 @@ import menuSuite from './menu.spec.js';
 import portalSuite from './portal.spec.js';
 import probeSuite from './probe.spec.js';
 import propsSuite from './props.spec.js';
+import sharedTreesSuite from './shared-trees.spec.js';
 import gtkCssSuite from './style/gtk-css.spec.js';
 import gtkPropsSuite from './style/gtk-props.spec.js';
 import layoutSuite from './style/layout.spec.js';
@@ -44,6 +45,7 @@ run({
     listModelSuite,
     adjustmentSuite,
     conformanceSuite,
+    sharedTreesSuite,
     generatorSuite,
     generatedSuite,
     listSuite,

--- a/packages/web/adwaita-core/src/conformance/index.ts
+++ b/packages/web/adwaita-core/src/conformance/index.ts
@@ -572,7 +572,7 @@ export type { HeaderBarPackVector, HeaderBarTitleSourceVector, HeaderBarTitleWid
 
 // --- Which vectors an AUTHORED WIDGET TREE reaches (ADR 0051) — no table of its own ---
 export {
-    SHARED_TREE_BLOCKS_WITHOUT_VECTORS,
+    SHARED_TREE_BLOCKS_WITHOUT_EXPECTATIONS,
     SHARED_TREE_TABLES,
     authoredNodes,
     reachedTables,

--- a/packages/web/adwaita-core/src/conformance/index.ts
+++ b/packages/web/adwaita-core/src/conformance/index.ts
@@ -569,3 +569,13 @@ export {
     HEADER_BAR_TITLE_WIDGET_VECTORS,
 } from './header-bar.js';
 export type { HeaderBarPackVector, HeaderBarTitleSourceVector, HeaderBarTitleWidgetVector } from './header-bar.js';
+
+// --- Which vectors an AUTHORED WIDGET TREE reaches (ADR 0051) — no table of its own ---
+export {
+    SHARED_TREE_BLOCKS_WITHOUT_VECTORS,
+    SHARED_TREE_TABLES,
+    authoredNodes,
+    reachedTables,
+    sharedTreeExpectations,
+} from './shared-trees.js';
+export type { SharedTreeExpectation, SharedTreeNode, SharedTreeObservable } from './shared-trees.js';

--- a/packages/web/adwaita-core/src/conformance/index.ts
+++ b/packages/web/adwaita-core/src/conformance/index.ts
@@ -575,7 +575,9 @@ export {
     SHARED_TREE_BLOCKS_WITHOUT_EXPECTATIONS,
     SHARED_TREE_TABLES,
     authoredNodes,
+    authoredTags,
     reachedTables,
     sharedTreeExpectations,
+    subjectIndexOf,
 } from './shared-trees.js';
 export type { SharedTreeExpectation, SharedTreeNode, SharedTreeObservable } from './shared-trees.js';

--- a/packages/web/adwaita-core/src/conformance/shared-trees.ts
+++ b/packages/web/adwaita-core/src/conformance/shared-trees.ts
@@ -180,6 +180,31 @@ export function authoredNodes(root: SharedTreeNode): { node: SharedTreeNode; pat
     return found;
 }
 
+/**
+ * The authored classes a realised tree must carry, in authored order.
+ *
+ * `tagOf` is the renderer's own spelling of a GIR class name — `hostTagOf` on the web, the
+ * GIR name itself in GTK. Both drivers filter their real tree down to this list and compare
+ * against it, so it lives here rather than in each of them: a driver deriving it privately
+ * is a second walk, free to disagree with the one {@link subjectIndexOf} addresses into.
+ */
+export function authoredTags(root: SharedTreeNode, tagOf: (gtype: string) => string = (gtype) => gtype): string[] {
+    return authoredNodes(root).map(({ node }) => tagOf(node.tag));
+}
+
+/**
+ * Where the node an expectation is about sits in that filtered walk.
+ *
+ * The pre-order addresses are unique and the filter preserves them, so this index into
+ * {@link authoredTags} is also the index into the realised tree — which is why a driver may
+ * pick its subject by position instead of by hunting for the first widget of the class. Both
+ * halves of that are asserted on Node in `shared-trees.spec.ts`, before either renderer
+ * relies on them.
+ */
+export function subjectIndexOf(root: SharedTreeNode, path: string): number {
+    return authoredNodes(root).findIndex((node) => node.path === path);
+}
+
 /** Every vector row the tree rooted at `root` instantiates, in pre-order. */
 export function sharedTreeExpectations(root: SharedTreeNode): SharedTreeExpectation[] {
     const found: SharedTreeExpectation[] = [];

--- a/packages/web/adwaita-core/src/conformance/shared-trees.ts
+++ b/packages/web/adwaita-core/src/conformance/shared-trees.ts
@@ -1,0 +1,203 @@
+// Which conformance vectors an AUTHORED WIDGET TREE reaches — the renderer-free half of
+// ADR 0051.
+//
+// WHAT THIS IS FOR. `scripts/adwaita-gallery-shared-trees.mjs` holds gallery blocks whose
+// widget tree is authored ONCE, in GIR class names, and rendered by more than one surface.
+// Arm 11 of `check-generated-website-data.mjs` compares those trees as DATA. What nothing
+// held was whether the RENDERERS behave the same on them — ADR 0027 § 9's criterion. A
+// driver per renderer builds the tree and asserts what this module derives from it.
+//
+// IT INVENTS NO EXPECTATION, and that is the whole design (ADR 0051 § 3). Every value a
+// driver asserts comes out of a vector table that already exists, so a failure is
+// attributable to the RENDERER rather than to an assertion written next to it. This module
+// only answers "which rows does this tree instantiate", and it answers it by MATCHING the
+// authored value against the row's input — never by classifying, never by re-deriving.
+//
+// WHY EXACT MATCHING AND NOT "THE RULE APPLIES". A rule-based reader would have to decide
+// which row a value is LIKE, which is a second implementation of the derivation the vectors
+// exist to pin down: it would agree with whatever it re-implemented, and the tree could
+// then be green against a renderer that is wrong. Exact matching cannot do that. Its cost
+// is coverage — most authored values are not vector inputs — and the cost is PRINTED by the
+// drivers rather than hidden, because a suite whose denominator is invisible claims more
+// than it measures.
+//
+// WHAT A TREE DRIVER STRUCTURALLY CANNOT REACH, measured rather than assumed:
+//
+//   · A `GParamSpec`-default table. `BANNER_DEFAULT_VECTORS` states the pspec defaults, and
+//     a tree driver reads a CONSTRUCTED widget. The two are different facts and they
+//     disagree: measured on libadwaita 1.9.3, `AdwBanner`'s `use-markup` pspec default is
+//     TRUE while a freshly constructed `AdwBanner` answers FALSE (`get_use_markup()` and
+//     `get_property` agree with each other). `gtk-host`'s README already names that class —
+//     construction and the pspec disagree in a hundred-odd places — so reading a pspec
+//     table off a built widget would assert the wrong one of two true things.
+//   · A table whose expectation is a LOCALIZED rendering. `SHORTCUT_LABEL_VECTORS` spells
+//     its keycaps in English; `Adw.ShortcutLabel` renders `gtk_accelerator_get_label`,
+//     which is translated. Measured: `<Control>C` draws `["Strg","C"]` on a de_DE host and
+//     `["Ctrl","C"]` under `LC_ALL=C`, and the locale cannot be changed from inside the
+//     process — `GLib.setenv` after `Gtk.init` moves neither. Asserting the row would
+//     assert a fact about the RUNNER, the same class `isEnvironmentDiagnostic` exists for.
+//   · The `emitted` half of a notify table. A tree authors a property, it does not author a
+//     listener attached before the write, so only the END STATE of such a row is reachable.
+//
+// Reference: refs/libadwaita/src/adw-entry-row.c, adw-switch-row.c, adw-banner.c
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+
+import { BANNER_BUTTON_TEXT_VECTORS, BANNER_BUTTON_VISIBLE_VECTORS } from './banner.js';
+import { ENTRY_TEXT_LENGTH_VECTORS } from './entry-row.js';
+import { SWITCH_ROW_NOTIFY_VECTORS } from './action-row.js';
+
+/** One node of an authored tree — the shape `ADWAITA_GALLERY_SHARED_TREES` is written in. */
+export interface SharedTreeNode {
+    /** A GIR class name, e.g. `AdwPreferencesGroup`. */
+    tag: string;
+    slot?: string;
+    props?: Readonly<Record<string, string | number | boolean>>;
+    children?: readonly SharedTreeNode[];
+}
+
+/**
+ * What a renderer must be able to READ off the widget it built.
+ *
+ * A closed vocabulary on purpose: it is the seam between this renderer-free module and the
+ * per-renderer drivers, and an open one would let a driver answer a question nobody else
+ * answers. Each name says WHICH widget and WHICH observation, never how to make it.
+ */
+export type SharedTreeObservable =
+    /** `adw_entry_row_get_text_length` — characters, not UTF-16 units. */
+    | 'entry-text-length'
+    /** `Adw.SwitchRow:active` after the tree's own write. */
+    | 'switch-row-active'
+    /** Whether the banner's action button is on screen. */
+    | 'banner-button-visible'
+    /** The text painted in the banner's action button, after mnemonic resolution. */
+    | 'banner-button-text';
+
+/** One vector row an authored node instantiates, addressed to the renderer that built it. */
+export interface SharedTreeExpectation {
+    /** Pre-order address inside the block, e.g. `AdwPreferencesGroup > AdwSwitchRow[1]`. */
+    path: string;
+    /** The GIR class of the node this is about. */
+    gtype: string;
+    /** The conformance table the row comes from — the name, so a failure cites its source. */
+    table: string;
+    observable: SharedTreeObservable;
+    expected: string | number | boolean;
+    /** The row's own `rule`, which is also the test title. */
+    rule: string;
+}
+
+/**
+ * The tables this module joins an authored tree against.
+ *
+ * NAMED IN CODE rather than in prose, because `check-adwaita-conformance-drivers.mjs` reads
+ * this list to decide which tables a tree driver drives. A table added here that no corpus
+ * node reaches fails the drivers' own suite — see `reachedTables` below, which is DERIVED
+ * from the corpus and not written down.
+ */
+export const SHARED_TREE_TABLES = [
+    'BANNER_BUTTON_TEXT_VECTORS',
+    'BANNER_BUTTON_VISIBLE_VECTORS',
+    'ENTRY_TEXT_LENGTH_VECTORS',
+    'SWITCH_ROW_NOTIFY_VECTORS',
+] as const;
+
+/**
+ * Blocks that reach NO vector row, with the measured reason — ADR 0051 § 4.
+ *
+ * A block in the corpus that proves nothing must SAY so, or the pass count reads as
+ * coverage it does not have. Self-retiring: a driver fails on a declared block that has
+ * started reaching a row, the same shape as arm 11's stale-divergence rule.
+ */
+export const SHARED_TREE_BLOCKS_WITHOUT_VECTORS: Readonly<Record<string, string>> = {
+    'Adw.ShortcutLabel':
+        'its only table, SHORTCUT_LABEL_VECTORS, spells keycaps in English while the widget renders ' +
+        'gtk_accelerator_get_label, which is translated — see the header. The browser renderer drives ' +
+        'the table from its own spec, where nothing translates.',
+    'Adw.WindowTitle':
+        'WINDOW_TITLE_VECTORS is a STEP table over a fresh widget and its rows spell their own titles; ' +
+        'the authored "Inbox"/"3 unread messages" is no row\'s input, and LABEL_VISIBILITY_VECTORS keys ' +
+        'on the label TEXT for the same reason.',
+};
+
+/** The steps a {@link SWITCH_ROW_NOTIFY_VECTORS} row would have to be, for an authored `active`. */
+const switchRowRowFor = (active: boolean | undefined) =>
+    SWITCH_ROW_NOTIFY_VECTORS.find((vector) =>
+        active === undefined
+            ? vector.steps.length === 0
+            : vector.steps.length === 1 &&
+              vector.steps[0]!.op === 'set-active' &&
+              (vector.steps[0] as { active: boolean }).active === active,
+    );
+
+/** The rows one node instantiates — no recursion, so the address is the caller's to build. */
+function expectationsForNode(node: SharedTreeNode, path: string): SharedTreeExpectation[] {
+    const props = node.props ?? {};
+    const found: SharedTreeExpectation[] = [];
+    const at = (
+        table: string,
+        observable: SharedTreeObservable,
+        expected: string | number | boolean,
+        rule: string,
+    ) => found.push({ path, gtype: node.tag, table, observable, expected, rule });
+
+    if (node.tag === 'AdwEntryRow') {
+        // An unset `text` is the empty entry, which is a row of the table like any other.
+        const text = typeof props.text === 'string' ? props.text : '';
+        const row = ENTRY_TEXT_LENGTH_VECTORS.find((vector) => vector.text === text);
+        if (row) at('ENTRY_TEXT_LENGTH_VECTORS', 'entry-text-length', row.length, row.rule);
+    }
+
+    if (node.tag === 'AdwSwitchRow') {
+        const active = typeof props.active === 'boolean' ? props.active : undefined;
+        const row = switchRowRowFor(active);
+        // Only the END STATE: `emitted` needs a listener attached before the write, and an
+        // authored tree has nowhere to put one — see the header.
+        if (row) at('SWITCH_ROW_NOTIFY_VECTORS', 'switch-row-active', row.active, row.rule);
+    }
+
+    if (node.tag === 'AdwBanner') {
+        const label = typeof props.buttonLabel === 'string' ? props.buttonLabel : undefined;
+        if (label !== undefined) {
+            const visible = BANNER_BUTTON_VISIBLE_VECTORS.find((vector) => vector.label === label);
+            if (visible) at('BANNER_BUTTON_VISIBLE_VECTORS', 'banner-button-visible', visible.visible, visible.rule);
+            const text = BANNER_BUTTON_TEXT_VECTORS.find((vector) => vector.label === label);
+            if (text) at('BANNER_BUTTON_TEXT_VECTORS', 'banner-button-text', text.text, text.rule);
+        }
+    }
+
+    return found;
+}
+
+/** Pre-order walk, carrying the address a failure has to name. */
+function walk(node: SharedTreeNode, path: string, visit: (node: SharedTreeNode, path: string) => void): void {
+    visit(node, path);
+    (node.children ?? []).forEach((child, index) => walk(child, `${path} > ${child.tag}[${index}]`, visit));
+}
+
+/** Every authored node of `root`, in pre-order — the sequence a realised tree must reproduce. */
+export function authoredNodes(root: SharedTreeNode): { node: SharedTreeNode; path: string }[] {
+    const found: { node: SharedTreeNode; path: string }[] = [];
+    walk(root, root.tag, (node, path) => found.push({ node, path }));
+    return found;
+}
+
+/** Every vector row the tree rooted at `root` instantiates, in pre-order. */
+export function sharedTreeExpectations(root: SharedTreeNode): SharedTreeExpectation[] {
+    const found: SharedTreeExpectation[] = [];
+    walk(root, root.tag, (node, path) => found.push(...expectationsForNode(node, path)));
+    return found;
+}
+
+/**
+ * The tables the CORPUS actually reaches, derived from the trees themselves.
+ *
+ * The counterweight to {@link SHARED_TREE_TABLES}: that list is a claim about what this
+ * module joins, this is what the corpus delivers. A driver holding them against each other
+ * is what stops a table being listed as tree-driven while no tree touches it — the false
+ * coverage class `check-adwaita-conformance-drivers.mjs`'s three incidents are all about.
+ */
+export function reachedTables(roots: readonly SharedTreeNode[]): string[] {
+    const seen = new Set<string>();
+    for (const root of roots) for (const expectation of sharedTreeExpectations(root)) seen.add(expectation.table);
+    return [...seen].sort();
+}

--- a/packages/web/adwaita-core/src/conformance/shared-trees.ts
+++ b/packages/web/adwaita-core/src/conformance/shared-trees.ts
@@ -110,12 +110,20 @@ export const SHARED_TREE_TABLES = [
  * A block in the corpus that proves nothing must SAY so, or the pass count reads as
  * coverage it does not have. Self-retiring: a driver fails on a declared block that has
  * started reaching a row, the same shape as arm 11's stale-divergence rule.
+ *
+ * A reason has to name the mechanism, not a consequence of it: the two below reach nothing
+ * for DIFFERENT reasons — one table is not joined, the other's rows do not match the
+ * authored values — and a declaration that blurs them is a silence nobody can retire.
  */
 export const SHARED_TREE_BLOCKS_WITHOUT_EXPECTATIONS: Readonly<Record<string, string>> = {
     'Adw.ShortcutLabel':
-        'its only table, SHORTCUT_LABEL_VECTORS, spells keycaps in English while the widget renders ' +
-        'gtk_accelerator_get_label, which is translated — see the header. The browser renderer drives ' +
-        'the table from its own spec, where nothing translates.',
+        'a CHOICE, not an impossibility: SHORTCUT_LABEL_VECTORS is deliberately off SHARED_TREE_TABLES, ' +
+        'because the row this block would instantiate is unreadable on a translated host — see the header. ' +
+        'What that costs is one-sided. `adwaita-web` drives the table from its own spec and would pass the ' +
+        "row here too; `gtk-host` drives it from NO spec, so libadwaita's own keycap rendering is the one " +
+        'thing this declaration leaves unchecked. Joining it wants `it.failing(…, { when: <translated host> })` ' +
+        'per tests/AGENTS.md rule 6 — a tolerated failure on a de_DE desk, a REAL assertion anywhere the host ' +
+        'is untranslated, which no workflow here opts out of.',
     'Adw.WindowTitle':
         'WINDOW_TITLE_VECTORS is a STEP table over a fresh widget and its rows spell their own titles; ' +
         'the authored "Inbox"/"3 unread messages" is no row\'s input, and LABEL_VISIBILITY_VECTORS keys ' +

--- a/packages/web/adwaita-core/src/conformance/shared-trees.ts
+++ b/packages/web/adwaita-core/src/conformance/shared-trees.ts
@@ -26,10 +26,13 @@
 //   · A `GParamSpec`-default table. `BANNER_DEFAULT_VECTORS` states the pspec defaults, and
 //     a tree driver reads a CONSTRUCTED widget. The two are different facts and they
 //     disagree: measured on libadwaita 1.9.3, `AdwBanner`'s `use-markup` pspec default is
-//     TRUE while a freshly constructed `AdwBanner` answers FALSE (`get_use_markup()` and
-//     `get_property` agree with each other). `gtk-host`'s README already names that class —
-//     construction and the pspec disagree in a hundred-odd places — so reading a pspec
-//     table off a built widget would assert the wrong one of two true things.
+//     TRUE while a freshly constructed `AdwBanner` answers FALSE. The mechanism is measured
+//     too — the banner's getter reads its template `GtkLabel`, whose own `use-markup`
+//     default is FALSE and which the pspec default never writes: assigning the internal
+//     label's property directly moves what the banner reports. `gtk-host`'s README already
+//     names that class — construction and the pspec disagree in a hundred-odd places — so
+//     reading a pspec table off a built widget would assert the wrong one of two true
+//     things. What the ports do with it is `status/open-todos.md`'s, not this module's.
 //   · A table whose expectation is a LOCALIZED rendering. `SHORTCUT_LABEL_VECTORS` spells
 //     its keycaps in English; `Adw.ShortcutLabel` renders `gtk_accelerator_get_label`,
 //     which is translated. Measured: `<Control>C` draws `["Strg","C"]` on a de_DE host and
@@ -133,12 +136,8 @@ const switchRowRowFor = (active: boolean | undefined) =>
 function expectationsForNode(node: SharedTreeNode, path: string): SharedTreeExpectation[] {
     const props = node.props ?? {};
     const found: SharedTreeExpectation[] = [];
-    const at = (
-        table: string,
-        observable: SharedTreeObservable,
-        expected: string | number | boolean,
-        rule: string,
-    ) => found.push({ path, gtype: node.tag, table, observable, expected, rule });
+    const at = (table: string, observable: SharedTreeObservable, expected: string | number | boolean, rule: string) =>
+        found.push({ path, gtype: node.tag, table, observable, expected, rule });
 
     if (node.tag === 'AdwEntryRow') {
         // An unset `text` is the empty entry, which is a row of the table like any other.

--- a/packages/web/adwaita-core/src/conformance/shared-trees.ts
+++ b/packages/web/adwaita-core/src/conformance/shared-trees.ts
@@ -108,7 +108,7 @@ export const SHARED_TREE_TABLES = [
  * coverage it does not have. Self-retiring: a driver fails on a declared block that has
  * started reaching a row, the same shape as arm 11's stale-divergence rule.
  */
-export const SHARED_TREE_BLOCKS_WITHOUT_VECTORS: Readonly<Record<string, string>> = {
+export const SHARED_TREE_BLOCKS_WITHOUT_EXPECTATIONS: Readonly<Record<string, string>> = {
     'Adw.ShortcutLabel':
         'its only table, SHORTCUT_LABEL_VECTORS, spells keycaps in English while the widget renders ' +
         'gtk_accelerator_get_label, which is translated — see the header. The browser renderer drives ' +

--- a/packages/web/adwaita-core/src/shared-trees.spec.ts
+++ b/packages/web/adwaita-core/src/shared-trees.spec.ts
@@ -1,0 +1,88 @@
+// The renderer-free half of ADR 0051's suite, on a runtime with no renderer at all.
+//
+// WHY IT EXISTS RATHER THAN LIVING IN THE DRIVERS. The two tree drivers run one per renderer
+// and one per runtime — `gtk-host` under GJS, `adwaita-web` under Firefox — so a rule they
+// each assert is a rule asserted twice, and neither leg runs on Node. Everything here is
+// about the CORPUS and the LEDGER rather than about a widget, so it belongs where both legs
+// can inherit it and where the Node run proves the join itself is right (tests/AGENTS.md
+// rule 3: Node proves the test, the renderer legs prove the implementations).
+//
+// It reads `scripts/adwaita-gallery-shared-trees.mjs` — the corpus itself, the same file the
+// two gallery generators emit from and the two drivers build.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { ADWAITA_GALLERY_SHARED_TREES } from '../../../../scripts/adwaita-gallery-shared-trees.mjs';
+import {
+    SHARED_TREE_BLOCKS_WITHOUT_EXPECTATIONS,
+    SHARED_TREE_TABLES,
+    authoredNodes,
+    reachedTables,
+    sharedTreeExpectations,
+} from './conformance/shared-trees.js';
+
+export default async () => {
+    await describe('the shared authored corpus, joined to the vectors', async () => {
+        await it('reaches exactly the tables the join claims', () => {
+            // `SHARED_TREE_TABLES` is what `check-adwaita-conformance-drivers.mjs` credits a
+            // renderer with. The gate can see that the file IMPORTS each of them; only a run
+            // can see whether an authored node instantiates a row, so that half is here.
+            expect(reachedTables(ADWAITA_GALLERY_SHARED_TREES.map((block) => block.root))).toStrictEqual([
+                ...SHARED_TREE_TABLES,
+            ]);
+        });
+
+        await it('addresses every expectation to a node the tree actually has', () => {
+            // Both drivers locate their subject by matching this `path` against the same
+            // pre-order walk. An address the walk does not produce would pick the wrong
+            // widget — or `undefined`, which reads as a renderer bug rather than a join bug.
+            for (const block of ADWAITA_GALLERY_SHARED_TREES) {
+                const addresses = new Set(authoredNodes(block.root).map(({ path }) => path));
+                for (const expectation of sharedTreeExpectations(block.root)) {
+                    expect(addresses.has(expectation.path)).toBe(true);
+                }
+            }
+        });
+
+        await it('gives every node address exactly once, so an index is a subject', () => {
+            for (const block of ADWAITA_GALLERY_SHARED_TREES) {
+                const paths = authoredNodes(block.root).map(({ path }) => path);
+                expect(new Set(paths).size).toBe(paths.length);
+            }
+        });
+
+        await it('declares a block that reaches nothing, and only such a block', () => {
+            // ADR 0051 § 4, both directions. The second is the self-retiring half: a
+            // declaration that has stopped being true fails, the shape arm 11 of
+            // `check-generated-website-data.mjs` already uses for a converged divergence.
+            for (const block of ADWAITA_GALLERY_SHARED_TREES) {
+                const reaches = sharedTreeExpectations(block.root).length > 0;
+                const declared = SHARED_TREE_BLOCKS_WITHOUT_EXPECTATIONS[block.widget] !== undefined;
+                expect(`${block.widget}: reaches=${reaches} declared=${declared}`).toBe(
+                    `${block.widget}: reaches=${reaches} declared=${!reaches}`,
+                );
+            }
+        });
+
+        await it('declares nothing that is not a block of the corpus', () => {
+            // A declaration for a block that has left the shared source explains a silence
+            // nobody is keeping, and it would go on reading as coverage-with-a-reason.
+            const blocks = new Set(ADWAITA_GALLERY_SHARED_TREES.map((block) => block.widget));
+            for (const widget of Object.keys(SHARED_TREE_BLOCKS_WITHOUT_EXPECTATIONS)) {
+                expect(`${widget} is in the corpus: ${blocks.has(widget)}`).toBe(`${widget} is in the corpus: true`);
+            }
+        });
+
+        await it('carries the row’s own rule, which is what a failure names', () => {
+            // The drivers put `rule` in the test title. An empty one turns an attributable
+            // failure into "something about a banner", which is the whole reason the vector
+            // tables carry the field.
+            for (const block of ADWAITA_GALLERY_SHARED_TREES) {
+                for (const expectation of sharedTreeExpectations(block.root)) {
+                    expect(expectation.rule.length > 0).toBe(true);
+                    expect(expectation.table.endsWith('_VECTORS')).toBe(true);
+                }
+            }
+        });
+    });
+};

--- a/packages/web/adwaita-core/src/test.mts
+++ b/packages/web/adwaita-core/src/test.mts
@@ -1,5 +1,6 @@
 import { run } from '@gjsify/unit';
 
+import sharedTreesTestSuite from './shared-trees.spec.js';
 import viewStackTestSuite from './view-stack.spec.js';
 import navigationViewTestSuite from './navigation-view.spec.js';
 import sidebarTestSuite from './sidebar.spec.js';
@@ -38,6 +39,7 @@ import scrollingTestSuite from './scrolling.spec.js';
 import swipeTestSuite from './swipe.spec.js';
 
 run({
+    sharedTreesTestSuite,
     aboutDialogTestSuite,
     adjustmentTestSuite,
     bannerTestSuite,

--- a/packages/web/adwaita-web/src/shared-trees.spec.ts
+++ b/packages/web/adwaita-web/src/shared-trees.spec.ts
@@ -23,7 +23,7 @@
 import { describe, expect, it } from '@gjsify/unit';
 
 import {
-    SHARED_TREE_BLOCKS_WITHOUT_VECTORS,
+    SHARED_TREE_BLOCKS_WITHOUT_EXPECTATIONS,
     SHARED_TREE_TABLES,
     authoredNodes,
     reachedTables,
@@ -133,7 +133,7 @@ export const AdwSharedTreesTest = async () => {
                 });
             }
 
-            const declared = Object.hasOwn(SHARED_TREE_BLOCKS_WITHOUT_VECTORS, block.widget);
+            const declared = SHARED_TREE_BLOCKS_WITHOUT_EXPECTATIONS[block.widget] !== undefined;
             if (expectations.length === 0) {
                 // ADR 0051 § 4: a block that proves nothing has to SAY so.
                 await it(`${block.widget} reaches no vector, and says why`, () => {

--- a/packages/web/adwaita-web/src/shared-trees.spec.ts
+++ b/packages/web/adwaita-web/src/shared-trees.spec.ts
@@ -19,14 +19,16 @@
 // The readers below go through the REAL DOM the element rendered, never a state object of
 // its own: an element asserting against its own bookkeeping agrees with itself while the
 // page is wrong.
+//
+// What is NOT here is everything that is not about this renderer — which tables the corpus
+// reaches, which block is declared to reach none, whether an expectation's address exists.
+// Those are facts about the CORPUS and are asserted once, in `adwaita-core`'s own suite,
+// which runs on Node as well as in a browser.
 
 import { describe, expect, it } from '@gjsify/unit';
 
 import {
-    SHARED_TREE_BLOCKS_WITHOUT_EXPECTATIONS,
-    SHARED_TREE_TABLES,
     authoredNodes,
-    reachedTables,
     sharedTreeExpectations,
     type SharedTreeExpectation,
     type SharedTreeNode,
@@ -132,25 +134,6 @@ export const AdwSharedTreesTest = async () => {
                     host.remove();
                 });
             }
-
-            const declared = SHARED_TREE_BLOCKS_WITHOUT_EXPECTATIONS[block.widget] !== undefined;
-            if (expectations.length === 0) {
-                // ADR 0051 § 4: a block that proves nothing has to SAY so.
-                await it(`${block.widget} reaches no vector, and says why`, () => {
-                    expect(declared).toBe(true);
-                });
-            } else if (declared) {
-                // Self-retiring: a declaration that has stopped being true fails.
-                await it(`${block.widget} is declared vector-free, and is not`, () => {
-                    expect(expectations.map((one) => one.table)).toStrictEqual([]);
-                });
-            }
         }
-    });
-
-    await describe('the tree driver claims no table the corpus misses', async () => {
-        await it('SHARED_TREE_TABLES is exactly what the corpus reaches', () => {
-            expect(reachedTables(authored.map((block) => block.root))).toStrictEqual([...SHARED_TREE_TABLES]);
-        });
     });
 };

--- a/packages/web/adwaita-web/src/shared-trees.spec.ts
+++ b/packages/web/adwaita-web/src/shared-trees.spec.ts
@@ -28,8 +28,9 @@
 import { describe, expect, it } from '@gjsify/unit';
 
 import {
-    authoredNodes,
+    authoredTags,
     sharedTreeExpectations,
+    subjectIndexOf,
     type SharedTreeExpectation,
     type SharedTreeNode,
 } from '@gjsify/adwaita-core/conformance';
@@ -59,13 +60,22 @@ function build(node: SharedTreeNode): HTMLElement {
     return el;
 }
 
-/** The element the authored root becomes, connected — these elements build on connect. */
-function mount(node: SharedTreeNode): { root: HTMLElement; host: HTMLElement } {
+/**
+ * Connect the authored root — these elements build on connect — run, and take it down again.
+ *
+ * The teardown is in a `finally` because a RED test must not leave a mounted tree behind:
+ * the next test would then be reading a document two blocks deep, and the failure it
+ * reported would name the wrong renderer.
+ */
+function mounted<T>(node: SharedTreeNode, use: (root: Element) => T): T {
     const host = document.createElement('div');
-    const root = build(node);
-    host.append(root);
+    host.append(build(node));
     document.body.append(host);
-    return { root, host };
+    try {
+        return use(host.firstElementChild!);
+    } finally {
+        host.remove();
+    }
 }
 
 const bannerButton = (banner: Element) => banner.querySelector<HTMLButtonElement>('.adw-banner-button');
@@ -82,56 +92,53 @@ function read(expectation: SharedTreeExpectation, el: Element): string | number 
             return (el as unknown as { textLength: number }).textLength;
         case 'switch-row-active':
             return (el as unknown as { active: boolean }).active;
-        case 'banner-button-visible':
-            return bannerButton(el) ? !bannerButton(el)!.hidden : false;
+        case 'banner-button-visible': {
+            const button = bannerButton(el);
+            return button ? !button.hidden : false;
+        }
         case 'banner-button-text':
             return bannerButton(el)?.textContent ?? '';
     }
 }
 
-/** Depth-first, root first — the DOM's own document order, the same walk GTK's is. */
-function descendants(root: Element): Element[] {
-    return [root, ...[...root.children].flatMap((child) => descendants(child))];
+/**
+ * The realised tree, depth-first in document order and filtered to the authored element
+ * names: the parts an element renders for itself (a listbox, a revealer, a title span) are
+ * not the renderer's promise; the ORDER and the NESTING of what was authored is.
+ */
+function realised(root: Element, wanted: readonly string[]): Element[] {
+    const set = new Set(wanted);
+    return [root, ...root.querySelectorAll('*')].filter((el) => set.has(el.tagName.toLowerCase()));
 }
 
 export const AdwSharedTreesTest = async () => {
-    const authored = ADWAITA_GALLERY_SHARED_TREES;
-
     await describe('the shared corpus builds through adwaita-web', async () => {
-        for (const block of authored) {
+        for (const block of ADWAITA_GALLERY_SHARED_TREES) {
             await it(`${block.widget} builds, and the REAL DOM carries the authored nodes in order`, () => {
-                const { root, host } = mount(block.root);
+                const wanted = authoredTags(block.root, hostTagOf);
 
-                const wanted = authoredNodes(block.root).map(({ node }) => hostTagOf(node.tag));
-                const set = new Set(wanted);
-                // Filtered to the authored element names: the parts an element renders for
-                // itself (a listbox, a revealer, a title span) are not the renderer's
-                // promise; the ORDER and the NESTING of what was authored is.
-                const built = descendants(root)
-                    .map((el) => el.tagName.toLowerCase())
-                    .filter((name) => set.has(name));
-
-                expect(built).toStrictEqual(wanted);
-                host.remove();
+                mounted(block.root, (root) => {
+                    const built = realised(root, wanted).map((el) => el.tagName.toLowerCase());
+                    expect(built).toStrictEqual(wanted);
+                });
             });
         }
     });
 
     await describe('the shared corpus against the adwaita-core vectors it reaches', async () => {
-        for (const block of authored) {
-            const expectations = sharedTreeExpectations(block.root);
-
-            for (const expectation of expectations) {
+        for (const block of ADWAITA_GALLERY_SHARED_TREES) {
+            for (const expectation of sharedTreeExpectations(block.root)) {
                 await it(`${block.widget} — ${expectation.path}: ${expectation.table} — ${expectation.rule}`, () => {
-                    const { root, host } = mount(block.root);
-                    const nodes = authoredNodes(block.root);
-                    const set = new Set(nodes.map(({ node }) => hostTagOf(node.tag)));
-                    const built = descendants(root).filter((el) => set.has(el.tagName.toLowerCase()));
-                    const subject = built[nodes.findIndex(({ path }) => path === expectation.path)]!;
-                    expect(subject.tagName.toLowerCase()).toBe(hostTagOf(expectation.gtype));
+                    mounted(block.root, (root) => {
+                        // The SAME filtered walk the shape test asserts, so the element an
+                        // expectation is read off is the one at the authored ADDRESS rather
+                        // than the first of its name the DOM happens to contain.
+                        const built = realised(root, authoredTags(block.root, hostTagOf));
+                        const subject = built[subjectIndexOf(block.root, expectation.path)]!;
+                        expect(subject.tagName.toLowerCase()).toBe(hostTagOf(expectation.gtype));
 
-                    expect(read(expectation, subject)).toBe(expectation.expected);
-                    host.remove();
+                        expect(read(expectation, subject)).toBe(expectation.expected);
+                    });
                 });
             }
         }

--- a/packages/web/adwaita-web/src/shared-trees.spec.ts
+++ b/packages/web/adwaita-web/src/shared-trees.spec.ts
@@ -1,0 +1,156 @@
+// ONE AUTHORED TREE, BUILT BY THIS RENDERER — ADR 0051, and the renderer ADR 0027 § 9
+// names by name: "the same authored tree, rendered through this host and through
+// `adwaita-web`, satisfies the same `@gjsify/adwaita-core/conformance` vectors with no
+// per-surface markup branch".
+//
+// The sibling driver is `packages/framework/gtk-host/src/shared-trees.spec.ts`. One corpus
+// — `scripts/adwaita-gallery-shared-trees.mjs`, read here and not transcribed — one set of
+// expectations, a driver per renderer: ADR 0030's shape one level up, so a green-here /
+// red-there diff is attributable to the RENDERER and not to two suites disagreeing about
+// what they test.
+//
+// TWO DECLARED TRANSFORMS ON THE WAY IN, and no third. `hostTagOf` turns the authored GIR
+// class name into the element name, which is the same case rule `gtk-host` stamps its tags
+// with; and an authored property name becomes its kebab-case ATTRIBUTE, because this
+// renderer's door is markup. Both are total functions over the corpus with no tag list and
+// no per-block case — a `switch` on a widget name here would be the per-surface branch
+// § 9 forbids, and the reason the corpus admits a block only when it needs no alias.
+//
+// The readers below go through the REAL DOM the element rendered, never a state object of
+// its own: an element asserting against its own bookkeeping agrees with itself while the
+// page is wrong.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import {
+    SHARED_TREE_BLOCKS_WITHOUT_VECTORS,
+    SHARED_TREE_TABLES,
+    authoredNodes,
+    reachedTables,
+    sharedTreeExpectations,
+    type SharedTreeExpectation,
+    type SharedTreeNode,
+} from '@gjsify/adwaita-core/conformance';
+
+import { ADWAITA_GALLERY_SHARED_TREES, hostTagOf } from '../../../../scripts/adwaita-gallery-shared-trees.mjs';
+
+import '@gjsify/adwaita-web';
+
+/** `buttonLabel` -> `button-label`. The authored spelling is camelCase for every surface. */
+const attributeOf = (prop: string) => prop.replace(/[A-Z]/g, (upper) => `-${upper.toLowerCase()}`);
+
+/**
+ * The whole renderer-specific half of this driver: an element, its authored properties as
+ * attributes, its children, in that order.
+ *
+ * A boolean is the ATTRIBUTE'S PRESENCE, which is what every element here reads
+ * (`hasAttribute('revealed')`, `hasAttribute('expanded')`) — spelling `"true"` would set a
+ * present attribute for `false` as well.
+ */
+function build(node: SharedTreeNode): HTMLElement {
+    const el = document.createElement(hostTagOf(node.tag));
+    for (const [prop, value] of Object.entries(node.props ?? {})) {
+        if (typeof value === 'boolean') el.toggleAttribute(attributeOf(prop), value);
+        else el.setAttribute(attributeOf(prop), String(value));
+    }
+    for (const child of node.children ?? []) el.append(build(child));
+    return el;
+}
+
+/** The element the authored root becomes, connected — these elements build on connect. */
+function mount(node: SharedTreeNode): { root: HTMLElement; host: HTMLElement } {
+    const host = document.createElement('div');
+    const root = build(node);
+    host.append(root);
+    document.body.append(host);
+    return { root, host };
+}
+
+const bannerButton = (banner: Element) => banner.querySelector<HTMLButtonElement>('.adw-banner-button');
+
+/**
+ * Read one observable off the element this renderer built.
+ *
+ * The ONE seam between the shared expectations and this renderer, and the mirror of
+ * `read()` in the gtk-host driver. Everything above it is renderer-free.
+ */
+function read(expectation: SharedTreeExpectation, el: Element): string | number | boolean {
+    switch (expectation.observable) {
+        case 'entry-text-length':
+            return (el as unknown as { textLength: number }).textLength;
+        case 'switch-row-active':
+            return (el as unknown as { active: boolean }).active;
+        case 'banner-button-visible':
+            return bannerButton(el) ? !bannerButton(el)!.hidden : false;
+        case 'banner-button-text':
+            return bannerButton(el)?.textContent ?? '';
+    }
+}
+
+/** Depth-first, root first — the DOM's own document order, the same walk GTK's is. */
+function descendants(root: Element): Element[] {
+    return [root, ...[...root.children].flatMap((child) => descendants(child))];
+}
+
+export const AdwSharedTreesTest = async () => {
+    const authored = ADWAITA_GALLERY_SHARED_TREES;
+
+    await describe('the shared corpus builds through adwaita-web', async () => {
+        for (const block of authored) {
+            await it(`${block.widget} builds, and the REAL DOM carries the authored nodes in order`, () => {
+                const { root, host } = mount(block.root);
+
+                const wanted = authoredNodes(block.root).map(({ node }) => hostTagOf(node.tag));
+                const set = new Set(wanted);
+                // Filtered to the authored element names: the parts an element renders for
+                // itself (a listbox, a revealer, a title span) are not the renderer's
+                // promise; the ORDER and the NESTING of what was authored is.
+                const built = descendants(root)
+                    .map((el) => el.tagName.toLowerCase())
+                    .filter((name) => set.has(name));
+
+                expect(built).toStrictEqual(wanted);
+                host.remove();
+            });
+        }
+    });
+
+    await describe('the shared corpus against the adwaita-core vectors it reaches', async () => {
+        for (const block of authored) {
+            const expectations = sharedTreeExpectations(block.root);
+
+            for (const expectation of expectations) {
+                await it(`${block.widget} — ${expectation.path}: ${expectation.table} — ${expectation.rule}`, () => {
+                    const { root, host } = mount(block.root);
+                    const nodes = authoredNodes(block.root);
+                    const set = new Set(nodes.map(({ node }) => hostTagOf(node.tag)));
+                    const built = descendants(root).filter((el) => set.has(el.tagName.toLowerCase()));
+                    const subject = built[nodes.findIndex(({ path }) => path === expectation.path)]!;
+                    expect(subject.tagName.toLowerCase()).toBe(hostTagOf(expectation.gtype));
+
+                    expect(read(expectation, subject)).toBe(expectation.expected);
+                    host.remove();
+                });
+            }
+
+            const declared = Object.hasOwn(SHARED_TREE_BLOCKS_WITHOUT_VECTORS, block.widget);
+            if (expectations.length === 0) {
+                // ADR 0051 § 4: a block that proves nothing has to SAY so.
+                await it(`${block.widget} reaches no vector, and says why`, () => {
+                    expect(declared).toBe(true);
+                });
+            } else if (declared) {
+                // Self-retiring: a declaration that has stopped being true fails.
+                await it(`${block.widget} is declared vector-free, and is not`, () => {
+                    expect(expectations.map((one) => one.table)).toStrictEqual([]);
+                });
+            }
+        }
+    });
+
+    await describe('the tree driver claims no table the corpus misses', async () => {
+        await it('SHARED_TREE_TABLES is exactly what the corpus reaches', () => {
+            expect(reachedTables(authored.map((block) => block.root))).toStrictEqual([...SHARED_TREE_TABLES]);
+        });
+    });
+};

--- a/packages/web/adwaita-web/src/test.browser.mts
+++ b/packages/web/adwaita-web/src/test.browser.mts
@@ -53,8 +53,10 @@ import { AdwEmptySectionsTest } from './empty-sections.spec.js';
 import { AdwSlottedChildrenTest } from './slotted-children.spec.js';
 import { AdwKeyboardOperableTest } from './keyboard-operable.spec.js';
 import { AdwFontsTest } from './adw-fonts.spec.js';
+import { AdwSharedTreesTest } from './shared-trees.spec.js';
 
 run({
+    AdwSharedTreesTest,
     AdwKeyboardOperableTest,
     AdwConnectLifecycleTest,
     AdwEmptySectionsTest,

--- a/scripts/adwaita-gallery-shared-trees.d.mts
+++ b/scripts/adwaita-gallery-shared-trees.d.mts
@@ -10,6 +10,14 @@
 //
 // A second transcript of the tree — generated or hand-copied — is the defect ADR 0051
 // exists to prevent, so there is deliberately no way to get one.
+//
+// NOTHING CHECKS THIS FILE AGAINST THE `.mjs`, so it declares ONLY what a TypeScript spec
+// imports — three names, each imported by at least one live spec, which makes a rename over
+// there a build error over here. A declaration nobody imports has no such backstop: it is a
+// claim about the module that can quietly stop being true, which is this file's own failure
+// mode. The `.mjs`'s other exports (`nativeScriptTree`,
+// `ADWAITA_GALLERY_TREE_DIVERGENCES`) have plain-`.mjs` consumers only and are deliberately
+// absent; add one here when, and only when, a spec imports it.
 
 /** One node of an authored tree, spelled in GIR class names. */
 export interface SharedNode {
@@ -35,9 +43,3 @@ export declare const hostTagOf: (gtype: string) => string;
 
 /** The shared block in `gtk-host` tags. */
 export declare const gtkHostTree: (widget: string) => SharedTree;
-
-/** The shared block in GIR class names — no transform, see the source. */
-export declare const nativeScriptTree: (widget: string) => SharedTree;
-
-/** Every gallery block that has a tree on both renderers and is still authored twice. */
-export declare const ADWAITA_GALLERY_TREE_DIVERGENCES: Record<string, string>;

--- a/scripts/adwaita-gallery-shared-trees.d.mts
+++ b/scripts/adwaita-gallery-shared-trees.d.mts
@@ -1,0 +1,43 @@
+// Types for `adwaita-gallery-shared-trees.mjs`, so the TREE DRIVERS can read the corpus
+// itself rather than a transcription of it (ADR 0051).
+//
+// WHY A DECLARATION FILE AND NOT A MOVE. The corpus is authored here because its two
+// consumers are plain-Node generators that run in CI jobs with no `node_modules` — a bare
+// specifier would not resolve for them. The drivers are TypeScript specs in two packages.
+// A declaration beside the source lets both read the SAME file: `tsc` resolves the types
+// here and never puts the `.mjs` in its program, so `rootDir` is not crossed, and the test
+// bundlers inline the module like any other relative import.
+//
+// A second transcript of the tree — generated or hand-copied — is the defect ADR 0051
+// exists to prevent, so there is deliberately no way to get one.
+
+/** One node of an authored tree, spelled in GIR class names. */
+export interface SharedNode {
+    tag: string;
+    slot?: string;
+    props?: Record<string, string | number | boolean>;
+    children?: SharedNode[];
+}
+
+/** One gallery block whose widget tree is authored once. */
+export interface SharedTree {
+    /** The `<AdwWidget title="…">` this belongs to, e.g. `Adw.Banner`. */
+    widget: string;
+    /** The gallery page it sits on. */
+    page: string;
+    root: SharedNode;
+}
+
+export declare const ADWAITA_GALLERY_SHARED_TREES: readonly SharedTree[];
+
+/** `AdwPreferencesGroup` -> `adw-preferences-group` — `gtk-host`'s own `tagOf`, restated. */
+export declare const hostTagOf: (gtype: string) => string;
+
+/** The shared block in `gtk-host` tags. */
+export declare const gtkHostTree: (widget: string) => SharedTree;
+
+/** The shared block in GIR class names — no transform, see the source. */
+export declare const nativeScriptTree: (widget: string) => SharedTree;
+
+/** Every gallery block that has a tree on both renderers and is still authored twice. */
+export declare const ADWAITA_GALLERY_TREE_DIVERGENCES: Record<string, string>;

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -55,7 +55,21 @@
 //   5. renderer-driven AND still carrying `CORE-ONLY:`                     → FAIL
 //
 // "Driven" = a LIVE renderer `*.spec.ts` names the table OUTSIDE a comment — the naming
-// is `namedPerSpec`, the liveness `suiteDrivers`.
+// is `namedPerSpec`, the liveness `suiteDrivers`. OR, since ADR 0051, driven through a TREE.
+//
+// TREE arm — a third kind of driver, and the one that names no table in its own source.
+// It builds an AUTHORED TREE neither renderer wrote and reads the rows that tree
+// instantiates; the join lives in `adwaita-core/src/conformance/shared-trees.ts`:
+//  13. a name in `SHARED_TREE_TABLES` that no conformance file declares          → FAIL
+//  14. a name in `SHARED_TREE_TABLES` no IMPORT of that file backs — a coverage
+//      claim with nothing behind it, the class this gate's three incidents are   → FAIL
+//  15. a table the binding IMPORTS and leaves off the list, which would silently
+//      under-credit every renderer driving it through a tree                     → FAIL
+//  16. a spec calling the join that no test entry hands to `run({…})`            → FAIL
+//  17. a binding that joins tables while NO live suite drives it                 → FAIL
+// The other half — a listed table no corpus node actually REACHES — is not statically
+// decidable here, because it needs the corpus evaluated. The drivers assert it themselves
+// against `reachedTables`, derived from the trees rather than written down.
 //
 // CLAIM arm — every comment CLAUSE in the core or either renderer that names a
 // vector table is resolved against reality (clause, not sentence — see clausesIn):
@@ -138,6 +152,36 @@ const RENDERERS = [
     { label: 'nativescript', dir: join(ROOT, 'packages/nativescript-bridge/adwaita/src') },
 ];
 const OPEN_TODOS = join(ROOT, 'status/open-todos.md');
+
+/**
+ * THE THIRD KIND OF DRIVER — a TREE driver (ADR 0051).
+ *
+ * The two above drive a table from a renderer's own spec, on a widget that spec constructs.
+ * A tree driver builds an AUTHORED TREE neither renderer wrote — the gallery blocks in
+ * `scripts/adwaita-gallery-shared-trees.mjs` — and reads the rows that tree instantiates off
+ * the widgets its renderer produced. It therefore names no table in its own source: the join
+ * lives in {@link TREE_BINDING}, and a table driven only that way would read as undriven
+ * here, which is the blindness this arm removes.
+ *
+ * It is derived, never claimed. The binding's table list is read from its CODE, held against
+ * the tables it actually imports, and credited only to a driver whose suite RUNS — the same
+ * three refusals the rest of this gate is built out of.
+ */
+const TREE_BINDING = join(CONFORMANCE_DIR, 'shared-trees.ts');
+/** The exported join a tree driver calls. Naming it is what makes a spec a tree driver. */
+const TREE_ENTRY = 'sharedTreeExpectations';
+/**
+ * Where a tree driver may live.
+ *
+ * `gtk-host` is on the list and is deliberately NOT a renderer: it is the GTK host rather
+ * than an Adwaita port, so a table only IT drives stays core-only for the table arm — the
+ * same treatment the OUTSIDE_DRIVER arm gives `@gjsify/gtk-host`'s menu suite. Being on this
+ * list still buys the honest half: if its driver stops running, this gate says so.
+ */
+const TREE_DRIVER_DIRS = [
+    ...RENDERERS.map((renderer) => ({ ...renderer, renderer: true })),
+    { label: 'gtk-host', dir: join(ROOT, 'packages/framework/gtk-host/src'), renderer: false },
+];
 
 /** The marker a core-only table must carry, in its own header. */
 const CORE_ONLY_MARKER = 'CORE-ONLY:';
@@ -493,7 +537,98 @@ const resolved = {
     specs: 0,
     promises: 0,
     outside: 0,
+    tree: 0,
 };
+
+// TREE arm. Runs BEFORE the table arm, because it decides which tables are driven.
+const treeTables = new Set();
+{
+    let source = null;
+    try {
+        source = readFileSync(TREE_BINDING, 'utf8');
+    } catch {
+        failures.push(
+            `${rel(ROOT, TREE_BINDING)}: the tree binding is gone, so nothing joins an authored tree to a ` +
+                'vector row and this arm credits nobody. Restore it, or delete the arm with it.',
+        );
+    }
+    if (source !== null) {
+        const code = stripComments(source);
+        const listed = /export const SHARED_TREE_TABLES\s*=\s*\[([\s\S]*?)\]/.exec(code)?.[1] ?? '';
+        for (const [, name] of listed.matchAll(/'([A-Z][A-Z0-9_]*_VECTORS)'/g)) treeTables.add(name);
+        // What the binding actually IMPORTS FOR VALUE. The two must agree: a name in the
+        // list that no import backs is a coverage claim with nothing behind it, and a table
+        // imported but left off the list makes this arm under-credit the renderers driving
+        // it. Import clauses and not every occurrence, because a DECLARATION naming the
+        // table it cannot reach ("its only table, SHORTCUT_LABEL_VECTORS, spells keycaps in
+        // English") is the opposite of a join, and reading it as one accused the honest
+        // wording — the same shape the CLAUSE_TURN split exists for one arm over.
+        const read = new Set(
+            [...code.matchAll(/import\s*\{([^}]*)\}\s*from/g)].flatMap(([, clause]) =>
+                [...clause.matchAll(/\b([A-Z][A-Z0-9_]*_VECTORS)\b/g)].map(([, name]) => name),
+            ),
+        );
+        for (const name of treeTables) {
+            if (!declared.has(name)) {
+                failures.push(`${rel(ROOT, TREE_BINDING)}: lists ${name}, which no conformance file declares.`);
+            } else if (!read.has(name)) {
+                failures.push(
+                    `${rel(ROOT, TREE_BINDING)}: lists ${name} as tree-driven while nothing in the file reads ` +
+                        'it, so no authored tree can reach a row of it. Join it, or drop it from the list.',
+                );
+            }
+        }
+        for (const name of read) {
+            if (declared.has(name) && !treeTables.has(name)) {
+                failures.push(
+                    `${rel(ROOT, TREE_BINDING)}: joins ${name} to the tree without listing it in ` +
+                        'SHARED_TREE_TABLES, so every renderer driving it through a tree goes uncredited here.',
+                );
+            }
+        }
+        if (treeTables.size === 0) {
+            failures.push(
+                `${rel(ROOT, TREE_BINDING)}: SHARED_TREE_TABLES is empty — the scan is broken, or the binding ` +
+                    'no longer reaches any table.',
+            );
+        }
+    }
+
+    // Which suites RUN a tree driver. Liveness comes from `suite-registration.mjs` for the
+    // same reason the SUITE arm's does: naming is not running, and the cheap second
+    // derivation of that fact is what opened #1365.
+    const treeDrivers = [];
+    for (const { label, dir, renderer } of TREE_DRIVER_DIRS) {
+        const { live } = readSuiteRegistration(dirname(dir));
+        for (const file of walk(dir)) {
+            if (!file.endsWith('.spec.ts') || !new RegExp(`\\b${TREE_ENTRY}\\b`).test(withoutComments(readFileSync(file, 'utf8')))) continue;
+            if (!live.has(file)) {
+                failures.push(
+                    `${rel(ROOT, file)}: drives the shared authored tree, but no test entry of ${label} hands ` +
+                        `its suite to \`run({…})\` — so it runs NOWHERE. Register it, or delete it.`,
+                );
+                continue;
+            }
+            treeDrivers.push({ label, renderer });
+        }
+    }
+    resolved.tree = treeDrivers.length;
+    if (treeTables.size > 0 && treeDrivers.length === 0) {
+        failures.push(
+            `${rel(ROOT, TREE_BINDING)}: joins ${treeTables.size} table(s) to the authored corpus and no live ` +
+                'suite drives it. ADR 0051 exists because a corpus nothing builds proves nothing.',
+        );
+    }
+    // A renderer that RUNS a tree driver drives every table the binding joins — which is the
+    // credit this arm exists to give. `gtk-host` is on the driver list and off this one.
+    for (const { label, renderer } of treeDrivers) {
+        if (!renderer) continue;
+        for (const name of treeTables) {
+            byLabel.get(label).add(name);
+            byRenderer.add(name);
+        }
+    }
+}
 
 // SUITE arm. The arms below key off which tables are driven, so a spec that names a table
 // while running nowhere would otherwise surface one step downstream, as "driven only by the
@@ -748,7 +883,8 @@ if (failures.length > 0) {
 
 console.log(
     `check-adwaita-conformance-drivers: ${tables.length} vector tables driven from ${resolved.specs} live ` +
-        `spec(s), ${resolved.exempted} core-only, ` +
+        `spec(s) and ${resolved.tree} live tree driver(s) over ${treeTables.size} joined table(s), ` +
+        `${resolved.exempted} core-only, ` +
         `${resolved.chains} coverage chain(s) walked to a driver. Read ${resolved.citations} prose citation(s), ` +
         `of which ${resolved.both} both-renderer claim(s), ${resolved.suite} single-suite claim(s) and ` +
         `${resolved.counted} counted glob(s) were resolved against the tree, and read the header of ` +

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -560,9 +560,9 @@ const treeTables = new Set();
         // list that no import backs is a coverage claim with nothing behind it, and a table
         // imported but left off the list makes this arm under-credit the renderers driving
         // it. Import clauses and not every occurrence, because a DECLARATION naming the
-        // table it cannot reach ("its only table, SHORTCUT_LABEL_VECTORS, spells keycaps in
-        // English") is the opposite of a join, and reading it as one accused the honest
-        // wording — the same shape the CLAUSE_TURN split exists for one arm over.
+        // table it does NOT join ("SHORTCUT_LABEL_VECTORS is deliberately off
+        // SHARED_TREE_TABLES") is the opposite of a join, and reading it as one accused the
+        // honest wording — the same shape the CLAUSE_TURN split exists for one arm over.
         const read = new Set(
             [...code.matchAll(/import\s*\{([^}]*)\}\s*from/g)].flatMap(([, clause]) =>
                 [...clause.matchAll(/\b([A-Z][A-Z0-9_]*_VECTORS)\b/g)].map(([, name]) => name),

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -601,7 +601,11 @@ const treeTables = new Set();
     for (const { label, dir, renderer } of TREE_DRIVER_DIRS) {
         const { live } = readSuiteRegistration(dirname(dir));
         for (const file of walk(dir)) {
-            if (!file.endsWith('.spec.ts') || !new RegExp(`\\b${TREE_ENTRY}\\b`).test(withoutComments(readFileSync(file, 'utf8')))) continue;
+            if (
+                !file.endsWith('.spec.ts') ||
+                !new RegExp(`\\b${TREE_ENTRY}\\b`).test(withoutComments(readFileSync(file, 'utf8')))
+            )
+                continue;
             if (!live.has(file)) {
                 failures.push(
                     `${rel(ROOT, file)}: drives the shared authored tree, but no test entry of ${label} hands ` +

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -599,6 +599,39 @@ build a tree out of in any runtime this repo tests in. A device-bound driver wou
 CI guard, which is why the second driver is `adwaita-web`: the renderer ADR 0027 § 9 named
 in the first place.
 
+### A constructed `Adw.Banner` does not interpret markup, and both ports say it does
+
+Found by the tree driver ADR 0051 landed, which is the first thing in this tree to read a
+`GParamSpec`-default table off a widget a renderer actually BUILT.
+
+`BANNER_DEFAULT_VECTORS` states `AdwBanner:use-markup` defaults to TRUE, and the pspec agrees
+— `Adw.Banner.find_property('use-markup').get_default_value()` is `true` on libadwaita 1.9.3.
+A freshly constructed `Adw.Banner` answers FALSE, from `get_use_markup()` and from
+`get_property('use-markup')` alike.
+
+**The mechanism, measured rather than read off the C** (`refs/libadwaita` is not a checkout
+here): the banner's getter DELEGATES to its template `GtkLabel`. `adw-banner.ui` — read out
+of the installed GResource at `/org/gnome/Adwaita/ui/adw-banner.ui` — sets `use-underline`,
+`ellipsize`, `wrap` and more on that label and never `use-markup`, so the label keeps
+`GtkLabel`'s own FALSE; and a pspec default is not written through a setter, so the banner's
+TRUE never reaches the label. Assigning `label.useMarkup = false` directly makes
+`banner.useMarkup` report `false`, and `banner.set_use_markup(true)` makes both report
+`true` — which is what identifies the read as a delegation rather than a stored field.
+
+**What it costs.** Both Adwaita ports implement the pspec default, so the same authored
+banner interprets `<b>bold</b>` in the browser and paints it literally in GTK. That is a
+user-visible rendering difference on the exact surface ADR 0027 § 9 is about.
+
+**Why it is not fixed here.** Deciding it changes what two published renderers paint, and it
+changes a conformance row whose `rule` cites `adw-banner.c` line numbers that cannot be
+checked without the submodule. The candidates are not equivalent: teach
+`BANNER_DEFAULT_VECTORS` to carry the CONSTRUCTED default beside the pspec one (the honest
+shape, since `gtk-host`'s contract already sides with construction and the two disagree in a
+hundred-odd places), or keep one column and decide which fact a renderer is held to. Either
+way it wants its own change with its own vectors. The tree drivers do not paper over it:
+they take no pspec-default table at all, and the reason is in
+`adwaita-core/src/conformance/shared-trees.ts`'s header.
+
 ### The gallery's two authored PANES are now measured too, and five of forty are one text
 
 The sibling fact to the entry above, one surface over. That one is about the gallery's two

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -594,12 +594,13 @@ tree has nowhere to put.
 **The NativeScript port is not the second driver, and cannot be one off-device.** ADR 0051
 proposed it and the measurement overturned that: every widget module under
 `packages/nativescript-bridge/adwaita/src/widgets/` evaluates a bare `@nativescript/core`
-specifier at module scope, `@nativescript/core` is an OPTIONAL peer that the workspace
-install never brings in, and the port's own specs say in their headers that they must not
-import those modules — they drive the pure siblings instead. So the port has no widget to
-build a tree out of in any runtime this repo tests in. A device-bound driver would not be a
-CI guard, which is why the second driver is `adwaita-web`: the renderer ADR 0027 § 9 named
-in the first place.
+specifier at module scope, and the port's own specs say in their headers that they must not
+import those modules — they drive the pure siblings instead. Installing the optional peer
+would not help: `@nativescript/core` ships a widget class only as `index.android.js` /
+`index.ios.js`, never a platform-neutral `index.js`, so the base class those widgets extend
+does not resolve outside a device — the measurement is in the ADR's Amendment 1. A
+device-bound driver would not be a CI guard, which is why the second driver is
+`adwaita-web`: the renderer ADR 0027 § 9 named in the first place.
 
 ### A constructed `Adw.Banner` does not interpret markup, and both ports say it does
 

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -466,12 +466,13 @@ and nothing here asserts that it behaves like one.
 
 The criterion that closes the GOAL out is in ADR 0027 § 9 and is unchanged: the same
 authored tree, rendered through the GTK host and through `adwaita-web`, satisfies the
-same `@gjsify/adwaita-core/conformance` vectors with no per-surface markup branch. The
-"same authored tree" half now exists for part of the gallery and is measured — see *The
-gallery's two authored trees agree on 7 blocks of 23* below.
-Until that is measured the goal stays a direction, not a claim — and the longer
-horizon it points at (NativeScript and browser builds from one native-authored
-source) needs its own ADR.
+same `@gjsify/adwaita-core/conformance` vectors with no per-surface markup branch. Both
+halves now exist for part of the gallery: the "same authored tree" half is measured by
+arm 11, and the BEHAVIOUR half by the two tree drivers ADR 0051 landed — see *The gallery's
+two authored trees agree on 7 blocks of 23* below for what they cover and what they do not.
+The goal is a claim about seven blocks and a direction past them — and the longer horizon it
+points at (NativeScript and browser builds from one native-authored source) still needs its
+own ADR.
 
 Two things the slot work left for whoever picks this up. **Ten of the 23 re-homing
 elements are deliberately not converted**: eight consume typed children into a state
@@ -571,20 +572,32 @@ seven were corrected here. It is worth keeping because of WHERE it hid: seven of
 copies agreed, so every majority-wins reading of the gallery would have propagated the
 typo, and no arm compares a chip label to anything at all.
 
-**What this does NOT close.** Two authored trees agreeing is not two renderers behaving the
-same, and the shared source is compared as DATA rather than as a rendered tree. The
-criterion still wants `@gjsify/adwaita-core/conformance` vectors run over one authored tree
-through both renderers; the seven blocks here are what such a suite would have to start
-from, and the ledger says what would have to converge before it could grow past them.
+**What this does NOT close, now that the suite exists.**
+[ADR 0051](../docs/adr/0051-one-authored-tree-rendered.md) is Accepted and the corpus is
+BUILT by two renderers — `packages/framework/gtk-host/src/shared-trees.spec.ts` on GJS and
+`packages/web/adwaita-web/src/shared-trees.spec.ts` in the browser, joined to the vectors by
+`adwaita-core/src/conformance/shared-trees.ts`. What is still open is the CORPUS, not the
+driver, and the ledger above is the backlog: the suite proves what it proves about seven
+blocks, four vector tables and six rows, and that denominator is printed by the drivers
+rather than written here.
 
-**[ADR 0051](../docs/adr/0051-one-authored-tree-rendered.md) proposes that suite** — one
-corpus and a driver per renderer in ADR 0030's shape, the expectations staying
-`adwaita-core`'s so a failure is attributable to the renderer rather than to a freshly
-written assertion, the remainder declared per block and self-retiring, and a fifth stage
-putting `adwaita-web` on the same corpus by emitting the gallery `preview` fence from it.
-It also carries the correction this entry implies and § 9 does not: § 9 names `adwaita-web`
-as the second renderer, and the corpus that exists pairs `gtk-host` with the NativeScript
-port, because those are the two the gallery authors from one source.
+Three limits are structural rather than backlog, and each is measured in the binding's own
+header: a `GParamSpec`-default table cannot be read off a CONSTRUCTED widget (`AdwBanner`'s
+`use-markup` pspec default is TRUE and a fresh `AdwBanner` answers FALSE on libadwaita
+1.9.3); a table whose expectation is a LOCALIZED rendering asserts a fact about the runner
+(`<Control>C` draws `["Strg","C"]` on a de_DE host, and the locale cannot be moved from
+inside the process); and the `emitted` half of a notify table needs a listener an authored
+tree has nowhere to put.
+
+**The NativeScript port is not the second driver, and cannot be one off-device.** ADR 0051
+proposed it and the measurement overturned that: every widget module under
+`packages/nativescript-bridge/adwaita/src/widgets/` evaluates a bare `@nativescript/core`
+specifier at module scope, `@nativescript/core` is an OPTIONAL peer that the workspace
+install never brings in, and the port's own specs say in their headers that they must not
+import those modules — they drive the pure siblings instead. So the port has no widget to
+build a tree out of in any runtime this repo tests in. A device-bound driver would not be a
+CI guard, which is why the second driver is `adwaita-web`: the renderer ADR 0027 § 9 named
+in the first place.
 
 ### The gallery's two authored PANES are now measured too, and five of forty are one text
 

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -577,9 +577,11 @@ typo, and no arm compares a chip label to anything at all.
 BUILT by two renderers — `packages/framework/gtk-host/src/shared-trees.spec.ts` on GJS and
 `packages/web/adwaita-web/src/shared-trees.spec.ts` in the browser, joined to the vectors by
 `adwaita-core/src/conformance/shared-trees.ts`. What is still open is the CORPUS, not the
-driver, and the ledger above is the backlog: the suite proves what it proves about seven
-blocks, four vector tables and six rows, and that denominator is printed by the drivers
-rather than written here.
+driver, and the ledger above is the backlog: the suite proves what it proves about the
+blocks in the shared source and the vector rows their authored values instantiate. That
+denominator is not written here on purpose — `check-adwaita-conformance-drivers.mjs` prints
+the joined tables and arm 11 the partition, every run, and a figure copied into this file
+would be right until the next row lands.
 
 Three limits are structural rather than backlog, and each is measured in the binding's own
 header: a `GParamSpec`-default table cannot be read off a CONSTRUCTED widget (`AdwBanner`'s


### PR DESCRIPTION
Closes the rung ADR 0051 was written for: the same authored tree, built by more than
one renderer, held to the same `@gjsify/adwaita-core/conformance` rows, with no
per-surface markup branch. That is ADR 0027 § 9's criterion, and until now nothing
held it.

ADR 0051 is now Accepted, with one of its own premises overturned by measurement.

## What was missing

`scripts/adwaita-gallery-shared-trees.mjs` holds seven gallery blocks whose widget
tree is authored once. Arm 11 of `check-generated-website-data.mjs` compares them as
DATA. Nothing built them. Now two renderers do.

* `packages/web/adwaita-core/src/conformance/shared-trees.ts` is the renderer-free
  join: `sharedTreeExpectations(root)` returns the vector ROWS an authored node
  instantiates, by matching the authored value against the row's own input. It writes
  no expected value of its own — ADR 0051 § 3 made structural rather than promised.
* `packages/framework/gtk-host/src/shared-trees.spec.ts` builds each block through
  `createElement`/`setProp`/`insert` into real libadwaita widgets, diagnostics gate on.
* `packages/web/adwaita-web/src/shared-trees.spec.ts` builds the same block out of
  custom elements, in Firefox.
* `packages/web/adwaita-core/src/shared-trees.spec.ts` holds the corpus-and-ledger
  half on Node AND GJS, so neither renderer leg carries a claim about the corpus.

Both drivers assert, on the REAL tree their renderer produced, that the authored nodes
appear in the authored order — the libadwaita revealers and listboxes between them are
the renderer's business, the nesting is not — and then read the reached rows off them.
Each has exactly one seam, a `read(expectation, node)` over a closed observable
vocabulary; everything above it is shared. The per-surface transforms are `hostTagOf`
on both sides plus a camelCase-to-kebab ATTRIBUTE rule on the web, both total over the
corpus, with no per-block branch on either side.

The corpus is read, not transcribed. A hand-written
`scripts/adwaita-gallery-shared-trees.d.mts` lets a TypeScript spec import the `.mjs`
the two gallery generators emit from: `tsc` resolves the declaration and never puts the
`.mjs` in its program, so no package's `rootDir` is crossed, and the corpus stays where
plain-Node generators reach it in a CI job with no `node_modules`.

Distance, derived every run: 7 blocks, 5 reaching a row, 2 declared with a measured
reason, 4 tables, 6 rows.

## The premise that did not hold: stage 2 cannot exist

Stage 2 asked for a NativeScript tree driver "off-device against the port's own
classes, the way the port's specs already run on GJS and Node". Measured:

* every module under `packages/nativescript-bridge/adwaita/src/widgets/` opens with a
  bare `@nativescript/core` import at module scope, because each class EXTENDS an NS
  view;
* `@nativescript/core` is an OPTIONAL peer the workspace install never brings in —
  `node_modules/@nativescript` holds `types`, `types-android`, `types-ios` and nothing
  else;
* the port's own specs say so in their headers and act on it: "this file must NOT
  import `./widgets/adw-banner.js` … the behaviour is exercised through
  `./widgets/chrome.js`, the pure sibling". What runs off-device is the port's pure
  derivations, never its widgets.

So the port has no widget to build a tree out of in any runtime this repo tests. An
Android emulator was offered and deliberately NOT used: a driver that needs a device
cannot be the check that fails a PR, which is the only thing this rung is for. The
second driver is therefore `adwaita-web`, the renderer § 9 named before ADR 0051
re-aimed it. The ADR's "One correction to § 9's own wording" is withdrawn in
§ Amendment 1 — it is still true about the CORPUS, it was wrong about the DRIVER.

## What the drivers found that nothing else had

**A `GParamSpec` default is not a constructed default.** `AdwBanner:use-markup`
declares TRUE (`find_property('use-markup').get_default_value()`); a freshly
constructed `Adw.Banner` answers FALSE. Mechanism measured, not guessed: the banner's
getter DELEGATES to its template `GtkLabel`, `adw-banner.ui` (read out of the installed
GResource) never sets `use-markup` on that label, and a pspec default is not written
through a setter — assigning `label.useMarkup` directly moves what the banner reports.
Both Adwaita ports implement the pspec default, so the same authored banner interprets
`<b>bold</b>` in the browser and paints it literally in GTK. Ledgered in
`status/open-todos.md`, with why it is a rendering change of its own rather than a
drive-by.

**A localized rendering is a fact about the runner.** `SHORTCUT_LABEL_VECTORS` spells
`<Control>C` as `[Ctrl][C]`; `Adw.ShortcutLabel` draws `gtk_accelerator_get_label` —
measured `["Strg","C"]` on this de_DE host, `["Ctrl","C"]` under `LC_ALL=C`, and the
locale cannot be moved from inside the process. Hence `Adw.ShortcutLabel` is a declared
block, not a passing one.

**A notify table's `emitted` half has nowhere to come from.** An authored tree writes a
property; it cannot attach a listener before the write. Only the END STATE is taken.

## The gate learned the tree driver (stage 3)

`check-adwaita-conformance-drivers.mjs` gains a TREE arm, derived and never claimed. It
reads the join's table list out of its CODE, refuses a listed table no import backs,
refuses an imported table left off the list, refuses a driver spec no entry hands to
`run({…})`, and refuses a binding no live suite drives. The one half it cannot decide
statically — a listed table no corpus node REACHES — the drivers assert themselves
against `reachedTables`. `gtk-host` is on the tree-driver list and deliberately NOT
counted as a renderer, so a table only it drives stays core-only.

## Negative controls, runs, and what was left alone

In the first comment below — a markdown table does not survive as a commit body, and
this text becomes one.

## Open item deleted

`status/open-todos.md`'s "the shared source is compared as DATA rather than as a
rendered tree" is gone — not struck through, not marked done. What stands in its place
is what is actually still open: the corpus, the three structural limits, and the new
banner-markup item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtCcG3LLsz9voXAG9DVjhD
