### PR TITLE
feat(scripts): hold the shared corpus against its preview fence

### DIFF
--- a/docs/adr/0051-one-authored-tree-rendered.md
+++ b/docs/adr/0051-one-authored-tree-rendered.md
@@ -348,28 +348,43 @@ at all, and the reason each reaches none is a measurement rather than an omissio
 
 Stage 5 asked for the gallery's `preview` fence to be emitted from
 `ADWAITA_GALLERY_SHARED_TREES` "instead of authoring it per block". Measured against
-the fences on `main` at `5a8895898d`, doing that would DELETE documentation, and the
-reason is structural rather than a matter of how much of the corpus has grown.
+the fences on `main` at `5a8895898d`, doing that would DELETE documentation from two of
+the seven shared blocks, and for a reason no amount of corpus growth removes: what a
+`SharedNode` can NAME is a GIR class, and those two fences teach with markup that has no
+GIR class to be named by.
 
-Three of the seven shared blocks — `Adw.ExpanderRow`, `Adw.Banner`, `Adw.WindowTitle` —
-already read exactly as the corpus would emit them. The other four each carry something
-the corpus cannot express, and none of the four is an authoring accident:
+The measurement is a throwaway emitter over `ADWAITA_GALLERY_SHARED_TREES`, diffed per
+block against the fence with the generated gloss lines set aside. **Five of the seven
+shared blocks already read exactly as the corpus would emit them** — `Adw.SwitchRow`,
+`Adw.EntryRow`, `Adw.ExpanderRow`, `Adw.Banner`, `Adw.WindowTitle`. Two do not, and
+neither is an authoring accident:
 
-- **`Adw.PreferencesGroup`** documents a `<button slot="header-suffix">` and an
-  `<adw-combo-row model='[…]'>`. The corpus uses no `slot` at all — the divergence
-  ledger says why, the two renderers spell slots differently and a block joins only
-  when it needs no alias — and a `Gio.ListModel` is one of the portable values ADRs
-  0042/0046/0047 gave the framework trees and a `SharedNode` deliberately cannot
-  author. Emitting this fence would drop both.
-- **`Adw.ShortcutLabel`** documents five accelerators side by side in a flex `<div>`,
-  including the empty-with-`disabled-text` case. A tree driver builds ONE tree, so the
-  corpus holds one node. Emitting this fence would drop four examples and the wrapper.
-- **`Adw.SwitchRow` and `Adw.EntryRow`** carry a generated gloss line
-  (`<!-- active: … -->`), which `generate-adwaita-attribute-comments.mjs` writes from
-  the GIR and arm 12 holds. A second emitter would be writing into a region a generator
-  already owns, from a source that does not know the GIR.
+- **`Adw.PreferencesGroup`** documents a `<button slot="header-suffix" class="adw-button
+  flat">Sign out</button>` and an `<adw-combo-row model='[…]'>`. A `SharedNode` names its
+  tag with a GIR class name — `hostTagOf` throws on anything else — and carries no text
+  content, so a CSS-classed HTML button is not a node it has any way to be. The combo row
+  is expressible as markup but not as a shared node: its framework sibling authors `model`
+  as a JS ARRAY (one of the portable values ADRs 0042/0046/0047 gave those trees) against
+  the fence's JSON string, which is the same one-value-two-doors split the `Adw.SpinRow`
+  ledger entry records. Emitting this fence would drop both children.
+- **`Adw.ShortcutLabel`** documents five accelerators side by side in a
+  `<div style="display:flex…">`, including the empty-with-`disabled-text` case. The
+  wrapper is the blocker and the count is not: a shared tree has one ROOT, not one node,
+  so five sibling labels are authorable — under a GIR container that would emit as
+  `<gtk-box>`, which is different markup from the one the block shows. Emitting this
+  fence would replace the wrapper and drop four examples.
 
-Behind the four there is one argument, and this ADR's own Risks section already stated
+**What is NOT a blocker, and was claimed as one.** `Adw.SwitchRow` and `Adw.EntryRow`
+differ from the corpus emission by exactly one line each, a generated gloss
+(`<!-- active: … -->`) that `generate-adwaita-attribute-comments.mjs` writes from the GIR
+and arm 12 holds. That is a region another generator owns, but the two compose rather than
+collide: `stripGenerated` removes every generated comment line and `rewriteFence` puts
+them back on every run — "so a rewrite is idempotent", in its own words — over markup it
+does not author. Measured by deleting the gloss line from the fence and re-running
+`applyMeanings`: it comes back. So the count of blocks a corpus emitter would damage is
+two, not four, and the case below rests on those two.
+
+Behind the two there is one argument, and this ADR's own Risks section already stated
 half of it: *"a block joins the shared source only when it needs no alias, so the corpus
 is selected for the property being tested"*. A corpus selected for AGREEMENT is exactly
 the wrong source for documentation, because what it drops is precisely what the two
@@ -386,12 +401,23 @@ today on the whole corpus, and it closes the hole arm 11 structurally cannot see
 while both describe a UI the block stopped showing. The ledger records that drift
 having happened once already, block by block, found by hand.
 
-Two transforms carry it and there is still no third: `hostTagOf`, and the
-camelCase→kebab attribute rule the `adwaita-web` driver already builds with. Entity
-decoding is markup's own escaping rather than a vocabulary mapping, and an entity the
-arm does not know FAILS rather than passing through — an undecoded value reports a
-mismatch between two strings that render identically, which is a worse failure than the
-missing entity it really is.
+**Why not emit the five and author the two**, now that the damage is measured at two
+blocks rather than four. Because the emitter is what stage 5 costs, and it is the same
+whether it serves five blocks or seven: turning a `SharedNode` into markup needs a
+quoting and entity-ENCODING rule, and nothing would hold that rule against the
+quote-aware reader the fences are already read with — one direction generated, the other
+checked, agreeing with each other by construction. A per-block opt-in also puts the
+authority in two places at once, which is what `content` in the divergence ledger was
+decided against. Containment needs no emitter and makes the same drift loud.
+
+Two transforms carry it and there is still no third: `hostTagOf`, and `attributeOf`,
+the camelCase→kebab attribute rule. Both are exported from
+`adwaita-gallery-shared-trees.mjs` and IMPORTED by the `adwaita-web` driver and by arm 13
+rather than restated in either, so the check cannot end up agreeing with its own copy of a
+rule instead of with the renderer it makes a claim about. Entity decoding is markup's own
+escaping rather than a vocabulary mapping, and an entity the arm does not know FAILS
+rather than passing through — an undecoded value reports a mismatch between two strings
+that render identically, which is a worse failure than the missing entity it really is.
 
 **What this does not decide.** Whether the corpus should GROW to carry slots and
 portable values is untouched and stays a corpus question, with the ledger as its

--- a/docs/adr/0051-one-authored-tree-rendered.md
+++ b/docs/adr/0051-one-authored-tree-rendered.md
@@ -1,8 +1,11 @@
 # 51. One authored tree, rendered: ADR 0027 § 9's criterion becomes a suite
 
-- Status: **Accepted** (2026-09-10) — amended, see § Amendment 1: the second driver is
-  `adwaita-web` and not the NativeScript port, because the port has no widget an
-  off-device suite can build. What was actually built is § What landed.
+- Status: **Accepted** (2026-09-10) — amended twice, both times by a measurement that
+  overturned a stage as written. § Amendment 1: the second driver is `adwaita-web` and
+  not the NativeScript port, because the port has no widget an off-device suite can
+  build. § Amendment 2: stage 5 points the wrong way — the `preview` fence is the
+  authority and the corpus is the subset, so the corpus is held AGAINST the fence
+  rather than emitted into it. What was actually built is § What landed.
 - Date: 2026-09-09
 - Deciders: Pascal Garber
 - Related: [ADR 0004 (headless Adwaita core)](0004-headless-adwaita-core.md), [ADR 0027 (GTK host layer)](0027-gtk-host-layer.md), [ADR 0028 (widget table provenance)](0028-widget-table-provenance.md), [ADR 0030 (one corpus, GJS as oracle)](0030-one-corpus-gjs-as-oracle.md), [ADR 0034 (widget vocabulary convergence)](0034-widget-vocabulary-convergence.md)
@@ -221,7 +224,7 @@ Each stage is independently useful and breaks nothing that ships.
 | 2 | ~~The same for the NativeScript port over `nativeScriptTree(widget)`~~ — **withdrawn, see § Amendment 1.** The port's widget classes extend `@nativescript/core` bases that no runtime here has, so there is no off-device tree to build. The second driver is `adwaita-web`, over the same corpus. | the same four, plus a block whose two drivers disagree — which is the finding the whole ADR exists to produce |
 | 3 | Teach `check-adwaita-conformance-drivers.mjs` the tree driver, so a table driven only from a tree is not read as undriven, and a tree claiming a table it does not reach fails. | a false coverage claim — the exact class that gate's three incidents are about |
 | 4 | Print the distance: blocks in the corpus, blocks reaching a vector, blocks declared, per renderer. Derived every run; no count in a header or in prose. | any figure that is written down rather than derived |
-| 5 | Put `adwaita-web` on the corpus: emit the gallery `preview` fence from `ADWAITA_GALLERY_SHARED_TREES` instead of authoring it per block, then drive it in `tests/browser`. This is the stage that closes § 9 in its own words. | a preview fence that is not what the shared tree emits; a web tree that fails a vector its two siblings pass |
+| 5 | Put `adwaita-web` on the corpus. Its first half — drive the corpus in a browser — landed with § Amendment 1. ~~Emit the gallery `preview` fence from `ADWAITA_GALLERY_SHARED_TREES` instead of authoring it per block~~ — **withdrawn, see § Amendment 2**; the fence is held against the corpus in the other direction instead. | a shared node the block's `preview` fence does not carry; a web tree that fails a vector its two siblings pass |
 
 Stages 1–4 need no new package and no change to any adapter. Stage 5 is the only one that
 touches the website's authored fences, and it is last because the two stages before it are
@@ -340,3 +343,58 @@ matter to the decision.
 
 The consequence for decision 4 is the one worth keeping: two of the seven blocks reach no row
 at all, and the reason each reaches none is a measurement rather than an omission.
+
+## Amendment 2 — stage 5 emits the wrong way round, and the fence is the authority
+
+Stage 5 asked for the gallery's `preview` fence to be emitted from
+`ADWAITA_GALLERY_SHARED_TREES` "instead of authoring it per block". Measured against
+the fences on `main` at `5a8895898d`, doing that would DELETE documentation, and the
+reason is structural rather than a matter of how much of the corpus has grown.
+
+Three of the seven shared blocks — `Adw.ExpanderRow`, `Adw.Banner`, `Adw.WindowTitle` —
+already read exactly as the corpus would emit them. The other four each carry something
+the corpus cannot express, and none of the four is an authoring accident:
+
+- **`Adw.PreferencesGroup`** documents a `<button slot="header-suffix">` and an
+  `<adw-combo-row model='[…]'>`. The corpus uses no `slot` at all — the divergence
+  ledger says why, the two renderers spell slots differently and a block joins only
+  when it needs no alias — and a `Gio.ListModel` is one of the portable values ADRs
+  0042/0046/0047 gave the framework trees and a `SharedNode` deliberately cannot
+  author. Emitting this fence would drop both.
+- **`Adw.ShortcutLabel`** documents five accelerators side by side in a flex `<div>`,
+  including the empty-with-`disabled-text` case. A tree driver builds ONE tree, so the
+  corpus holds one node. Emitting this fence would drop four examples and the wrapper.
+- **`Adw.SwitchRow` and `Adw.EntryRow`** carry a generated gloss line
+  (`<!-- active: … -->`), which `generate-adwaita-attribute-comments.mjs` writes from
+  the GIR and arm 12 holds. A second emitter would be writing into a region a generator
+  already owns, from a source that does not know the GIR.
+
+Behind the four there is one argument, and this ADR's own Risks section already stated
+half of it: *"a block joins the shared source only when it needs no alias, so the corpus
+is selected for the property being tested"*. A corpus selected for AGREEMENT is exactly
+the wrong source for documentation, because what it drops is precisely what the two
+renderers disagree about — which is what a reader most needs the page to show. The
+divergence ledger had already settled the direction in the other artifact's favour:
+*"the block's own `preview` fragment is the authority"*.
+
+**So the rung is the containment, in the other direction.** Arm 13 of
+`check-generated-website-data.mjs` asserts that every node of a shared tree occurs in
+that block's `preview` fence — same element, same attributes, same values, in the same
+order — with the fence free to carry more. That is a claim that can be true, it holds
+today on the whole corpus, and it closes the hole arm 11 structurally cannot see: arm
+11 compares the two authored TREES to each other, and they can agree with each other
+while both describe a UI the block stopped showing. The ledger records that drift
+having happened once already, block by block, found by hand.
+
+Two transforms carry it and there is still no third: `hostTagOf`, and the
+camelCase→kebab attribute rule the `adwaita-web` driver already builds with. Entity
+decoding is markup's own escaping rather than a vocabulary mapping, and an entity the
+arm does not know FAILS rather than passing through — an undecoded value reports a
+mismatch between two strings that render identically, which is a worse failure than the
+missing entity it really is.
+
+**What this does not decide.** Whether the corpus should GROW to carry slots and
+portable values is untouched and stays a corpus question, with the ledger as its
+backlog. And the containment claim is made only over the shared corpus; the framework
+tree of a ledgered block is not held against its fence by anything, which is a wider
+arm and a separate measurement.

--- a/packages/web/adwaita-web/src/shared-trees.spec.ts
+++ b/packages/web/adwaita-web/src/shared-trees.spec.ts
@@ -35,12 +35,17 @@ import {
     type SharedTreeNode,
 } from '@gjsify/adwaita-core/conformance';
 
-import { ADWAITA_GALLERY_SHARED_TREES, hostTagOf } from '../../../../scripts/adwaita-gallery-shared-trees.mjs';
+// `attributeOf` — `buttonLabel` -> `button-label` — comes from the corpus rather than
+// being spelled again here, because arm 13 of `check-generated-website-data.mjs` reads
+// gallery fences back through the SAME rule: two copies would let this driver and that
+// check agree with each other while the fence a reader copies means something else.
+import {
+    ADWAITA_GALLERY_SHARED_TREES,
+    attributeOf,
+    hostTagOf,
+} from '../../../../scripts/adwaita-gallery-shared-trees.mjs';
 
 import '@gjsify/adwaita-web';
-
-/** `buttonLabel` -> `button-label`. The authored spelling is camelCase for every surface. */
-const attributeOf = (prop: string) => prop.replace(/[A-Z]/g, (upper) => `-${upper.toLowerCase()}`);
 
 /**
  * The whole renderer-specific half of this driver: an element, its authored properties as

--- a/scripts/adwaita-gallery-shared-trees.d.mts
+++ b/scripts/adwaita-gallery-shared-trees.d.mts
@@ -12,8 +12,8 @@
 // exists to prevent, so there is deliberately no way to get one.
 //
 // NOTHING CHECKS THIS FILE AGAINST THE `.mjs`, so it declares ONLY what a TypeScript spec
-// imports — three names, each imported by at least one live spec, which makes a rename over
-// there a build error over here. A declaration nobody imports has no such backstop: it is a
+// imports — every name below is imported by at least one live spec, which makes a rename
+// over there a build error over here. A declaration nobody imports has no such backstop: it is a
 // claim about the module that can quietly stop being true, which is this file's own failure
 // mode. The `.mjs`'s other exports (`nativeScriptTree`,
 // `ADWAITA_GALLERY_TREE_DIVERGENCES`) have plain-`.mjs` consumers only and are deliberately
@@ -40,6 +40,9 @@ export declare const ADWAITA_GALLERY_SHARED_TREES: readonly SharedTree[];
 
 /** `AdwPreferencesGroup` -> `adw-preferences-group` — `gtk-host`'s own `tagOf`, restated. */
 export declare const hostTagOf: (gtype: string) => string;
+
+/** `buttonLabel` -> `button-label` — an authored prop as the DOM attribute it becomes. */
+export declare const attributeOf: (prop: string) => string;
 
 /** The shared block in `gtk-host` tags. */
 export declare const gtkHostTree: (widget: string) => SharedTree;

--- a/scripts/adwaita-gallery-shared-trees.mjs
+++ b/scripts/adwaita-gallery-shared-trees.mjs
@@ -35,8 +35,18 @@
 // refusal stands and this file does not weaken it.
 //
 // A block joins this file only when its tree needs NO alias at all: the same widget
-// names, the same property names, the same values, in the same order. The single
-// transform is {@link hostTagOf}, which turns the GIR class name a block is authored
+// names, the same property names, the same values, in the same order. And what it
+// authors must be CONTAINED in that block's own `preview` fence — same elements,
+// attributes and values, in the same order — which arm 13 of
+// `check-generated-website-data.mjs` holds, because a corpus two renderers are tested
+// against proves nothing about a UI the page stopped showing.
+//
+// CONTAINMENT, and in that direction. The fence is the authority (see the `content`
+// kind in {@link ADWAITA_GALLERY_TREE_DIVERGENCES}) and is free to teach more than a
+// `SharedNode` can express; ADR 0051 § Amendment 2 measured, block by block, what
+// emitting the fence FROM here would have deleted.
+//
+// The single transform is {@link hostTagOf}, which turns the GIR class name a block is authored
 // in into the `gtk-host` tag — `AdwPreferencesGroup` -> `adw-preferences-group`, a
 // deterministic case rule and not a semantic mapping. It is `gtk-host`'s OWN rule
 // (`tagOf` in `packages/framework/gtk-host/src/tags.ts`), and arm 11 runs it against

--- a/scripts/adwaita-gallery-shared-trees.mjs
+++ b/scripts/adwaita-gallery-shared-trees.mjs
@@ -36,7 +36,7 @@
 //
 // A block joins this file only when its tree needs NO alias at all: the same widget
 // names, the same property names, the same values, in the same order. And what it
-// authors must be CONTAINED in that block's own `preview` fence — same elements,
+// authors must be CONTAINED in the fence its block shows a reader — same elements,
 // attributes and values, in the same order — which arm 13 of
 // `check-generated-website-data.mjs` holds, because a corpus two renderers are tested
 // against proves nothing about a UI the page stopped showing.

--- a/scripts/adwaita-gallery-shared-trees.mjs
+++ b/scripts/adwaita-gallery-shared-trees.mjs
@@ -221,6 +221,24 @@ export const hostTagOf = (gtype) => {
     return out.join('');
 };
 
+/**
+ * `buttonLabel` -> `button-label`, the second and last transform.
+ *
+ * AUTHORED HERE BECAUSE TWO PLACES NEED THE SAME ONE, which is the short version of the
+ * lesson {@link hostTagOf} spells out above. `adwaita-web`'s tree driver
+ * (`packages/web/adwaita-web/src/shared-trees.spec.ts`) turns an authored prop into a DOM
+ * attribute with this rule, and arm 13 of `check-generated-website-data.mjs` reads a
+ * fence's attributes back through it. A one-liner restated in the checker would make the
+ * checker agree with its own copy rather than with the renderer it is a claim about, and
+ * nothing would hold the two spellings together the way arm 11 holds `hostTagOf` against
+ * `gtk-host`'s generated table. The driver already imports this module for the corpus
+ * itself, so one export is the whole cost.
+ *
+ * NOT AN ALIAS TABLE and not a third transform: a case rule over the authored NAME, with
+ * no entry to give a name it does not recognise.
+ */
+export const attributeOf = (prop) => prop.replace(/[A-Z]/g, (upper) => `-${upper.toLowerCase()}`);
+
 const SHARED_BY_WIDGET = new Map(ADWAITA_GALLERY_SHARED_TREES.map((tree) => [tree.widget, tree]));
 
 const entryFor = (widget) => {

--- a/scripts/check-generated-website-data.mjs
+++ b/scripts/check-generated-website-data.mjs
@@ -1295,6 +1295,7 @@ const depthFirst = (node, out = []) => {
 
 const fenceByTitle = new Map(applied.fences.map((fence) => [fence.title, fence]));
 let containedNodes = 0;
+let comparedValues = 0;
 let fenceElements = 0;
 for (const tree of ADWAITA_GALLERY_SHARED_TREES) {
     const fence = fenceByTitle.get(tree.widget);
@@ -1326,6 +1327,7 @@ for (const tree of ADWAITA_GALLERY_SHARED_TREES) {
         for (const [prop, value] of Object.entries(node.props ?? {})) {
             const attribute = prop.replace(/[A-Z]/g, (upper) => `-${upper.toLowerCase()}`);
             const present = element.values.has(attribute);
+            comparedValues += 1;
             // A BOOLEAN IS THE ATTRIBUTE'S PRESENCE, which is the rule `adwaita-web`'s
             // driver builds with (`toggleAttribute`) and the elements read back with
             // `hasAttribute`. So `false` is the attribute being ABSENT, and the test
@@ -1384,10 +1386,18 @@ for (const tree of ADWAITA_GALLERY_SHARED_TREES) {
 if (ADWAITA_GALLERY_SHARED_TREES.length > 0 && containedNodes === 0) {
     failures.push('no shared node was matched against a preview fence at all — arm 13 proved nothing');
 }
+// MATCHING A NODE IS NOT COMPARING A VALUE, and the node count cannot tell the two
+// apart: with the property loop neutered, every node still matches, the note still
+// prints the same figure and the arm is green having compared nothing. Measured by
+// doing exactly that, which is the only way to learn what a guard does not cover.
+if (containedNodes > 0 && comparedValues === 0) {
+    failures.push('arm 13 matched shared nodes but compared no authored value — it proved only that tags line up');
+}
 
 notes.push(
-    `${containedNodes} shared node(s) from ${ADWAITA_GALLERY_SHARED_TREES.length} authored tree(s) found in ` +
-        `${fenceElements} preview element(s) — the corpus is that far inside what the gallery documents`,
+    `${containedNodes} shared node(s) and ${comparedValues} authored value(s) from ` +
+        `${ADWAITA_GALLERY_SHARED_TREES.length} tree(s) found in ${fenceElements} preview element(s) — the corpus ` +
+        'is that far inside what the gallery documents',
 );
 
 // A scan whose corpus is empty reports green while proving nothing.

--- a/scripts/check-generated-website-data.mjs
+++ b/scripts/check-generated-website-data.mjs
@@ -1330,6 +1330,23 @@ for (const tree of ADWAITA_GALLERY_SHARED_TREES) {
         const element = elements[cursor];
         cursor += 1;
         containedNodes += 1;
+        // A SLOT IS NOT COMPARED HERE, so a shared node carrying one has to be loud
+        // rather than quietly unheld — the shape a rule falls out of its own check by.
+        // No shared tree has one: the two renderers spell slots differently
+        // (`start`/`title`/`end` against `startBox`/`titleWidget`/`endBox` in the
+        // divergence ledger), which is why a slotted block does not meet the no-alias
+        // admission rule to begin with. Comparing `node.slot` to the fence's `slot=`
+        // would bless the gtk-host spelling as the corpus's, which is the one thing
+        // this corpus exists to refuse; so the day a block is admitted with a slot, it
+        // came with a decision about what a shared slot SPELLS, and this arm is taught
+        // that rather than guessing it.
+        if (node.slot !== undefined) {
+            failures.push(
+                `${tree.widget}: authored node ${index} <${wanted}> carries slot="${node.slot}", and arm 13 does ` +
+                    'not hold a slot against the fence. The two renderers spell slots differently, so there is no ' +
+                    'shared spelling to compare against — teach this arm the one the corpus settled on.',
+            );
+        }
         for (const [prop, value] of Object.entries(node.props ?? {})) {
             const attribute = attributeOf(prop);
             const present = element.values.has(attribute);

--- a/scripts/check-generated-website-data.mjs
+++ b/scripts/check-generated-website-data.mjs
@@ -90,7 +90,7 @@
 //      ledgered block whose two trees have BECOME identical fails, the same
 //      self-retiring shape as (5b). (4)-(9) each hold ONE tree against ONE renderer,
 //      which is why they were all green while one block drew two different widgets.
-//  13. Every node of a shared tree occurs in that block's `preview` fence — same
+//  13. Every node of a shared tree occurs in the fence its block shows a reader — same
 //      element, same attributes, same values, in the same order. (11) compares the two
 //      authored trees to EACH OTHER, and they can agree while both describe a UI the
 //      block stopped showing; the fence is what a reader copies, and the divergence
@@ -1247,8 +1247,13 @@ notes.push(
 // ---------------------------------------------------------------------------
 
 /**
- * Every node of a shared tree occurs in that block's `preview` fence, same element,
- * same attributes, same values, in the same order.
+ * Every node of a shared tree occurs in the fence its block SHOWS A READER, same
+ * element, same attributes, same values, in the same order.
+ *
+ * WHICH FENCE is {@link galleryFences}'s decision and not a second one taken here — the
+ * `web` fragment where a block has one, `preview` otherwise. Every shared block resolves
+ * to `preview` today, and every message below names the slot it actually read rather than
+ * assuming that stays true.
  *
  * WHY CONTAINMENT AND NOT EQUALITY, which is the direction ADR 0051 § 5 proposed and
  * this arm is the measured answer to. The fence is the RICHER artifact and the ledger
@@ -1262,7 +1267,7 @@ notes.push(
  *
  * THE MATCH IS GREEDY on the element name, in document order, and a matched element
  * must then agree on every authored value. Searching on for a later instance that fits
- * would turn a drifted value into a silent re-anchor — the fence draws five
+ * would turn a drifted value into a silent re-anchor — one block draws a row of
  * `<adw-shortcut-label>`s, so "found one that matches" is available and worthless.
  *
  * WHAT IT CATCHES that arm 11 cannot. Arm 11 compares the two authored TREES to each
@@ -1302,7 +1307,7 @@ for (const tree of ADWAITA_GALLERY_SHARED_TREES) {
     const fence = fenceByTitle.get(tree.widget);
     if (fence === undefined) {
         failures.push(
-            `${tree.widget} is a shared tree with no preview fence on any gallery page, so the corpus describes ` +
+            `${tree.widget} is a shared tree with no fence on any gallery page, so the corpus describes ` +
                 'a UI the site does not show. Either the block was renamed or it was removed from the gallery ' +
                 'while its tree stayed in the shared source.',
         );
@@ -1397,7 +1402,7 @@ if (containedNodes > 0 && comparedValues === 0) {
 
 notes.push(
     `${containedNodes} shared node(s) and ${comparedValues} authored value(s) from ` +
-        `${ADWAITA_GALLERY_SHARED_TREES.length} tree(s) found in ${fenceElements} preview element(s) — the corpus ` +
+        `${ADWAITA_GALLERY_SHARED_TREES.length} tree(s) found in ${fenceElements} fence element(s) — the corpus ` +
         'is that far inside what the gallery documents',
 );
 

--- a/scripts/check-generated-website-data.mjs
+++ b/scripts/check-generated-website-data.mjs
@@ -1256,7 +1256,7 @@ notes.push(
  * no alias, so everything the two renderers disagree about is exactly what the corpus
  * cannot carry — and that is content the DOCS are entitled to teach. Measured over the
  * shared blocks, emitting the fence from the corpus would delete a `slot=` child and a
- * `Gio.ListModel` row from one block and four of five examples from another. The
+ * `Gio.ListModel` row from one block and all but one of the examples from another. The
  * corpus is a subset of the documentation; asserting that is a claim that can be true.
  *
  * THE MATCH IS GREEDY on the element name, in document order, and a matched element
@@ -1350,8 +1350,8 @@ for (const tree of ADWAITA_GALLERY_SHARED_TREES) {
             const got = decodeEntities(raw ?? '', (entity) =>
                 failures.push(
                     `${fence.rel}: <${wanted} ${attribute}> carries the entity ${entity}, which arm 13 cannot ` +
-                        'decode. Add it to ENTITIES beside the five already there — comparing it undecoded ' +
-                        'reports a mismatch between two strings that render the same.',
+                        `decode. Add it to the ${Object.keys(ENTITIES).length} already in ENTITIES — comparing it ` +
+                        'undecoded reports a mismatch between two strings that render the same.',
                 ),
             );
             if (got === String(value)) continue;

--- a/scripts/check-generated-website-data.mjs
+++ b/scripts/check-generated-website-data.mjs
@@ -1325,19 +1325,25 @@ for (const tree of ADWAITA_GALLERY_SHARED_TREES) {
         containedNodes += 1;
         for (const [prop, value] of Object.entries(node.props ?? {})) {
             const attribute = prop.replace(/[A-Z]/g, (upper) => `-${upper.toLowerCase()}`);
-            if (!element.values.has(attribute)) {
-                failures.push(
-                    `${tree.widget}: authored node ${index} <${wanted}> sets ${prop}, and the ${fence.slot} fence ` +
-                        `of ${fence.rel} sets no ${attribute} on it. Both tree drivers assert that value; the ` +
-                        'page a reader copies does not carry it.',
-                );
-                continue;
-            }
-            const raw = element.values.get(attribute);
-            // A boolean is the attribute's PRESENCE on this renderer — the same rule
-            // `adwaita-web`'s driver builds with — so `false` is the attribute being
-            // absent and there is nothing here for it to disagree with.
+            const present = element.values.has(attribute);
+            // A BOOLEAN IS THE ATTRIBUTE'S PRESENCE, which is the rule `adwaita-web`'s
+            // driver builds with (`toggleAttribute`) and the elements read back with
+            // `hasAttribute`. So `false` is the attribute being ABSENT, and the test
+            // belongs BEFORE the not-set failure below — which is a claim about a
+            // VALUE, and a false boolean has none. Both directions were wrong without
+            // it: a fence that correctly omitted `active` failed against a node
+            // authoring `active: false`, and a fence that spelled it while the node
+            // said false — a real disagreement — passed in silence.
             if (typeof value === 'boolean') {
+                if (value !== present) {
+                    failures.push(
+                        `${tree.widget}: authored node ${index} <${wanted}> sets ${prop} to ${value}, and the ` +
+                            `${fence.slot} fence of ${fence.rel} ${present ? 'sets' : 'does not set'} ${attribute} ` +
+                            'on it. A boolean is the attribute being there: present is true, absent is false.',
+                    );
+                    continue;
+                }
+                const raw = element.values.get(attribute);
                 if (value && raw !== null && raw !== '') {
                     failures.push(
                         `${tree.widget}: <${wanted}> ${attribute} is authored as a boolean, and ${fence.rel} ` +
@@ -1347,6 +1353,15 @@ for (const tree of ADWAITA_GALLERY_SHARED_TREES) {
                 }
                 continue;
             }
+            if (!present) {
+                failures.push(
+                    `${tree.widget}: authored node ${index} <${wanted}> sets ${prop}, and the ${fence.slot} fence ` +
+                        `of ${fence.rel} sets no ${attribute} on it. Both tree drivers assert that value; the ` +
+                        'page a reader copies does not carry it.',
+                );
+                continue;
+            }
+            const raw = element.values.get(attribute);
             const got = decodeEntities(raw ?? '', (entity) =>
                 failures.push(
                     `${fence.rel}: <${wanted} ${attribute}> carries the entity ${entity}, which arm 13 cannot ` +

--- a/scripts/check-generated-website-data.mjs
+++ b/scripts/check-generated-website-data.mjs
@@ -112,6 +112,7 @@ import { ADWAITA_GALLERY_NS_REFUSALS, ADWAITA_GALLERY_NS_TEMPLATES } from './adw
 import {
     ADWAITA_GALLERY_SHARED_TREES,
     ADWAITA_GALLERY_TREE_DIVERGENCES,
+    attributeOf,
     hostTagOf,
 } from './adwaita-gallery-shared-trees.mjs';
 import { ADWAITA_GALLERY_REFUSALS, ADWAITA_GALLERY_TREES } from './adwaita-gallery-trees.mjs';
@@ -1325,7 +1326,7 @@ for (const tree of ADWAITA_GALLERY_SHARED_TREES) {
         cursor += 1;
         containedNodes += 1;
         for (const [prop, value] of Object.entries(node.props ?? {})) {
-            const attribute = prop.replace(/[A-Z]/g, (upper) => `-${upper.toLowerCase()}`);
+            const attribute = attributeOf(prop);
             const present = element.values.has(attribute);
             comparedValues += 1;
             // A BOOLEAN IS THE ATTRIBUTE'S PRESENCE, which is the rule `adwaita-web`'s

--- a/scripts/check-generated-website-data.mjs
+++ b/scripts/check-generated-website-data.mjs
@@ -90,6 +90,14 @@
 //      ledgered block whose two trees have BECOME identical fails, the same
 //      self-retiring shape as (5b). (4)-(9) each hold ONE tree against ONE renderer,
 //      which is why they were all green while one block drew two different widgets.
+//  13. Every node of a shared tree occurs in that block's `preview` fence — same
+//      element, same attributes, same values, in the same order. (11) compares the two
+//      authored trees to EACH OTHER, and they can agree while both describe a UI the
+//      block stopped showing; the fence is what a reader copies, and the divergence
+//      ledger already calls it the authority. CONTAINMENT and not equality: the corpus
+//      admits a block only when its two trees need no alias, so what the renderers
+//      disagree about is exactly what it cannot carry — and the docs are entitled to
+//      teach that. ADR 0051 § Amendment 2 is the measurement behind the direction.
 //
 // Plain Node over the repo's own files — no install, no build, no astro render.
 //
@@ -113,6 +121,7 @@ import {
     ATTRIBUTE_MEANING_LEDGER,
     ATTRIBUTE_OXFMT_EXEMPT_OUTPUTS,
     AUTHORED_MEANINGS,
+    markupElements,
     MEANINGS_MODULE,
     meaningCounts,
 } from './generate-adwaita-attribute-comments.mjs';
@@ -1051,8 +1060,10 @@ const nsByWidget = new Map(ADWAITA_GALLERY_NS_TEMPLATES.map((tree) => [tree.widg
  * `subtitle` in is not part of the UI. Compared as written, a parity branch that
  * closes a `property` divergence by adding the missing props in a different order
  * would leave its ledger entry standing with nothing to notice — the self-retiring
- * half would have been the half that silently passes. (Measured on today's 23 pairs:
- * no divergence is order-only, so this changes no verdict and closes the hole.)
+ * half would have been the half that silently passes. (Measured over every pair when
+ * the sort landed: no divergence was order-only, so it changed no verdict and closed
+ * the hole. The pair count is printed below, never written here — this comment carried
+ * one and it was behind the tree within two merges.)
  */
 const shapeOf = (node, tagOf) =>
     JSON.stringify({
@@ -1159,7 +1170,7 @@ for (const [gtype, tag] of HOST_WIDGET_ROWS) {
 }
 
 // An EMPTY shared source is deliberately not a failure — it is the honest state of a
-// gallery where nothing agrees yet, and the arm still compares all 23 pairs. What
+// gallery where nothing agrees yet, and the arm still compares every pair. What
 // would be vacuous is having no pair to compare at all. (An emptied shared source is
 // loud anyway: both generators call `gtkHostTree`/`nativeScriptTree` by name, and
 // `entryFor` throws that name.)
@@ -1228,6 +1239,140 @@ notes.push(
         `glossed from the GIR, ${measuredCounts.nameSuffices} where the name suffices, ` +
         `${Object.keys(ATTRIBUTE_MEANING_LEDGER).length} with no GIR property, ` +
         `${Object.keys(AUTHORED_MEANINGS).length} authored; ${measuredCounts.commentLines} comment line(s)`,
+);
+
+// ---------------------------------------------------------------------------
+// 13. the shared corpus is a SUBSET of the UI its block documents
+// ---------------------------------------------------------------------------
+
+/**
+ * Every node of a shared tree occurs in that block's `preview` fence, same element,
+ * same attributes, same values, in the same order.
+ *
+ * WHY CONTAINMENT AND NOT EQUALITY, which is the direction ADR 0051 § 5 proposed and
+ * this arm is the measured answer to. The fence is the RICHER artifact and the ledger
+ * in `adwaita-gallery-shared-trees.mjs` already calls it the authority. The corpus is
+ * a deliberately narrow subset: a block joins it only when its two authored trees need
+ * no alias, so everything the two renderers disagree about is exactly what the corpus
+ * cannot carry — and that is content the DOCS are entitled to teach. Measured over the
+ * shared blocks, emitting the fence from the corpus would delete a `slot=` child and a
+ * `Gio.ListModel` row from one block and four of five examples from another. The
+ * corpus is a subset of the documentation; asserting that is a claim that can be true.
+ *
+ * THE MATCH IS GREEDY on the element name, in document order, and a matched element
+ * must then agree on every authored value. Searching on for a later instance that fits
+ * would turn a drifted value into a silent re-anchor — the fence draws five
+ * `<adw-shortcut-label>`s, so "found one that matches" is available and worthless.
+ *
+ * WHAT IT CATCHES that arm 11 cannot. Arm 11 compares the two authored TREES to each
+ * other; both can agree and both be a description of a UI the block no longer shows.
+ * The ledger records that exact drift having happened once already in the other
+ * direction, block by block, found by hand.
+ */
+const ENTITIES = { lt: '<', gt: '>', amp: '&', quot: '"', apos: "'" };
+
+/**
+ * A fence value in the vocabulary the corpus is authored in.
+ *
+ * An unknown entity FAILS rather than passing through: `&nbsp;` compared as its own
+ * bytes would report a value mismatch naming two strings that look identical, which is
+ * a worse failure than the missing entity it really is.
+ */
+const decodeEntities = (value, onUnknown) =>
+    value.replace(/&[^;\s]+;/g, (entity) => {
+        const name = entity.slice(1, -1);
+        if (Object.hasOwn(ENTITIES, name)) return ENTITIES[name];
+        onUnknown(entity);
+        return entity;
+    });
+
+/** The authored nodes depth-first — the order both tree drivers assert the DOM in. */
+const depthFirst = (node, out = []) => {
+    out.push(node);
+    for (const child of node.children ?? []) depthFirst(child, out);
+    return out;
+};
+
+const fenceByTitle = new Map(applied.fences.map((fence) => [fence.title, fence]));
+let containedNodes = 0;
+let fenceElements = 0;
+for (const tree of ADWAITA_GALLERY_SHARED_TREES) {
+    const fence = fenceByTitle.get(tree.widget);
+    if (fence === undefined) {
+        failures.push(
+            `${tree.widget} is a shared tree with no preview fence on any gallery page, so the corpus describes ` +
+                'a UI the site does not show. Either the block was renamed or it was removed from the gallery ' +
+                'while its tree stayed in the shared source.',
+        );
+        continue;
+    }
+    const elements = markupElements(fence.body);
+    fenceElements += elements.length;
+    let cursor = 0;
+    for (const [index, node] of depthFirst(tree.root).entries()) {
+        const wanted = hostTagOf(node.tag);
+        while (cursor < elements.length && elements[cursor].tag !== wanted) cursor += 1;
+        if (cursor === elements.length) {
+            failures.push(
+                `${tree.widget}: authored node ${index} <${wanted}> has no matching element left in the ` +
+                    `${fence.slot} fence of ${fence.rel}. The shared corpus is supposed to be a subset of what ` +
+                    'the block documents — one of the two was edited without the other.',
+            );
+            break;
+        }
+        const element = elements[cursor];
+        cursor += 1;
+        containedNodes += 1;
+        for (const [prop, value] of Object.entries(node.props ?? {})) {
+            const attribute = prop.replace(/[A-Z]/g, (upper) => `-${upper.toLowerCase()}`);
+            if (!element.values.has(attribute)) {
+                failures.push(
+                    `${tree.widget}: authored node ${index} <${wanted}> sets ${prop}, and the ${fence.slot} fence ` +
+                        `of ${fence.rel} sets no ${attribute} on it. Both tree drivers assert that value; the ` +
+                        'page a reader copies does not carry it.',
+                );
+                continue;
+            }
+            const raw = element.values.get(attribute);
+            // A boolean is the attribute's PRESENCE on this renderer — the same rule
+            // `adwaita-web`'s driver builds with — so `false` is the attribute being
+            // absent and there is nothing here for it to disagree with.
+            if (typeof value === 'boolean') {
+                if (value && raw !== null && raw !== '') {
+                    failures.push(
+                        `${tree.widget}: <${wanted}> ${attribute} is authored as a boolean, and ${fence.rel} ` +
+                            `spells it "${raw}". The elements read it with hasAttribute(), so a value there is ` +
+                            'read as true whatever it says.',
+                    );
+                }
+                continue;
+            }
+            const got = decodeEntities(raw ?? '', (entity) =>
+                failures.push(
+                    `${fence.rel}: <${wanted} ${attribute}> carries the entity ${entity}, which arm 13 cannot ` +
+                        'decode. Add it to ENTITIES beside the five already there — comparing it undecoded ' +
+                        'reports a mismatch between two strings that render the same.',
+                ),
+            );
+            if (got === String(value)) continue;
+            failures.push(
+                `${tree.widget}: <${wanted}> ${prop} is authored "${value}" and the ${fence.slot} fence of ` +
+                    `${fence.rel} shows "${got}". The corpus two renderers are tested against and the markup a ` +
+                    'reader copies describe different UIs.',
+            );
+        }
+    }
+}
+
+// The corpus can legitimately be empty (arm 11 says why), but an arm that walked no
+// node proved nothing, and the fences are what would have gone missing.
+if (ADWAITA_GALLERY_SHARED_TREES.length > 0 && containedNodes === 0) {
+    failures.push('no shared node was matched against a preview fence at all — arm 13 proved nothing');
+}
+
+notes.push(
+    `${containedNodes} shared node(s) from ${ADWAITA_GALLERY_SHARED_TREES.length} authored tree(s) found in ` +
+        `${fenceElements} preview element(s) — the corpus is that far inside what the gallery documents`,
 );
 
 // A scan whose corpus is empty reports green while proving nothing.

--- a/scripts/check-generated-website-data.mjs
+++ b/scripts/check-generated-website-data.mjs
@@ -1407,7 +1407,7 @@ for (const tree of ADWAITA_GALLERY_SHARED_TREES) {
 // The corpus can legitimately be empty (arm 11 says why), but an arm that walked no
 // node proved nothing, and the fences are what would have gone missing.
 if (ADWAITA_GALLERY_SHARED_TREES.length > 0 && containedNodes === 0) {
-    failures.push('no shared node was matched against a preview fence at all — arm 13 proved nothing');
+    failures.push('no shared node was matched against a fence at all — arm 13 proved nothing');
 }
 // MATCHING A NODE IS NOT COMPARING A VALUE, and the node count cannot tell the two
 // apart: with the property loop neutered, every node still matches, the note still

--- a/scripts/generate-adwaita-attribute-comments.mjs
+++ b/scripts/generate-adwaita-attribute-comments.mjs
@@ -597,7 +597,7 @@ const commentRanges = (markup) => {
 
 /**
  * Every `adw-*` / `gtk-*` opening tag in `markup`, in source order, with the offset of
- * its `<` and the attributes that instance sets.
+ * its `<`, the attributes that instance sets and the value each one carries.
  *
  * PER INSTANCE, which is the difference from the union the deleted attribute pane
  * showed: /adwaita/buttons/ paints five `<gtk-button>`s, one per style, and a comment
@@ -606,6 +606,13 @@ const commentRanges = (markup) => {
  *
  * A QUOTE-AWARE walk rather than `/<tag[^>]*>/`, because an attribute value may hold a
  * `>` — `<gtk-drop-down>`'s `model` carries JSON. Comments are skipped.
+ *
+ * `values` is a Map beside the `attributes` list rather than a second walk of the same
+ * markup: arm 13 of `check-generated-website-data.mjs` needs what a fence SETS and this
+ * loop already parses it. `null` is a bare attribute (`active`), which is a different
+ * fact from the empty string (`accelerator=""`) and stays distinguishable. Values are
+ * the fence's own bytes, entities included — decoding is the caller's, because only the
+ * caller knows which vocabulary it is decoding INTO.
  */
 export function markupElements(markup) {
     const comments = commentRanges(markup);
@@ -622,14 +629,17 @@ export function markupElements(markup) {
             at += 1;
         }
         const attributes = [];
+        const values = new Map();
         const inside = markup.slice(open.index + open[0].length, at);
         for (const found of inside.matchAll(
             /([a-zA-Z_:][\w:.-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g,
         )) {
             const name = found[1].toLowerCase();
-            if (!attributes.includes(name)) attributes.push(name);
+            if (attributes.includes(name)) continue;
+            attributes.push(name);
+            values.set(name, found[2] ?? found[3] ?? found[4] ?? null);
         }
-        elements.push({ tag: open[1], start: open.index, attributes });
+        elements.push({ tag: open[1], start: open.index, attributes, values });
     }
     return elements;
 }

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -486,7 +486,7 @@ And `bindEmptySections` derives SYNCHRONOUSLY, so it must run AFTER the router's
 only un-hides a microtask later, after `_syncClasses` has measured a bar at
 `offsetHeight` 0. That cost 8 real failures once; the three call sites now say so.
 
-### The gallery's two authored trees agree on 7 blocks of 23, and the rest is ledgered
+### The gallery's two authored trees agree on a minority of blocks, and the rest is ledgered
 
 ADR 0027 § 9's criterion is *"the same authored tree, rendered through the GTK host and
 through `adwaita-web`, satisfies the same `@gjsify/adwaita-core/conformance` vectors with
@@ -502,26 +502,29 @@ a host and an authentication toggle on three tabs and *"Advanced"* with a develo
 toggle and an endpoint on the fourth, children in the opposite order, for as long as both
 files existed. Nothing compared one to the other.
 
-**The census that sized the work.** 40 blocks; 23 carry a tree on both renderers, and the
-other 17 are refused by one or by both with a reason already recorded. Of the 23, compared
-node by node with the GIR-name case rule as the only transform:
+**The census that sized the work.** Some blocks carry a tree on both renderers; the rest
+are refused by one or by both with a reason already recorded. The paired ones are compared
+node by node with the GIR-name case rule as the only transform, and land in five buckets:
 
-| | blocks | |
-|---|---|---|
-| identical | 7 | authored once in `scripts/adwaita-gallery-shared-trees.mjs` |
-| `property` | 5 | same shape and tags; one renderer has no such property |
-| `vocabulary` | 2 | same shape; a tag, slot or property is spelled differently |
-| `composition` | 7 | genuinely different UIs, each forced by a renderer |
-| `content` | 2 | nothing forced them apart — two authors, two examples |
+| | |
+|---|---|
+| identical | authored once in `scripts/adwaita-gallery-shared-trees.mjs` |
+| `property` | same shape and tags; one renderer has no such property |
+| `vocabulary` | same shape; a tag, slot or property is spelled differently |
+| `composition` | genuinely different UIs, each forced by a renderer |
+| `content` | nothing forced them apart — two authors, two examples |
 
-Every number is recomputed by arm 11 of `check-generated-website-data.mjs`, which prints
-the partition on every run and fails on a ledgered block whose two trees have BECOME
-identical — the self-retiring shape of arm 5b's stale-refusal rule, so the branches closing
-the renderer gaps one property at a time cannot leave a dead reason standing.
+**How many are in each bucket is not written here.** Arm 11 of
+`check-generated-website-data.mjs` recomputes the partition and prints it on every run,
+and it fails on a ledgered block whose two trees have BECOME identical — the self-retiring
+shape of arm 5b's stale-refusal rule, so the branches closing the renderer gaps one
+property at a time cannot leave a dead reason standing. This entry used to carry the
+counts in a table and in its own heading; both were behind the tree by the time anyone
+read them, which is the reason the numbers are gone rather than corrected.
 
-**What blocks the remaining 16, in the order it can be paid.**
+**What blocks the ledgered ones, in the order it can be paid.**
 
-*The 5 `property` ones are renderer work and are already in flight or trivially scoped.*
+*The `property` ones are renderer work and are already in flight or trivially scoped.*
 `Adw.Avatar` needs `showInitials` and `iconName` on the NativeScript `AdwAvatar`, whose
 whole Adwaita surface today is `size` and `text` — and whose `set text` always renders
 initials, so there is no icon path to reach either. `Gtk.Entry` needs nothing:
@@ -538,7 +541,7 @@ Adwaita symbolic SVG STRING on the port. A property that agrees on its name and 
 its value is worse than one that is missing, and `check-vocabulary-alignment.mjs` counts it
 as agreement.
 
-*The 2 `vocabulary` ones close for free when the convergence that gate already counts down
+*The `vocabulary` ones close for free when the convergence that gate already counts down
 lands* — `label`/`text`, `wrap`/`textWrap`, `cssClasses`/`class`, and the three header-bar
 slots spelled `start`/`title`/`end` against `startBox`/`titleWidget`/`endBox`. Slots are
 why no shared tree uses one yet: the shared source admits a block only when it needs no
@@ -546,15 +549,15 @@ alias, and every slotted pair still needs three. `Adw.Spinner` sat here until it
 half was read: a `vocabulary` entry PROMISES the block lands in the shared source for free
 when the renames land, so a missing property filed under it is a promise nothing can keep.
 
-*The 7 `composition` ones each need a decision before they need code*, and two of them are
+*The `composition` ones each need a decision before they need code*, and two of them are
 the same decision twice: an `AdwHeaderBar` title is a slotted `AdwWindowTitle` child on GTK
 and a plain `title` property on the port, so `Adw.OverlaySplitView` and `Adw.ToolbarView`
 carry two nodes more on one side than the other. Converging them means deciding which
 renderer is wrong, which is an ADR 0034 question and not a gallery one.
 
-*The 2 `content` ones are the ones nobody has an excuse for*, and they are left as measured
-rather than fixed because closing the LIST would not move either into the shared source:
-both also carry a `cssClasses` against the port's style-class property, and that half does
+*The `content` ones are the ones nobody has an excuse for*, and two of them are left as
+measured rather than fixed because closing the LIST would not move either into the shared
+source: both also carry a `cssClasses` against the port's style-class property, and that half does
 not close by renaming. `@nativescript/core`'s `ViewBase` already owns the name — its
 constructor assigns `this.cssClasses = new Set()`, its `ClassSelector.match` reads
 `node.cssClasses.has(…)` and its `className` setter clears and refills the same Set — so
@@ -563,10 +566,14 @@ engine a live mutable Set, and the value kinds differ besides (`string[]` agains
 `Set<string>`). Padding the lists moves them from `content` to `vocabulary`, which is a
 bucket sideways and not a block shared. `Adw.WrapBox`: the block
 preview and three tabs show eight chips, the NativeScript template six. `Gtk.Button`: five
-buttons against four, the icon-only circular one missing. The rule that settles both is the
-one `Adw.WrapBox`'s own tree already states — a gallery block is one widget written several
-ways, so its `preview` fragment is the authority — and in both cases it is the NativeScript
-template that drifted from it.
+buttons against four, the icon-only circular one missing. `Adw.SpinRow` joined them later
+and is the one with a second half: the examples differ ("Font size" against "Copies"), and
+so does the value KIND, which does not close by matching the numbers — an adjustment is an
+OBJECT a JSX expression carries on one side and the JSON STRING its XML door parses on the
+other (ADR 0047 § 5). The rule that settles the LIST half is the one `Adw.WrapBox`'s own
+tree already states — a gallery block is one widget written several ways, so its `preview`
+fragment is the authority — and in all three cases it is the NativeScript template that
+drifted from it.
 
 The census also found the `Adw.WrapBox` chip list spelled `Typescript` in seven authored
 sites and `TypeScript` in one — the NativeScript template, the only one that was right. All
@@ -603,6 +610,27 @@ would not help: `@nativescript/core` ships a widget class only as `index.android
 does not resolve outside a device — the measurement is in the ADR's Amendment 1. A
 device-bound driver would not be a CI guard, which is why the second driver is
 `adwaita-web`: the renderer ADR 0027 § 9 named in the first place.
+
+**The `preview` fence is NOT emitted from the corpus, and the direction is settled the
+other way.** ADR 0051's last open stage asked for exactly that, and the measurement
+overturned it — ADR 0051 § Amendment 2 carries it block by block. Three shared blocks
+already read as the corpus would emit them; the other four each document something a
+`SharedNode` cannot author, and not one of the four is an accident: a `slot=` child and a
+`Gio.ListModel` row (the corpus uses no slot at all, and ADRs 0042/0046/0047's portable
+values have no shared spelling), four further examples of one widget beside a flex wrapper
+(a tree driver builds ONE tree), and a generated gloss line that
+`generate-adwaita-attribute-comments.mjs` owns and arm 12 holds. The corpus is SELECTED for
+agreement between two renderers, so what it drops is exactly what they disagree about —
+which is what a reader most needs the page to show. What landed instead is arm 13 of
+`check-generated-website-data.mjs`: every node of a shared tree occurs in that block's
+`preview` fence, same element, attributes and values, in the same order, the fence free to
+carry more. That closes what arm 11 cannot see — two authored trees can agree with each
+other and both describe a UI the block stopped showing.
+
+Still open beside it, and deliberately not claimed by arm 13: the framework tree of a
+LEDGERED block is held against its own fence by nothing. That is the wider arm, and it
+needs its own measurement first — the ledger's `content` entries say the templates drifted
+from the fence, which is the same drift one artifact over and was found by hand.
 
 ### A constructed `Adw.Banner` does not interpret markup, and both ports say it does
 

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -613,9 +613,10 @@ device-bound driver would not be a CI guard, which is why the second driver is
 
 **The `preview` fence is NOT emitted from the corpus, and the direction is settled the
 other way.** ADR 0051's last open stage asked for exactly that, and the measurement
-overturned it — ADR 0051 § Amendment 2 carries it block by block. Three shared blocks
-already read as the corpus would emit them; the other four each document something a
-`SharedNode` cannot author, and not one of the four is an accident: a `slot=` child and a
+overturned it — ADR 0051 § Amendment 2 carries it block by block, and the count is left
+there with its commit rather than copied here. Some shared blocks already read as the
+corpus would emit them; the rest each document something a `SharedNode` cannot author, and
+not one of those is an accident: a `slot=` child and a
 `Gio.ListModel` row (the corpus uses no slot at all, and ADRs 0042/0046/0047's portable
 values have no shared spelling), four further examples of one widget beside a flex wrapper
 (a tree driver builds ONE tree), and a generated gloss line that

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -471,10 +471,10 @@ authored tree, rendered through the GTK host and through `adwaita-web`, satisfie
 same `@gjsify/adwaita-core/conformance` vectors with no per-surface markup branch. Both
 halves now exist for part of the gallery: the "same authored tree" half is measured by
 arm 11, and the BEHAVIOUR half by the two tree drivers ADR 0051 landed — see *The gallery's
-two authored trees agree on 7 blocks of 23* below for what they cover and what they do not.
-The goal is a claim about seven blocks and a direction past them — and the longer horizon it
-points at (NativeScript and browser builds from one native-authored source) still needs its
-own ADR.
+two authored trees agree on a minority of blocks* below for what they cover and what they
+do not. The goal is a claim about the shared blocks and a direction past them — and the
+longer horizon it points at (NativeScript and browser builds from one native-authored
+source) still needs its own ADR.
 
 Two things the slot work left for whoever picks this up. **Ten of the 23 re-homing
 elements are deliberately not converted**: eight consume typed children into a state
@@ -555,11 +555,12 @@ and a plain `title` property on the port, so `Adw.OverlaySplitView` and `Adw.Too
 carry two nodes more on one side than the other. Converging them means deciding which
 renderer is wrong, which is an ADR 0034 question and not a gallery one.
 
-*The `content` ones are the ones nobody has an excuse for*, and two of them are left as
-measured rather than fixed because closing the LIST would not move either into the shared
-source: both also carry a `cssClasses` against the port's style-class property, and that half does
-not close by renaming. `@nativescript/core`'s `ViewBase` already owns the name — its
-constructor assigns `this.cssClasses = new Set()`, its `ClassSelector.match` reads
+*The `content` ones are the ones nobody has an excuse for*, and `Adw.WrapBox` and
+`Gtk.Button` are left as measured rather than fixed because closing the LIST would not move
+either into the shared source: each also carries a `cssClasses` against the port's
+style-class property, and that half does not close by renaming. `@nativescript/core`'s
+`ViewBase` already owns the name — its constructor assigns `this.cssClasses = new Set()`,
+its `ClassSelector.match` reads
 `node.cssClasses.has(…)` and its `className` setter clears and refills the same Set — so
 taking the name means shadowing that field with an accessor pair that still hands the CSS
 engine a live mutable Set, and the value kinds differ besides (`string[]` against
@@ -572,7 +573,7 @@ so does the value KIND, which does not close by matching the numbers — an adju
 OBJECT a JSX expression carries on one side and the JSON STRING its XML door parses on the
 other (ADR 0047 § 5). The rule that settles the LIST half is the one `Adw.WrapBox`'s own
 tree already states — a gallery block is one widget written several ways, so its `preview`
-fragment is the authority — and in all three cases it is the NativeScript template that
+fragment is the authority — and in every case here it is the NativeScript template that
 drifted from it.
 
 The census also found the `Adw.WrapBox` chip list spelled `Typescript` in seven authored


### PR DESCRIPTION
**Stage 5 as ADR 0051 wrote it does not carry, and the measurement is the first
thing here.** It asked for the gallery's `preview` fence to be emitted from
`ADWAITA_GALLERY_SHARED_TREES`. Doing that would DELETE documentation — from two
of the seven shared blocks, and for a reason no amount of corpus growth removes.

Measured with a throwaway emitter over the corpus, diffed per block against the
fence with the generated gloss lines set aside: **five** of the seven already
read exactly as the corpus would emit them. Two do not, and neither is an
authoring accident:

- `Adw.PreferencesGroup` teaches with a `<button slot="header-suffix"
  class="adw-button flat">Sign out</button>` and an `<adw-combo-row model='[…]'>`.
  A `SharedNode` names its tag with a GIR class and carries no text, so a
  CSS-classed HTML button is not a node it can be; the combo row's framework
  sibling authors `model` as a JS ARRAY against the fence's JSON string, the same
  one-value-two-doors split the `Adw.SpinRow` ledger entry records.
- `Adw.ShortcutLabel` teaches five accelerators in a `<div style="display:flex…">`.
  The wrapper is the blocker and the count is not — a tree has one ROOT, not one
  node — and a GIR container would emit as `<gtk-box>`, different markup from the
  one the block shows.

Behind the two is one argument this ADR's Risks section already half-stated: the
corpus is **selected for agreement** between two renderers, so what it drops is
exactly what they disagree about — which is what a reader most needs to see. The
divergence ledger had settled the direction already: *"the block's own `preview`
fragment is the authority"*.

## The rung that is actually available

Arm 13 of `check-generated-website-data.mjs`: every node of a shared tree occurs
in the fence its block shows a reader — same element, same attributes, same
values, in the same order — with the fence free to carry more. Containment, not
equality.

It closes what arm 11 structurally cannot see. Arm 11 compares the two authored
TREES to each other, and they can agree while both describe a UI the block
stopped showing. The ledger records that drift having happened once already.

The match is greedy on the element name in document order, and a matched element
must then agree on every authored value. Searching on for a later instance that
fits would turn a drifted value into a silent re-anchor.

Two transforms and no third: `hostTagOf` and `attributeOf`, both exported from
the corpus module and IMPORTED by `adwaita-web`'s driver and by arm 13, so the
check cannot end up agreeing with its own copy of a rule instead of with the
renderer it makes a claim about. Entity decoding is markup's escaping, not a
vocabulary mapping, and an unknown entity FAILS rather than passing through.
Neither gallery generator's refusal of an alias table is weakened.

`markupElements` keeps the attribute values it was already parsing and
discarding, so the one quote-aware fence reader stays one.

## What review changed

- A false boolean is an ABSENT attribute, which the branch's own comment claimed
  and the code did not do: the presence test ran first, so a fence that correctly
  omitted `active` failed against a node authoring `active: false`, and a fence
  that spelled it while the node said false — a real disagreement — passed in
  silence. Both directions now hold, each with a control.
- Arm 13 refused to be vacuous on the node axis and was vacuous on the one that
  carries the claim: neutering the property loop leaves every node matched, the
  note printing the same figure, and the arm green having compared nothing. The
  compared values are counted, printed and asserted non-zero.
- `attributeOf` was spelled twice — once in the driver, once in the arm. It moves
  to the corpus module beside `hostTagOf`; `tsc` holds the declaration.
- Amendment 2's count was three-and-four; re-measured it is five-and-two, and the
  gloss line that made `Adw.SwitchRow`/`Adw.EntryRow` look blocked is a region
  another generator strips and re-inserts on every run.

## Verification

`check-generated-website-data`, `check-adr-index`, `check-adwaita-conformance-drivers`,
`check-agent-context-size --check`, `check-vocabulary-alignment`, `audit-runtimes
--check` — all exit 0, and the worktree is byte-identical before and after.
`oxlint` and `oxfmt --check` clean on every touched file. `commitlint --from
origin/main --to HEAD` exit 0.

Ten negative controls, both directions, in a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtCcG3LLsz9voXAG9DVjhD
