### PR TITLE
docs(adr): parse blueprint into SharedNode

### DIFF
--- a/docs/adr/0033-declarative-templates-preferred.md
+++ b/docs/adr/0033-declarative-templates-preferred.md
@@ -1,9 +1,9 @@
 # 33. A widget tree is declared in a template file; TypeScript holds the behaviour
 
-- Status: **Proposed**
+- Status: **Accepted**
 - Date: 2026-08-28
 - Deciders: Pascal Garber
-- Related: [ADR 0027 (GTK host layer)](0027-gtk-host-layer.md), [ADR 0028 (widget table provenance)](0028-widget-table-provenance.md), [ADR 0032 (React Native on the GTK host)](0032-react-native-on-the-gtk-host.md)
+- Related: [ADR 0027 (GTK host layer)](0027-gtk-host-layer.md), [ADR 0028 (widget table provenance)](0028-widget-table-provenance.md), [ADR 0032 (React Native on the GTK host)](0032-react-native-on-the-gtk-host.md), [ADR 0053 (Blueprint parsed in-repo)](0053-blueprint-parsed-in-repo.md)
 
 ## Context
 

--- a/docs/adr/0053-blueprint-parsed-in-repo.md
+++ b/docs/adr/0053-blueprint-parsed-in-repo.md
@@ -1,0 +1,183 @@
+# 53. Blueprint is parsed in-repo, into the node shape ADR 0051 already renders
+
+- Status: **Accepted**
+- Date: 2026-09-10
+- Deciders: Pascal Garber
+- Related: [ADR 0002 (bootstrap bundle minimization)](0002-bootstrap-bundle-minimization.md), [ADR 0028 (widget table provenance)](0028-widget-table-provenance.md), [ADR 0029 (girs widget vocabulary)](0029-girs-widget-vocabulary.md), [ADR 0030 (one corpus, GJS as oracle)](0030-one-corpus-gjs-as-oracle.md), [ADR 0033 (declarative templates preferred)](0033-declarative-templates-preferred.md), [ADR 0051 (one authored tree, rendered)](0051-one-authored-tree-rendered.md)
+
+## Context
+
+Two things are true at once in this repo and have not been connected. ADR 0033 enforces that a
+widget tree is DECLARED rather than assembled, and on GTK the declarative form is Blueprint.
+ADR 0051 authors one tree that both renderers build, and it does NOT use Blueprint: its corpus is
+a plain object tree in GIR class names, `SharedNode { tag, slot?, props?, children? }`
+(`scripts/adwaita-gallery-shared-trees.d.mts:23-28`), chosen because that spelling is the one both
+renderers already carry, and authoring in either renderer's markup would make one of them the
+reference and the other a translation.
+
+Read quickly, that reasoning rules Blueprint out. Read carefully, it does not — because it is
+about a different LEVEL. GIR is the vocabulary. Blueprint and `SharedNode` are both NOTATIONS
+over that vocabulary. `adw-*` elements and GtkBuilder XML are the runtime formats underneath
+them. Blueprint is not a runtime format: it compiles TO GtkBuilder XML, which puts it on
+`SharedNode`'s level rather than one below it.
+
+### What the eleven `.blp` files actually use
+
+Measured across every `.blp` tracked in this repo, 2026-09-10: `using` 22, `template` 13, child
+slots `[start]`/`[end]` 23, `styles` 5, `bind` 6 — and ZERO signal handlers, menu blocks or inline
+`Gtk.Adjustment` objects. Against `SharedNode` that census maps almost entirely:
+
+| Blueprint | `SharedNode` | GIR-derived? |
+|---|---|---|
+| `using Adw 1;` | carried by the class name | yes — namespace and version |
+| `Adw.HeaderBar { }` | `tag: 'AdwHeaderBar'` | yes — the GIR type |
+| `title: "…"` | `props: { title: '…' }` | yes — a ParamSpec |
+| `[start]` | `slot: 'start'` | yes — ADR 0029 § 4 derives slot candidates from GIR |
+| `styles ["flat"]` | `cssClasses: ['flat']` | yes — ADR 0049 decided style classes are a list |
+| `template $Foo: Adw.Bin` | — | **no** — a GtkBuilder composite-template declaration |
+| `bind …` | — | **no** — a GObject property binding |
+
+Two constructs stand outside, and `template` is not even a tree construct: it is a file-level
+statement that this tree IS the template of a class. So the distance between the two notations is
+two constructs and a packaging concern, not a vocabulary.
+
+The gap runs the other way too. `SharedNode.props` admits `string | number | boolean` and nothing
+else, so none of the portable values ADRs 0042, 0046 and 0047 introduced — a menu model, a list
+model, an adjustment — can appear in a shared tree today. Blueprint writes all three as inline
+objects. Neither notation contains the other.
+
+### What the external compiler costs
+
+Blueprint reaches the build by shelling out to GNOME's `blueprint-compiler`, and that binary is
+not placeable on the hosts this project supports. Finding it takes 268 lines
+(`packages/infra/vite-plugin-blueprint/src/resolve-compiler.ts`) plus a 237-line spec against a
+plugin whose work is 75: on Windows the only route is an MSYS2 install that ships the tool as a
+shebang script Windows cannot execute, whose typelibs then collide with the gjsify GTK runtime
+bundle's own.
+
+The cost lands where the rule is enforced. Eleven `.blp` exist in the tree and NONE is in a
+library package. `packages/framework/adwaita-app/src/loading-stack.ts:12-25` records a `.blp`
+written and REVERTED — the compiler is absent on the macOS and Windows runners, and library-mode
+Blueprint arrives only in 0.43.0, so a cold bootstrap from the published CLI (ADR 0002) hands the
+`.blp` to rolldown's JavaScript parser, where `using Gtk 4.0;` reads as a using declaration with
+no initializer. It carries the single `oxlint-disable gjsify/prefer-blueprint-template` in the
+repo. `packages/framework/storybook/src/window.ts:13-15` builds its window programmatically for
+the same reason. And `scripts/check-doc-fences.mjs` returns `blueprint-compiler is not on PATH`
+(`:368-369`) and skips the whole fence class wherever the binary is missing — a gate reporting
+green because it could not run.
+
+## Decision
+
+**Blueprint is parsed in this repo, in TypeScript, and it parses INTO `SharedNode` — the node
+shape ADR 0051's renderers already consume. `blueprint-compiler` stops being a build dependency
+and becomes the oracle the parser is measured against.**
+
+1. **The parser's output is `SharedNode`, not a private AST.** Blueprint becomes a second
+   authoring surface over the shape that already exists, rather than a parallel pipeline beside
+   it. This is what makes the parser worth more than a toolchain swap, and it is also the
+   constraint that keeps it honest: a construct with no `SharedNode` spelling has nowhere to go.
+
+2. **That equivalence is PROVED, not asserted.** The mapping table above is a reading of two
+   notations, and a reading is not a measurement. For every `.blp` in the corpus a hand-written
+   `SharedNode` tree states what it should parse to, and the parser is held to it. Until that
+   suite exists the equivalence is not claimed anywhere — not in docs, not in a review.
+
+3. **Scope is a SUBSET, and an unrecognised construct is a hard error naming its line.** Never a
+   silent pass-through: output that looks plausible and means something else is the defect a
+   hand-written parser most easily introduces. `template` and `bind` are the two constructs the
+   census found outside `SharedNode`; they are accepted only on the GTK path, where GtkBuilder
+   gives them meaning, and refused with that reason anywhere else.
+
+4. **`blueprint-compiler` is the oracle for the emitted GtkBuilder XML, and for NOTHING ELSE.** A
+   byte-equal XML diff proves the parser and the tree it produced. It is not evidence about
+   anything built from that tree afterwards, and it must not be cited as such — in review or in a
+   job summary. The claim is narrow, and stating it narrowly now is cheaper than retracting it
+   later, when the parser is long correct and something downstream is not.
+
+5. **The parser runs in SHADOW until it is silent.** `blueprint-compiler` stays authoritative for
+   the build; the in-repo parser runs beside it and reports every divergence, and becomes
+   authoritative when it reports none across the corpus. The shadow run is also what grows clause
+   3's subset — each divergence is the next unit of work — and after an upstream release, a
+   shadow run that starts reporting again IS the upgrade notice.
+
+6. **The corpus is WRITTEN, not collected.** One small `.blp` per language rule, checked in, no
+   third-party licensing to track, complete on every runner — plus the eleven real files as a
+   reality probe. A sweep over the vendored `.blp` under `refs/` may be a LOCAL extra; it must
+   never become the part of the corpus CI lacks, or the run that gates the merge checks less than
+   the run on a laptop. Per ADR 0030 § 5 a tolerated divergence is DATA, never an `if` inside the
+   parser.
+
+7. **Done is a deletion, not a feature list.** This work is complete when these are gone:
+   `resolve-compiler.ts` and its spec — 505 lines that exist only to find a binary — the
+   `oxlint-disable` in `loading-stack.ts`, the programmatic window in `@gjsify/storybook`, the
+   `not on PATH` skip in `check-doc-fences.mjs`, and the MSYS2 branch of `gjsify system-check`.
+   Until the parser is authoritative no library package gains a `.blp`; porting continues where
+   the compiler already runs, in showcases, apps and templates. A parser that adds a package
+   without removing those has not finished — it has forked.
+
+## Consequences
+
+- ADR 0028 keeps `blueprint-compiler` as external validation against the installed typelib. That
+  role is unchanged, and clause 4 narrows rather than removes it: it stops being something the
+  build needs and becomes something the tests need, which is where an oracle belongs.
+- `check-doc-fences.mjs` can stop skipping, and the `prefer-blueprint-template` rule becomes
+  enforceable where it currently cannot be. Its one suppression is deleted rather than re-argued.
+- Clause 1 gives the shared corpus a second front door without touching its source of truth. What
+  it does NOT give is a reason to move the corpus: `SharedNode` stays the authored form until
+  something measures that Blueprint serves it better.
+- Clause 2 will find disagreements. The mapping table is a claim about `[start]` and `styles`
+  that nothing has run, and the honest expectation is that the first suite moves at least one row
+  of it.
+- A parser for a language this project does not own is a maintenance surface, and clause 5 keeps
+  its cost continuously visible instead of surfacing it at the next GNOME release.
+- The subset is a real limit while it lasts: a `.blp` using a construct the parser has not
+  reached fails loudly under clause 3. That is the intended trade against silent wrong output,
+  and clause 5 means the build is unaffected until the parser is authoritative.
+
+## Implementation
+
+- The first PR carries the written corpus, the `SharedNode` expectations of clause 2 and the
+  shadow harness — not a parser already claiming a subset. A harness with nothing to compare
+  reports green while proving nothing.
+- The parser is a package of its own; `@gjsify/vite-plugin-blueprint` becomes its consumer and
+  keeps its public interface, so no showcase changes when the authority flips.
+- No AGENTS.md change lands with this ADR: nothing here changes a rule an agent follows today.
+  The rule changes belong to the PR that earns them — the lint suppression and the fence gate's
+  skip path both go when clause 7 is satisfied.
+- Follow-up work is tracked in `status/open-todos.md` per governance; this ADR records the *why*.
+
+## Alternatives rejected
+
+- **Keep `blueprint-compiler` and install it on every runner.** Consistent, and pays the Windows
+  and macOS toolchain cost twice — once now, once again the next time a library package wants a
+  template. It cannot fix the cold-bootstrap case at all, where the transform does not exist yet
+  regardless of what is installed.
+- **A private AST instead of `SharedNode`.** Simpler to write and it makes Blueprint a parallel
+  pipeline whose agreement with the shared corpus nothing checks — the arrangement ADR 0029 § 4
+  rejects, arrived at from a new direction.
+- **Full language parity before anything is usable.** Maximises what the differential test proves
+  and delays every deletion in clause 7 behind the language's least-used corners.
+- **Passing unknown constructs through unchanged.** Never blocks, always builds, produces output
+  that is plausible and wrong — discovered at runtime, in a shipped program.
+- **Checking in the compiled GtkBuilder XML beside each `.blp`.** Removes the build dependency
+  immediately and puts a generated artifact in the tree that drifts from its source at the first
+  forgotten regeneration.
+- **Collecting the corpus from the vendored `.blp` under `refs/`.** The largest corpus for no
+  authoring effort, and CI does not have those pools.
+
+## What this does not decide
+
+- **Which notation the shared corpus is authored in.** ADR 0051 chose `SharedNode` with a reason
+  this ADR does not touch. Clause 1 adds a second reader of that shape; it does not propose
+  replacing the first, and a change of the authored form would be a supersession of 0051 with its
+  own measurement to bring.
+- **The build-from-one-source horizon.** ADR 0051 Decision 6 and ADR 0034 § 8 both leave it open
+  deliberately. A parser makes `.blp` READABLE, which is a different question from what a tree is
+  written in or what surfaces it reaches.
+- **Whether `.blp` becomes an EMITTED dialect of the corpus.** That direction needs no parser and
+  is a separate decision; the two are independent and either can land first.
+- **Whether `SharedNode` grows to hold the portable values** of ADRs 0042, 0046 and 0047. Its
+  props are scalars today, so a Blueprint inline object has no shared spelling — clause 3 refuses
+  it, and widening the shape belongs to the ADR that needs it.
+- **Whether the parser is ever published for use outside this repo.** It is a build-time tool
+  here first; a public contract carries its own upstream question.

--- a/docs/adr/0053-blueprint-parsed-in-repo.md
+++ b/docs/adr/0053-blueprint-parsed-in-repo.md
@@ -88,17 +88,23 @@ the fences.
 node shape ADR 0051's renderers already consume. `blueprint-compiler` stops being a build
 dependency and becomes the oracle the parser is measured against.**
 
-1. **The parser's output is `SharedNode`, not a private AST.** Blueprint becomes a second
-   authoring surface over the shape that already exists, rather than a parallel pipeline
-   beside it. This is what makes the parser worth more than a toolchain swap, and it is also
-   the constraint that keeps it honest: a construct with no `SharedNode` spelling has
-   nowhere to go.
+1. **The parser produces a full AST, and `SharedNode` is a DECLARED PROJECTION of it.** One
+   representation cannot serve both halves of this ADR: clause 4 wants byte-equal GtkBuilder
+   XML, which needs every construct the census found, and `SharedNode` carries none of the
+   six. So the AST is the parser's output, the XML is emitted from the AST, and the
+   projection is a second, LOSSY exit whose losses are exactly those six — named at the seam
+   rather than discovered downstream. Blueprint thereby becomes a second READER of the shape
+   ADR 0051's renderers consume, and NOT a second authoring surface: 0051 Decision 1 keeps
+   `ADWAITA_GALLERY_SHARED_TREES` the corpus, and no block of it originates from a `.blp`
+   while that decision stands.
 
 2. **That equivalence is PROVED, not asserted.** The mapping table above is a reading of two
    notations, and a reading is not a measurement. For every `.blp` in the corpus a
    hand-written `SharedNode` tree states what it should parse to, and the parser is held to
    it. Until that suite exists the equivalence is not claimed anywhere — not in docs, not in
-   a review.
+   a review. ADR 0051 § Alternatives rejected turned down a translator between two markup
+   vocabularies on a measurement; the projection in clause 1 is a translator in one
+   direction, so it carries that burden of proof rather than an exemption from it.
 
 3. **Scope is a SUBSET, and an unrecognised construct is a hard error naming its line.**
    Never a silent pass-through: output that looks plausible and means something else is the
@@ -107,12 +113,16 @@ dependency and becomes the oracle the parser is measured against.**
    outside `SharedNode`; they are accepted only on the GTK path, where GtkBuilder gives them
    meaning, and refused with that reason anywhere else.
 
-4. **`blueprint-compiler` is the oracle for the emitted GtkBuilder XML, and for NOTHING
-   ELSE.** A byte-equal XML diff proves the parser and the tree it produced. It is not
-   evidence about anything built from that tree afterwards, and it must not be cited as such
-   — in review or in a job summary. The claim is narrow, and stating it narrowly now is
-   cheaper than retracting it later, when the parser is long correct and something
-   downstream is not.
+4. **`blueprint-compiler` proves the emitted GtkBuilder XML, and nothing built from the AST
+   afterwards.** A byte-equal diff proves the parser and the AST it produced. It is not
+   evidence about the `SharedNode` projection, about a renderer, or about anything else
+   downstream, and it must not be cited as such — in review or in a job summary. Stating the
+   claim narrowly now is cheaper than retracting it later, when the parser is long correct
+   and something downstream is not. What the diff does NOT retire is the other use ADR 0028
+   § 6 makes of the same binary: validation against the installed typelib, which a parser
+   reading into a tree does not perform. `Gtk.Box { spacinng: 4; }` parses cleanly into a
+   prop nothing rejects until a ParamSpec lookup at runtime. The compiler keeps that role
+   wherever it is present.
 
 5. **The parser runs in SHADOW until it is silent.** `blueprint-compiler` stays
    authoritative for the build; the in-repo parser runs beside it and reports every
@@ -129,21 +139,25 @@ dependency and becomes the oracle the parser is measured against.**
 
 7. **Done is a deletion, not a feature list.** This work is complete when these are gone:
    `resolve-compiler.ts` and its spec — 505 lines that exist only to find a binary and
-   explain its absence — the `oxlint-disable` in `loading-stack.ts`, the programmatic window
-   in `@gjsify/storybook`, the `not on PATH` skip in `check-doc-fences.mjs`, and the MSYS2
-   branch of `gjsify system-check`. Until the parser is authoritative no library package
-   gains a `.blp`; porting continues where the compiler already runs, in showcases, apps and
-   templates. A parser that adds a package without removing those has not finished — it has
-   forked.
+   explain its absence — the line-level `oxlint-disable` in `loading-stack.ts`, and the
+   MSYS2 branch of `gjsify system-check`. `check-doc-fences.mjs`'s skip does not vanish but
+   becomes TWO-STAGE: the parse arm runs everywhere, the typelib arm wherever clause 4's
+   compiler is present, and the report names which of the two ran. `@gjsify/storybook`'s
+   programmatic window is a DIFFERENT item — `.oxlintrc.json` scopes that whole package off
+   the rule, so what it needs is a scoping decision and not a deletion. Until the parser is
+   authoritative no library package gains a `.blp`; porting continues where the compiler
+   already runs, in showcases, apps and templates. A parser that adds a package without
+   removing the rest has not finished — it has forked.
 
 ## Consequences
 
-- ADR 0028 keeps `blueprint-compiler` as external validation against the installed typelib.
-  That role is unchanged, and clause 4 narrows rather than removes it: it stops being
-  something the build needs and becomes something the tests need, which is where an oracle
-  belongs.
-- `check-doc-fences.mjs` can stop skipping, so its blueprint arm becomes real off the
-  ci-fedora image, and `loading-stack.ts`'s suppression is deleted rather than re-argued.
+- ADR 0028 § 6 keeps `blueprint-compiler` as validation against the installed typelib, and
+  clause 4 leaves that role untouched. What changes is only its position: it stops being
+  something a bundle needs in order to build and becomes something the tests and one CI arm
+  need, which is where an oracle belongs.
+- `check-doc-fences.mjs`'s blueprint arm becomes real off the ci-fedora image for the half a
+  parser can answer, and `loading-stack.ts`'s line-level suppression is deleted rather than
+  re-argued.
 - Clause 1 gives the shared corpus a second front door without touching its source of truth.
   What it does NOT give is a reason to move the corpus: `SharedNode` stays the authored form
   until something measures that Blueprint serves it better.
@@ -166,9 +180,10 @@ dependency and becomes the oracle the parser is measured against.**
   Windows and macOS toolchain cost twice — once now, once again the next time a library
   package wants a template. It cannot fix the cold-bootstrap case at all, where the
   transform does not exist yet regardless of what is installed.
-- **A private AST instead of `SharedNode`.** Simpler to write and it makes Blueprint a
+- **An AST with no declared projection.** Simpler to write, and it makes Blueprint a
   parallel pipeline whose agreement with the shared corpus nothing checks — a second truth
-  of exactly the kind ADR 0030 § 2 refuses, arrived at from a new direction.
+  of exactly the kind ADR 0030 § 2 refuses, arrived at from a new direction. Clause 1 keeps
+  the AST and makes the projection the thing that is tested.
 - **Full language parity before anything is usable.** Maximises what the differential test
   proves and delays every deletion in clause 7 behind the language's least-used corners.
 - **Passing unknown constructs through unchanged.** Never blocks, always builds, produces
@@ -209,6 +224,15 @@ dependency and becomes the oracle the parser is measured against.**
   reports green while proving nothing.
 - The parser is a package of its own; `@gjsify/vite-plugin-blueprint` becomes its consumer
   and keeps its public interface, so no showcase changes when the authority flips.
+- **Where `SharedNode` lives is the first unresolved question, and it comes before any
+  parser code.** Today the type is a hand-written `scripts/adwaita-gallery-shared-trees.d.mts`
+  whose own header refuses a second transcript of the tree. A package that produces the
+  projection needs that type somewhere a package can import, and neither copying it nor
+  moving it out of `scripts/` is free.
+- ADR 0028 § 6 turned down an in-repo Blueprint VALIDATOR, on the measured grounds that
+  building one would duplicate a better tool for no gain. This is a compiler replacement and
+  clause 4 explicitly leaves validation to the tool 0028 chose — but it is an adjacent
+  question 0028 closed, and a reviewer should find that named here rather than discover it.
 - No AGENTS.md change lands with this ADR: nothing here changes a rule an agent follows
   today. The rule changes belong to the PR that earns them — the lint suppression and the
   fence gate's skip path both go when clause 7 is satisfied.

--- a/docs/adr/0053-blueprint-parsed-in-repo.md
+++ b/docs/adr/0053-blueprint-parsed-in-repo.md
@@ -3,181 +3,214 @@
 - Status: **Accepted**
 - Date: 2026-09-10
 - Deciders: Pascal Garber
-- Related: [ADR 0002 (bootstrap bundle minimization)](0002-bootstrap-bundle-minimization.md), [ADR 0028 (widget table provenance)](0028-widget-table-provenance.md), [ADR 0029 (girs widget vocabulary)](0029-girs-widget-vocabulary.md), [ADR 0030 (one corpus, GJS as oracle)](0030-one-corpus-gjs-as-oracle.md), [ADR 0033 (declarative templates preferred)](0033-declarative-templates-preferred.md), [ADR 0051 (one authored tree, rendered)](0051-one-authored-tree-rendered.md)
+- Related: [ADR 0002 (bootstrap bundle minimization)](0002-bootstrap-bundle-minimization.md), [ADR 0028 (widget table provenance)](0028-widget-table-provenance.md), [ADR 0029 (girs widget vocabulary)](0029-girs-widget-vocabulary.md), [ADR 0030 (one corpus, GJS as oracle)](0030-one-corpus-gjs-as-oracle.md), [ADR 0033 (declarative templates preferred)](0033-declarative-templates-preferred.md), [ADR 0034 (widget vocabulary convergence)](0034-widget-vocabulary-convergence.md), [ADR 0049 (style classes are a list)](0049-style-classes-are-a-list.md), [ADR 0051 (one authored tree, rendered)](0051-one-authored-tree-rendered.md)
 
 ## Context
 
-Two things are true at once in this repo and have not been connected. ADR 0033 enforces that a
-widget tree is DECLARED rather than assembled, and on GTK the declarative form is Blueprint.
-ADR 0051 authors one tree that both renderers build, and it does NOT use Blueprint: its corpus is
-a plain object tree in GIR class names, `SharedNode { tag, slot?, props?, children? }`
-(`scripts/adwaita-gallery-shared-trees.d.mts:23-28`), chosen because that spelling is the one both
-renderers already carry, and authoring in either renderer's markup would make one of them the
-reference and the other a translation.
+Two things are true at once in this repo and have not been connected. ADR 0033 enforces
+that a widget tree is DECLARED rather than assembled, and on GTK the declarative form is
+Blueprint. ADR 0051 authors one tree that both renderers build, and it does NOT use
+Blueprint: its corpus is a plain object tree in GIR class names, `SharedNode { tag, slot?,
+props?, children? }` (`scripts/adwaita-gallery-shared-trees.d.mts:23-28`), chosen because
+that spelling is the one both renderers already carry, and authoring in either renderer's
+markup would make one of them the reference and the other a translation.
 
-Read quickly, that reasoning rules Blueprint out. Read carefully, it does not — because it is
-about a different LEVEL. GIR is the vocabulary. Blueprint and `SharedNode` are both NOTATIONS
-over that vocabulary. `adw-*` elements and GtkBuilder XML are the runtime formats underneath
-them. Blueprint is not a runtime format: it compiles TO GtkBuilder XML, which puts it on
-`SharedNode`'s level rather than one below it.
+Read quickly, that reasoning rules Blueprint out. Read carefully, it does not — because it
+is about a different LEVEL. GIR is the vocabulary. Blueprint and `SharedNode` are both
+NOTATIONS over that vocabulary. `adw-*` elements and GtkBuilder XML are the runtime formats
+underneath them. Blueprint is not a runtime format: it compiles TO GtkBuilder XML, which
+puts it on `SharedNode`'s level rather than one below it.
 
 ### What the eleven `.blp` files actually use
 
-Measured across every `.blp` tracked in this repo, 2026-09-10: `using` 22, `template` 13, child
-slots `[start]`/`[end]` 23, `styles` 5, `bind` 6 — and ZERO signal handlers, menu blocks or inline
-`Gtk.Adjustment` objects. Against `SharedNode` that census maps almost entirely:
+Measured across every `.blp` tracked in this repo, 2026-09-10:
 
-| Blueprint | `SharedNode` | GIR-derived? |
-|---|---|---|
-| `using Adw 1;` | carried by the class name | yes — namespace and version |
-| `Adw.HeaderBar { }` | `tag: 'AdwHeaderBar'` | yes — the GIR type |
-| `title: "…"` | `props: { title: '…' }` | yes — a ParamSpec |
-| `[start]` | `slot: 'start'` | yes — ADR 0029 § 4 derives slot candidates from GIR |
-| `styles ["flat"]` | `cssClasses: ['flat']` | yes — ADR 0049 decided style classes are a list |
-| `template $Foo: Adw.Bin` | — | **no** — a GtkBuilder composite-template declaration |
-| `bind …` | — | **no** — a GObject property binding |
+| Blueprint | count | `SharedNode` | GIR-derived? |
+|---|---|---|---|
+| `using Adw 1;` | 22 | carried by the class name | yes — namespace and version |
+| `Adw.HeaderBar { }` | 81 | `tag: 'AdwHeaderBar'` | yes — the GIR type |
+| `title: "…"` | 197 | `props: { title: '…' }` | yes — a ParamSpec |
+| `[start]`, `[end]`, `[top]`, `[bottom]`, `[center]`, `[breakpoint]` | 23 | `slot: 'start'` | yes — ADR 0029 § 4 derives slot candidates from GIR |
+| `content: Adw.ToolbarView { }` | 19 | a child carrying `slot: 'content'` | yes — a ParamSpec, read as a slot |
+| `styles ["flat"]` | 5 | `cssClasses: ['flat']` | yes — ADR 0049 decided style classes are a list |
+| `template $Foo: Adw.Bin` | 11 | — | **no** — a GtkBuilder composite-template declaration |
+| `Gtk.Box canvasContainer { }` | 41 of those | — | **no** — a GtkBuilder object id |
+| `_("Back")` | 23 | — | **no** — a `translatable` attribute on the emitted XML |
+| `bind …` | 6 | — | **no** — a GObject property binding, addressed by id |
+| `condition (…)` + `setters { }` | 6 + 6 | — | **no** — `Adw.Breakpoint`'s own grammar |
 
-Two constructs stand outside, and `template` is not even a tree construct: it is a file-level
-statement that this tree IS the template of a class. So the distance between the two notations is
-two constructs and a packaging concern, not a vocabulary.
+Zero signal handlers (`=>`), zero `menu` blocks and zero inline `Gtk.Adjustment` objects.
 
-The gap runs the other way too. `SharedNode.props` admits `string | number | boolean` and nothing
-else, so none of the portable values ADRs 0042, 0046 and 0047 introduced — a menu model, a list
-model, an adjustment — can appear in a shared tree today. Blueprint writes all three as inline
-objects. Neither notation contains the other.
+Six construct classes stand outside `SharedNode`, and they are not all the same kind of
+outside. `template` is not even a tree construct: it is a file-level statement that this
+tree IS the template of a class. An object id is addressing, and it is what `bind` resolves
+against — a notation with no ids cannot express `bind` at all, which is why those two fall
+together. `_()` is the one that costs: the VALUE survives as a `SharedNode` string and the
+translatable MARKING does not, and that marking is the whole reason ADR 0033 prefers a
+template — a caption `xgettext` cannot see is untranslatABLE while merely looking
+untranslated.
+
+The gap runs the other way too. `SharedNode.props` admits `string | number | boolean` and
+nothing else, so none of the portable values ADRs 0042, 0046 and 0047 introduced — a menu
+model, a list model, an adjustment — can appear in a shared tree today. Blueprint writes
+all three as inline objects. Neither notation contains the other.
 
 ### What the external compiler costs
 
-Blueprint reaches the build by shelling out to GNOME's `blueprint-compiler`, and that binary is
-not placeable on the hosts this project supports. Finding it takes 268 lines
-(`packages/infra/vite-plugin-blueprint/src/resolve-compiler.ts`) plus a 237-line spec against a
-plugin whose work is 75: on Windows the only route is an MSYS2 install that ships the tool as a
-shebang script Windows cannot execute, whose typelibs then collide with the gjsify GTK runtime
-bundle's own.
+Blueprint reaches the build by shelling out to GNOME's `blueprint-compiler`, and placing
+that binary is platform-shaped work rather than an install line. Finding it takes 268 lines
+(`packages/infra/vite-plugin-blueprint/src/resolve-compiler.ts`) plus a 237-line spec
+against a plugin whose work is 75: on Windows the only route is an MSYS2 install — the tool
+is pure Python but reads typelibs through `GIRepository`, so it needs a PyGObject that
+publishes no Windows wheel — which ships it as a shebang script Windows cannot execute, and
+whose typelibs then collide with the gjsify GTK runtime bundle's own.
 
-The cost lands where the rule is enforced. Eleven `.blp` exist in the tree and NONE is in a
-library package. `packages/framework/adwaita-app/src/loading-stack.ts:12-25` records a `.blp`
-written and REVERTED — the compiler is absent on the macOS and Windows runners, and library-mode
-Blueprint arrives only in 0.43.0, so a cold bootstrap from the published CLI (ADR 0002) hands the
-`.blp` to rolldown's JavaScript parser, where `using Gtk 4.0;` reads as a using declaration with
-no initializer. It carries the single `oxlint-disable gjsify/prefer-blueprint-template` in the
-repo. `packages/framework/storybook/src/window.ts:13-15` builds its window programmatically for
-the same reason. And `scripts/check-doc-fences.mjs` returns `blueprint-compiler is not on PATH`
-(`:368-369`) and skips the whole fence class wherever the binary is missing — a gate reporting
-green because it could not run.
+The cost lands where the rule is enforced. Eleven `.blp` exist in the tree and NONE is under
+`packages/`. `packages/framework/adwaita-app/src/loading-stack.ts:12-25` records a `.blp`
+written and REVERTED — the compiler is absent on the macOS and Windows runners, and
+library-mode Blueprint arrives only in 0.43.0, so a cold bootstrap from the published CLI
+(ADR 0002) hands the `.blp` to rolldown's JavaScript parser, where `using Gtk 4.0;` reads as
+a using declaration with no initializer. It carries the single line-level
+`oxlint-disable gjsify/prefer-blueprint-template` in the repo.
+`packages/framework/storybook/src/window.ts:13-15` builds its window programmatically for
+the neighbouring reason it states itself: the blueprint plugin runs for `--app` bundles and
+not for `--library`, so a published library cannot rely on it — and `.oxlintrc.json` scopes
+that whole package off the rule rather than suppressing it per line. And
+`scripts/check-doc-fences.mjs` returns `blueprint-compiler is not on PATH` (`:368-369`) and
+skips the whole fence class wherever the binary is missing. The skip is announced rather
+than silent, and the arm is real in exactly one place — the `tree-checks` job, whose
+ci-fedora image bakes the compiler — so every other run of that script proves nothing about
+the fences.
 
 ## Decision
 
-**Blueprint is parsed in this repo, in TypeScript, and it parses INTO `SharedNode` — the node
-shape ADR 0051's renderers already consume. `blueprint-compiler` stops being a build dependency
-and becomes the oracle the parser is measured against.**
+**Blueprint is parsed in this repo, in TypeScript, and it parses INTO `SharedNode` — the
+node shape ADR 0051's renderers already consume. `blueprint-compiler` stops being a build
+dependency and becomes the oracle the parser is measured against.**
 
 1. **The parser's output is `SharedNode`, not a private AST.** Blueprint becomes a second
-   authoring surface over the shape that already exists, rather than a parallel pipeline beside
-   it. This is what makes the parser worth more than a toolchain swap, and it is also the
-   constraint that keeps it honest: a construct with no `SharedNode` spelling has nowhere to go.
+   authoring surface over the shape that already exists, rather than a parallel pipeline
+   beside it. This is what makes the parser worth more than a toolchain swap, and it is also
+   the constraint that keeps it honest: a construct with no `SharedNode` spelling has
+   nowhere to go.
 
 2. **That equivalence is PROVED, not asserted.** The mapping table above is a reading of two
-   notations, and a reading is not a measurement. For every `.blp` in the corpus a hand-written
-   `SharedNode` tree states what it should parse to, and the parser is held to it. Until that
-   suite exists the equivalence is not claimed anywhere — not in docs, not in a review.
+   notations, and a reading is not a measurement. For every `.blp` in the corpus a
+   hand-written `SharedNode` tree states what it should parse to, and the parser is held to
+   it. Until that suite exists the equivalence is not claimed anywhere — not in docs, not in
+   a review.
 
-3. **Scope is a SUBSET, and an unrecognised construct is a hard error naming its line.** Never a
-   silent pass-through: output that looks plausible and means something else is the defect a
-   hand-written parser most easily introduces. `template` and `bind` are the two constructs the
-   census found outside `SharedNode`; they are accepted only on the GTK path, where GtkBuilder
-   gives them meaning, and refused with that reason anywhere else.
+3. **Scope is a SUBSET, and an unrecognised construct is a hard error naming its line.**
+   Never a silent pass-through: output that looks plausible and means something else is the
+   defect a hand-written parser most easily introduces. `template`, object ids, `_()`,
+   `bind` and `Adw.Breakpoint`'s `condition`/`setters` are the constructs the census found
+   outside `SharedNode`; they are accepted only on the GTK path, where GtkBuilder gives them
+   meaning, and refused with that reason anywhere else.
 
-4. **`blueprint-compiler` is the oracle for the emitted GtkBuilder XML, and for NOTHING ELSE.** A
-   byte-equal XML diff proves the parser and the tree it produced. It is not evidence about
-   anything built from that tree afterwards, and it must not be cited as such — in review or in a
-   job summary. The claim is narrow, and stating it narrowly now is cheaper than retracting it
-   later, when the parser is long correct and something downstream is not.
+4. **`blueprint-compiler` is the oracle for the emitted GtkBuilder XML, and for NOTHING
+   ELSE.** A byte-equal XML diff proves the parser and the tree it produced. It is not
+   evidence about anything built from that tree afterwards, and it must not be cited as such
+   — in review or in a job summary. The claim is narrow, and stating it narrowly now is
+   cheaper than retracting it later, when the parser is long correct and something
+   downstream is not.
 
-5. **The parser runs in SHADOW until it is silent.** `blueprint-compiler` stays authoritative for
-   the build; the in-repo parser runs beside it and reports every divergence, and becomes
-   authoritative when it reports none across the corpus. The shadow run is also what grows clause
-   3's subset — each divergence is the next unit of work — and after an upstream release, a
-   shadow run that starts reporting again IS the upgrade notice.
+5. **The parser runs in SHADOW until it is silent.** `blueprint-compiler` stays
+   authoritative for the build; the in-repo parser runs beside it and reports every
+   divergence, and becomes authoritative when it reports none across the corpus. The shadow
+   run is also what grows clause 3's subset — each divergence is the next unit of work — and
+   after an upstream release, a shadow run that starts reporting again IS the upgrade notice.
 
-6. **The corpus is WRITTEN, not collected.** One small `.blp` per language rule, checked in, no
-   third-party licensing to track, complete on every runner — plus the eleven real files as a
-   reality probe. A sweep over the vendored `.blp` under `refs/` may be a LOCAL extra; it must
-   never become the part of the corpus CI lacks, or the run that gates the merge checks less than
-   the run on a laptop. Per ADR 0030 § 5 a tolerated divergence is DATA, never an `if` inside the
-   parser.
+6. **The corpus is WRITTEN, not collected.** One small `.blp` per language rule, checked in,
+   no third-party licensing to track, complete on every runner — plus the eleven real files
+   as a reality probe. A sweep over third-party `.blp` may be a LOCAL extra; it must never
+   become the part of the corpus CI lacks, or the run that gates the merge checks less than
+   the run on a laptop. Per ADR 0030 § 5 an exemption is DATA, never a code path: a tolerated
+   divergence is a ledger entry, never an `if` inside the parser.
 
 7. **Done is a deletion, not a feature list.** This work is complete when these are gone:
-   `resolve-compiler.ts` and its spec — 505 lines that exist only to find a binary — the
-   `oxlint-disable` in `loading-stack.ts`, the programmatic window in `@gjsify/storybook`, the
-   `not on PATH` skip in `check-doc-fences.mjs`, and the MSYS2 branch of `gjsify system-check`.
-   Until the parser is authoritative no library package gains a `.blp`; porting continues where
-   the compiler already runs, in showcases, apps and templates. A parser that adds a package
-   without removing those has not finished — it has forked.
+   `resolve-compiler.ts` and its spec — 505 lines that exist only to find a binary and
+   explain its absence — the `oxlint-disable` in `loading-stack.ts`, the programmatic window
+   in `@gjsify/storybook`, the `not on PATH` skip in `check-doc-fences.mjs`, and the MSYS2
+   branch of `gjsify system-check`. Until the parser is authoritative no library package
+   gains a `.blp`; porting continues where the compiler already runs, in showcases, apps and
+   templates. A parser that adds a package without removing those has not finished — it has
+   forked.
 
 ## Consequences
 
-- ADR 0028 keeps `blueprint-compiler` as external validation against the installed typelib. That
-  role is unchanged, and clause 4 narrows rather than removes it: it stops being something the
-  build needs and becomes something the tests need, which is where an oracle belongs.
-- `check-doc-fences.mjs` can stop skipping, and the `prefer-blueprint-template` rule becomes
-  enforceable where it currently cannot be. Its one suppression is deleted rather than re-argued.
-- Clause 1 gives the shared corpus a second front door without touching its source of truth. What
-  it does NOT give is a reason to move the corpus: `SharedNode` stays the authored form until
-  something measures that Blueprint serves it better.
-- Clause 2 will find disagreements. The mapping table is a claim about `[start]` and `styles`
-  that nothing has run, and the honest expectation is that the first suite moves at least one row
-  of it.
-- A parser for a language this project does not own is a maintenance surface, and clause 5 keeps
-  its cost continuously visible instead of surfacing it at the next GNOME release.
+- ADR 0028 keeps `blueprint-compiler` as external validation against the installed typelib.
+  That role is unchanged, and clause 4 narrows rather than removes it: it stops being
+  something the build needs and becomes something the tests need, which is where an oracle
+  belongs.
+- `check-doc-fences.mjs` can stop skipping, so its blueprint arm becomes real off the
+  ci-fedora image, and `loading-stack.ts`'s suppression is deleted rather than re-argued.
+- Clause 1 gives the shared corpus a second front door without touching its source of truth.
+  What it does NOT give is a reason to move the corpus: `SharedNode` stays the authored form
+  until something measures that Blueprint serves it better.
+- Clause 2 will find disagreements. The mapping table is a claim about slots, object-valued
+  properties and `styles` that nothing has run, and the honest expectation is that the first
+  suite moves at least one row of it.
+- The translatable marker is the sharpest case under clause 3, and it points back at ADR
+  0033: parsing a caption into a `SharedNode` string drops the one attribute that made the
+  template worth preferring. Either the shape grows a spelling for it or the GTK path keeps
+  the marker on its own — decided by the ADR that needs it, not here.
+- A parser for a language this project does not own is a maintenance surface, and clause 5
+  keeps its cost continuously visible instead of surfacing it at the next GNOME release.
 - The subset is a real limit while it lasts: a `.blp` using a construct the parser has not
-  reached fails loudly under clause 3. That is the intended trade against silent wrong output,
-  and clause 5 means the build is unaffected until the parser is authoritative.
+  reached fails loudly under clause 3. That is the intended trade against silent wrong
+  output, and clause 5 means the build is unaffected until the parser is authoritative.
+
+## Alternatives rejected
+
+- **Keep `blueprint-compiler` and install it on every runner.** Consistent, and pays the
+  Windows and macOS toolchain cost twice — once now, once again the next time a library
+  package wants a template. It cannot fix the cold-bootstrap case at all, where the
+  transform does not exist yet regardless of what is installed.
+- **A private AST instead of `SharedNode`.** Simpler to write and it makes Blueprint a
+  parallel pipeline whose agreement with the shared corpus nothing checks — a second truth
+  of exactly the kind ADR 0030 § 2 refuses, arrived at from a new direction.
+- **Full language parity before anything is usable.** Maximises what the differential test
+  proves and delays every deletion in clause 7 behind the language's least-used corners.
+- **Passing unknown constructs through unchanged.** Never blocks, always builds, produces
+  output that is plausible and wrong — discovered at runtime, in a shipped program.
+- **Checking in the compiled GtkBuilder XML beside each `.blp`.** Removes the build
+  dependency immediately and puts a generated artifact in the tree that drifts from its
+  source at the first forgotten regeneration.
+- **Collecting the corpus from third-party `.blp` under `refs/`.** Authoring effort near
+  zero, and those pools are read-only submodules a CI checkout does not initialise. Measured
+  on this working checkout: 95 pool directories, none of them Blueprint's, and not one
+  `.blp` between them.
+
+## What this does not decide
+
+- **Which notation the shared corpus is authored in.** ADR 0051 chose `SharedNode` with a
+  reason this ADR does not touch. Clause 1 adds a second reader of that shape; it does not
+  propose replacing the first, and a change of the authored form would be a supersession of
+  0051 with its own measurement to bring.
+- **The build-from-one-source horizon.** ADR 0051 Decision 6 leaves it open deliberately.
+  ADR 0034 § 8 is not neutral about the neighbouring translator question, and this ADR does
+  not overturn it either: write the tree ONCE in the vocabulary that runs and emit the
+  dialects, rather than translating between two hand-written surfaces. A parser makes `.blp`
+  READABLE, which is a different question from what a tree is written in or what surfaces it
+  reaches.
+- **Whether `.blp` becomes an EMITTED dialect of the corpus.** That direction needs no parser
+  and is a separate decision; the two are independent and either can land first.
+- **Whether `SharedNode` grows to hold the portable values** of ADRs 0042, 0046 and 0047, or
+  a translatable marker. Its props are scalars today, so a Blueprint inline object has no
+  shared spelling — clause 3 refuses it, and widening the shape belongs to the ADR that
+  needs it.
+- **Whether the parser is ever published for use outside this repo.** It is a build-time tool
+  here first; a public contract carries its own upstream question.
 
 ## Implementation
 
 - The first PR carries the written corpus, the `SharedNode` expectations of clause 2 and the
   shadow harness — not a parser already claiming a subset. A harness with nothing to compare
   reports green while proving nothing.
-- The parser is a package of its own; `@gjsify/vite-plugin-blueprint` becomes its consumer and
-  keeps its public interface, so no showcase changes when the authority flips.
-- No AGENTS.md change lands with this ADR: nothing here changes a rule an agent follows today.
-  The rule changes belong to the PR that earns them — the lint suppression and the fence gate's
-  skip path both go when clause 7 is satisfied.
-- Follow-up work is tracked in `status/open-todos.md` per governance; this ADR records the *why*.
-
-## Alternatives rejected
-
-- **Keep `blueprint-compiler` and install it on every runner.** Consistent, and pays the Windows
-  and macOS toolchain cost twice — once now, once again the next time a library package wants a
-  template. It cannot fix the cold-bootstrap case at all, where the transform does not exist yet
-  regardless of what is installed.
-- **A private AST instead of `SharedNode`.** Simpler to write and it makes Blueprint a parallel
-  pipeline whose agreement with the shared corpus nothing checks — the arrangement ADR 0029 § 4
-  rejects, arrived at from a new direction.
-- **Full language parity before anything is usable.** Maximises what the differential test proves
-  and delays every deletion in clause 7 behind the language's least-used corners.
-- **Passing unknown constructs through unchanged.** Never blocks, always builds, produces output
-  that is plausible and wrong — discovered at runtime, in a shipped program.
-- **Checking in the compiled GtkBuilder XML beside each `.blp`.** Removes the build dependency
-  immediately and puts a generated artifact in the tree that drifts from its source at the first
-  forgotten regeneration.
-- **Collecting the corpus from the vendored `.blp` under `refs/`.** The largest corpus for no
-  authoring effort, and CI does not have those pools.
-
-## What this does not decide
-
-- **Which notation the shared corpus is authored in.** ADR 0051 chose `SharedNode` with a reason
-  this ADR does not touch. Clause 1 adds a second reader of that shape; it does not propose
-  replacing the first, and a change of the authored form would be a supersession of 0051 with its
-  own measurement to bring.
-- **The build-from-one-source horizon.** ADR 0051 Decision 6 and ADR 0034 § 8 both leave it open
-  deliberately. A parser makes `.blp` READABLE, which is a different question from what a tree is
-  written in or what surfaces it reaches.
-- **Whether `.blp` becomes an EMITTED dialect of the corpus.** That direction needs no parser and
-  is a separate decision; the two are independent and either can land first.
-- **Whether `SharedNode` grows to hold the portable values** of ADRs 0042, 0046 and 0047. Its
-  props are scalars today, so a Blueprint inline object has no shared spelling — clause 3 refuses
-  it, and widening the shape belongs to the ADR that needs it.
-- **Whether the parser is ever published for use outside this repo.** It is a build-time tool
-  here first; a public contract carries its own upstream question.
+- The parser is a package of its own; `@gjsify/vite-plugin-blueprint` becomes its consumer
+  and keeps its public interface, so no showcase changes when the authority flips.
+- No AGENTS.md change lands with this ADR: nothing here changes a rule an agent follows
+  today. The rule changes belong to the PR that earns them — the lint suppression and the
+  fence gate's skip path both go when clause 7 is satisfied.
+- Follow-up work is tracked in `status/open-todos.md` per governance; this ADR records the
+  *why*.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,7 +53,7 @@ the TODO records the *what's left*.
 | [0030](0030-one-corpus-gjs-as-oracle.md) | One test corpus per claim, parameterised by runtime; GJS is the oracle | Accepted |
 | [0031](0031-node-gi-napi-outside-the-workspace.md) | `node-gi` and `napi` stay outside the npm workspace | Accepted |
 | [0032](0032-react-native-on-the-gtk-host.md) | A React Native view layer over the GTK host, split so every binding can use the shared half | Proposed |
-| [0033](0033-declarative-templates-preferred.md) | A widget tree is declared in a template file; TypeScript holds the behaviour | Proposed |
+| [0033](0033-declarative-templates-preferred.md) | A widget tree is declared in a template file; TypeScript holds the behaviour | Accepted |
 | [0034](0034-widget-vocabulary-convergence.md) | Every widget surface: named from the GIR, exported as a namespace, remainder declared | Proposed |
 | [0035](0035-web-view-on-win32.md) | A web view on Windows: WebView2 behind the same `gi://WebKit` 6.0 namespace | Accepted |
 | [0036](0036-third-party-react-native-surfaces.md) | Third-party React Native surfaces: one registry, one package, one subpath each | Proposed |
@@ -73,6 +73,7 @@ the TODO records the *what's left*.
 | [0050](0050-effect-platform-services-for-gnome.md) | Effect's platform services for GNOME are a platform package, not a renderer | Accepted |
 | [0051](0051-one-authored-tree-rendered.md) | One authored tree, rendered: ADR 0027 § 9's criterion becomes a suite | Accepted |
 | [0052](0052-attribute-meaning-in-the-fence.md) | An attribute's meaning is a generated comment in the fence a reader copies | Proposed |
+| [0053](0053-blueprint-parsed-in-repo.md) | Blueprint is parsed in-repo, into the node shape ADR 0051 already renders | Accepted |
 | [0054](0054-toplevel-placement-and-the-unparentable-refusal.md) | The quiet half of the abort class: `toplevel` placement and a structural refusal | Accepted |
 
 Source review: [docs/reports/2026-07-01-architecture-review.md](../reports/2026-07-01-architecture-review.md)

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -5846,3 +5846,74 @@ icon anywhere** — no `icon-name` in any `.ts` or `.blp`. Adding the dependency
 ship 26.5 KiB and a startup call to apps with no icons. The day a template draws one, the
 change is one line: `runAdwaitaApp` already defaults this on, and a hand-built application
 calls `installBundledIconTheme()`.
+
+### Blueprint reaches the build through a binary two of three runners lack
+
+`@gjsify/vite-plugin-blueprint` shells out to GNOME's `blueprint-compiler`. Finding it takes 268
+lines (`packages/infra/vite-plugin-blueprint/src/resolve-compiler.ts`) plus a 237-line spec,
+against a plugin whose work is 75: Windows has only an MSYS2 route that installs the tool as a
+shebang script Windows cannot execute, whose typelibs then collide with the gjsify GTK runtime
+bundle's own. The consequences are measured rather than predicted: eleven `.blp` exist in the
+tree and none is in a library package; `packages/framework/adwaita-app/src/loading-stack.ts`
+carries a `.blp` that was written and reverted, and with it the repo's single
+`oxlint-disable gjsify/prefer-blueprint-template`; `packages/framework/storybook/src/window.ts`
+builds its window programmatically for the same reason; `scripts/check-doc-fences.mjs` returns
+`blueprint-compiler is not on PATH` (`:368-369`) and skips the whole fence class wherever the
+binary is missing.
+
+ADR 0053 decides the shape: an in-repo TypeScript parser that parses INTO `SharedNode` — the node
+shape ADR 0051's renderers already consume — run in shadow beside `blueprint-compiler` until it
+reports no divergence, and only then authoritative. Its subset is grown by the shadow run and an
+unrecognised construct is a hard error naming its line.
+
+Two pieces of that are not yet measured and should be built before anything else. First, the
+claim that Blueprint and `SharedNode` describe the same tree is a READING of the two notations,
+not a measurement: of the constructs the eleven files actually use (`using` 22, `template` 13,
+`[start]`/`[end]` 23, `styles` 5, `bind` 6, and zero signal handlers, menus or inline
+adjustments), everything but `template` and `bind` appears to map, but nothing has run it. ADR
+0053 clause 2 makes a hand-written `SharedNode` expectation per corpus file the proof, and the
+honest expectation is that the first suite moves at least one row of that table. Second, the
+first PR carries the written corpus and the shadow harness, NOT a parser already claiming a
+subset — a harness with nothing to compare reports green while proving nothing.
+
+Done is a deletion list, not a feature list: `resolve-compiler.ts` and its spec, the
+`oxlint-disable`, the programmatic storybook window, the `not on PATH` skip, and the MSYS2 branch
+of `gjsify system-check`.
+
+### Does the shared corpus want a second authored notation?
+
+ADR 0051 authors the shared trees as `SharedNode` in GIR class names, because that spelling is
+the one both renderers already carry and authoring in either renderer's markup would make one of
+them the reference and the other a translation. ADR 0053 adds a Blueprint READER over the same
+shape but explicitly does not propose replacing the authored form.
+
+What is left open is whether it should — and the question is now narrower than it looks, because
+the two notations sit on the same level. GIR is the vocabulary; Blueprint and `SharedNode` are
+both notations over it; `adw-*` elements and GtkBuilder XML are the runtime formats underneath.
+Blueprint compiles to GtkBuilder XML rather than being it, so 0051's argument about a renderer's
+markup does not reach it directly. Against that: `template` and `bind` have no `SharedNode`
+spelling, and `SharedNode.props` admits `string | number | boolean` only, so none of the portable
+values from ADRs 0042, 0046 and 0047 can be written in a shared tree at all while Blueprint
+writes all three as inline objects. Neither notation contains the other, which is why this is a
+real question and not a preference.
+
+The opposite direction costs less and is also unclaimed: `.blp` as a fourth EMITTED dialect of
+the corpus beside `gtkHostTree()` and `nativeScriptTree()`, which needs no parser and leaves
+0051's reasoning untouched. Either could land first. Deciding it belongs to whoever brings a
+measurement — a supersession of 0051 needs more than an argument about levels.
+
+### A developer who picks Vue gets the desktop and nothing else
+
+`packages/framework/gtk-host/src/adapters/` holds React, Solid and Vue over one widget table no
+adapter may duplicate, and all three reach GTK only. `@gjsify/adwaita-web` ships its custom
+elements and `@gjsify/adwaita-nativescript` its widgets, and neither has a framework binding: on
+those surfaces a tree is written against the DOM API or as NativeScript XML by hand.
+
+This is recorded as a GAP, not as a proposal. ADR 0051 Decision 5 already sets the policy —
+nothing more is extracted than the second driver needs, and "extract a `host-core` package first,
+then find a consumer" is explicitly rejected — and 0051 also measured that the adapters carry no
+runtime `gi://` imports at all, so a second renderer would be a parameterisation of the node type
+rather than a rewrite. The cheapest evidence, if anyone wants it, is the web leg: custom elements
+are the best-supported interop target in the browser, so Vue or Solid against `adw-*` is mostly
+an `isCustomElement` predicate plus type declarations rather than a reconciler. A consumer that
+needs it is what would start this, per the policy above.

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -5849,58 +5849,45 @@ calls `installBundledIconTheme()`.
 
 ### Blueprint reaches the build through a binary two of three runners lack
 
-`@gjsify/vite-plugin-blueprint` shells out to GNOME's `blueprint-compiler`. Finding it takes 268
-lines (`packages/infra/vite-plugin-blueprint/src/resolve-compiler.ts`) plus a 237-line spec,
-against a plugin whose work is 75: Windows has only an MSYS2 route that installs the tool as a
-shebang script Windows cannot execute, whose typelibs then collide with the gjsify GTK runtime
-bundle's own. The consequences are measured rather than predicted: eleven `.blp` exist in the
-tree and none is in a library package; `packages/framework/adwaita-app/src/loading-stack.ts`
-carries a `.blp` that was written and reverted, and with it the repo's single
-`oxlint-disable gjsify/prefer-blueprint-template`; `packages/framework/storybook/src/window.ts`
-builds its window programmatically for the same reason; `scripts/check-doc-fences.mjs` returns
-`blueprint-compiler is not on PATH` (`:368-369`) and skips the whole fence class wherever the
-binary is missing.
+`@gjsify/vite-plugin-blueprint` shells out to GNOME's `blueprint-compiler`, which is installed on
+neither the macOS nor the Windows runner. ADR 0053 carries the census and the reasoning and
+decides the shape — an in-repo TypeScript parser whose output is `SharedNode`, run in shadow
+beside the compiler until it reports no divergence. What is left here is the order of the work.
 
-ADR 0053 decides the shape: an in-repo TypeScript parser that parses INTO `SharedNode` — the node
-shape ADR 0051's renderers already consume — run in shadow beside `blueprint-compiler` until it
-reports no divergence, and only then authoritative. Its subset is grown by the shadow run and an
-unrecognised construct is a hard error naming its line.
+The first PR carries the WRITTEN corpus, the hand-written `SharedNode` expectation per corpus
+file (clause 2) and the shadow harness — NOT a parser already claiming a subset, because a
+harness with nothing to compare reports green while proving nothing. The subset then grows one
+shadow divergence at a time.
 
-Two pieces of that are not yet measured and should be built before anything else. First, the
-claim that Blueprint and `SharedNode` describe the same tree is a READING of the two notations,
-not a measurement: of the constructs the eleven files actually use (`using` 22, `template` 13,
-`[start]`/`[end]` 23, `styles` 5, `bind` 6, and zero signal handlers, menus or inline
-adjustments), everything but `template` and `bind` appears to map, but nothing has run it. ADR
-0053 clause 2 makes a hand-written `SharedNode` expectation per corpus file the proof, and the
-honest expectation is that the first suite moves at least one row of that table. Second, the
-first PR carries the written corpus and the shadow harness, NOT a parser already claiming a
-subset — a harness with nothing to compare reports green while proving nothing.
+Two things that suite has to settle before anything is claimed. The equivalence of the two
+notations is a READING and nothing has run it, so the honest expectation is that the first suite
+moves at least one row of the ADR's mapping table. And six construct classes have no `SharedNode`
+spelling at all — `template`, object ids, `_()`, `bind`, and `Adw.Breakpoint`'s `condition` and
+`setters`. The translatable marker is the one that costs: a caption parsed into a plain string
+loses exactly the attribute ADR 0033 prefers a template for.
 
-Done is a deletion list, not a feature list: `resolve-compiler.ts` and its spec, the
-`oxlint-disable`, the programmatic storybook window, the `not on PATH` skip, and the MSYS2 branch
-of `gjsify system-check`.
+Done is a deletion list, not a feature list: `resolve-compiler.ts` and its spec (505 lines), the
+one `oxlint-disable` in `loading-stack.ts`, the programmatic storybook window, the `not on PATH`
+skip in `check-doc-fences.mjs`, and the MSYS2 branch of `gjsify system-check`.
 
 ### Does the shared corpus want a second authored notation?
 
 ADR 0051 authors the shared trees as `SharedNode` in GIR class names, because that spelling is
 the one both renderers already carry and authoring in either renderer's markup would make one of
 them the reference and the other a translation. ADR 0053 adds a Blueprint READER over the same
-shape but explicitly does not propose replacing the authored form.
+shape and explicitly does not propose replacing the authored form. Whether it should is open,
+and 0053 § Context has the level argument that makes it a real question rather than a
+preference: neither notation contains the other. Against a move, concretely — six Blueprint
+constructs have no `SharedNode` spelling, and `SharedNode.props` is `string | number | boolean`,
+so none of ADRs 0042, 0046 and 0047's portable values can be written in a shared tree at all,
+while Blueprint writes all three as inline objects.
 
-What is left open is whether it should — and the question is now narrower than it looks, because
-the two notations sit on the same level. GIR is the vocabulary; Blueprint and `SharedNode` are
-both notations over it; `adw-*` elements and GtkBuilder XML are the runtime formats underneath.
-Blueprint compiles to GtkBuilder XML rather than being it, so 0051's argument about a renderer's
-markup does not reach it directly. Against that: `template` and `bind` have no `SharedNode`
-spelling, and `SharedNode.props` admits `string | number | boolean` only, so none of the portable
-values from ADRs 0042, 0046 and 0047 can be written in a shared tree at all while Blueprint
-writes all three as inline objects. Neither notation contains the other, which is why this is a
-real question and not a preference.
-
-The opposite direction costs less and is also unclaimed: `.blp` as a fourth EMITTED dialect of
-the corpus beside `gtkHostTree()` and `nativeScriptTree()`, which needs no parser and leaves
-0051's reasoning untouched. Either could land first. Deciding it belongs to whoever brings a
-measurement — a supersession of 0051 needs more than an argument about levels.
+The opposite direction costs less and is also unclaimed: `.blp` as a third EMITTED dialect of
+the corpus beside `gtkHostTree()` and `nativeScriptTree()`. It needs no parser, it leaves 0051's
+reasoning untouched, and it is the shape ADR 0034 § 8 already names as this repository's answer
+to the neighbouring translator question — write the tree once in the vocabulary that runs and
+emit the dialects. Either could land first. Deciding the authored form belongs to whoever brings
+a measurement: a supersession of 0051 needs more than an argument about levels.
 
 ### A developer who picks Vue gets the desktop and nothing else
 
@@ -5910,10 +5897,11 @@ elements and `@gjsify/adwaita-nativescript` its widgets, and neither has a frame
 those surfaces a tree is written against the DOM API or as NativeScript XML by hand.
 
 This is recorded as a GAP, not as a proposal. ADR 0051 Decision 5 already sets the policy —
-nothing more is extracted than the second driver needs, and "extract a `host-core` package first,
-then find a consumer" is explicitly rejected — and 0051 also measured that the adapters carry no
-runtime `gi://` imports at all, so a second renderer would be a parameterisation of the node type
-rather than a rewrite. The cheapest evidence, if anyone wants it, is the web leg: custom elements
-are the best-supported interop target in the browser, so Vue or Solid against `adw-*` is mostly
-an `isCustomElement` predicate plus type declarations rather than a reconciler. A consumer that
-needs it is what would start this, per the policy above.
+nothing more is extracted than the second driver needs — and its rejected alternatives name the
+inverse outright: "extract a `host-core` package first, then find a consumer". 0051 also measured
+that the three adapters carry no runtime `gi://` import at all, so a second renderer behind the
+same ops would be a parameterisation of the node type rather than a rewrite. The cheapest
+evidence, if anyone wants it, is the web leg: custom elements are the best-supported interop
+target in the browser, so Vue or Solid against `adw-*` is mostly an `isCustomElement` predicate
+plus type declarations rather than a reconciler. A consumer that needs it is what would start
+this, per the policy above.

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -5900,8 +5900,7 @@ This is recorded as a GAP, not as a proposal. ADR 0051 Decision 5 already sets t
 nothing more is extracted than the second driver needs — and its rejected alternatives name the
 inverse outright: "extract a `host-core` package first, then find a consumer". 0051 also measured
 that the three adapters carry no runtime `gi://` import at all, so a second renderer behind the
-same ops would be a parameterisation of the node type rather than a rewrite. The cheapest
-evidence, if anyone wants it, is the web leg: custom elements are the best-supported interop
-target in the browser, so Vue or Solid against `adw-*` is mostly an `isCustomElement` predicate
-plus type declarations rather than a reconciler. A consumer that needs it is what would start
-this, per the policy above.
+same ops would be a parameterisation of the node type rather than a rewrite. A consumer that needs it is what would start
+this, per the policy above. No estimate of the web leg's cost belongs here until someone
+measures one: a browser binding that resolved custom elements directly would bypass the
+gtk-host ops entirely, so it would not even be evidence for the parameterisation above.


### PR DESCRIPTION
ADR 0033 enforces that a widget tree is DECLARED, and on GTK the declarative form is
Blueprint. ADR 0051 authors one tree both renderers build — and does not use Blueprint:
its corpus is `SharedNode { tag, slot?, props?, children? }` in GIR class names, chosen
because authoring in either renderer's markup "would make one of them the reference and
the other a translation".

Read quickly, that rules Blueprint out. Read carefully, it does not, because it is about
a different LEVEL. GIR is the vocabulary. Blueprint and `SharedNode` are both notations
over it. `adw-*` elements and GtkBuilder XML are the runtime formats underneath them.
0051's argument targets that bottom layer, and Blueprint compiles TO GtkBuilder XML
rather than being it. (Full mapping table in a comment below, kept out of commit history.)

## The census, and what it corrected

Measured across every tracked `.blp`. SIX construct classes stand outside `SharedNode`,
not the two an earlier draft of this PR claimed: `template` (11), object ids (41), `_()`
(23), `bind` (6), `Adw.Breakpoint`'s `condition`/`setters` (6+6), and object-valued
properties (19). Zero signal handlers, zero menu blocks, zero inline adjustments.

They are not the same kind of outside. `template` is not a tree construct at all but a
file-level declaration. An object id is addressing, and it is what `bind` resolves
against — a notation without ids cannot express `bind`. `_()` is the expensive one: the
value survives as a string, the translatable MARKING does not, and that marking is the
whole reason ADR 0033 prefers a template.

The gap runs both ways: `SharedNode.props` admits `string | number | boolean`, so none of
the portable values from ADRs 0042, 0046 and 0047 can appear in a shared tree, while
Blueprint writes all three inline. Neither notation contains the other.

## What is decided

1. The parser produces a full AST; `SharedNode` is a DECLARED LOSSY PROJECTION of it. One
   representation cannot serve both halves — clause 4 needs every construct, the
   projection carries none of the six. Losses are named at the seam, not found downstream.
   Blueprint is a second READER, not a second authoring surface: ADR 0051 Decision 1 keeps
   `ADWAITA_GALLERY_SHARED_TREES` the corpus.
2. The equivalence is PROVED, not asserted — a hand-written `SharedNode` expectation per
   corpus file. ADR 0051 rejected a markup translator on a measurement; the projection is
   a translator in one direction and carries that burden rather than an exemption.
3. Subset scope; an unrecognised construct is a hard error naming its line.
4. `blueprint-compiler` proves the emitted XML and nothing built from the AST afterwards.
   It does NOT retire ADR 0028 § 6's other use of the same binary — typelib validation,
   which a parser does not perform: `Gtk.Box { spacinng: 4; }` parses clean.
5. Shadow run until silent, then authoritative.
6. The corpus is WRITTEN, not collected.
7. Done is a deletion list: `resolve-compiler.ts` + spec (505 lines that only find a
   binary), the line-level `oxlint-disable`, the MSYS2 branch of `system-check`. The
   doc-fence skip becomes TWO-STAGE rather than vanishing. `@gjsify/storybook` is a
   separate item — `.oxlintrc.json` scopes the package off the rule, so it needs a scoping
   decision, not a deletion.

## What is deliberately NOT decided

Which notation the corpus is AUTHORED in stays ADR 0051's. The build-from-one-source
horizon stays where 0051 Decision 6 left it. `.blp` as an EMITTED dialect needs no parser
and is separate. Where `SharedNode` has to live before a package can produce it is named
as the first unresolved implementation question rather than assumed away.

## Scope

Docs only: ADR 0053, ADR 0033 to Accepted, the index rows, three `status/open-todos.md`
entries. No AGENTS.md change. ADR 0033 is moved to Accepted because it is already binding
in practice — AGENTS.md, `docs/code-anti-patterns.md` and `.oxlintrc.json` all treat it so
— not because a gate enforces it; 0033 explicitly declines a gate.

Two independent reviews ran over this branch: one fact-checking every number against the
tree, one checking each clause against the ADRs it touches. Both found real defects. The
census above and the AST/projection split in clause 1 are their corrections.

This branch was rebuilt on current `main` after 0034–0052 landed mid-work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAGzf2HfFRVGeAv3u3tr9J
