### PR TITLE
fix(vite-plugin-gettext): a catalog lands where gettext looks

### DIFF
--- a/packages/infra/vite-plugin-gettext/README.md
+++ b/packages/infra/vite-plugin-gettext/README.md
@@ -34,6 +34,44 @@ Requires `gettext` tools (`msgfmt`, `xgettext`) to be installed on the system.
   fuzzy entries out of the `.mo`. A run that really does replace that many strings raises the
   option.
 
+## One catalog, three namespaces
+
+A catalog is called one thing in the repository and has to be spelled three different ways
+downstream. They disagree, so the `.po` basename is not passed through unchanged:
+
+| Target | Namespace | `zh_Hans.po` | `pt_BR.po` |
+|---|---|---|---|
+| `.mo` directory (`gettextPlugin`, `msgfmtPlugin`) | POSIX locale | `locale/zh_CN/`, `locale/zh_SG/` | `locale/pt_BR/` |
+| JSON file (`po2jsonPlugin`) | Android qualifier | `zh.json` | `pt-BR.json` |
+| the `.po` in the repo | BCP-47-ish (Weblate) | `zh_Hans` | `pt_BR` |
+
+Weblate names simplified Chinese `zh_Hans`, which is BCP-47 and **not** a POSIX locale — glibc
+never probes it, so a catalog compiled under that name ships complete and renders in English for
+every Chinese user while the build exits 0. The compiled catalog is therefore installed under the
+locale directories real users actually resolve, keeping the original name alongside them so
+nothing that already worked stops.
+
+On the JSON side the filename becomes an Android resource qualifier
+(`values-<lang>[-r<REGION>]`), where an underscore is illegal: `pt_BR.json` would yield
+`values-pt_BR`, a directory Android never consults.
+
+**A catalog whose script subtag maps to no known name fails the build**, naming every such
+catalog at once. A build that cannot say where a catalog goes must not quietly put it somewhere —
+"somewhere" is indistinguishable from "correct" until a user of that language complains. Map it
+explicitly with `localeNames`, one catalog at a time, so mapping one language does not disarm the
+check for the rest:
+
+```typescript
+gettextPlugin({
+    poDirectory: 'po',
+    moDirectory: 'dist',
+    localeNames: { az_Arab: ['az_IR'] },
+});
+```
+
+Two catalogs that would land on one output name (a Weblate `zh_Hans.po` beside a hand-made
+`zh_CN.po`) fail the same way, rather than letting one overwrite the other.
+
 ```typescript
 xgettextPlugin({
     sources: ['src/**/*.blp', 'data/**/*.desktop.in', '!src/**/*.generated.blp'],

--- a/packages/infra/vite-plugin-gettext/src/catalog-names.spec.ts
+++ b/packages/infra/vite-plugin-gettext/src/catalog-names.spec.ts
@@ -1,0 +1,159 @@
+// The name mapping on its own — no gettext, no filesystem. `gettext.spec.ts`
+// proves the plugins WIRE it and that glibc agrees; these cases pin down what it
+// answers, including the shapes that occur once and are therefore the ones a
+// later "simplification" quietly changes.
+
+import { describe, expect, it } from '@gjsify/unit';
+import {
+    catalogNames,
+    CollidingCatalogNameError,
+    planCatalogNames,
+    posixLocaleDirectories,
+    UnmappableCatalogNameError,
+} from './catalog-names.js';
+
+const posix = { pluginName: 'vite-plugin-gettext', namespace: 'posix' as const };
+const bcp47 = { pluginName: 'vite-plugin-gettext-po2json', namespace: 'bcp47' as const };
+
+/** What `fn` threw, so a case can assert the TYPE and the message it carries. */
+function thrownBy(fn: () => void): unknown {
+    try {
+        fn();
+    } catch (error) {
+        return error;
+    }
+    return undefined;
+}
+
+export default async () => {
+    await describe('posixLocaleDirectories', async () => {
+        await it('maps a Weblate script subtag to the locales glibc probes', async () => {
+            // The bug: `zh_Hans` alone is a directory nothing looks up. Measured
+            // against glibc — `zh_CN` is NOT reached by a `zh_SG` user, so both
+            // territories are written rather than one standing in for the other.
+            const dirs = posixLocaleDirectories('zh_Hans');
+            expect(dirs?.includes('zh_CN')).toBe(true);
+            expect(dirs?.includes('zh_SG')).toBe(true);
+        });
+
+        await it('keeps the original name alongside the mapped ones', async () => {
+            // Additive: no deployment that already found a catalog stops finding
+            // it. It is never the ONLY entry, which is the actual defect.
+            const dirs = posixLocaleDirectories('zh_Hans');
+            expect(dirs?.includes('zh_Hans')).toBe(true);
+            expect((dirs?.length ?? 0) > 1).toBe(true);
+        });
+
+        await it('folds a BCP-47 hyphen to the POSIX underscore', async () => {
+            // Measured: a `pt-BR` directory is reached by NO selector at all.
+            expect(posixLocaleDirectories('pt-BR')?.includes('pt_BR')).toBe(true);
+        });
+
+        await it('leaves a name that is already POSIX alone', async () => {
+            expect(posixLocaleDirectories('de')).toStrictEqual(['de']);
+            expect(posixLocaleDirectories('pt_BR')).toStrictEqual(['pt_BR']);
+        });
+
+        await it('writes a modifier script without a territory', async () => {
+            // Measured: `sr@latin` is reached by `sr_RS@latin` users, while
+            // `sr_RS@latin` is reached only by itself. The broader form is the
+            // right one, and it is the counter-intuitive one.
+            expect(posixLocaleDirectories('sr_Latn')?.includes('sr@latin')).toBe(true);
+        });
+
+        await it('lets an explicit territory settle the name over the script', async () => {
+            expect(posixLocaleDirectories('zh_Hans_CN')?.includes('zh_CN')).toBe(true);
+        });
+
+        await it('refuses a script subtag it has no mapping for', async () => {
+            // Guessing a territory here would reproduce the original bug with a
+            // different name, so the answer is "I cannot place this".
+            expect(posixLocaleDirectories('az_Arab')).toBe(undefined);
+        });
+
+        await it('takes a configured override for an unknown script', async () => {
+            const dirs = posixLocaleDirectories('az_Arab', { az_Arab: ['az_IR'] });
+            expect(dirs?.includes('az_IR')).toBe(true);
+        });
+    });
+
+    await describe('catalogNames — the Android namespace', async () => {
+        await it('gives simplified Chinese the name the repo already tracks', async () => {
+            // `values-zh_Hans` is not a directory Android consults: an
+            // underscore is illegal in a resource qualifier.
+            expect(catalogNames('zh_Hans')?.bcp47).toBe('zh');
+        });
+
+        await it('hyphenates a region so the qualifier comes out legal', async () => {
+            // `pt_BR` -> `values-pt_BR` (broken); `pt-BR` -> `values-pt-rBR`.
+            expect(catalogNames('pt_BR')?.bcp47).toBe('pt-BR');
+        });
+
+        await it('disagrees with the POSIX name for the same catalog', async () => {
+            // The whole reason the two namespaces are separate data.
+            const names = catalogNames('pt_BR');
+            expect(names?.posix.includes('pt_BR')).toBe(true);
+            expect(names?.bcp47).toBe('pt-BR');
+        });
+
+        await it('refuses a script that has no Android qualifier', async () => {
+            // `sr_Latn` has a POSIX home (`sr@latin`) but no legal qualifier —
+            // the two namespaces answer differently, which is the point.
+            expect(posixLocaleDirectories('sr_Latn')?.includes('sr@latin')).toBe(true);
+            expect(catalogNames('sr_Latn')).toBe(undefined);
+        });
+    });
+
+    await describe('planCatalogNames', async () => {
+        await it('names every unmappable catalog, not just the first', async () => {
+            // Reporting one at a time turns a single misconfiguration into a
+            // build-fix-build loop.
+            const thrown = thrownBy(() => planCatalogNames(['de', 'az_Arab', 'ks_Arab'], posix));
+
+            expect(thrown instanceof UnmappableCatalogNameError).toBe(true);
+            expect((thrown as UnmappableCatalogNameError).catalogs).toStrictEqual(['az_Arab', 'ks_Arab']);
+        });
+
+        await it('says what would happen, not just that it refused', async () => {
+            const thrown = thrownBy(() => planCatalogNames(['az_Arab'], posix));
+            const message = (thrown as Error).message;
+
+            // The message has to carry the reason the failure is invisible
+            // otherwise, or the next reader "fixes" it by disabling the guard.
+            expect(message.includes('az_Arab.po')).toBe(true);
+            expect(message.includes('exit 0')).toBe(true);
+            expect(message.includes('localeNames')).toBe(true);
+        });
+
+        await it('refuses two catalogs that would land in one directory', async () => {
+            // `zh_Hans.po` beside a hand-made `zh_CN.po`: without this, whichever
+            // is written last wins and the other's translations are absent.
+            const thrown = thrownBy(() => planCatalogNames(['zh_Hans', 'zh_CN'], posix));
+
+            expect(thrown instanceof CollidingCatalogNameError).toBe(true);
+            expect((thrown as CollidingCatalogNameError).claimed).toBe('zh_CN');
+        });
+
+        await it('accepts both Chinese scripts side by side', async () => {
+            // The territories are disjoint on purpose; a broad `zh` for either
+            // would have collided here and served the wrong script.
+            const plans = planCatalogNames(['zh_Hans', 'zh_Hant'], posix);
+            expect(plans.length).toBe(2);
+        });
+
+        await it('passes an ordinary catalogue set through untouched', async () => {
+            const plans = planCatalogNames(['de', 'fr', 'pt', 'pt_BR'], posix);
+            expect(plans.map((plan) => plan.posix[0])).toStrictEqual(['de', 'fr', 'pt', 'pt_BR']);
+        });
+
+        await it('refuses a JSON name collision independently of the POSIX one', async () => {
+            // `zh_Hans` -> `zh` and a plain `zh.po` -> `zh`: legal as POSIX
+            // directories, a collision as filenames. The namespaces are checked
+            // separately because they can disagree about what collides.
+            expect(planCatalogNames(['zh_Hans', 'zh'], posix).length).toBe(2);
+            expect(thrownBy(() => planCatalogNames(['zh_Hans', 'zh'], bcp47))).toBeInstanceOf(
+                CollidingCatalogNameError,
+            );
+        });
+    });
+};

--- a/packages/infra/vite-plugin-gettext/src/catalog-names.ts
+++ b/packages/infra/vite-plugin-gettext/src/catalog-names.ts
@@ -1,0 +1,404 @@
+// One catalog, three namespaces — and the table that keeps them apart.
+//
+// A catalog is called ONE thing in the repository and has to be spelled three
+// different ways downstream. They disagree on the same catalog, so passing the
+// name through unchanged is wrong in two of the three places.
+//
+//   | target                       | namespace         | zh_Hans | pt_BR |
+//   |------------------------------|-------------------|---------|-------|
+//   | gettext `.mo` directory      | POSIX locale      | zh_CN   | pt_BR |
+//   | Android resources (via JSON) | Android qualifier | zh      | pt-BR |
+//   | Weblate / the `.po` in repo  | BCP-47-ish        | zh_Hans | pt_BR |
+//
+// THE INCIDENT, POSIX SIDE (JumpLink/Learn6502#182, measured 2026-09-11).
+// Catalogs are maintained on Weblate, which names simplified Chinese `zh_Hans`.
+// The compiler used the `.po` basename verbatim as the locale directory, so the
+// catalog landed in `locale/zh_Hans/LC_MESSAGES/`. `zh_Hans` is BCP-47, not a
+// POSIX locale name, and glibc never probes it. Measured against the real
+// shipped `.mo` with the glibc `gettext` CLI as the oracle:
+//
+//     LANGUAGE=zh_Hans -> 黄色      (a selector no real user has)
+//     LANGUAGE=zh_CN   -> Yellow    <- what an actual user in China gets
+//     LANGUAGE=zh_TW   -> Yellow
+//     LANGUAGE=de      -> Gelb      (control: ordinary names were always fine)
+//
+// A complete Chinese catalog shipped and every Chinese user saw English. The
+// build exited 0; 14 of the 15 catalogs were fine, which is why nobody looked.
+//
+// THE INCIDENT, ANDROID SIDE (JumpLink/Learn6502#179). `po2json` wrote the same
+// basename as the JSON filename, and `@nativescript/localize` turns that
+// filename straight into an Android resource directory (`hooks/converter.js`:
+// values-${language.replace(/^(.+?)-(.+?)$/, '$1-r$2')}). Running that
+// transformation over the names in play:
+//
+//     de       -> values-de        ok
+//     pt-BR    -> values-pt-rBR    ok      <- the name the repo tracks
+//     pt_BR    -> values-pt_BR     BROKEN  <- what po2json wrote
+//     zh       -> values-zh        ok      <- the name the repo tracks
+//     zh_Hans  -> values-zh_Hans   BROKEN  <- what po2json wrote
+//     zh-Hans  -> values-zh-rHans  BROKEN  (a script subtag needs values-b+zh+Hans)
+//
+// An underscore is not legal in an Android resource qualifier, so those are
+// directories Android never consults. Both generations sat in the tree at once:
+// the tracked, correct `pt-BR.json`/`zh.json` and the generated, dead
+// `pt_BR.json`/`zh_Hans.json` beside them.
+//
+// NOT MEASURED: that Android then loads the resulting directory. The qualifier
+// rule is derived from the hook's source and the transformation above was
+// executed, but no emulator or device ran. The POSIX side, by contrast, was
+// measured end to end against glibc.
+//
+// Why this cannot be fixed by renaming the `.po`: the name comes from Weblate,
+// it is correct there, and the two downstream namespaces would still disagree
+// with each other. The mapping has to happen where each artifact is written.
+//
+// The mapping is DATA in one table read by both plugins, rather than logic in
+// each — two copies of this reasoning would drift, and the drifted one wins
+// silently.
+//
+// The decisions live here, apart from the I/O that acts on them, so they can be
+// tested without gettext installed and without a filesystem.
+
+import { GettextGuardError } from './guards.js';
+
+/** A catalog name whose script subtag maps to no name we know. */
+export class UnmappableCatalogNameError extends GettextGuardError {
+    constructor(
+        message: string,
+        /** The catalog names that could not be mapped, verbatim as the `.po` is called. */
+        readonly catalogs: readonly string[],
+    ) {
+        super(message);
+        this.name = 'UnmappableCatalogNameError';
+    }
+}
+
+/** Two catalogs claim one output name; one would overwrite the other. */
+export class CollidingCatalogNameError extends GettextGuardError {
+    constructor(
+        message: string,
+        /** The name claimed twice, and the catalogs claiming it. */
+        readonly claimed: string,
+        readonly catalogs: readonly string[],
+    ) {
+        super(message);
+        this.name = 'CollidingCatalogNameError';
+    }
+}
+
+/** How one catalog is spelled in each namespace that consumes it. */
+export interface CatalogNames {
+    /** The `.po` basename, verbatim. What an error message names. */
+    catalog: string;
+    /** `.mo` locale directories, in write order. */
+    posix: readonly string[];
+    /** JSON basename — a BCP-47 tag `@nativescript/localize` can qualify. */
+    bcp47: string;
+}
+
+/** A script subtag's spelling in the two generated namespaces. */
+interface ScriptMapping {
+    posix: readonly string[];
+    /**
+     * Omitted where no SAFE Android qualifier exists. The hook's regex yields a
+     * legal qualifier only for `<lang>` and `<lang>-<REGION>`; a script subtag
+     * would need `values-b+<lang>+<Script>`, which the hook cannot emit. Such a
+     * catalog is reported rather than given a name that merely looks right.
+     */
+    bcp47?: string;
+}
+
+/**
+ * Script subtag → the names that serve it.
+ *
+ * The POSIX column was MEASURED on glibc 2.42 / gettext 0.26 by installing a
+ * catalog under the target alone and asking the `gettext` CLI which selectors
+ * reached it. Two rules came out of that and explain the shapes below:
+ *
+ *   - a bare `<lang>` directory is reached by `<lang>_<TERRITORY>` users
+ *     (`sr` answered `sr_RS`), so a script that is simply the language's normal
+ *     one needs no territory at all;
+ *   - `<lang>@<modifier>` is reached by `<lang>_<TERRITORY>@<modifier>` users,
+ *     while `<lang>_<TERRITORY>@<modifier>` is reached ONLY by itself, so the
+ *     modifier forms are deliberately written WITHOUT a territory. This is the
+ *     one place where the narrower spelling is the tempting one and is wrong.
+ *
+ * Chinese needs its territories spelled out: `zh_CN` is NOT reached by a
+ * `zh_SG` user (measured), and the broad `zh` IS reached by `zh_TW` — so a
+ * simplified catalog installed as `zh` would serve traditional users simplified
+ * text. The territories are explicit precisely to avoid that.
+ *
+ * A POSIX target absent from the building host is still written: the catalog is
+ * compiled once and installed on machines whose locale set this build cannot
+ * see (`zh_MO` is absent on Fedora 44 and present elsewhere). A directory
+ * nobody probes costs a few KB; a missing one costs the language.
+ *
+ * The table is deliberately NOT exhaustive. An unknown script is REPORTED
+ * rather than guessed — a guessed territory is the same silent-wrong-name
+ * failure this module exists to end.
+ */
+const SCRIPT_NAMES: Readonly<Record<string, ScriptMapping>> = {
+    // Chinese: the script IS the axis users select on, and both halves ship.
+    // `zh` for simplified is the name Learn6502 already tracks and yields
+    // `values-zh`; traditional takes the territory form, `values-zh-rTW`.
+    zh_Hans: { posix: ['zh_CN', 'zh_SG'], bcp47: 'zh' },
+    zh_Hant: { posix: ['zh_TW', 'zh_HK', 'zh_MO'], bcp47: 'zh-TW' },
+    // Scripts glibc expresses as an @modifier. None has a safe Android
+    // qualifier: the distinction they carry is exactly the one the hook drops.
+    sr_Latn: { posix: ['sr@latin'] },
+    uz_Cyrl: { posix: ['uz@cyrillic'] },
+    be_Latn: { posix: ['be@latin'] },
+    // Scripts that are the language's ordinary one: the bare language covers it
+    // in both namespaces, because there is no distinction left to express.
+    sr_Cyrl: { posix: ['sr'], bcp47: 'sr' },
+    uz_Latn: { posix: ['uz'], bcp47: 'uz' },
+    az_Latn: { posix: ['az'], bcp47: 'az' },
+    bs_Latn: { posix: ['bs'], bcp47: 'bs' },
+    mn_Cyrl: { posix: ['mn'], bcp47: 'mn' },
+    tg_Cyrl: { posix: ['tg'], bcp47: 'tg' },
+    kk_Cyrl: { posix: ['kk'], bcp47: 'kk' },
+    ky_Cyrl: { posix: ['ky'], bcp47: 'ky' },
+    // Scripts glibc separates by territory, which Android can qualify too.
+    pa_Guru: { posix: ['pa_IN'], bcp47: 'pa-IN' },
+    pa_Arab: { posix: ['pa_PK'], bcp47: 'pa-PK' },
+};
+
+/**
+ * `language`, optional `Script`, optional `TERRITORY` of a catalog name.
+ *
+ * Matched after hyphens are folded to underscores, so one pattern reads both the
+ * BCP-47 spelling Weblate writes (`pt-BR`, `zh-Hans`) and the POSIX one. A name
+ * already carrying an `@modifier` is handled before this: it is POSIX by
+ * construction and needs no mapping.
+ */
+const CATALOG_NAME = /^([a-z]{2,3})(?:_([A-Z][a-z]{3}))?(?:_([A-Z]{2}|\d{3}))?$/;
+
+/** Which generated namespace a lookup is for, so errors can say what broke. */
+export type CatalogNamespace = 'posix' | 'bcp47';
+
+/** The script mapping for a catalog name, if it carries a script subtag at all. */
+function scriptMappingFor(normalized: string): ScriptMapping | undefined {
+    const parsed = CATALOG_NAME.exec(normalized);
+    if (!parsed?.[2] || parsed[3]) {
+        return undefined;
+    }
+    return SCRIPT_NAMES[`${parsed[1]}_${parsed[2]}`];
+}
+
+/**
+ * How one catalog is spelled everywhere, or `undefined` when its script subtag
+ * has no name in the namespace asked for.
+ *
+ * The ORIGINAL name is always kept among the POSIX directories. It is additive —
+ * no deployment that already found a catalog can stop finding it — and it keeps
+ * the compiled tree greppable against the catalogs it came from. It is never the
+ * only entry, because on its own it is precisely what nothing probes. The JSON
+ * side gets no such alias: a filename is one name, and a second copy under the
+ * dead spelling is what left two generations in the tree to begin with.
+ */
+export function catalogNames(
+    catalog: string,
+    overrides?: Readonly<Record<string, readonly string[]>>,
+): CatalogNames | undefined {
+    // A configured override answers for the name as written AND as normalised,
+    // so a project need not know which spelling this module reasons about.
+    const normalized = catalog.replace(/-/g, '_');
+    const override = overrides?.[catalog] ?? overrides?.[normalized];
+    if (override && override.length > 0) {
+        return {
+            catalog,
+            posix: dedupe([...override, catalog]),
+            bcp47: override[0].split('@')[0].replace(/_/g, '-'),
+        };
+    }
+
+    // A name carrying an @modifier is POSIX by construction — the modifier is
+    // the thing BCP-47 has no spelling for, so nothing but a hand-written POSIX
+    // name can have produced it. Android cannot express it either; the bare
+    // language is the honest remainder.
+    if (normalized.includes('@')) {
+        return { catalog, posix: [normalized], bcp47: normalized.split('@')[0].replace(/_/g, '-') };
+    }
+
+    const parsed = CATALOG_NAME.exec(normalized);
+    if (!parsed) {
+        // Not a shape this module recognises. Passed through rather than
+        // reported: gettext's own fallback still reaches a plain `<lang>`
+        // prefix, and reporting every unusual name would make the guard noise
+        // instead of signal. Only a SCRIPT subtag is a measured silent failure.
+        return { catalog, posix: [normalized], bcp47: normalized.replace(/_/g, '-') };
+    }
+
+    const [, language, script, territory] = parsed;
+
+    if (!script) {
+        // `de`, `pt_BR`, `zh_CN` — already exactly what glibc probes. The only
+        // work a hyphenated `pt-BR` needed was the underscore; Android needs the
+        // hyphen back, which is why the two columns differ here for free.
+        return { catalog, posix: dedupe([normalized, catalog]), bcp47: normalized.replace(/_/g, '-') };
+    }
+
+    // An explicit territory beside the script settles it without the table:
+    // `zh_Hans_CN` is `zh_CN`, whatever the script says.
+    if (territory) {
+        return {
+            catalog,
+            posix: dedupe([`${language}_${territory}`, catalog]),
+            bcp47: `${language}-${territory}`,
+        };
+    }
+
+    const mapped = SCRIPT_NAMES[`${language}_${script}`];
+    if (!mapped?.bcp47) {
+        return undefined;
+    }
+    return { catalog, posix: dedupe([...mapped.posix, catalog]), bcp47: mapped.bcp47 };
+}
+
+/**
+ * The POSIX directories alone.
+ *
+ * A script with a POSIX mapping but no safe Android qualifier (`sr_Latn`) is
+ * answerable here and not by {@link catalogNames}: the `.mo` side knows exactly
+ * where it goes. Splitting the lookup this way is what lets the gettext plugin
+ * stay correct for catalogs the JSON plugin has to refuse.
+ */
+export function posixLocaleDirectories(
+    catalog: string,
+    overrides?: Readonly<Record<string, readonly string[]>>,
+): readonly string[] | undefined {
+    const both = catalogNames(catalog, overrides);
+    if (both) {
+        return both.posix;
+    }
+    const mapped = scriptMappingFor(catalog.replace(/-/g, '_'));
+    return mapped ? dedupe([...mapped.posix, catalog]) : undefined;
+}
+
+/**
+ * Plans every catalog for ONE namespace, and fails if any cannot be spelled.
+ *
+ * FAILING IS THE DEFAULT ON PURPOSE, on the same asymmetry the source-pattern
+ * guard is built on: a false failure costs one build and one line of config, a
+ * missed one ships a whole language that silently renders in English — which is
+ * what `zh_Hans` did, undetected, for as long as the catalog existed. A build
+ * that cannot say where a catalog goes must not quietly put it somewhere,
+ * because "somewhere" is indistinguishable from "correct" until a user of that
+ * language complains.
+ *
+ * Every unmappable name is named in ONE error rather than the first aborting, so
+ * a project adopting several Weblate languages fixes them in a single pass
+ * instead of a build-fix-build loop.
+ */
+export function planCatalogNames(
+    catalogs: readonly string[],
+    context: {
+        pluginName: string;
+        namespace: CatalogNamespace;
+        /** Per-catalog override, e.g. `{ az_Arab: ['az_IR'] }`. */
+        localeNames?: Readonly<Record<string, readonly string[]>>;
+    },
+): CatalogNames[] {
+    const plans: CatalogNames[] = [];
+    const unmappable: string[] = [];
+
+    for (const catalog of catalogs) {
+        if (context.namespace === 'posix') {
+            const posix = posixLocaleDirectories(catalog, context.localeNames);
+            if (!posix) {
+                unmappable.push(catalog);
+                continue;
+            }
+            plans.push({ catalog, posix, bcp47: '' });
+            continue;
+        }
+
+        const names = catalogNames(catalog, context.localeNames);
+        if (!names) {
+            unmappable.push(catalog);
+            continue;
+        }
+        plans.push(names);
+    }
+
+    if (unmappable.length > 0) {
+        throw new UnmappableCatalogNameError(unmappableMessage(unmappable, context), unmappable);
+    }
+
+    assertNoCollision(plans, context);
+    return plans;
+}
+
+function unmappableMessage(
+    unmappable: readonly string[],
+    context: { pluginName: string; namespace: CatalogNamespace },
+): string {
+    const list = unmappable.map((name) => `  - ${name}.po`).join('\n');
+    const subject = unmappable.length === 1 ? 'a catalog carries' : `${unmappable.length} catalogs carry`;
+
+    if (context.namespace === 'posix') {
+        return (
+            `[${context.pluginName}] ${subject} a script subtag with no known POSIX locale:\n` +
+            `${list}\n` +
+            'Compiling it under that name produces a directory glibc never probes, so the language ships ' +
+            'complete and renders in English — the build would exit 0 and nothing would look wrong.\n' +
+            "Map it explicitly in the plugin's `localeNames`, e.g. `{ 'az_Arab': ['az_IR'] }`, using the " +
+            'name `locale -a` lists on the target system.'
+        );
+    }
+
+    return (
+        `[${context.pluginName}] ${subject} a script subtag that has no Android resource qualifier:\n` +
+        `${list}\n` +
+        'A qualifier is built as `values-<lang>[-r<REGION>]` and cannot express a script, so the generated ' +
+        'directory would be one Android never consults — and the build would exit 0.\n' +
+        "Map it explicitly in the plugin's `localeNames`, e.g. `{ 'sr_Latn': ['sr'] }`, choosing the " +
+        'language or region tag the app should serve it as.'
+    );
+}
+
+/**
+ * Fails when two catalogs claim the same output name.
+ *
+ * Reachable as soon as a project keeps both spellings of one language — a
+ * `zh_Hans.po` from Weblate beside a hand-made `zh_CN.po` both resolve to
+ * `zh_CN`. Without this, whichever is written last wins by iteration order, the
+ * other's translations are simply absent, and the build still exits 0. That is
+ * the same shape as the bug this module fixes, so it is guarded here rather than
+ * left to be discovered the same way.
+ */
+function assertNoCollision(
+    plans: readonly CatalogNames[],
+    context: { pluginName: string; namespace: CatalogNamespace },
+): void {
+    const claimedBy = new Map<string, string[]>();
+    for (const plan of plans) {
+        const claims = context.namespace === 'posix' ? plan.posix : [plan.bcp47];
+        for (const claim of claims) {
+            const claimants = claimedBy.get(claim);
+            if (claimants) {
+                claimants.push(plan.catalog);
+            } else {
+                claimedBy.set(claim, [plan.catalog]);
+            }
+        }
+    }
+
+    for (const [claimed, catalogs] of claimedBy) {
+        if (catalogs.length > 1) {
+            const where = context.namespace === 'posix' ? `locale/${claimed}/` : `${claimed}.json`;
+            throw new CollidingCatalogNameError(
+                `[${context.pluginName}] ${catalogs.map((name) => `${name}.po`).join(' and ')} both compile to ` +
+                    `${where}. One would overwrite the other and the build would still exit 0.\n` +
+                    "Keep one catalog per language, or pin them apart with the plugin's `localeNames`.",
+                claimed,
+                catalogs,
+            );
+        }
+    }
+}
+
+/** First occurrence wins, so the mapped name stays ahead of the original. */
+function dedupe(values: readonly string[]): string[] {
+    return [...new Set(values)];
+}

--- a/packages/infra/vite-plugin-gettext/src/gettext.spec.ts
+++ b/packages/infra/vite-plugin-gettext/src/gettext.spec.ts
@@ -1,0 +1,231 @@
+// Where a compiled catalog lands, and whether gettext itself can find it.
+//
+// Measured 2026-09-11 in JumpLink/Learn6502 (#182): a Weblate `zh_Hans.po` was
+// compiled to `locale/zh_Hans/LC_MESSAGES/`, which glibc never probes, so every
+// Chinese user saw English while a complete catalog shipped.
+//
+// These cases drive the REAL `buildStart` against the REAL gettext binaries,
+// because what went wrong was where files are written, not a parser. The
+// question "can this be looked up" is answered by the glibc `gettext` CLI —
+// asking our own implementation whether its own directory choice was right
+// could not see it be wrong, which is exactly how the bug survived. The CLI is
+// the only oracle here that is genuinely independent.
+//
+// THE MEASUREMENT TRAP, paid for once: `LC_ALL` must name an INSTALLED, non-C
+// locale. Under `C`, `C.UTF-8`, `POSIX` or an uninstalled locale, glibc falls
+// back to C and ignores `LANGUAGE` COMPLETELY — every probe then returns the
+// untranslated msgid and the suite measures nothing while looking green. The
+// language is selected by `LANGUAGE`; `LC_ALL` only has to be a real locale.
+
+import fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execa } from 'execa';
+import { describe, expect, it } from '@gjsify/unit';
+import { gettextPlugin } from './gettext.js';
+import { po2jsonPlugin } from './po2json.js';
+import { UnmappableCatalogNameError } from './catalog-names.js';
+
+const DOMAIN = 'probe';
+
+/** Calls the plugin's real `buildStart`, which is where compilation is driven. */
+async function runBuildStart(plugin: unknown): Promise<void> {
+    await (plugin as { buildStart: () => Promise<void> }).buildStart();
+}
+
+async function fixture(): Promise<string> {
+    return await fs.mkdtemp(path.join(tmpdir(), 'gjsify-gettext-'));
+}
+
+/** A catalog translating "Yellow" to a marker that says WHICH catalog answered. */
+async function catalog(dir: string, name: string, translation: string): Promise<void> {
+    await fs.writeFile(
+        path.join(dir, `${name}.po`),
+        [
+            'msgid ""',
+            'msgstr "Content-Type: text/plain; charset=UTF-8\\n"',
+            '',
+            'msgid "Yellow"',
+            `msgstr "${translation}"`,
+            '',
+        ].join('\n'),
+        'utf-8',
+    );
+}
+
+async function exists(file: string): Promise<boolean> {
+    try {
+        await fs.stat(file);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * An installed non-C locale, or `undefined` when the host has none.
+ *
+ * Cached because `locale -a` lists hundreds of entries and every probe would
+ * otherwise re-read them.
+ */
+let localeProbe: string | undefined | null = null;
+async function usableLocale(): Promise<string | undefined> {
+    if (localeProbe !== null) {
+        return localeProbe;
+    }
+    try {
+        const { stdout } = await execa('locale', ['-a']);
+        const candidates = stdout.split('\n').map((line) => line.trim());
+        // en_US first for a stable message language, then any UTF-8 locale that
+        // is not the C one — `C.UTF-8` is a C locale and disables LANGUAGE.
+        localeProbe =
+            candidates.find((name) => /^en_US\.(utf8|UTF-8)$/i.test(name)) ??
+            candidates.find((name) => /\.(utf8|UTF-8)$/i.test(name) && !/^(C|POSIX)\b/i.test(name));
+    } catch {
+        localeProbe = undefined;
+    }
+    return localeProbe;
+}
+
+/** What glibc returns for `msgid` when the user's language is `language`. */
+async function askGettext(moRoot: string, language: string, msgid: string): Promise<string> {
+    const locale = await usableLocale();
+    const { stdout } = await execa('gettext', [DOMAIN, msgid], {
+        env: {
+            LC_ALL: locale,
+            LANG: locale,
+            LANGUAGE: language,
+            TEXTDOMAINDIR: moRoot,
+            OUTPUT_CHARSET: 'UTF-8',
+        },
+        extendEnv: true,
+    });
+    return stdout;
+}
+
+export default async () => {
+    await describe('gettextPlugin — POSIX locale directories', async () => {
+        await it('compiles a Weblate script name into the locales glibc probes', async () => {
+            const dir = await fixture();
+            await catalog(dir, 'zh_Hans', '黄色');
+
+            await runBuildStart(
+                gettextPlugin({ poDirectory: dir, moDirectory: path.join(dir, 'dist'), filename: `${DOMAIN}.mo` }),
+            );
+
+            const locales = path.join(dir, 'dist', 'locale');
+            // The directory a real user's locale actually reaches.
+            expect(await exists(path.join(locales, 'zh_CN', 'LC_MESSAGES', `${DOMAIN}.mo`))).toBe(true);
+            expect(await exists(path.join(locales, 'zh_SG', 'LC_MESSAGES', `${DOMAIN}.mo`))).toBe(true);
+            // And the original, kept so nothing that already worked stops.
+            expect(await exists(path.join(locales, 'zh_Hans', 'LC_MESSAGES', `${DOMAIN}.mo`))).toBe(true);
+        });
+
+        await it('folds a hyphenated catalog name to the POSIX spelling', async () => {
+            const dir = await fixture();
+            await catalog(dir, 'pt-BR', 'Amarelo');
+
+            await runBuildStart(
+                gettextPlugin({ poDirectory: dir, moDirectory: path.join(dir, 'dist'), filename: `${DOMAIN}.mo` }),
+            );
+
+            expect(await exists(path.join(dir, 'dist', 'locale', 'pt_BR', 'LC_MESSAGES', `${DOMAIN}.mo`))).toBe(true);
+        });
+
+        await it('refuses a catalog it cannot place instead of compiling it somewhere', async () => {
+            const dir = await fixture();
+            await catalog(dir, 'az_Arab', 'Sarı');
+
+            let thrown: unknown;
+            try {
+                await runBuildStart(
+                    gettextPlugin({ poDirectory: dir, moDirectory: path.join(dir, 'dist'), filename: `${DOMAIN}.mo` }),
+                );
+            } catch (error) {
+                thrown = error;
+            }
+
+            // The guard must survive the plugin's catch-and-wrap, or its
+            // instruction is buried under "Failed to compile MO files: Error: …".
+            expect(thrown).toBeInstanceOf(UnmappableCatalogNameError);
+            expect((thrown as Error).message.includes('az_Arab.po')).toBe(true);
+        });
+    });
+
+    await describe('gettextPlugin — glibc as the oracle', async () => {
+        const locale = await usableLocale();
+
+        await it.failing(
+            'a user with a real Chinese locale gets the Chinese catalog',
+            async () => {
+                const dir = await fixture();
+                await catalog(dir, 'zh_Hans', '黄色');
+                await catalog(dir, 'de', 'Gelb');
+
+                const moRoot = path.join(dir, 'dist', 'locale');
+                await runBuildStart(
+                    gettextPlugin({
+                        poDirectory: dir,
+                        moDirectory: path.join(dir, 'dist'),
+                        filename: `${DOMAIN}.mo`,
+                    }),
+                );
+
+                // THE DISCRIMINATOR. `de` is an ordinary name that was never
+                // broken, so it proves the probe can see translations at all. If
+                // this fails the environment cannot do gettext lookups and every
+                // assertion below would pass vacuously as English.
+                expect(await askGettext(moRoot, 'de', 'Yellow')).toBe('Gelb');
+
+                // A selector no real user has — what the bug made the only
+                // working one.
+                expect(await askGettext(moRoot, 'zh_Hans', 'Yellow')).toBe('黄色');
+                // What an actual user in China has. This is the regression.
+                expect(await askGettext(moRoot, 'zh_CN', 'Yellow')).toBe('黄色');
+                expect(await askGettext(moRoot, 'zh_SG', 'Yellow')).toBe('黄色');
+
+                // Not claimed: a simplified catalog must not answer a
+                // traditional user. It is why the broad `zh` is never written.
+                expect(await askGettext(moRoot, 'zh_TW', 'Yellow')).toBe('Yellow');
+            },
+            'the host has no installed non-C locale, so glibc ignores LANGUAGE and the oracle cannot run',
+            { when: !locale },
+        );
+    });
+
+    await describe('po2jsonPlugin — the Android namespace', async () => {
+        await it('names the JSON so the resource qualifier comes out legal', async () => {
+            // `zh_Hans.json` -> `values-zh_Hans` and `pt_BR.json` ->
+            // `values-pt_BR`: an underscore is illegal in a qualifier, so those
+            // are directories Android never consults.
+            const dir = await fixture();
+            await catalog(dir, 'zh_Hans', '黄色');
+            await catalog(dir, 'pt_BR', 'Amarelo');
+            const json = path.join(dir, 'json');
+
+            await runBuildStart(po2jsonPlugin({ poDirectory: dir, jsonDirectory: json }));
+
+            expect(await exists(path.join(json, 'zh.json'))).toBe(true);
+            expect(await exists(path.join(json, 'pt-BR.json'))).toBe(true);
+            // The dead spellings must not be written beside them — two
+            // generations in one tree is what made this hard to see.
+            expect(await exists(path.join(json, 'zh_Hans.json'))).toBe(false);
+            expect(await exists(path.join(json, 'pt_BR.json'))).toBe(false);
+        });
+
+        await it('keeps the POSIX and Android names apart for one catalog', async () => {
+            // The same `pt_BR.po` is `pt_BR` as a locale directory and `pt-BR`
+            // as a JSON file. One string cannot serve both.
+            const dir = await fixture();
+            await catalog(dir, 'pt_BR', 'Amarelo');
+
+            await runBuildStart(
+                gettextPlugin({ poDirectory: dir, moDirectory: path.join(dir, 'dist'), filename: `${DOMAIN}.mo` }),
+            );
+            await runBuildStart(po2jsonPlugin({ poDirectory: dir, jsonDirectory: path.join(dir, 'json') }));
+
+            expect(await exists(path.join(dir, 'dist', 'locale', 'pt_BR', 'LC_MESSAGES', `${DOMAIN}.mo`))).toBe(true);
+            expect(await exists(path.join(dir, 'json', 'pt-BR.json'))).toBe(true);
+        });
+    });
+};

--- a/packages/infra/vite-plugin-gettext/src/gettext.ts
+++ b/packages/infra/vite-plugin-gettext/src/gettext.ts
@@ -2,17 +2,23 @@ import { type Plugin } from 'vite';
 import { execa } from 'execa';
 import path from 'node:path';
 import type { GettextPluginOptions } from './types.js';
+import { GettextGuardError } from './guards.js';
+import { planCatalogNames } from './catalog-names.js';
 import { checkDependencies, findAvailableLanguages, generateLinguasFile, ensureDirectory } from './utils.js';
 
 /**
  * Creates a Vite plugin that compiles PO translation files to binary MO format
  * The MO files are placed in the standard gettext directory structure:
  * {moDirectory}/locale/{lang}/LC_MESSAGES/messages.mo
+ *
+ * The directory is the catalog's POSIX locale name, which is NOT always the
+ * `.po` basename — a Weblate `zh_Hans.po` is installed as `zh_CN`, because
+ * `zh_Hans` is a name glibc never probes. See `catalog-names.ts`.
  * @param options Configuration options for the plugin
  * @returns A Vite plugin that handles PO compilation
  */
 export function gettextPlugin(options: GettextPluginOptions): Plugin {
-    const { poDirectory, moDirectory, filename = 'messages.mo', verbose = false } = options;
+    const { poDirectory, moDirectory, filename = 'messages.mo', verbose = false, localeNames } = options;
 
     const pluginName = 'vite-plugin-gettext';
 
@@ -43,23 +49,36 @@ export function gettextPlugin(options: GettextPluginOptions): Plugin {
             // Generate LINGUAS file
             await generateLinguasFile(languages, poDirectory, verbose);
 
+            // Resolve every catalog's locale directories BEFORE compiling any of
+            // them, so a name nobody can place stops the build instead of
+            // leaving a half-written tree that looks complete.
+            const plans = planCatalogNames(languages, { pluginName, namespace: 'posix', localeNames });
+
             // Create MO directory
             await ensureDirectory(path.join(moDirectory, 'locale'));
 
-            for (const lang of languages) {
-                const poFile = path.join(poDirectory, `${lang}.po`);
-                const moPath = path.join(moDirectory, 'locale', lang, 'LC_MESSAGES');
-                const moFile = path.join(moPath, filename);
+            for (const plan of plans) {
+                const poFile = path.join(poDirectory, `${plan.catalog}.po`);
 
-                await ensureDirectory(moPath);
+                for (const localeDir of plan.posix) {
+                    const moPath = path.join(moDirectory, 'locale', localeDir, 'LC_MESSAGES');
+                    const moFile = path.join(moPath, filename);
 
-                if (verbose) {
-                    console.log(`[${pluginName}] Compiling ${poFile} to ${moFile}`);
+                    await ensureDirectory(moPath);
+
+                    if (verbose) {
+                        console.log(`[${pluginName}] Compiling ${poFile} to ${moFile}`);
+                    }
+
+                    await execa('msgfmt', ['--output-file=' + moFile, poFile]);
                 }
-
-                await execa('msgfmt', ['--output-file=' + moFile, poFile]);
             }
         } catch (error) {
+            // A guard's message IS the guard — wrapping it in "Failed to compile
+            // MO files: Error: …" buries the instruction that makes it useful.
+            if (error instanceof GettextGuardError) {
+                throw error;
+            }
             throw new Error(`Failed to compile MO files: ${error}`);
         }
     }

--- a/packages/infra/vite-plugin-gettext/src/index.ts
+++ b/packages/infra/vite-plugin-gettext/src/index.ts
@@ -1,7 +1,21 @@
 export { CatalogShrinkError, EmptySourcePatternError, GettextGuardError, InvalidEntryLossError } from './guards.js';
+export {
+    catalogNames,
+    CollidingCatalogNameError,
+    planCatalogNames,
+    posixLocaleDirectories,
+    UnmappableCatalogNameError,
+} from './catalog-names.js';
+export type { CatalogNames, CatalogNamespace } from './catalog-names.js';
 export { gettextPlugin } from './gettext.js';
 export { msgfmtPlugin } from './msgfmt.js';
 export { xgettextPlugin } from './xgettext.js';
 export { po2jsonPlugin } from './po2json.js';
-export type { GettextPluginOptions, MsgfmtPluginOptions, MsgfmtFormat, XGettextPluginOptions } from './types.js';
+export type {
+    GettextPluginOptions,
+    GettextPo2JsonPluginOptions,
+    MsgfmtPluginOptions,
+    MsgfmtFormat,
+    XGettextPluginOptions,
+} from './types.js';
 export * from './utils.js';

--- a/packages/infra/vite-plugin-gettext/src/linguas.spec.ts
+++ b/packages/infra/vite-plugin-gettext/src/linguas.spec.ts
@@ -1,0 +1,96 @@
+// The LINGUAS file, and why it kept rewriting itself.
+//
+// Measured 2026-09-11 in JumpLink/Learn6502 (#179): `gjsify workspace
+// @learn6502/translations build` changed `LINGUAS` on every run over an
+// untouched tree — `de`, `es` and `uk` moved to the end and the trailing
+// newline disappeared, producing a diff on each build that looked like work.
+//
+// Two causes, both in the generator: the language list came straight from
+// `fs.readdir`, whose order is unspecified and varies by filesystem and by the
+// directory's history, and the file was joined with `\n` between entries and
+// nothing after the last one.
+//
+// The determinism case below drives the generator TWICE with the SAME set in
+// DIFFERENT orders and demands byte equality. That closes the CLASS — any
+// non-determinism in this generator — rather than the two instances that were
+// found, and it tests it on every host, instead of hoping a CI filesystem
+// happens to hand back a scrambled directory.
+
+import fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from '@gjsify/unit';
+import { gettextPlugin } from './gettext.js';
+import { generateLinguasFile } from './utils.js';
+
+async function fixture(): Promise<string> {
+    return await fs.mkdtemp(path.join(tmpdir(), 'gjsify-linguas-'));
+}
+
+/** A minimal catalog, enough for the plugin to count it as a language. */
+async function catalog(dir: string, name: string): Promise<void> {
+    await fs.writeFile(
+        path.join(dir, `${name}.po`),
+        ['msgid ""', 'msgstr "Content-Type: text/plain; charset=UTF-8\\n"', ''].join('\n'),
+        'utf-8',
+    );
+}
+
+export default async () => {
+    await describe('generateLinguasFile', async () => {
+        await it('writes the same bytes whatever order the languages arrive in', async () => {
+            const first = await fixture();
+            const second = await fixture();
+            const languages = ['de', 'es', 'fi', 'pt', 'pt_BR', 'uk', 'zh_Hans'];
+
+            await generateLinguasFile([...languages], first);
+            await generateLinguasFile([...languages].reverse(), second);
+
+            const a = await fs.readFile(path.join(first, 'LINGUAS'), 'utf-8');
+            const b = await fs.readFile(path.join(second, 'LINGUAS'), 'utf-8');
+            expect(a).toBe(b);
+        });
+
+        await it('ends with a newline', async () => {
+            // Without it git reports "\ No newline at end of file" on every
+            // regeneration, and anything appending to the list joins its first
+            // entry onto the last language.
+            const dir = await fixture();
+            await generateLinguasFile(['de', 'fr'], dir);
+
+            expect((await fs.readFile(path.join(dir, 'LINGUAS'), 'utf-8')).endsWith('\n')).toBe(true);
+        });
+
+        await it('sorts by code unit, not by the builder locale', async () => {
+            // `localeCompare` would order by whoever ran the build, which makes
+            // the committed file depend on the host: the same class of bug.
+            const dir = await fixture();
+            await generateLinguasFile(['zh_Hans', 'pt_BR', 'pt', 'de'], dir);
+
+            expect(await fs.readFile(path.join(dir, 'LINGUAS'), 'utf-8')).toBe('de\npt\npt_BR\nzh_Hans\n');
+        });
+
+        await it('is stable across two full plugin runs', async () => {
+            // The end-to-end version of the same claim: a second build on an
+            // untouched tree must not produce a diff.
+            const dir = await fixture();
+            await catalog(dir, 'de');
+            await catalog(dir, 'zh_Hans');
+            await catalog(dir, 'pt_BR');
+
+            const plugin = gettextPlugin({
+                poDirectory: dir,
+                moDirectory: path.join(dir, 'dist'),
+                filename: 'probe.mo',
+            });
+
+            await (plugin as unknown as { buildStart: () => Promise<void> }).buildStart();
+            const first = await fs.readFile(path.join(dir, 'LINGUAS'), 'utf-8');
+            await (plugin as unknown as { buildStart: () => Promise<void> }).buildStart();
+            const second = await fs.readFile(path.join(dir, 'LINGUAS'), 'utf-8');
+
+            expect(first).toBe(second);
+            expect(first).toBe('de\npt_BR\nzh_Hans\n');
+        });
+    });
+};

--- a/packages/infra/vite-plugin-gettext/src/msgfmt.ts
+++ b/packages/infra/vite-plugin-gettext/src/msgfmt.ts
@@ -3,6 +3,8 @@ import { execa } from 'execa';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import type { MsgfmtPluginOptions, MsgfmtFormat } from './types.js';
+import { GettextGuardError } from './guards.js';
+import { planCatalogNames } from './catalog-names.js';
 import { checkDependencies, findAvailableLanguages, ensureDirectory } from './utils.js';
 
 /**
@@ -79,6 +81,7 @@ export function msgfmtPlugin(options: MsgfmtPluginOptions): Plugin {
         msgfmtOptions = [],
         useLocaleStructure = true,
         removeComments = true,
+        localeNames,
     } = options;
 
     const pluginName = 'vite-plugin-msgfmt';
@@ -155,48 +158,53 @@ export function msgfmtPlugin(options: MsgfmtPluginOptions): Plugin {
                     return;
                 }
 
+                // Only the gettext locale structure is looked up by glibc, so
+                // only it needs POSIX names. The flat `<outputDirectory>/<lang>`
+                // layout is read by whatever the project points at it, and
+                // renaming there would break a consumer to fix nobody.
+                const usesLocaleLookup = useLocaleStructure && format === 'mo';
+                const plans = usesLocaleLookup
+                    ? planCatalogNames(languages, { pluginName, namespace: 'posix', localeNames })
+                    : languages.map((catalog) => ({ catalog, posix: [catalog], bcp47: '' }));
+
                 // Process each language individually for other formats
-                for (const lang of languages) {
-                    const poFile = path.join(poDirectory, `${lang}.po`);
+                for (const plan of plans) {
+                    const poFile = path.join(poDirectory, `${plan.catalog}.po`);
 
-                    let outputPath: string;
-                    let outputFile: string;
-
-                    if (useLocaleStructure && format === 'mo') {
-                        // Use standard gettext locale structure
-                        outputPath = path.join(outputDirectory, 'locale', lang, 'LC_MESSAGES');
-                        outputFile = path.join(
+                    for (const name of plan.posix) {
+                        const outputPath = usesLocaleLookup
+                            ? path.join(outputDirectory, 'locale', name, 'LC_MESSAGES')
+                            : path.join(outputDirectory, name);
+                        const outputFile = path.join(
                             outputPath,
                             options.filename || `${domain}${getOutputExtension(format)}`,
                         );
-                    } else {
-                        // Use simple language-based structure
-                        outputPath = path.join(outputDirectory, lang);
-                        outputFile = path.join(
-                            outputPath,
-                            options.filename || `${domain}${getOutputExtension(format)}`,
-                        );
+
+                        // Create the directory structure
+                        await ensureDirectory(outputPath);
+
+                        if (verbose) {
+                            console.log(`[${pluginName}] Compiling ${poFile} to ${outputFile}`);
+                        }
+
+                        // Build arguments for individual processing
+                        const baseArgs = ['--output-file=' + outputFile, `--${format}`, poFile];
+                        const args = buildMsgfmtArgs(baseArgs, { msgfmtOptions });
+
+                        if (verbose) {
+                            console.log(`[${pluginName}] Running msgfmt with: ${args.join(' ')}`);
+                        }
+
+                        await execa('msgfmt', args);
                     }
-
-                    // Create the directory structure
-                    await ensureDirectory(outputPath);
-
-                    if (verbose) {
-                        console.log(`[${pluginName}] Compiling ${poFile} to ${outputFile}`);
-                    }
-
-                    // Build arguments for individual processing
-                    const baseArgs = ['--output-file=' + outputFile, `--${format}`, poFile];
-                    const args = buildMsgfmtArgs(baseArgs, { msgfmtOptions });
-
-                    if (verbose) {
-                        console.log(`[${pluginName}] Running msgfmt with: ${args.join(' ')}`);
-                    }
-
-                    await execa('msgfmt', args);
                 }
             }
         } catch (error) {
+            // A guard's message IS the guard — wrapping it buries the
+            // instruction that makes it useful.
+            if (error instanceof GettextGuardError) {
+                throw error;
+            }
             throw new Error(`Failed to compile files: ${error}`);
         }
     }

--- a/packages/infra/vite-plugin-gettext/src/po2json.ts
+++ b/packages/infra/vite-plugin-gettext/src/po2json.ts
@@ -3,6 +3,8 @@ import path from 'node:path';
 import fs from 'node:fs/promises';
 import * as gettextParser from 'gettext-parser';
 import type { GettextPo2JsonPluginOptions } from './types.js';
+import { GettextGuardError } from './guards.js';
+import { planCatalogNames } from './catalog-names.js';
 import { findAvailableLanguages, ensureDirectory } from './utils.js';
 
 /**
@@ -112,6 +114,7 @@ export function po2jsonPlugin(options: GettextPo2JsonPluginOptions): Plugin {
         defaultLanguage = 'en',
         verbose = false,
         additionalTranslations = {},
+        localeNames,
     } = options;
 
     const pluginName = 'vite-plugin-gettext-po2json';
@@ -146,8 +149,13 @@ export function po2jsonPlugin(options: GettextPo2JsonPluginOptions): Plugin {
             // Collection of all translations to create the default language file
             const allTranslations: Record<string, Record<string, string>> = {};
 
+            // The JSON filename is the ANDROID namespace, not the catalog name:
+            // `@nativescript/localize` turns it straight into a resource
+            // qualifier, where an underscore is illegal. See `catalog-names.ts`.
+            const plans = planCatalogNames(languages, { pluginName, namespace: 'bcp47', localeNames });
+
             // Skip the default language if it exists in the list
-            const nonDefaultLanguages = languages.filter((lang) => lang !== defaultLanguage);
+            const nonDefaultPlans = plans.filter((plan) => plan.catalog !== defaultLanguage);
 
             // Handle default language if it exists in the list
             if (languages.includes(defaultLanguage)) {
@@ -178,9 +186,10 @@ export function po2jsonPlugin(options: GettextPo2JsonPluginOptions): Plugin {
             }
 
             // Add additional translations for all languages
-            for (const lang of nonDefaultLanguages) {
+            for (const plan of nonDefaultPlans) {
+                const lang = plan.catalog;
                 const poFile = path.join(poDirectory, `${lang}.po`);
-                const jsonFile = path.join(jsonDirectory, `${lang}.json`);
+                const jsonFile = path.join(jsonDirectory, `${plan.bcp47}.json`);
 
                 if (verbose) {
                     console.log(`[${pluginName}] Converting ${poFile} to ${jsonFile}`);
@@ -224,6 +233,11 @@ export function po2jsonPlugin(options: GettextPo2JsonPluginOptions): Plugin {
                 additionalTranslations,
             );
         } catch (error) {
+            // A guard's message IS the guard — wrapping it buries the
+            // instruction that makes it useful.
+            if (error instanceof GettextGuardError) {
+                throw error;
+            }
             throw new Error(`Failed to convert PO files to JSON: ${error}`);
         }
     }

--- a/packages/infra/vite-plugin-gettext/src/test.mts
+++ b/packages/infra/vite-plugin-gettext/src/test.mts
@@ -3,5 +3,7 @@ import { run } from '@gjsify/unit';
 import guardsSuite from './guards.spec.js';
 import xgettextSuite from './xgettext.spec.js';
 import linguasSuite from './linguas.spec.js';
+import catalogNamesSuite from './catalog-names.spec.js';
+import gettextSuite from './gettext.spec.js';
 
-run({ guardsSuite, xgettextSuite, linguasSuite });
+run({ guardsSuite, xgettextSuite, linguasSuite, catalogNamesSuite, gettextSuite });

--- a/packages/infra/vite-plugin-gettext/src/test.mts
+++ b/packages/infra/vite-plugin-gettext/src/test.mts
@@ -2,5 +2,6 @@ import { run } from '@gjsify/unit';
 
 import guardsSuite from './guards.spec.js';
 import xgettextSuite from './xgettext.spec.js';
+import linguasSuite from './linguas.spec.js';
 
-run({ guardsSuite, xgettextSuite });
+run({ guardsSuite, xgettextSuite, linguasSuite });

--- a/packages/infra/vite-plugin-gettext/src/types.ts
+++ b/packages/infra/vite-plugin-gettext/src/types.ts
@@ -77,6 +77,14 @@ export interface GettextPluginOptions {
     filename?: string;
     /** Enable verbose logging */
     verbose?: boolean;
+    /**
+     * Output names for catalogs whose name carries a script subtag the built-in
+     * table does not know, e.g. `{ az_Arab: ['az_IR'] }`.
+     *
+     * Per catalog rather than one blanket switch, so mapping one language does
+     * not disarm the check for the rest.
+     */
+    localeNames?: Record<string, readonly string[]>;
 }
 
 /**
@@ -119,6 +127,12 @@ export interface MsgfmtPluginOptions {
     useLocaleStructure?: boolean;
     /** Whether to remove XML comments from output files, defaults to true */
     removeComments?: boolean;
+    /**
+     * Locale directories for catalogs whose name carries a script subtag the
+     * built-in table does not know. Applies only to the gettext locale
+     * structure, which is the layout glibc looks up.
+     */
+    localeNames?: Record<string, readonly string[]>;
 }
 
 export interface PluginOptions {
@@ -156,4 +170,13 @@ export interface GettextPo2JsonPluginOptions {
      * The English text will be translated for non-default languages if translations exist
      */
     additionalTranslations?: Record<string, string>;
+
+    /**
+     * JSON basenames for catalogs whose name carries a script subtag with no
+     * Android resource qualifier, e.g. `{ sr_Latn: ['sr'] }`.
+     *
+     * The first entry is used, with `_` folded to `-`: a qualifier is
+     * `values-<lang>[-r<REGION>]` and cannot carry a script.
+     */
+    localeNames?: Record<string, readonly string[]>;
 }

--- a/packages/infra/vite-plugin-gettext/src/utils.ts
+++ b/packages/infra/vite-plugin-gettext/src/utils.ts
@@ -40,7 +40,23 @@ export async function findAvailableLanguages(
 ): Promise<string[]> {
     try {
         const files = await fs.readdir(poDirectory);
-        const languages = files.filter((file) => file.endsWith('.po')).map((file) => path.basename(file, '.po'));
+        const languages = files
+            .filter((file) => file.endsWith('.po'))
+            .map((file) => path.basename(file, '.po'))
+            // SORTED AT THE SOURCE, so every consumer is deterministic at once —
+            // the LINGUAS file, the compile order, and the locale-directory plan.
+            // `fs.readdir` returns filesystem order, which Node explicitly does
+            // not specify: on ext4 a small directory reads back in CREATION
+            // order, so a language that was removed and re-added moves to the end
+            // and LINGUAS is rewritten on a tree nobody touched
+            // (JumpLink/Learn6502#179).
+            //
+            // No comparator ON PURPOSE. The default is UTF-16 code-unit order —
+            // total, and identical on every host. `localeCompare` would order by
+            // the BUILDER's locale, which makes committed output depend on who
+            // built it: the same host-dependent-artifact bug in a new place.
+            // Locale names are ASCII, so code-unit order is also byte order.
+            .sort();
 
         if (verbose) {
             console.log(`[${pluginName}] Found languages: ${languages.join(', ')}`);
@@ -63,7 +79,12 @@ export async function findAvailableLanguages(
  */
 export async function generateLinguasFile(languages: string[], poDirectory: string, verbose = false) {
     const linguasPath = path.join(poDirectory, 'LINGUAS');
-    const content = languages.join('\n');
+    // Trailing newline: a POSIX text file ends with one. Without it git reports
+    // "\ No newline at end of file" on every regeneration, and any tool that
+    // appends to the list silently joins its first entry onto the last language.
+    // Sorted here as well as in `findAvailableLanguages` so a caller that
+    // assembles the list itself still gets a stable file.
+    const content = `${[...languages].sort().join('\n')}\n`;
 
     try {
         await fs.writeFile(linguasPath, content);


### PR DESCRIPTION
Two independent defects in `@gjsify/vite-plugin-gettext`, both in how a catalog's name
reaches an output path. Triggered by JumpLink/Learn6502#182 (locale names) and
JumpLink/Learn6502#179 (LINGUAS + the JSON names).

The measured lookup tables are in a comment below, so this body stays within the
line length commitlint allows for the squash commit.

## 1. A catalog landed where gettext never looks

Catalogs maintained on Weblate are named in BCP-47, which names simplified Chinese
`zh_Hans`. The compiler used the `.po` basename verbatim as the locale directory
(`src/gettext.ts:51`, language list from `src/utils.ts:43`; `src/msgfmt.ts:167` for the
msgfmt path), so the catalog landed in `locale/zh_Hans/LC_MESSAGES/`.

`zh_Hans` is not a POSIX locale name. `locale -a` has no such entry and glibc never
probes it.

Before, against the real Learn6502 `.mo`, with the glibc `gettext` CLI as the oracle:

```
zh_Hans    -> 黄色       (a selector no real user has)
zh_CN      -> Yellow     <-- MISSING: this is what a real user gets
zh_TW      -> Yellow     <-- MISSING
de         -> Gelb       (control: ordinary names were always fine)
```

A complete Chinese catalog shipped and every Chinese user saw English. The build exited
0, and 14 of the 15 catalogs were fine — which is why nobody looked.

After, same catalogs, same oracle:

```
zh_Hans    -> 黄色       (still works; the mapping is additive)
zh_CN      -> 黄色       FIXED
zh_SG      -> 黄色       FIXED
zh_TW      -> Yellow     correctly NOT claimed (see below)
de         -> Gelb       (control)
```

Three rules came out of the measurements, each counter-intuitive in one direction:

- a bare `<lang>` directory is reached by `<lang>_<TERRITORY>` users, so a script that is
  simply the language's normal one needs no territory;
- `<lang>@<modifier>` is reached by `<lang>_<TERRITORY>@<modifier>` users, while the
  narrower `<lang>_<TERRITORY>@<modifier>` is reached only by itself — here the tempting
  spelling is the wrong one;
- the broad `zh` is reached by `zh_TW` too, so installing a simplified catalog as `zh`
  would serve traditional users simplified text. Chinese territories are therefore
  spelled out and `zh` is never written — which is why `zh_TW -> Yellow` above is
  correct, not a gap.

The original name is kept alongside the mapped ones: additive, so no deployment that
already resolved a catalog stops resolving it, and the compiled tree stays greppable
against `po/`. It is never the only entry, which was the defect. A POSIX target absent
from the building host is still written (`zh_MO` is absent on Fedora 44, present
elsewhere) — the catalog is installed on machines whose locale set the build cannot see.

## 2. The same basename was also an Android resource qualifier

`po2json` wrote the basename as the JSON filename, and `@nativescript/localize` turns
that filename straight into a resource directory (`hooks/converter.js`, via
`` values-${language.replace(/^(.+?)-(.+?)$/, '$1-r$2')} ``). Running that transformation
over the names in play:

```
de       -> values-de        ok
pt-BR    -> values-pt-rBR    ok      <- the name the repo tracks
pt_BR    -> values-pt_BR     BROKEN  <- what po2json wrote
zh       -> values-zh        ok      <- the name the repo tracks
zh_Hans  -> values-zh_Hans   BROKEN  <- what po2json wrote
zh-Hans  -> values-zh-rHans  BROKEN  (a script subtag needs values-b+zh+Hans)
```

An underscore is not legal in a resource qualifier. Both generations sat in the tree at
once: the tracked, correct `pt-BR.json`/`zh.json` and the generated, dead
`pt_BR.json`/`zh_Hans.json`.

So the three targets have three namespaces and must not share a string. The mapping is
data in one table (`src/catalog-names.ts`) read by both plugins, not logic in each — two
copies of this reasoning drift, and the drifted copy wins silently. Evidence that this
restores rather than invents: after the fix the generator produces, against the real 16
catalogs, a filename set byte-identical to the one the repo already tracks.

Not measured: that Android then loads the resulting directory. The qualifier rule is
derived from the hook's source and the transformation above was executed against it, but
no emulator or device ran. The POSIX side is measured end to end against glibc.

## 3. LINGUAS was rewritten on every build

`gjsify workspace @learn6502/translations build` changed `LINGUAS` on an untouched tree
every run — `de`, `es`, `uk` moved to the end and the trailing newline vanished. Causes,
both in `src/utils.ts`: the list came straight from `fs.readdir` (order unspecified; on
ext4 a small directory reads back in creation order, so a language removed and re-added
moves to the end), and `join('\n')` left the last line without a newline.

Sorted at the source in `findAvailableLanguages`, so every consumer is deterministic at
once. No comparator on purpose — the default is UTF-16 code-unit order, identical on
every host, whereas `localeCompare` would order by the builder's locale and make
committed output depend on who built it.

## The mechanism, not just the instances

A silent fix would let the next catalog land wrong the same way. So:

- a catalog whose script subtag maps to no known name FAILS the build, naming every such
  catalog at once rather than aborting on the first. Same asymmetry the existing
  source-pattern guard is built on: a false failure costs one build and one config line,
  a missed one ships a whole language that renders in English. Escape hatch is
  `localeNames`, per catalog, so mapping one language does not disarm the rest.
- two catalogs claiming one output name fail too (`zh_Hans.po` beside a hand-made
  `zh_CN.po`), instead of one overwriting the other at exit 0.
- the determinism test runs the generator twice with the same set in different orders and
  demands byte equality — closing the class rather than the two instances, and doing it
  on every host instead of hoping a CI filesystem hands back a scrambled directory.

## Red to green

The new tests were run against the unmodified implementation (impl files reverted to
`origin/main`, tests kept):

```
10 of 55 tests failed - 88 assertions
  POSIX locale directories > compiles a Weblate script name into the locales glibc probes
  POSIX locale directories > folds a hyphenated catalog name to the POSIX spelling
  POSIX locale directories > refuses a catalog it cannot place instead of compiling it
  glibc as the oracle > a user with a real Chinese locale gets the Chinese catalog
  generateLinguasFile > writes the same bytes whatever order the languages arrive in
  generateLinguasFile > ends with a newline
  generateLinguasFile > sorts by code unit, not by the builder locale
  generateLinguasFile > is stable across two full plugin runs
  po2jsonPlugin > names the JSON so the resource qualifier comes out legal
  po2jsonPlugin > keeps the POSIX and Android names apart for one catalog
```

With the fix: `55 tests passed - 96 assertions`.

The oracle test asks the glibc `gettext` CLI, not our own implementation — asking the
implementation whether its own directory choice was right cannot see it be wrong, which
is how this survived.

The measurement trap, paid for once and now written into the spec header: `LC_ALL` must
name an installed, non-C locale. Under `C`, `C.UTF-8`, `POSIX` or an uninstalled locale,
glibc falls back to C and ignores `LANGUAGE` completely — every probe returns the
untranslated msgid and the suite measures nothing while looking green:

```
LC_ALL=en_US.UTF-8 -> HIT:zh_CN
LC_ALL=C.UTF-8     -> Yellow
LC_ALL=C           -> Yellow
(unset)            -> Yellow
```

The suite therefore discovers a usable locale at runtime, carries a `de` discriminator
that proves the probe can see translations at all, and falls back to
`it.failing(..., { when: !locale })` on a host that has none — so it runs as an ordinary
test wherever it can and self-retires rather than passing vacuously.

## Validation

`gjsify tsc --noEmit`, `gjsify run build`, `gjsify lint` (0 errors, 0 findings in this
package), `gjsify format`, full package suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8QkeZTJyNXrniXhrsncT6
