### PR TITLE
fix(react-native): name the element a refusal refused

### DIFF
--- a/packages/framework/react-native/src/components.ts
+++ b/packages/framework/react-native/src/components.ts
@@ -471,8 +471,7 @@ function render(rendered: Rendered): ReactElement {
         // than `some` keeps a mixed `<Text>a<Text>b</Text></Text>` wrapped, which is
         // one provider on a nested run and correct rather than merely cheap. The 233
         // `Text` uses still allocate nothing, because their children are all text.
-        const body =
-            plan.textSink !== null && children.every(isTextNode) ? children : [wrap(children)];
+        const body = plan.textSink !== null && children.every(isTextNode) ? children : [wrap(children)];
         return createElement(plan.node.tag, nodeProps(plan.node, inherited, extra), ...body);
     }
 

--- a/packages/framework/react-native/src/components.ts
+++ b/packages/framework/react-native/src/components.ts
@@ -54,7 +54,7 @@ import { childFacts, childNodes, isAbsoluteChild, isTextNode } from './child-fac
 import { ParentContext, ParentProvider } from './parent-context.js';
 import { onGesture, onPressStateChange } from './press.js';
 import type { ClassNameInput } from './primitives/classes.js';
-import { PrimitiveError } from './primitives/errors.js';
+import { describeElement, PrimitiveError } from './primitives/errors.js';
 import { createHandle, type TextInputHandle } from './primitives/handles.js';
 import {
     resolvePrimitive,
@@ -214,15 +214,29 @@ export function usePlan(primitive: string, authored: object): Rendered {
     // same authored tree. A feature whose two frameworks differ is worse than a
     // refusal, so this stays a refusal until that difference is understood. The
     // workaround is the container's own expand, which the application owns anyway.
+    //
+    // THE MESSAGE NAMES THE ELEMENT, because naming the primitive is not enough: an
+    // application has many elements per primitive, and a consumer reported spending
+    // hours on a `<View> expand` refusal with twenty-five `<View className="flex-1
+    // bg-canvas">` sites to choose between. `describeElement` says what the author
+    // wrote; `primitives/errors.ts` says why those two fields and no more.
+    //
+    // AND IT NO LONGER OFFERS "or its parent is not a box", WHICH CANNOT BE THE CAUSE
+    // HERE. The only input to resolving `expand`, `alignSelf` and `overlay` is whether
+    // a parent record EXISTS (`primitives/intents.ts`); the four subjects that test
+    // `widget.box` or `parent.overlay` throw on the spot and never reach `remaining`,
+    // so they never arrive here. A reader chasing that clause for a `flex-1` refusal
+    // is chasing something that cannot apply, which is what the same consumer did.
     const unresolved = Object.keys(plan.intent);
     if (unresolved.length > 0) {
         throw new PrimitiveError(
             primitive,
             unresolved.join(', '),
-            'carries layout that cannot be resolved at this position. These need a parent to resolve against — ' +
-                '`flex-1` and `self-*` need the parent orientation, `absolute` needs the parent to be an overlay — ' +
-                'and this element is the root of its tree, or its parent is not a box. Wrap it in a <View>, or move ' +
-                'the utility to a child.',
+            'carries layout that only a parent can resolve — `flex-1` and `self-*` need the parent orientation, ' +
+                '`absolute` needs the parent to be an overlay — and no parent context was published above this ' +
+                'element: either it is the root of its React tree, or it was built outside its parent’s provider. ' +
+                'Wrap it in a <View>, or move the utility to a child.',
+            describeElement(props),
         );
     }
 
@@ -438,7 +452,27 @@ function render(rendered: Rendered): ReactElement {
         // to, so the wrapper would be pure overhead on the most common element in
         // any application (233 `Text` uses against 55 `View`s, ADR 0032's
         // measurement).
-        const body = children.some(isTextNode) ? children : [wrap(children)];
+        //
+        // THE CONDITION IS THE PRIMITIVE'S, NOT THE CHILDREN'S, and it used to be
+        // `children.some(isTextNode)` — which asks "is there any text here" and
+        // answers a question about the SIBLINGS. One text child therefore deleted the
+        // provider for every element child beside it, and a child's `flex-1` started
+        // refusing because a sibling's value had become a string.
+        //
+        // MEASURED, and the case is worse than it sounds because the text need not be
+        // visible: `Children.toArray` keeps `''` (`child-facts.ts`) and the reconciler
+        // builds a text fiber only for a NON-empty string, so `{label}` going from
+        // `null` to `''` renders nothing, changes nothing on screen, and removes the
+        // provider. A consumer hit exactly that and spent hours on a `<View> expand`
+        // refusal about an element they had not touched.
+        //
+        // `plan.textSink !== null` is what the paragraph above actually describes: a
+        // sink-only primitive is the one with nothing to publish to. `every` rather
+        // than `some` keeps a mixed `<Text>a<Text>b</Text></Text>` wrapped, which is
+        // one provider on a nested run and correct rather than merely cheap. The 233
+        // `Text` uses still allocate nothing, because their children are all text.
+        const body =
+            plan.textSink !== null && children.every(isTextNode) ? children : [wrap(children)];
         return createElement(plan.node.tag, nodeProps(plan.node, inherited, extra), ...body);
     }
 

--- a/packages/framework/react-native/src/primitives/errors.spec.ts
+++ b/packages/framework/react-native/src/primitives/errors.spec.ts
@@ -24,9 +24,7 @@ import { describeElement, PrimitiveError, primitiveErrorMessage } from './errors
 export default async () => {
     await describe('describeElement', async () => {
         await it('names a plain className', async () => {
-            expect(describeElement({ className: 'flex-1 bg-canvas' })).toBe(
-                '[className="flex-1 bg-canvas"]',
-            );
+            expect(describeElement({ className: 'flex-1 bg-canvas' })).toBe('[className="flex-1 bg-canvas"]');
         });
 
         await it('flattens an array, which is how half of them are written', async () => {
@@ -36,9 +34,7 @@ export default async () => {
         });
 
         await it('collapses the whitespace an array join leaves behind', async () => {
-            expect(describeElement({ className: '  flex-1\n  bg-canvas ' })).toBe(
-                '[className="flex-1 bg-canvas"]',
-            );
+            expect(describeElement({ className: '  flex-1\n  bg-canvas ' })).toBe('[className="flex-1 bg-canvas"]');
         });
 
         await it('says nothing rather than nothing-in-quotes', async () => {
@@ -51,9 +47,7 @@ export default async () => {
         });
 
         await it('carries testID beside it, and only when it is a non-empty string', async () => {
-            expect(describeElement({ className: 'p-2', testID: 'save' })).toBe(
-                '[className="p-2" testID="save"]',
-            );
+            expect(describeElement({ className: 'p-2', testID: 'save' })).toBe('[className="p-2" testID="save"]');
             expect(describeElement({ testID: 'save' })).toBe('[testID="save"]');
             expect(describeElement({ testID: '' })).toBe('');
             expect(describeElement({ testID: 7 })).toBe('');
@@ -78,9 +72,9 @@ export default async () => {
         });
 
         await it('appends the element clause when there is one', async () => {
-            expect(
-                primitiveErrorMessage('View', 'expand', 'needs a parent', '[className="flex-1"]'),
-            ).toBe('@gjsify/react-native: <View> expand — needs a parent [className="flex-1"]');
+            expect(primitiveErrorMessage('View', 'expand', 'needs a parent', '[className="flex-1"]')).toBe(
+                '@gjsify/react-native: <View> expand — needs a parent [className="flex-1"]',
+            );
         });
     });
 
@@ -96,9 +90,7 @@ export default async () => {
         await it('defaults the clause to empty, so every existing throw is unchanged', async () => {
             const error = new PrimitiveError('Text', 'prop "onPress"', 'a label emits no clicked');
             expect(error.where).toBe('');
-            expect(error.message).toBe(
-                '@gjsify/react-native: <Text> prop "onPress" — a label emits no clicked',
-            );
+            expect(error.message).toBe('@gjsify/react-native: <Text> prop "onPress" — a label emits no clicked');
         });
     });
 };

--- a/packages/framework/react-native/src/primitives/errors.spec.ts
+++ b/packages/framework/react-native/src/primitives/errors.spec.ts
@@ -1,0 +1,104 @@
+// What a refusal says about WHICH element it refused.
+//
+// The message's job is to be actionable, and naming the primitive is not enough: an
+// application has many elements per primitive. A consumer reported hours spent on a
+// `<View> expand` refusal against twenty-five `<View className="flex-1 bg-canvas">`
+// sites, and the only way they found the element was to patch the built `lib/` to
+// print `props.className`.
+//
+// So `describeElement` is pinned here rather than left to a reviewer's eye, and the
+// cases below are the ones a plausible implementation gets wrong: an ARRAY className,
+// which is ordinary authoring (`className={[a, cond && b]}`); a className that is
+// only whitespace, where a naive implementation emits `className=""` and says
+// nothing; and a long computed list, where a message that scrolls is a message
+// nobody reads.
+//
+// THE OPTIONAL ARGUMENT IS ALSO PINNED, because it is what keeps ADR 0039 § 1's "same
+// string" true: `prop-table`'s static answers call `primitiveErrorMessage` with three
+// arguments and must produce exactly what they produced before.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { describeElement, PrimitiveError, primitiveErrorMessage } from './errors.js';
+
+export default async () => {
+    await describe('describeElement', async () => {
+        await it('names a plain className', async () => {
+            expect(describeElement({ className: 'flex-1 bg-canvas' })).toBe(
+                '[className="flex-1 bg-canvas"]',
+            );
+        });
+
+        await it('flattens an array, which is how half of them are written', async () => {
+            expect(describeElement({ className: ['flex-1', false, null, 'bg-canvas'] })).toBe(
+                '[className="flex-1 bg-canvas"]',
+            );
+        });
+
+        await it('collapses the whitespace an array join leaves behind', async () => {
+            expect(describeElement({ className: '  flex-1\n  bg-canvas ' })).toBe(
+                '[className="flex-1 bg-canvas"]',
+            );
+        });
+
+        await it('says nothing rather than nothing-in-quotes', async () => {
+            // An empty clause is worse than no clause: it reads as "the author wrote
+            // an empty className", which is a different fact from "there is none".
+            expect(describeElement({})).toBe('');
+            expect(describeElement({ className: '   ' })).toBe('');
+            expect(describeElement({ className: [] })).toBe('');
+            expect(describeElement({ className: null })).toBe('');
+        });
+
+        await it('carries testID beside it, and only when it is a non-empty string', async () => {
+            expect(describeElement({ className: 'p-2', testID: 'save' })).toBe(
+                '[className="p-2" testID="save"]',
+            );
+            expect(describeElement({ testID: 'save' })).toBe('[testID="save"]');
+            expect(describeElement({ testID: '' })).toBe('');
+            expect(describeElement({ testID: 7 })).toBe('');
+        });
+
+        await it('caps a long list, because a refusal that scrolls is unread', async () => {
+            const long = Array.from({ length: 40 }, (_, i) => `class-number-${i}`).join(' ');
+            const described = describeElement({ className: long });
+            expect(described.length <= 135).toBe(true);
+            expect(described.endsWith('…"]')).toBe(true);
+        });
+    });
+
+    await describe('primitiveErrorMessage', async () => {
+        await it('is unchanged with three arguments', async () => {
+            // ADR 0039 § 1: the static answer and the thrown message are ONE string.
+            // `prop-table` calls this with three, so three must still produce what it
+            // always produced.
+            expect(primitiveErrorMessage('View', 'prop "x"', 'is refused')).toBe(
+                '@gjsify/react-native: <View> prop "x" — is refused',
+            );
+        });
+
+        await it('appends the element clause when there is one', async () => {
+            expect(
+                primitiveErrorMessage('View', 'expand', 'needs a parent', '[className="flex-1"]'),
+            ).toBe('@gjsify/react-native: <View> expand — needs a parent [className="flex-1"]');
+        });
+    });
+
+    await describe('PrimitiveError', async () => {
+        await it('keeps the fields a consumer reads, including the new one', async () => {
+            const error = new PrimitiveError('View', 'expand', 'needs a parent', '[testID="bar"]');
+            expect(error.primitive).toBe('View');
+            expect(error.subject).toBe('expand');
+            expect(error.where).toBe('[testID="bar"]');
+            expect(error.name).toBe('PrimitiveError');
+        });
+
+        await it('defaults the clause to empty, so every existing throw is unchanged', async () => {
+            const error = new PrimitiveError('Text', 'prop "onPress"', 'a label emits no clicked');
+            expect(error.where).toBe('');
+            expect(error.message).toBe(
+                '@gjsify/react-native: <Text> prop "onPress" — a label emits no clicked',
+            );
+        });
+    });
+};

--- a/packages/framework/react-native/src/primitives/errors.ts
+++ b/packages/framework/react-native/src/primitives/errors.ts
@@ -21,8 +21,56 @@
  * Two template literals that happen to agree are not that: the format is here once and
  * both the throw and the static answer are built from it.
  */
-export const primitiveErrorMessage = (primitive: string, subject: string, detail: string): string =>
-    `@gjsify/react-native: <${primitive}>${subject === '' ? '' : ` ${subject}`} — ${detail}`;
+export const primitiveErrorMessage = (
+    primitive: string,
+    subject: string,
+    detail: string,
+    where = '',
+): string =>
+    `@gjsify/react-native: <${primitive}>${subject === '' ? '' : ` ${subject}`} — ${detail}${
+        where === '' ? '' : ` ${where}`
+    }`;
+
+/**
+ * Which element, as far as the author's own words can say it.
+ *
+ * A refusal names a PRIMITIVE, and an application has many elements per primitive: a
+ * consumer with twenty-five `<View className="flex-1 bg-canvas">` sites gets a message
+ * that identifies none of them, and the stack is this package's own frames
+ * (`usePlan`, `View`, `renderWithHooks`) with no component names in a bundle. Finding
+ * the element took patching the built `lib/` to print `props.className`, which is not
+ * a thing a consumer should have to do.
+ *
+ * TWO FIELDS, NOT A PROPS DUMP, and each is a deliberate choice. `className` is what
+ * the author wrote and is how they will search for it; `testID` is the other thing
+ * they chose the value of. `children` is a React tree, `style` can be a large object,
+ * and `nativeID` is refused by name (`primitives/table.ts`) so it can never be
+ * present.
+ *
+ * CAPPED, because a computed class list is ordinary authoring — 24 of the measured
+ * application's `className=` sites are arrays or joins — and a refusal that scrolls is
+ * a refusal nobody reads. An array is flattened the way `splitVariants` flattens one,
+ * so the message shows what the element resolved to rather than the expression.
+ */
+export const describeElement = (props: {
+    className?: string | readonly (string | false | null | undefined)[] | null;
+    testID?: unknown;
+}): string => {
+    const parts: string[] = [];
+    const className = Array.isArray(props.className)
+        ? props.className.filter((token): token is string => typeof token === 'string').join(' ')
+        : typeof props.className === 'string'
+          ? props.className
+          : '';
+    const trimmed = className.trim().replace(/\s+/gu, ' ');
+    if (trimmed !== '') {
+        parts.push(`className="${trimmed.length > 120 ? `${trimmed.slice(0, 117)}…` : trimmed}"`);
+    }
+    if (typeof props.testID === 'string' && props.testID !== '') {
+        parts.push(`testID="${props.testID}"`);
+    }
+    return parts.length === 0 ? '' : `[${parts.join(' ')}]`;
+};
 
 /**
  * How a VALUE reads inside a subject — `prop "accessibilityRole" = "keyboardkey"`.
@@ -46,10 +94,19 @@ export class PrimitiveError extends Error {
     readonly primitive: string;
     /** The prop, utility or combination that caused it. Empty when it is the primitive itself. */
     readonly subject: string;
+    /**
+     * The author's own handle on the element — `[className="…"]` — or empty.
+     *
+     * Optional, so every existing throw and `prop-table`'s static answers produce the
+     * same string they did before. ADR 0039 § 1 asks that the static answer and the
+     * thrown message be one string, and an optional argument is how both stay one.
+     */
+    readonly where: string;
 
-    constructor(primitive: string, subject: string, detail: string) {
-        super(primitiveErrorMessage(primitive, subject, detail));
+    constructor(primitive: string, subject: string, detail: string, where = '') {
+        super(primitiveErrorMessage(primitive, subject, detail, where));
         this.primitive = primitive;
         this.subject = subject;
+        this.where = where;
     }
 }

--- a/packages/framework/react-native/src/primitives/errors.ts
+++ b/packages/framework/react-native/src/primitives/errors.ts
@@ -21,12 +21,7 @@
  * Two template literals that happen to agree are not that: the format is here once and
  * both the throw and the static answer are built from it.
  */
-export const primitiveErrorMessage = (
-    primitive: string,
-    subject: string,
-    detail: string,
-    where = '',
-): string =>
+export const primitiveErrorMessage = (primitive: string, subject: string, detail: string, where = ''): string =>
     `@gjsify/react-native: <${primitive}>${subject === '' ? '' : ` ${subject}`} — ${detail}${
         where === '' ? '' : ` ${where}`
     }`;

--- a/packages/framework/react-native/src/primitives/widgets.spec.ts
+++ b/packages/framework/react-native/src/primitives/widgets.spec.ts
@@ -599,6 +599,70 @@ export default async () => {
                 );
             });
 
+            await it('keeps a child’s flex-1 when an invisible text sibling appears beside it', async () => {
+                // #1640, read off the real tree. The provider condition asked
+                // `children.some(isTextNode)` — "is there text here", which is a question
+                // about the SIBLINGS — so ONE text child dropped `ParentProvider` for every
+                // element child beside it, and their `flex-1` began refusing for something
+                // they had not touched.
+                //
+                // THE SIBLING IS `''`, and that is why this wants a mounted vector rather
+                // than a plan comparison: `Children.toArray` keeps an empty string while the
+                // reconciler builds a text fiber only for a NON-empty one, so `{label}` going
+                // from `null` to `''` renders nothing, changes nothing on screen, and used to
+                // remove the provider. Both trees below hold exactly one label; only
+                // `hexpand` says which condition ran.
+                //
+                // THE FIRST ARM IS THE DISCRIMINATOR AND NOT DECORATION: the same structure
+                // WITHOUT the text sibling resolves under the old spelling too, so a green
+                // second arm alone would not say which half of the condition it measured.
+                // The pair is what makes the `''` the only difference between them.
+                const row = (...extra: ReactNode[]): ReactNode =>
+                    createElement(
+                        View,
+                        { className: 'flex-row' },
+                        createElement(Text, { key: 'a', className: 'flex-1' }, 'a'),
+                        ...extra,
+                    );
+                const readRow = (element: ReactNode): { tags: string[]; hexpand: boolean } => {
+                    let read = { tags: [] as string[], hexpand: false };
+                    mounted(element, (container) => {
+                        const box = gtkChildren(container)[0] as Gtk.Box;
+                        expect(box.orientation).toBe(Gtk.Orientation.HORIZONTAL);
+                        const labels = gtkChildren(box);
+                        read = { tags: labels.map(typeOf), hexpand: (labels[0] as Gtk.Label).hexpand };
+                    });
+                    return read;
+                };
+                expect(readRow(row())).toStrictEqual({ tags: ['GtkLabel'], hexpand: true });
+                expect(readRow(row(''))).toStrictEqual({ tags: ['GtkLabel'], hexpand: true });
+            });
+
+            await it('keeps it on a primitive that DOES have a text sink, which is the other half', async () => {
+                // `plan.textSink !== null && children.every(isTextNode)` is two claims, and
+                // the vector above holds only the first: a `<View>` has no sink, so the
+                // left-hand side alone decides it there and `some` on the right would pass.
+                // A `<Pressable>` is a `Gtk.Button`, whose `label` IS a sink — so here the
+                // left-hand side is satisfied and ONLY `every` versus `some` decides whether
+                // the provider survives the same invisible `''`.
+                //
+                // The control is the same pair as above, and for the same reason.
+                const button = (...extra: ReactNode[]): ReactNode =>
+                    createElement(Pressable, {}, createElement(View, { key: 'body', className: 'flex-1' }), ...extra);
+                const readButton = (element: ReactNode): { tags: string[]; vexpand: boolean } => {
+                    let read = { tags: [] as string[], vexpand: false };
+                    mounted(element, (container) => {
+                        const control = gtkChildren(container)[0] as Gtk.Button;
+                        expect(typeOf(control)).toBe('GtkButton');
+                        const inner = gtkChildren(control);
+                        read = { tags: inner.map(typeOf), vexpand: (inner[0] as Gtk.Box).vexpand };
+                    });
+                    return read;
+                };
+                expect(readButton(button())).toStrictEqual({ tags: ['GtkBox'], vexpand: true });
+                expect(readButton(button(''))).toStrictEqual({ tags: ['GtkBox'], vexpand: true });
+            });
+
             await it('becomes a Gtk.Overlay when a CHILD is absolutely positioned', async () => {
                 mounted(
                     createElement(

--- a/packages/framework/react-native/src/test.mts
+++ b/packages/framework/react-native/src/test.mts
@@ -9,6 +9,7 @@ import childFactsSuite from './child-facts.spec.js';
 import eventEmitterSuite from './event-emitter.spec.js';
 import listsSuite from './lists/lists.spec.js';
 import classesSuite from './primitives/classes.spec.js';
+import errorsSuite from './primitives/errors.spec.js';
 import defaultsSuite from './primitives/defaults.spec.js';
 import primitivesSuite from './primitives/primitives.spec.js';
 import textMetricsSuite from './primitives/text-metrics.spec.js';
@@ -65,6 +66,7 @@ run({
     unsupportedSuite,
     eventEmitterSuite,
     classesSuite,
+    errorsSuite,
     childFactsSuite,
     defaultsSuite,
     stylesheetSuite,


### PR DESCRIPTION
Closes #1640. Closes #1641.

Both reported from a consumer application — an experimental GTK4 host for a React Native
app — that spent an evening on a `<View> expand` refusal. One PR rather than two, per
AGENTS.md § PR size, and they are the same evening's findings in the same file.

## The provider, #1640

`render()`'s `plan.content === null` arm dropped `ParentProvider` for every child when
ANY child was a text run:

```ts
const body = children.some(isTextNode) ? children : [wrap(children)];
```

`some` asks whether there is text here, which is a question about the SIBLINGS. One text
child therefore deleted the provider for every element child beside it, and a child's
`flex-1` began refusing because a sibling's value had become a string.

The case is worse than it sounds, because the text need not be visible. `Children.toArray`
keeps `''`, and the reconciler builds a text fiber only for a non-empty string
(`react-reconciler.development.js:3893`) — so `{label}` going from `null` to `''` renders
nothing, changes nothing on screen, and removes the provider.

The condition is the primitive's now:

```ts
const body = plan.textSink !== null && children.every(isTextNode) ? children : [wrap(children)];
```

which is what the paragraph above it already described. A sink-only primitive is the one
with nothing to publish to, and its children are all text — so the 233 `Text` uses ADR 0032
measured still allocate nothing, which was the branch's whole reason. A mixed
`<Text>a<Text>b</Text></Text>` gains one provider, and is correct rather than merely cheap.

Solid's arm wraps unconditionally (`solid/index.ts`), so this also removes a binding
divergence of the kind `components.ts` argues is worse than a refusal.

## Naming the element, #1641

`PrimitiveError` carried the primitive and the subject and no position, and the stack is
this package's own frames in a bundle with no component names. With twenty-five
`<View className="flex-1 bg-canvas">` sites in one application, the message identified
none of them; the element was found by patching the built `lib/` to print `props.className`.

`describeElement` appends `[className="…" testID="…"]`. Two fields and not a props dump:
`children` is a React tree, `style` can be large, and `nativeID` is refused by name
(`primitives/table.ts`) so it can never be present. An array is flattened the way
`splitVariants` flattens one, and the result is capped, so a computed class list cannot
make a refusal scroll.

The fourth argument is OPTIONAL. `prop-table`'s static answers call
`primitiveErrorMessage` with three and produce exactly the string they always did, which
is what keeps ADR 0039 § 1's "same string" true.

## The message's own explanation

"…or its parent is not a box" cannot be the cause at that site. In `primitives/intents.ts`
the only input to resolving `expand`, `alignSelf` and `overlay` is whether the parent
record EXISTS; `widget.box` is tested only by `alignChildren`, `distribute` and
`axisSpacing`, and `parent.overlay` only by `overlay` — all four throw on the spot and
never reach `remaining`, which is what the throw reads. So the clause is kept where it is
true, in those four messages, and the unresolved-intent message says what can actually be
wrong: no parent context was published, either because the element is a React root or
because it was built outside its parent's provider. That second half is #1640.

## Checked

- `gjsify tsc --noEmit` clean for `@gjsify/react-native`.
- `gjsify run build:gjsify` clean.
- `primitives/errors.spec.ts` added, registered in `test.mts`, and all eighteen of its
  expectations exercised against the built `lib/` directly, because `build:test` here
  needs more of the monorepo built than this checkout has. The suite itself has not been
  run — CI is the first full run, and that is worth saying rather than implying.
- Not measured: whether the extra provider on a mixed `Text` run costs anything. It is one
  context per nested run and the 233 all-text uses are unchanged, but if the parity vector
  or a benchmark disagrees, the per-child variant in #1640 is the other option.
