### PR TITLE
fix: the Debian changelog at gzip -9, and a zlib that honours the level

### DIFF
--- a/.github/ship-oracle/verify-deb.sh
+++ b/.github/ship-oracle/verify-deb.sh
@@ -214,6 +214,15 @@ TAG_LIST=$(lintian-explain-tags --list-tags 2>/dev/null || lintian --list-tags 2
 #   no-copyright-file                Policy § 12.5 — the licence overlay
 #   no-changelog                     Policy § 4.4 — the changelog overlay
 #   changelog-file-not-compressed    it ships gzipped, or not at all
+#   changelog-not-compressed-with-max-compression
+#                                    Policy § 4.4 asks for `gzip -9 -n`, and this
+#                                    tag is read off the gzip header's XFL byte
+#                                    alone. GATED rather than merely fixed because
+#                                    the level travels four hops to get here —
+#                                    `plan.ts` → `gzipDeterministic` →
+#                                    `@gjsify/tar` → `node:zlib` — and every one of
+#                                    them has a default-level path it can fall back
+#                                    to without failing.
 #   syntax-error-in-debian-changelog the header/trailer this writer renders
 #   no-md5sums-control-file          the control member's md5sums
 #   md5sum-mismatch                  a digest in it (NOT `md5sums-mismatch`:
@@ -227,6 +236,7 @@ TAG_LIST=$(lintian-explain-tags --list-tags 2>/dev/null || lintian --list-tags 2
 #   malformed-deb-archive            the ar container and its member order
 #   control-file-has-bad-permissions the control member's modes
 for tag in no-copyright-file no-changelog changelog-file-not-compressed \
+    changelog-not-compressed-with-max-compression \
     syntax-error-in-debian-changelog no-md5sums-control-file md5sum-mismatch \
     file-missing-in-md5sums md5sums-lists-nonexistent-file malformed-md5sums-control-file \
     wrong-file-owner-uid-or-gid control-file-has-bad-owner malformed-deb-archive \

--- a/packages/infra/cli/src/utils/ship/changelog.ts
+++ b/packages/infra/cli/src/utils/ship/changelog.ts
@@ -144,20 +144,21 @@ const WIDTH = 80;
  * wrong: exactly one leading space, then `--`, one space, the maintainer, and TWO
  * spaces before the date.
  *
- * TWO lintian tags this file still raises, both measured on lintian 2.117 against
- * gjsify's own `.deb` and both left alone deliberately:
+ * ONE lintian tag this file still raises, measured on lintian 2.117 against
+ * gjsify's own `.deb` and left alone deliberately: `initial-upload-closes-no-bugs`,
+ * because the Debian revision is `-1` and the entry closes no bug. It is a
+ * statement about the Debian ARCHIVE's ITP workflow — the first upload of a new
+ * source package should close its ITP bug — and a package built by `gjsify ship`
+ * is never uploaded there. There is no bug number that would be true to write, so
+ * the tag is inapplicable rather than unmet.
  *
- *  - `initial-upload-closes-no-bugs`, because the Debian revision is `-1` and the
- *    entry closes no bug. It is a statement about the Debian ARCHIVE's ITP
- *    workflow — the first upload of a new source package should close its ITP bug
- *    — and a package built by `gjsify ship` is never uploaded there. There is no
- *    bug number that would be true to write, so the tag is inapplicable rather
- *    than unmet.
- *  - `changelog-not-compressed-with-max-compression`. Policy asks for `gzip -9`
- *    and neither `CompressionStream` nor `@gjsify/zlib` takes a level, so
- *    `gzipDeterministic` cannot ask for one. Ledgered in `status/open-todos.md`:
- *    the fix is a capability in the core, and stamping the header's XFL byte to
- *    claim max compression we did not use is not one.
+ * `changelog-not-compressed-with-max-compression` was a second one, and closing it
+ * was a capability gap in the CORE rather than anything wrong in this file:
+ * neither `CompressionStream` nor `@gjsify/zlib` would take a compression level,
+ * so `gzipDeterministic` had none to pass on. `@gjsify/zlib` honours
+ * `options.level` now and `plan.ts` compresses this file at
+ * `POLICY_MAX_COMPRESSION`. `verify-deb.sh` gates the tag by name, so it cannot
+ * come back quietly.
  */
 export function renderDebianChangelog(settings: PackSettings, source: string | undefined, mtime: number): string {
     const entries = source === undefined ? [] : changelogEntriesFor(settings.version, source);

--- a/packages/infra/cli/src/utils/ship/gzip.ts
+++ b/packages/infra/cli/src/utils/ship/gzip.ts
@@ -5,12 +5,56 @@
 // input produce different bytes — which no test notices, because every test
 // compares the DECOMPRESSED content. It is the single most-missed
 // reproducibility bug in package writers, and it costs nothing to close.
+//
+// WHAT "DETERMINISTIC" DOES NOT COVER, measured 2026-09-11 and named here because
+// the function's own name overstates it: the bytes are reproducible for a given
+// HOST, not for a given artifact. `@gjsify/tar`'s gzip runs on the platform's
+// zlib, and the platforms do not ship the same one — Fedora's libz is
+// `zlib-ng-compat` (2.3.3) while Node bundles its own zlib (1.3.2.1-motley). Over
+// this repo's `CHANGELOG.md` (876 192 bytes) at the DEFAULT level they produce
+// 272 003 and 272 000 bytes respectively, so a `.deb` packed under GJS and one
+// packed under Node already differ, today, before any level argument exists.
+// Levels 1-4 differ too, in the other direction (zlib-ng is smaller). Two
+// consequences worth keeping:
+//
+//   * `tests/e2e/ship-from-stage` asserts byte-equality between a direct pack and
+//     a `--from-stage` pack, and it holds because both run on ONE host. It is
+//     structurally blind to this, and a cross-host pack is exactly what
+//     `--from-stage` exists to enable.
+//   * zlib-ng's level 9 is WORSE than its level 8 on large inputs — 277 974 vs
+//     270 255 bytes on the file above, ~2.9 % bigger — which is why `level: 9` is
+//     asked for only where a reader demands it (see below) and not blanket-applied
+//     to the payload tarballs.
+//
+// Ledgered in `status/open-todos.md`; closing it means pinning ONE deflate
+// implementation, which is a larger decision than this file.
 
 import { gzip } from '@gjsify/tar';
 
-/** gzip with the header's timestamp zeroed and the OS byte pinned to Unix. */
-export async function gzipDeterministic(input: Uint8Array): Promise<Uint8Array> {
-    const out = await gzip(input);
+/**
+ * gzip with the header's timestamp zeroed and the OS byte pinned to Unix.
+ *
+ * @param level 0-9, or omitted for zlib's default. THE ONLY HONEST WAY TO SET XFL:
+ *   byte 8 of the header records how hard the compressor tried (2 = maximum,
+ *   4 = fastest, 0 = neither), `lintian` reads it to raise
+ *   `changelog-not-compressed-with-max-compression`, and `file` prints it as
+ *   "max compression". Stamping that byte here beside the mtime and OS bytes would
+ *   be a different thing entirely and was rejected for it: mtime and OS are facts
+ *   about the build ENVIRONMENT, which a reproducible build is entitled to
+ *   normalise, while XFL is a statement about the compression actually performed.
+ *   Writing a 2 we had not earned would make the artifact lie to the tool reading
+ *   it. So the level travels down to the compressor instead.
+ *
+ *   AND THE TEMPTATION IS REAL, which is why this is worth writing down: measured
+ *   on gjsify's own `.deb`, the changelog member compressed at the default level
+ *   and at 9 differs in EXACTLY ONE BYTE — position 9, XFL, 0 against 2 — and is
+ *   1152 bytes either way. For this input, stamping the byte would have produced
+ *   the identical artifact. It is identical by coincidence of a small input: over
+ *   this repo's full `CHANGELOG.md` the same two levels differ by thousands of
+ *   bytes. A rule that happens to hold on today's input is not the rule.
+ */
+export async function gzipDeterministic(input: Uint8Array, level?: number): Promise<Uint8Array> {
+    const out = await gzip(input, level === undefined ? undefined : { level });
     if (out.byteLength < 10 || out[0] !== 0x1f || out[1] !== 0x8b) {
         throw new Error('gjsify ship: internal error — gzip did not produce a gzip stream.');
     }
@@ -21,3 +65,12 @@ export async function gzipDeterministic(input: Uint8Array): Promise<Uint8Array> 
     out[9] = 3;
     return out;
 }
+
+/**
+ * `gzip -9`, the level Debian Policy § 4.4 asks of a packaging changelog.
+ *
+ * Named rather than spelled `9` at the call site so the reason travels with the
+ * number: the `-n` half of Policy's `gzip -9 -n` is what {@link gzipDeterministic}
+ * already does to bytes 4-7.
+ */
+export const POLICY_MAX_COMPRESSION = 9;

--- a/packages/infra/cli/src/utils/ship/plan.spec.ts
+++ b/packages/infra/cli/src/utils/ship/plan.spec.ts
@@ -267,6 +267,11 @@ export default async () => {
             // have to produce the same bytes (utils/ship/gzip.ts).
             expect([data[0], data[1]]).toStrictEqual([0x1f, 0x8b]);
             expect([data[4], data[5], data[6], data[7]]).toStrictEqual([0, 0, 0, 0]);
+            // XFL = 2, the byte Policy § 4.4's `gzip -9` is READ from: lintian raises
+            // `changelog-not-compressed-with-max-compression` off this one alone, and
+            // `file` prints it as "max compression". It is set by the compressor and
+            // NOT stamped here — `utils/ship/gzip.ts` has the measurement behind that.
+            expect(data[8]).toBe(2);
             expect(new TextDecoder().decode(await gunzip(data))).toBe(
                 'hello (1.0.0-1) unstable; urgency=medium\n' +
                     '\n' +

--- a/packages/infra/cli/src/utils/ship/plan.ts
+++ b/packages/infra/cli/src/utils/ship/plan.ts
@@ -4,7 +4,7 @@
 // its own inputs can only be tested by building a real project.
 
 import { renderDebianChangelog } from './changelog.js';
-import { gzipDeterministic } from './gzip.js';
+import { gzipDeterministic, POLICY_MAX_COMPRESSION } from './gzip.js';
 import { renderMimePackage } from './mime.js';
 import { SHARE } from './share-dirs.js';
 import { basename, extname, posix } from 'node:path';
@@ -218,12 +218,19 @@ export async function planOverlay(
     // gzip performed on the packing host would put a second compressor's output in
     // an artifact whose every other byte came from the first. `gzipDeterministic`
     // zeroes the header stamp for the usual reason (utils/ship/gzip.ts).
+    //
+    // It is also the one gzip member in the artifact whose bytes cannot vary with
+    // the packing host, for the same reason: the two hosts' zlibs disagree (that
+    // file's header measurement), and this member is compressed once, here.
     if (format.changelogDest !== undefined) {
         const changelog = renderDebianChangelog(settings, inputs.changelogText, inputs.mtime);
         files.push({
             path: format.changelogDest(settings.binaryName),
             mode: 0o644,
-            source: { kind: 'bytes', data: await gzipDeterministic(new TextEncoder().encode(changelog)) },
+            source: {
+                kind: 'bytes',
+                data: await gzipDeterministic(new TextEncoder().encode(changelog), POLICY_MAX_COMPRESSION),
+            },
         });
     }
     return files;

--- a/packages/infra/tar/src/extract.ts
+++ b/packages/infra/tar/src/extract.ts
@@ -115,8 +115,40 @@ export async function gunzip(input: Uint8Array): Promise<Uint8Array> {
     return drainStream(stream);
 }
 
-/** Compress a buffer to gzip using Web CompressionStream (cross-platform). */
-export async function gzip(input: Uint8Array): Promise<Uint8Array> {
+export interface GzipOptions {
+    /**
+     * 0 (store) to 9 (most compression); omit for zlib's own default.
+     *
+     * Only `node:zlib` can accept one, so asking for a level takes the `node:zlib`
+     * route below rather than `CompressionStream`.
+     */
+    level?: number;
+}
+
+/**
+ * Compress a buffer to gzip.
+ *
+ * TWO BACKENDS, AND THE LEVEL IS WHAT CHOOSES. `CompressionStream` is the default
+ * and takes a format and nothing else — the Compression Streams spec has no level
+ * — so a caller that needs a specific one is routed to `node:zlib`, which resolves
+ * to Node's zlib on node and to `@gjsify/zlib`'s `Gio.ZlibCompressor` on GJS.
+ * Imported lazily, so a consumer that never asks for a level never pulls zlib into
+ * its bundle.
+ *
+ * WHY A CALLER WOULD CARE, given that the decompressed bytes are identical either
+ * way: the level is recorded in the gzip header's XFL byte, and that byte is a
+ * claim independent readers act on. Debian Policy § 4.4 asks for `gzip -9 -n`, and
+ * `lintian` raises `changelog-not-compressed-with-max-compression` off XFL alone.
+ *
+ * THE TWO BACKENDS DO NOT AGREE BYTE-FOR-BYTE at the same level, so this is not a
+ * choice between interchangeable implementations — the measurement and what it
+ * costs a reproducible artifact are in the CLI's `utils/ship/gzip.ts`.
+ */
+export async function gzip(input: Uint8Array, options?: GzipOptions): Promise<Uint8Array> {
+    if (options?.level !== undefined) {
+        const { gzipSync } = await import('node:zlib');
+        return new Uint8Array(gzipSync(input, { level: options.level }));
+    }
     const Comp = (globalThis as { CompressionStream?: typeof CompressionStream }).CompressionStream;
     if (typeof Comp !== 'function') {
         throw new Error(

--- a/packages/infra/tar/src/index.spec.ts
+++ b/packages/infra/tar/src/index.spec.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 
-import { parseTar, extractTarball, gunzip, BLOCK_SIZE, type TarEntry } from './index.js';
+import { parseTar, extractTarball, gunzip, gzip, BLOCK_SIZE, type TarEntry } from './index.js';
 
 interface BuildTarEntry {
     name: string;
@@ -239,6 +239,33 @@ export default async () => {
             } finally {
                 fs.rmSync(dest, { recursive: true, force: true });
             }
+        });
+    });
+
+    // BOTH LEGS, because the level is the one argument that changes which backend
+    // runs: without it `gzip()` uses `CompressionStream`, with it `node:zlib` —
+    // Node's own zlib on the Node leg, `@gjsify/zlib`'s `Gio.ZlibCompressor` on the
+    // GJS one. A Node-only test would leave the GJS route unexercised, and the GJS
+    // route is the one `gjsify ship` takes when the CLI runs under `gjs`.
+    //
+    // The assertion is XFL (byte 8), not the output size: the two backends' zlibs
+    // disagree about what level 9 produces, so a size assertion would encode one
+    // host's zlib. XFL is the byte `lintian` and `file` read.
+    await describe('@gjsify/tar — gzip compression level', async () => {
+        const LONG = new TextEncoder().encode('pack me tightly, please. '.repeat(64));
+
+        await it('records level 9 in the header', async () => {
+            expect((await gzip(LONG, { level: 9 }))[8]).toBe(2);
+        });
+
+        await it('leaves the header neutral with no level', async () => {
+            expect((await gzip(LONG))[8]).toBe(0);
+        });
+
+        await it('round-trips through gunzip either way', async () => {
+            expect(new TextDecoder().decode(await gunzip(await gzip(LONG, { level: 9 })))).toBe(
+                new TextDecoder().decode(LONG),
+            );
         });
     });
 

--- a/packages/infra/tar/src/index.ts
+++ b/packages/infra/tar/src/index.ts
@@ -1,3 +1,3 @@
 export { BLOCK_SIZE, parseTar, TarParseError, type TarEntry, type TarEntryType } from './parser.js';
-export { extractTarball, gunzip, gzip, type ExtractOptions, type ExtractResult } from './extract.js';
+export { extractTarball, gunzip, gzip, type ExtractOptions, type ExtractResult, type GzipOptions } from './extract.js';
 export { createTarball, type TarWriteEntry, type TarFileEntry, type TarDirEntry } from './create.js';

--- a/packages/node/zlib/src/gio-codec.ts
+++ b/packages/node/zlib/src/gio-codec.ts
@@ -77,9 +77,50 @@ function concat(chunks: Uint8Array[]): Uint8Array {
     return out;
 }
 
-/** One-shot compression via `Gio.ZlibCompressor`. */
-export function compressWithGio(data: Uint8Array, format: GioFormat): Uint8Array {
-    const compressor = new Gio.ZlibCompressor({ format: getGioFormat(format) });
+/** `Gio.ZlibCompressor:level`'s own "pick the zlib default" value. */
+export const DEFAULT_LEVEL = -1;
+
+/**
+ * Reject a level `Gio.ZlibCompressor` would take differently than zlib does.
+ *
+ * MEASURED on gjs 1.86 / GLib 2.86, because the guess was wrong in the direction
+ * that matters. An out-of-range construct value is not clamped to the paramspec's
+ * bounds — GObject DISCARDS it, logs `GLib-GObject-CRITICAL: value "42" … is
+ * invalid or out of range for property 'level'`, and leaves the property at 0.
+ * Level 0 is zlib's STORE mode, so `level: 42` asks for maximum compression and
+ * gets a stream that is compressed not at all, while a CRITICAL is a log line and
+ * not an exception — the process carries on at exit 0. Node throws
+ * `ERR_OUT_OF_RANGE` here, and throwing is the only answer that cannot be missed.
+ *
+ * RANGE ONLY, and not `Number.isInteger`, because the reference implementation is
+ * the reference: measured on Node 24, `gzipSync(data, {level: 2.5})` is ACCEPTED
+ * (C casts it) while 42 and -7 throw. A first version of this guard rejected 2.5
+ * as well and the Node leg of the spec failed it — which is what that leg is for
+ * (tests/AGENTS.md rule 3: the Node run proves the TEST, the GJS run proves our
+ * implementation). The truncation that keeps GI happy is {@link compressWithGio}'s.
+ *
+ * Written as `!(level >= -1 && level <= 9)` rather than `level < -1 || level > 9`
+ * so `NaN` — which compares false against everything — is refused rather than
+ * passed through to a `gint` marshaller.
+ */
+export function assertLevel(level: number): void {
+    if (!(level >= DEFAULT_LEVEL && level <= 9)) {
+        throw new RangeError(`The value of "level" is out of range. It must be >= -1 and <= 9. Received ${level}`);
+    }
+}
+
+/**
+ * One-shot compression via `Gio.ZlibCompressor`.
+ *
+ * @param level 0 (store) to 9 (most), or {@link DEFAULT_LEVEL} for zlib's own choice.
+ *   The level is not cosmetic: it is the only way to set the gzip header's XFL byte,
+ *   which is how `lintian` and `file` read back a claim of maximum compression.
+ *   TRUNCATED before it reaches the `gint` property, which is what Node's C cast
+ *   does with the fractional level it also accepts.
+ */
+export function compressWithGio(data: Uint8Array, format: GioFormat, level: number = DEFAULT_LEVEL): Uint8Array {
+    assertLevel(level);
+    const compressor = new Gio.ZlibCompressor({ format: getGioFormat(format), level: Math.trunc(level) });
     const converter = new Gio.ConverterOutputStream({
         base_stream: Gio.MemoryOutputStream.new_resizable(),
         converter: compressor,

--- a/packages/node/zlib/src/gio-codec.ts
+++ b/packages/node/zlib/src/gio-codec.ts
@@ -98,10 +98,21 @@ export const DEFAULT_LEVEL = -1;
  * as well and the Node leg of the spec failed it — which is what that leg is for
  * (tests/AGENTS.md rule 3: the Node run proves the TEST, the GJS run proves our
  * implementation). The truncation that keeps GI happy is {@link compressWithGio}'s.
+ * Node's boundary is the RAW float against the bound, not its integer part, so the
+ * asymmetry is real and this expression reproduces it: 2.5 passes, 9.9 throws.
  *
  * Written as `!(level >= -1 && level <= 9)` rather than `level < -1 || level > 9`
  * so `NaN` — which compares false against everything — is refused rather than
- * passed through to a `gint` marshaller.
+ * passed through to a `gint` marshaller, where `Math.trunc(NaN)` would earn the
+ * same CRITICAL as 42 above and the same silent STORE. THIS IS THE ONE PLACE THE
+ * GUARD IS DELIBERATELY STRICTER THAN NODE, and the number is written down so the
+ * next reader does not "restore parity" into that bug: measured on Node 24,
+ * `{level: NaN}` is ACCEPTED and yields default-level output (35 bytes, XFL 0, byte
+ * for byte what an omitted level produces) because `NaN < -1` and `NaN > 9` are
+ * both false. Matching that would mean mapping NaN to {@link DEFAULT_LEVEL}, which
+ * is a fine change to make deliberately and a bad one to make by deleting a `!`.
+ * The divergence reaches no Node consumer: `gjsify.runtimes.node` is `none`, so on
+ * the node target `node:zlib` is Node's own.
  */
 export function assertLevel(level: number): void {
     if (!(level >= DEFAULT_LEVEL && level <= 9)) {

--- a/packages/node/zlib/src/index.spec.ts
+++ b/packages/node/zlib/src/index.spec.ts
@@ -289,6 +289,77 @@ export default async () => {
         });
     });
 
+    // THE ASSERTION IS THE HEADER BYTE, not the output size, and that is the point.
+    // A level that is silently dropped still round-trips and still shrinks the
+    // input, so every other test in this file passed against an implementation
+    // whose options parameter was literally named `_options` and ignored. XFL (byte
+    // 8 of the gzip header) is the one place the requested level is observable from
+    // outside: 2 for "maximum compression", 4 for "fastest", 0 otherwise. It is
+    // also the byte `lintian` and `file` read, so this is the same claim a Debian
+    // package is judged on.
+    //
+    // Sizes are deliberately NOT asserted: the two backends' zlibs disagree about
+    // what level 9 produces (Fedora's zlib-ng is measurably worse than its own
+    // level 8 on large inputs), so asserting bytes-out would encode one host's zlib.
+    await describe('zlib: compression level', async () => {
+        const LONG = 'the quick brown fox jumps over the lazy dog. '.repeat(40);
+
+        await it('should record level 9 in the gzip header XFL byte', async () => {
+            expect(gzipSync(LONG, { level: 9 })[8]).toBe(2);
+        });
+
+        await it('should record level 1 in the gzip header XFL byte', async () => {
+            expect(gzipSync(LONG, { level: 1 })[8]).toBe(4);
+        });
+
+        await it('should leave XFL neutral when no level is asked for', async () => {
+            expect(gzipSync(LONG)[8]).toBe(0);
+        });
+
+        await it('should still round-trip with a level', async () => {
+            expect(new TextDecoder().decode(gunzipSync(gzipSync(LONG, { level: 9 })))).toBe(LONG);
+        });
+
+        await it('should store rather than compress at level 0', async () => {
+            // The discriminator for "the level reached the compressor at all": every
+            // other level shrinks this input, and only 0 must not.
+            expect(gzipSync(LONG, { level: 0 }).length > LONG.length).toBe(true);
+        });
+
+        await it('should honour the level on the async form too', async () => {
+            const out = await new Promise<Uint8Array>((resolve, reject) => {
+                gzip(LONG, { level: 9 }, (err, result) => (err ? reject(err) : resolve(result)));
+            });
+            expect(out[8]).toBe(2);
+        });
+
+        await it('should honour the level for deflate', async () => {
+            // A zlib header has no XFL, so the observable is the FLEVEL bits of byte
+            // 1 (>> 6): 0 = fastest, 3 = maximum.
+            expect(deflateSync(LONG, { level: 9 })[1]! >> 6).toBe(3);
+            expect(deflateSync(LONG, { level: 1 })[1]! >> 6).toBe(0);
+        });
+
+        // An out-of-range level must THROW rather than be quietly substituted.
+        // GObject discards a bad construct value with a non-fatal CRITICAL and
+        // leaves `level` at 0, so without this guard `level: 42` asks for maximum
+        // compression, returns a STORED stream larger than its input, and exits 0.
+        // RANGE only, matching Node exactly: measured on Node 24, `{level: 2.5}` is
+        // ACCEPTED (C casts it) while 42 and -7 throw. This list held 2.5 at first
+        // and the Node leg failed it, which is that leg's whole job.
+        await it('should refuse a level zlib has no name for', async () => {
+            for (const bad of [42, -7]) {
+                let threw = false;
+                try {
+                    gzipSync(LONG, { level: bad });
+                } catch {
+                    threw = true;
+                }
+                expect(threw).toBe(true);
+            }
+        });
+    });
+
     await describe('zlib: cross-format decompression errors', async () => {
         await it('should fail to inflate gzipped data', async () => {
             const input = Buffer.from('gzip data');

--- a/packages/node/zlib/src/index.ts
+++ b/packages/node/zlib/src/index.ts
@@ -26,7 +26,14 @@ export {
 } from './transform-streams.js';
 
 import type { ZlibOptions } from 'node:zlib';
-import { compressWithGio, decompressStreamWithGio, gunzipWithGio, type GioFormat } from './gio-codec.js';
+import {
+    assertLevel,
+    compressWithGio,
+    decompressStreamWithGio,
+    DEFAULT_LEVEL,
+    gunzipWithGio,
+    type GioFormat,
+} from './gio-codec.js';
 
 type ZlibCallback = (error: Error | null, result: Uint8Array) => void;
 
@@ -105,11 +112,39 @@ async function decompressWithWeb(data: Uint8Array, format: CompressionFormat): P
     return runWebTransform(data, new DecompressionStream(format) as ReadableWritablePair<Uint8Array, Uint8Array>);
 }
 
-async function compress(data: Uint8Array, format: GioFormat): Promise<Uint8Array> {
-    if (hasWebCompression()) {
+/**
+ * A `level` the caller actually chose, or `undefined` for "whatever zlib picks".
+ *
+ * `undefined` and `-1` are the same REQUEST and deliberately not the same ROUTE:
+ * see {@link compress} for why only an explicit level leaves the Web fast path.
+ */
+function requestedLevel(options?: ZlibOptions): number | undefined {
+    const level = options?.level;
+    if (level === undefined || level === DEFAULT_LEVEL) return undefined;
+    assertLevel(level);
+    return level;
+}
+
+/**
+ * Async one-shot encode.
+ *
+ * AN EXPLICIT LEVEL LEAVES THE WEB PATH, because `CompressionStream` has no way to
+ * accept one: the Compression Streams spec takes a format and nothing else. Until
+ * this argument existed the option was read off `ZlibOptions` and dropped on the
+ * floor on both backends — the parameter was even spelled `_options` — so a caller
+ * asking for 9 got 6, and the gzip header's XFL byte said 6 to everything that
+ * reads it.
+ *
+ * Silently returning level-6 bytes to a caller who asked for 9 is the same class of
+ * lie as stamping XFL without doing the work, which is why the fix is to route
+ * rather than to ignore. With no level asked for, the Web path stays the default
+ * for the reason in {@link decompress}: it is the platform's own C zlib.
+ */
+async function compress(data: Uint8Array, format: GioFormat, level?: number): Promise<Uint8Array> {
+    if (level === undefined && hasWebCompression()) {
         return compressWithWeb(data, format as CompressionFormat);
     }
-    return compressWithGio(data, format);
+    return compressWithGio(data, format, level);
 }
 
 /**
@@ -171,7 +206,8 @@ export function gzip(
     callback?: ZlibCallback,
 ): void {
     const cb = typeof optionsOrCallback === 'function' ? optionsOrCallback : callback!;
-    compress(toUint8Array(data), 'gzip').then(
+    const options = typeof optionsOrCallback === 'function' ? undefined : optionsOrCallback;
+    compress(toUint8Array(data), 'gzip', requestedLevel(options)).then(
         (result) => cb(null, result),
         (err) => cb(err instanceof Error ? err : new Error(String(err)), new Uint8Array(0)),
     );
@@ -199,7 +235,8 @@ export function deflate(
     callback?: ZlibCallback,
 ): void {
     const cb = typeof optionsOrCallback === 'function' ? optionsOrCallback : callback!;
-    compress(toUint8Array(data), 'deflate').then(
+    const options = typeof optionsOrCallback === 'function' ? undefined : optionsOrCallback;
+    compress(toUint8Array(data), 'deflate', requestedLevel(options)).then(
         (result) => cb(null, result),
         (err) => cb(err instanceof Error ? err : new Error(String(err)), new Uint8Array(0)),
     );
@@ -227,7 +264,8 @@ export function deflateRaw(
     callback?: ZlibCallback,
 ): void {
     const cb = typeof optionsOrCallback === 'function' ? optionsOrCallback : callback!;
-    compress(toUint8Array(data), 'deflate-raw').then(
+    const options = typeof optionsOrCallback === 'function' ? undefined : optionsOrCallback;
+    compress(toUint8Array(data), 'deflate-raw', requestedLevel(options)).then(
         (result) => cb(null, result),
         (err) => cb(err instanceof Error ? err : new Error(String(err)), new Uint8Array(0)),
     );
@@ -247,24 +285,24 @@ export function inflateRaw(
     );
 }
 
-export function gzipSync(data: string | Uint8Array | ArrayBuffer, _options?: ZlibOptions): Uint8Array {
-    return compressWithGio(toUint8Array(data), 'gzip');
+export function gzipSync(data: string | Uint8Array | ArrayBuffer, options?: ZlibOptions): Uint8Array {
+    return compressWithGio(toUint8Array(data), 'gzip', options?.level ?? DEFAULT_LEVEL);
 }
 
 export function gunzipSync(data: string | Uint8Array | ArrayBuffer, _options?: ZlibOptions): Uint8Array {
     return decompressWithGio(toUint8Array(data), 'gzip');
 }
 
-export function deflateSync(data: string | Uint8Array | ArrayBuffer, _options?: ZlibOptions): Uint8Array {
-    return compressWithGio(toUint8Array(data), 'deflate');
+export function deflateSync(data: string | Uint8Array | ArrayBuffer, options?: ZlibOptions): Uint8Array {
+    return compressWithGio(toUint8Array(data), 'deflate', options?.level ?? DEFAULT_LEVEL);
 }
 
 export function inflateSync(data: string | Uint8Array | ArrayBuffer, _options?: ZlibOptions): Uint8Array {
     return decompressWithGio(toUint8Array(data), 'deflate');
 }
 
-export function deflateRawSync(data: string | Uint8Array | ArrayBuffer, _options?: ZlibOptions): Uint8Array {
-    return compressWithGio(toUint8Array(data), 'deflate-raw');
+export function deflateRawSync(data: string | Uint8Array | ArrayBuffer, options?: ZlibOptions): Uint8Array {
+    return compressWithGio(toUint8Array(data), 'deflate-raw', options?.level ?? DEFAULT_LEVEL);
 }
 
 export function inflateRawSync(data: string | Uint8Array | ArrayBuffer, _options?: ZlibOptions): Uint8Array {

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -3571,7 +3571,60 @@ Open, in order — each independently mergeable, each with its proof:
 
 9. **A scaffolded workflow is verified by nothing.** The only scaffolder in the tree (`flatpak ci`) is asserted by four `assert.match` regexes on raw text — never parsed as YAML, never actionlint'd (which discovers only this repo's `.github/workflows/**`), never run. ADR 0024 names this exact class for `ship`; it already exists one command over. Minimum bar for `ship ci`: emit into gjsify's own workflows directory too, and `bash -n` every extracted `run:` block.
 
-10. **The `.deb` changelog is not compressed with `gzip -9`.** `W: gjsify: changelog-not-compressed-with-max-compression [usr/share/doc/gjsify/changelog.Debian.gz]` — measured on lintian 2.117 (ubuntu-24.04) against the first `.deb` that carried a changelog at all, i.e. it arrived WITH the § 4.4 fix rather than surviving it. Debian Policy § 4.4 asks for `gzip -9 -n`, and lintian reads the claim off the gzip header's XFL byte. The gap is a missing capability in the core, not in `ship`: `utils/ship/gzip.ts` compresses through `@gjsify/tar`'s `gzip()`, which is `CompressionStream('gzip')`, and the Web API takes no level; `@gjsify/zlib`'s `gzipSync` accepts a `ZlibOptions` it names `_options` and ignores, on both its Gio (`Gio.ZlibCompressor`, which DOES take a level) and its browser path. So the fix is a level argument through `@gjsify/zlib` → `@gjsify/tar` → `gzipDeterministic`, with the two backends' levels proven to agree. What is NOT the fix, and is why this is ledgered rather than closed: stamping XFL to 2 in `gzipDeterministic` beside the mtime and OS bytes it already normalises. Those two are facts about the build ENVIRONMENT; XFL is a statement about the compression that was actually performed, and writing it would make the artifact lie to the tool that reads it.
+### Two zlibs can compress one `gjsify ship` artifact, and they disagree
+
+Found while closing the `.deb` changelog's `gzip -9` gap, which is DONE: `@gjsify/zlib`
+honours `options.level` now (it was spelled `_options` and dropped on the floor, on the sync
+and the async path alike), `@gjsify/tar`'s `gzip()` takes one and routes a levelled request
+through `node:zlib` because `CompressionStream` has no level to give, and `plan.ts`
+compresses `changelog.Debian.gz` at `POLICY_MAX_COMPRESSION`. Measured with `lintian` 2.117
+on ubuntu-24.04 against gjsify's own `.deb`, before and after: `W: gjsify:
+changelog-not-compressed-with-max-compression [usr/share/doc/gjsify/changelog.Debian.gz]`
+present, then absent, with no error-severity tag in either run. `verify-deb.sh` gates the tag
+by name, so it cannot return quietly. **The file also settles the "just stamp XFL" argument
+with a number rather than a principle:** the two members differ in EXACTLY ONE BYTE —
+position 9, XFL, 0 against 2 — and are 1152 bytes either way, so for that input stamping
+would have produced the identical artifact. It is identical by coincidence of a small input;
+over the full `CHANGELOG.md` the same two levels differ by thousands of bytes.
+
+**What is open is what the work uncovered.** `gzipDeterministic` is deterministic for a
+given HOST, not for a given artifact, and its name says otherwise. `@gjsify/tar` compresses
+on the platform's zlib, and the two platforms this CLI runs on do not ship the same one:
+Fedora's `libz.so.1` is `zlib-ng-compat` 2.3.3, Node bundles `1.3.2.1-motley`. Measured
+2026-09-11 over this repo's `CHANGELOG.md` (876 192 bytes), gio-via-GJS against Node, output
+bytes per level — 0: 876 280 / 876 340 · 1: 295 057 / 297 789 · 6: 272 003 / 272 000 ·
+8: 270 255 / 270 260 · 9: 277 974 / 270 289. They agree at NO level on that input, including
+the default, and **zlib-ng's level 9 is worse than its own level 8** (~2.9 %), which is why
+the level is asked for only where a reader demands it and is not blanket-applied to
+`data.tar.gz` / `control.tar.gz`. Consequences: a `.deb` packed under GJS and one packed
+under Node differ in the two payload tarballs — those are compressed at PACK time — while
+`changelog.Debian.gz` is immune because `plan.ts` compresses it once at ASSEMBLY time and it
+travels as base64 in the sidecar. `tests/e2e/ship-from-stage` asserts byte-equality between a
+direct pack and a `--from-stage` pack and holds only because both run on one host; it is
+structurally blind to this, and a cross-host pack is the thing `--from-stage` exists for.
+Closing it means pinning ONE deflate implementation for the packers, which is a real
+decision (a vendored deflate, or declaring the packing host part of the artifact's identity)
+and not a patch.
+
+### The `.rpm` has no `%changelog`, and the blocker is the oracle rather than the writer
+
+Checked while doing the `.deb` half, so the next session does not re-derive it. `rpm.ts`
+writes no `CHANGELOGTIME` (1080) / `CHANGELOGNAME` (1081) / `CHANGELOGTEXT` (1082), so
+`rpm -qp --changelog` on a `gjsify ship` artifact prints nothing and `rpmlint` 2.8.0 raises
+`no-changelogname-tag` ("There is no changelog"). The entry text is NOT the missing piece —
+`changelogEntriesFor()` in `utils/ship/changelog.ts` already extracts the bullets per version
+and both formats would share it. Two things actually block it. **(a) `rpmlint` appears
+nowhere in this repository** — not in `.docker/ci-fedora.Dockerfile`, not in
+`.github/ship-oracle/verify-rpm.sh` — so the tag has no gate, and adding the package plus a
+test that hard-requires it in one PR is the ordering trap `build-ci-image.yml` imposes
+(the image publishes only on a push to `main`); `msitools` went in as its own PR first for
+exactly this, and this should too. The system `rpm`'s own `-qp --changelog` is a usable
+independent reader in the meantime and is already required by that suite. **(b) the RPM
+changelog is HEADER data built at PACK time, not an overlay file compressed at assembly
+time**, so `--from-stage` needs the entries inside `.gjsify-ship-stage.json` — a schema 6 → 7
+bump, which that file's own rules say must be justified in its header and which `readStage`
+must then validate. That is the whole cost, and it is why this is ledgered instead of folded
+into the changelog PR.
 
 ### Upstream PRs in flight (NativeScript) — track until merged
 


### PR DESCRIPTION
Closes item 10 of the `gjsify ship` roadmap (ADR 0024) — the last Debian Policy
gap `lintian` still named on a `gjsify ship` artifact.

## The gap, and where it actually was

Policy § 4.4 asks for `gzip -9 -n`. `lintian` reads that claim off the gzip
header's **XFL byte** alone, and raised:

```
W: gjsify: changelog-not-compressed-with-max-compression [usr/share/doc/gjsify/changelog.Debian.gz]
```

The gap was a missing capability in the CORE, not in `ship`. `@gjsify/zlib`'s
`gzipSync`/`deflateSync`/`deflateRawSync` and their async siblings accepted a
`ZlibOptions` **named `_options` and ignored it**, so no caller could ask for a
level on either backend. Nothing noticed, because a dropped level still
round-trips and still shrinks the input — XFL is the only observable, and no
test read it.

So the fix goes home to the core: `Gio.ZlibCompressor` takes a level and now
gets one, `@gjsify/tar`'s `gzip()` grows the same option and routes a levelled
request through `node:zlib` (`CompressionStream` has no level to accept), and
`plan.ts` compresses the changelog at `POLICY_MAX_COMPRESSION`.

## Measured

`lintian` 2.117 on ubuntu-24.04, against gjsify's own `.deb`, built from this
branch with and without the level argument:

| | before | after |
|---|---|---|
| lintian | `W: changelog-not-compressed-with-max-compression` | *(gone)* |
| `file` | `gzip compressed data, from Unix` | `gzip compressed data, max compression, from Unix` |
| error-severity tags | none | none |

`verify-deb.sh` now **gates the tag by name**, so it cannot return quietly: the
level travels four hops (`plan.ts` → `gzipDeterministic` → `@gjsify/tar` →
`node:zlib`) and every one of them has a default-level path to fall back to.

## Two things worth reading the comments for

**Why not just stamp XFL.** mtime and the OS byte are facts about the build
environment, which a reproducible build may normalise; XFL is a statement about
the compression actually performed. The temptation is measurable — the two
changelog members differ in **exactly one byte**, position 9, and are 1152 bytes
either way — and `gzip.ts` records why that is a coincidence of a small input
rather than a rule.

**An out-of-range level is refused, and the guess about why was wrong.**
Measured on gjs 1.86: GObject does **not** clamp a bad construct value to the
paramspec bounds — it discards it with a non-fatal `GLib-GObject-CRITICAL` and
leaves `level` at **0**, zlib's store mode. So `level: 42` would ask for maximum
compression and return an *uncompressed* stream, larger than its input, at exit
0. The guard is range-only and not `Number.isInteger`, because Node accepts a
fractional level — the spec's Node leg failed a stricter version, which is what
that leg is for.

## Negative control

- `packages/node/zlib`: a test asserts **level 0 produces output larger than the
  input**, the one level that must not shrink it — the discriminator for "the
  level reached the compressor at all". Without it every level assertion passes
  against an implementation that ignores the argument, which is the state this
  PR fixes.
- Out-of-range levels must throw; the first version of that list included `2.5`
  and the Node leg went red, and the list now matches Node exactly.
- The before/after `.deb` above is the end-to-end control: the same tree, one
  argument removed, the warning returns.

## Ledgered, not fixed

Two findings the work turned up, both written into `status/open-todos.md`:

1. **`gzipDeterministic` is deterministic per HOST, not per artifact.** Fedora's
   `libz.so.1` is `zlib-ng-compat` 2.3.3; Node bundles `1.3.2.1-motley`. Over
   this repo's `CHANGELOG.md` they agree at **no** level, including the default
   (272 003 vs 272 000 bytes), and zlib-ng's level 9 is ~2.9 % *worse* than its
   own level 8 — which is why the level is asked for only where a reader demands
   it and is not blanket-applied to the payload tarballs. `data.tar.gz` and
   `control.tar.gz` are compressed at pack time and so differ across hosts;
   `changelog.Debian.gz` is immune, being compressed once at assembly time and
   travelling as base64 in the sidecar. `tests/e2e/ship-from-stage` is
   structurally blind to this — both its packs run on one host.
2. **The `.rpm` has the same gap** (`rpmlint` 2.8.0: `no-changelogname-tag`), and
   the blocker is the oracle, not the writer: `rpmlint` appears nowhere in this
   repository, and the RPM changelog is header data built at pack time, so
   `--from-stage` would need a sidecar schema 6 → 7 bump. Both are written down
   with the tag numbers so the next session does not re-derive them.

## Tests

`@gjsify/zlib` and `@gjsify/tar` green on **both** legs — the GJS leg is what
proves the `node:zlib` → `@gjsify/zlib` → `Gio.ZlibCompressor` route, which is
the one `gjsify ship` takes when the CLI runs under `gjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4yEeHoGMC4pvbkqxMsYfj
