### PR TITLE
fix(ship): a symbolic icon is a context, and a zip says which OS it is for

### DIFF
--- a/.github/ship-oracle/verify-app-zip.sh
+++ b/.github/ship-oracle/verify-app-zip.sh
@@ -37,9 +37,9 @@
 # when it fails. Reproduce with
 #
 #   bash .github/ship-oracle/verify-app-zip.sh \
-#       "ship/out/ship-demo-1.2.3-1.arm64.zip" "ship/out/Ship Demo.app"
+#       "ship/out/ship-demo-1.2.3-1.macos.arm64.zip" "ship/out/Ship Demo.app"
 #   bash .github/ship-oracle/verify-app-zip.sh \
-#       "ship/out/ship-demo-1.2.3-1.x64.zip" "ship/out/Ship Demo" "program directory"
+#       "ship/out/ship-demo-1.2.3-1.windows.x64.zip" "ship/out/Ship Demo" "program directory"
 #
 # THE SECOND ARGUMENT IS THE `.app` ARTIFACT, not the stage, and the difference is
 # one file: both darwin formats pack the staged payload PLUS the format's licence

--- a/docs/adr/0024-ship-installable-artifacts.md
+++ b/docs/adr/0024-ship-installable-artifacts.md
@@ -655,6 +655,22 @@ Linux, `candle`+`light` (WiX Toolset v3.14, preinstalled on `windows-latest`) on
   shortcut points at the same `.cmd`, and `node.exe` is still a CONSOLE-subsystem image with no
   `nodew.exe` beside it.
 
+**Landed since, and it is § 2's "its icons" taken literally: `symbolic` is a CONTEXT, not a size.**
+`planIcons` sent every SVG to `scalable/` and renamed every icon to the bare app id, so the icon
+PAIR a modern GNOME app ships — `hicolor/scalable/apps/<id>.svg` beside
+`hicolor/symbolic/apps/<id>-symbolic.svg` — collapsed onto one destination and `ship` refused to run
+at all. Both halves were wrong, and `refs/adwaita-icon-theme/index.theme` is the measurement:
+`symbolic/apps` is listed in `Directories=` beside `scalable/apps`, with `Context=Applications`,
+`Size=16`, `MinSize=8`, `MaxSize=512`, `Type=Scalable` against the scalable row's `Size=128`. Its
+own directory, never a size — the freedesktop icon theme specification has no notion of it at all,
+which is exactly why reading the EXTENSION cannot see it. And GTK resolves a symbolic icon by the
+`-symbolic` name suffix, so the rename has to keep it: the same sentence `planIcons` already makes
+about `Icon=` pointing at the app id, applied to the other lookup. Cost of the gap, measured on
+Learn6502: its own Meson path installs both files and `ship` could install neither, so a `.deb` was
+a REGRESSION against the Flatpak of the same app. `isSymbolicIcon` reads the two signals the size
+logic already reads — a `symbolic/` path component or a `-symbolic` name — and SVG only, because the
+raster form `gtk-encode-symbolic-svg` writes is installed at a size instead.
+
 **Stage 1 (the ELF glibc floor) was already landed when this ADR was written**, and this paragraph
 previously said the opposite. Both halves are in the tree and have been since 2026-08-01,
 `7896c51b02` (#897): the reader is `@gjsify/manifest-conformance`'s `binary.mjs`

--- a/docs/adr/0024-ship-installable-artifacts.md
+++ b/docs/adr/0024-ship-installable-artifacts.md
@@ -671,6 +671,26 @@ a REGRESSION against the Flatpak of the same app. `isSymbolicIcon` reads the two
 logic already reads — a `symbolic/` path component or a `-symbolic` name — and SVG only, because the
 raster form `gtk-encode-symbolic-svg` writes is installed at a size instead.
 
+**Also landed, and it CHANGES A PUBLISHED NAME: the two zips say which OS they are.** § 2's table
+lists "zip" under macOS and "portable zip" under Windows and never asked what either is CALLED, so
+`windows-dir-zip` was written to `macos-app-zip`'s pattern and both emitted
+`<binary>-<version>-<release>.<arch>.zip`. What separated them inside one `ship/out/` was a
+coincidence between two unrelated arch tables — `MACOS_ARCH` maps `x64` to `x86_64`, `WINDOWS_ARCH`
+to `x64` — and `WINDOWS_ARCH` has one row only because gvsbuild publishes no arm64 GTK (#1117).
+That is a blocker standing in, not a design: the day it lifts, both formats write `…-1.arm64.zip`
+to the same directory and the second overwrites the first at exit 0. The user-facing half was
+already costing something, because the name is the whole of what a release page offers to choose
+by — a lone `…-1.arm64.zip` beside a Windows zip names no operating system. So the rows are
+`…-<release>.macos.<arch>.zip` and `…-<release>.windows.<arch>.zip`, in the user's spelling rather
+than `process.platform`'s, which is the call § A3's arch tables already make. `.deb`, `.rpm`,
+`.flatpak`, `.dmg` and `.msi` name their platform by extension and are untouched; `.zip` is the one
+container this table puts on two operating systems. **Breaking** for anything that downloads a
+darwin or windows zip by name — the rows shipped in v0.47.0 — and the rule is now held over the
+WHOLE table instead of by these two rows: every format is asked for its filename with the SAME arch
+label and the set must be unique, so holding the label fixed makes the latent collision red today
+and a row copied from its neighbour cannot reintroduce the class (`flatpak.spec.ts` § *format
+descriptors*; reasoning in `docs/ship-formats.md`).
+
 **Stage 1 (the ELF glibc floor) was already landed when this ADR was written**, and this paragraph
 previously said the opposite. Both halves are in the tree and have been since 2026-08-01,
 `7896c51b02` (#897): the reader is `@gjsify/manifest-conformance`'s `binary.mjs`

--- a/docs/ship-formats.md
+++ b/docs/ship-formats.md
@@ -83,6 +83,32 @@ Without that synthesis the archive expands into whatever directory the user was 
 `app\`, `share\` and a loose `.cmd` across it — and every entry would be individually correct, so
 no listing of names reads as wrong.
 
+### An artifact name must identify its format on its own
+
+`fileName` is a row's field, and the two zip rows are why it is worth a rule rather than a
+convention. `windows-dir-zip` was written to `macos-app-zip`'s pattern —
+`<binary>-<version>-<release>.<arch>.zip`, the second row copied from the first — and what kept the
+two apart in one `ship/out/` was a coincidence between two unrelated arch tables: `MACOS_ARCH` maps
+`x64` to `x86_64`, `WINDOWS_ARCH` maps it to `x64`. That is not a separation, it is a gap that had
+not closed yet: `WINDOWS_ARCH` has a single row only because gvsbuild publishes no arm64 GTK
+([#1117](https://github.com/gjsify/gjsify/issues/1117)), so the day a Windows/arm64 row lands both
+formats write `…-1.arm64.zip` to the same directory and the second overwrites the first at exit 0.
+It was already costing something before that: a lone `My App-0.7.0-1.arm64.zip` on a GitHub release
+page beside a Windows zip does not say which operating system it is for, and the name is the only
+thing a user has to choose by.
+
+So every zip row carries its OS (`macos`, `windows`), and the spelling is the USER's rather than
+`process.platform`'s — the same call `MACOS_ARCH` makes when it labels an artifact `x86_64` instead
+of `x64`. `.deb`, `.rpm`, `.flatpak`, `.dmg` and `.msi` each name one platform by extension and need
+no token; `.zip` names none and is the only container this table puts on more than one OS.
+
+The rule is held by a test over the WHOLE table rather than by these two rows
+(`flatpak.spec.ts` § *format descriptors*): every row is asked for its filename with the SAME arch
+label, and the set must be unique. Holding the label fixed is the point — it measures whether a row
+is distinguishable BY ITSELF or only by an arch table that may grow a value tomorrow, and it makes
+the latent Windows/arm64 collision observable today, years before the blocker lifts. A row added by
+copying its neighbour reds there.
+
 `windows-dir` is also the row where `archName` is one value: `wingtk/gvsbuild` hardcodes
 `self.platform = "x64"` and publishes no arm64 GTK, so there is nothing to build
 `@gjsify/gtk-runtime-win32-arm64` out of and no GTK for a Windows/ARM artifact to load

--- a/packages/infra/cli/AGENTS.md
+++ b/packages/infra/cli/AGENTS.md
@@ -63,6 +63,10 @@ content is one prefix row (`/app`) plus `buildsystem: simple` + `cp -a stage/.` 
 removes meson from the sandbox — and the six `gjsify.flatpak` BUILD keys have a per-KEY deprecation
 window into `gjsify.ship.flatpak` that `flatpak init` resolves too (one-sided, it would silently
 rewrite the manifest that command commits); the `AppMetadata` half is an alias and is NOT deprecated.
+**`symbolic` is an icon CONTEXT, never a size** — its own hicolor directory
+(`refs/adwaita-icon-theme/index.theme`), and GTK looks one up as `<app id>-symbolic`, so the staged
+rename keeps the suffix. Answering `scalable` for every SVG collapsed the pair a GNOME app ships
+onto one path and refused the pack.
 
 **AND WHICH OS'S LAYOUT IT WRAPS** — `FormatDescriptor.layoutOs`, NOT `host.finishOn`; `gjsify ship
 <linux|darwin|windows>` picks the layout, `defaultFormatIds(os)` filters on both, and a bare

--- a/packages/infra/cli/AGENTS.md
+++ b/packages/infra/cli/AGENTS.md
@@ -67,6 +67,9 @@ rewrite the manifest that command commits); the `AppMetadata` half is an alias a
 (`refs/adwaita-icon-theme/index.theme`), and GTK looks one up as `<app id>-symbolic`, so the staged
 rename keeps the suffix. Answering `scalable` for every SVG collapsed the pair a GNOME app ships
 onto one path and refused the pack.
+**And a row's `fileName` must identify its FORMAT alone**: the two zips were separated only by a
+coincidence between two arch tables, so every row is asked for its name with the SAME arch label
+and the set must be unique.
 
 **AND WHICH OS'S LAYOUT IT WRAPS** — `FormatDescriptor.layoutOs`, NOT `host.finishOn`; `gjsify ship
 <linux|darwin|windows>` picks the layout, `defaultFormatIds(os)` filters on both, and a bare

--- a/packages/infra/cli/src/utils/ship/flatpak.spec.ts
+++ b/packages/infra/cli/src/utils/ship/flatpak.spec.ts
@@ -34,6 +34,12 @@ function packSettings(overrides: Partial<PackSettings> = {}): PackSettings {
     return {
         binaryName: 'hello-app',
         appId: 'org.example.Hello',
+        // The DISPLAY name, and it was missing until a test asked a non-Flatpak row
+        // for its filename: `windows-dir` calls `windowsProgramDirName`, which reads
+        // it, so the omission surfaced as `Cannot read properties of undefined`
+        // rather than as a type error — a `Partial<PackSettings>` spread satisfies
+        // the required field as far as the compiler is concerned.
+        name: 'Hello App',
         version: '1.2.3',
         release: '1',
         maintainer: 'Dev <dev@example.org>',
@@ -277,6 +283,48 @@ export default async () => {
             // Not a label: the arch is part of `app/<id>/<arch>/<branch>`, so a
             // guess is a ref nothing can install.
             expect(() => FORMATS.flatpak.archName('s390x', false)).toThrow();
+        });
+
+        await it('gives every format an artifact name no other format can produce', async () => {
+            // THE ARCH LABEL IS HELD FIXED, and that is the whole measurement: it
+            // asks whether a row is distinguishable BY ITSELF, or only by an arch
+            // table that may grow a value tomorrow. `macos-app-zip` and
+            // `windows-dir-zip` were the second kind — separated by nothing but
+            // `MACOS_ARCH` mapping `x64` to `x86_64` where `WINDOWS_ARCH` maps it to
+            // `x64`, with #1117 the only reason the latter has one row. Passing the
+            // real per-row labels would therefore be green today and red years from
+            // now, in someone else's PR. Reasoning: `docs/ship-formats.md`.
+            //
+            // Over ALL rows rather than the zip pair, because the next format added
+            // by copying its neighbour is the one nobody thinks to check.
+            const settings = packSettings();
+            const byName = new Map<string, string>();
+            const collisions: string[] = [];
+            for (const id of FORMAT_IDS) {
+                const name = FORMATS[id].fileName(settings, 'SAME-ARCH');
+                const previous = byName.get(name);
+                if (previous !== undefined) collisions.push(`${previous} and ${id} both write ${name}`);
+                byName.set(name, id);
+            }
+            expect(collisions).toStrictEqual([]);
+        });
+
+        await it('names the operating system on every artifact whose extension does not', async () => {
+            // The other direction, because uniqueness alone is satisfied by any two
+            // strings that differ — including two that differ uselessly. `.zip` is
+            // the only container this table puts on more than one OS, so it is the
+            // only name that has to say which, in the spelling a downloader reads.
+            for (const id of FORMAT_IDS) {
+                const name = FORMATS[id].fileName(packSettings(), 'SAME-ARCH');
+                if (!name.endsWith('.zip')) continue;
+                expect(/\.(macos|windows|linux)\./.test(name)).toBe(true);
+            }
+            expect(FORMATS['macos-app-zip'].fileName(packSettings(), 'arm64')).toBe(
+                'hello-app-1.2.3-1.macos.arm64.zip',
+            );
+            expect(FORMATS['windows-dir-zip'].fileName(packSettings(), 'x64')).toBe(
+                'hello-app-1.2.3-1.windows.x64.zip',
+            );
         });
     });
 

--- a/packages/infra/cli/src/utils/ship/formats.ts
+++ b/packages/infra/cli/src/utils/ship/formats.ts
@@ -482,7 +482,22 @@ export const FORMATS: Record<FormatId, FormatDescriptor> = {
         // is a download: it lands in a browser's downloads folder beside other
         // files, so it carries the version and the arch, and it avoids the spaces
         // a display name may contain.
-        fileName: (s: PackSettings, archLabel: string) => `${s.binaryName}-${s.version}-${s.release}.${archLabel}.zip`,
+        //
+        // AND THE OPERATING SYSTEM, which the extension does not name. Every other
+        // row's suffix names exactly one platform — `.deb`, `.rpm`, `.flatpak`,
+        // `.dmg`, `.msi` — and `.zip` names none, so this row and `windows-dir-zip`
+        // are the only two artifacts in the table a user cannot tell apart by
+        // looking at them. Before this token they were separated by nothing but a
+        // coincidence between two unrelated arch tables (`MACOS_ARCH` maps x64 to
+        // `x86_64`, `WINDOWS_ARCH` to `x64`), which put a bare `…-1.arm64.zip` on a
+        // release page beside a Windows zip with no way to choose — and would have
+        // had the two formats silently overwrite each other in `ship/out/` the day
+        // a Windows/arm64 row became possible, an upstream blocker (#1117) being
+        // all that stood in the way. `macos`, not `darwin`, for the same reason
+        // `MACOS_ARCH` writes `x86_64` rather than `x64`: this label is read by
+        // whoever downloads the file, never by `process.platform`.
+        fileName: (s: PackSettings, archLabel: string) =>
+            `${s.binaryName}-${s.version}-${s.release}.macos.${archLabel}.zip`,
         artifactKind: 'file',
     },
     // ── macOS (#1354 M4) ─────────────────────────────────────────────────
@@ -694,7 +709,15 @@ export const FORMATS: Record<FormatId, FormatDescriptor> = {
         // pair splits them: this one is a download that lands in a browser's
         // folder beside other files, so it carries the version and the arch and
         // avoids the spaces a display name may contain.
-        fileName: (s: PackSettings, archLabel: string) => `${s.binaryName}-${s.version}-${s.release}.${archLabel}.zip`,
+        //
+        // …and the OS, for the reason spelled out on the `macos-app-zip` row it was
+        // copied from: `.zip` is the one container this table puts on more than one
+        // operating system, so it is the one name that has to say which. `windows`
+        // rather than `win32` — the spelling is the user's, like the `x64` this row
+        // keeps because Node's own archives, gvsbuild's assets and the runner label
+        // all use it.
+        fileName: (s: PackSettings, archLabel: string) =>
+            `${s.binaryName}-${s.version}-${s.release}.windows.${archLabel}.zip`,
         artifactKind: 'file',
     },
     // ── The Windows installer (#1354 M5) ─────────────────────────────────

--- a/packages/infra/cli/src/utils/ship/plan.spec.ts
+++ b/packages/infra/cli/src/utils/ship/plan.spec.ts
@@ -12,7 +12,7 @@
 import { describe, expect, it } from '@gjsify/unit';
 import { gunzip } from '@gjsify/tar';
 
-import { assertOverlayIsLicensed, iconSizeDir, planOverlay, planStage, type StageInputs } from './plan.js';
+import { assertOverlayIsLicensed, iconThemeDir, planOverlay, planStage, type StageInputs } from './plan.js';
 import { FORMATS } from './formats.js';
 import { renderLauncher } from './launcher.js';
 import { LAYOUTS } from './layout.js';
@@ -124,10 +124,52 @@ export default async () => {
             expect(paths).toContain('share/icons/hicolor/scalable/apps/org.example.Hello.svg');
         });
 
+        await it('stages the app icon PAIR a GNOME app ships, symbolic one included', async () => {
+            // The two files a modern GNOME app installs, spelled exactly as its own
+            // meson does (measured in Learn6502's `data/icons/meson.build`). Before
+            // `isSymbolicIcon` they planned onto ONE destination and `ship` refused
+            // to run — so this case is the consumer report, not a variation on the
+            // one above it. Why `symbolic` is a directory rather than a size, and
+            // why the suffix survives the rename: `isSymbolicIcon` in `plan.ts`.
+            const paths = planStage(
+                settings({
+                    iconFiles: [
+                        '/project/data/icons/hicolor/scalable/apps/org.example.Hello.svg',
+                        '/project/data/icons/hicolor/symbolic/apps/org.example.Hello-symbolic.svg',
+                    ],
+                }),
+                inputs(),
+            ).map((file) => file.path);
+            expect(paths).toContain('share/icons/hicolor/scalable/apps/org.example.Hello.svg');
+            expect(paths).toContain('share/icons/hicolor/symbolic/apps/org.example.Hello-symbolic.svg');
+        });
+
+        await it('renames a symbolic icon after the app id and KEEPS the suffix', async () => {
+            // The rename is the point — `Icon=` and the MetaInfo `<id>` name the app
+            // id, not the author's basename — but for a symbolic icon the name GTK
+            // looks up is `<id>-symbolic`. Source basename discarded, suffix kept.
+            const paths = planStage(
+                settings({ iconFiles: ['/project/data/icons/hicolor/symbolic/apps/whatever-symbolic.svg'] }),
+                inputs(),
+            ).map((file) => file.path);
+            expect(paths).toContain('share/icons/hicolor/symbolic/apps/org.example.Hello-symbolic.svg');
+        });
+
         await it('refuses two icons that would install as the same file', async () => {
             expect(() => planStage(settings({ iconFiles: ['/a/icon-64.png', '/b/other-64.png'] }), inputs())).toThrow(
                 'both install as',
             );
+        });
+
+        await it('still refuses two SYMBOLIC icons that would install as the same file', async () => {
+            // The collision check has to survive the new destination: two symbolic
+            // SVGs now agree on `symbolic/apps/<id>-symbolic.svg` the same way two
+            // 64px PNGs agree on `64x64/apps/<id>.png`. A context that silently
+            // overwrote would be the defect this fix exists to remove, one directory
+            // over.
+            expect(() =>
+                planStage(settings({ iconFiles: ['/a/one-symbolic.svg', '/b/two-symbolic.svg'] }), inputs()),
+            ).toThrow('both install as');
         });
 
         await it('refuses a schema whose name does not start with the app id', async () => {
@@ -309,15 +351,42 @@ export default async () => {
         });
     });
 
-    await describe('iconSizeDir', async () => {
+    await describe('iconThemeDir', async () => {
         await it('reads the size from the path, the filename, or the extension', async () => {
-            expect(iconSizeDir('/a/hicolor/256x256/apps/x.png')).toBe('256x256');
-            expect(iconSizeDir('/a/icon-48.png')).toBe('48x48');
-            expect(iconSizeDir('/a/icon.svg')).toBe('scalable');
+            expect(iconThemeDir('/a/hicolor/256x256/apps/x.png')).toBe('256x256');
+            expect(iconThemeDir('/a/icon-48.png')).toBe('48x48');
+            expect(iconThemeDir('/a/icon.svg')).toBe('scalable');
         });
 
         await it('refuses an icon whose size it cannot tell', async () => {
-            expect(() => iconSizeDir('/a/icon.png')).toThrow('cannot tell what size');
+            expect(() => iconThemeDir('/a/icon.png')).toThrow('cannot tell what size');
+        });
+
+        await it('answers `symbolic` for the context directory, which is not a size', async () => {
+            // The scalable row is asserted beside it on purpose: `symbolic` being a
+            // separate answer is only meaningful if the ordinary SVG still gets the
+            // old one. Both sides in one case, so a rule that swallowed every SVG
+            // into `symbolic/` could not pass here either.
+            expect(iconThemeDir('/a/hicolor/symbolic/apps/x-symbolic.svg')).toBe('symbolic');
+            expect(iconThemeDir('/a/hicolor/scalable/apps/x.svg')).toBe('scalable');
+        });
+
+        await it('takes either signal — the directory the author used, or the name', async () => {
+            // One case per signal, each with the OTHER absent: a file in `symbolic/`
+            // that is not named `-symbolic`, and one named `-symbolic` sitting
+            // nowhere in particular. Testing a path that carries both would pass for
+            // an implementation reading only one of them.
+            expect(iconThemeDir('/a/hicolor/symbolic/apps/plain.svg')).toBe('symbolic');
+            expect(iconThemeDir('/a/anywhere/app-symbolic.svg')).toBe('symbolic');
+        });
+
+        await it('leaves a PNG out of the symbolic context, which is Type=Scalable', async () => {
+            // The boundary `isSymbolicIcon` draws at the extension, from both sides:
+            // a `-symbolic` PNG in a sized directory still answers the size, and one
+            // with no size to read is still refused rather than quietly becoming a
+            // scalable icon that does not scale.
+            expect(iconThemeDir('/a/icons/16x16/status/x-symbolic.png')).toBe('16x16');
+            expect(() => iconThemeDir('/a/x-symbolic.png')).toThrow('cannot tell what size');
         });
     });
 };

--- a/packages/infra/cli/src/utils/ship/plan.ts
+++ b/packages/infra/cli/src/utils/ship/plan.ts
@@ -281,20 +281,28 @@ function renderDebianCopyright(settings: ShipSettings, licenseText: string): str
  * Icons land in the hicolor theme, named after the app id — that name is what
  * the desktop entry's `Icon=` and the MetaInfo `<id>` both point at, so a file
  * keeping its source basename installs an icon nothing ever looks up.
+ *
+ * A SYMBOLIC icon keeps the `-symbolic` half of that name, and for the same
+ * reason rather than as an exception: the name GTK resolves a symbolic icon by
+ * is `<app id>-symbolic`, so renaming the file to the bare id installs an icon
+ * nothing ever looks up — one sentence, applied to both lookups.
  */
 function planIcons(settings: ShipSettings): StagedFile[] {
     const out: StagedFile[] = [];
     const seen = new Map<string, string>();
     for (const icon of settings.iconFiles) {
         const ext = extname(icon);
-        const dir = iconSizeDir(icon);
-        const path = `${SHARE.icons}/${dir}/apps/${settings.appId}${ext}`;
+        const dir = iconThemeDir(icon);
+        const name = isSymbolicIcon(icon) ? `${settings.appId}-symbolic` : settings.appId;
+        const path = `${SHARE.icons}/${dir}/apps/${name}${ext}`;
         const previous = seen.get(path);
         if (previous !== undefined) {
             throw new Error(
                 `gjsify ship: ${icon} and ${previous} both install as ${path}. ` +
-                    'Icon size is read from the path (`.../128x128/...`) or the filename (`icon-128.png`); ' +
-                    'give them distinguishable sizes or point `gjsify.ship.icon` at a single file.',
+                    'An icon is keyed on its context and its size: `symbolic` is read from a `symbolic/` ' +
+                    'path component or a `-symbolic` filename, the size from the path (`.../128x128/...`) ' +
+                    'or the filename (`icon-128.png`). Give them distinguishable sizes, or point ' +
+                    '`gjsify.ship.icon` at a single file.',
             );
         }
         seen.set(path, icon);
@@ -304,11 +312,45 @@ function planIcons(settings: ShipSettings): StagedFile[] {
 }
 
 /**
- * The hicolor subdirectory for an icon: `scalable` for SVG, otherwise the
- * pixel size read from a `<n>x<n>` path component or a trailing number in the
- * filename.
+ * Whether an icon belongs in the theme's SYMBOLIC context rather than at a size.
+ *
+ * `symbolic` is a directory of its own in a hicolor theme and NOT a size value.
+ * Measured in `refs/adwaita-icon-theme/index.theme`, which lists `symbolic/apps`
+ * in `Directories=` beside `scalable/apps` and `16x16/apps` and gives it its own
+ * section — `Context=Applications`, `Size=16`, `MinSize=8`, `MaxSize=512`,
+ * `Type=Scalable` — against the scalable row's `Size=128`. The freedesktop icon
+ * theme specification has no notion of `symbolic` at all: a theme expresses it by
+ * giving the directory a section, which is exactly why reading the EXTENSION
+ * cannot see it, and why this question has to be asked before the size one.
+ *
+ * TWO SIGNALS, the same pair `iconThemeDir` already reads for a size: the
+ * directory an author put the file in, and the name they gave it. GTK resolves a
+ * symbolic icon by the `-symbolic` name suffix, so an author who wrote the name
+ * has said as much as one who wrote the path.
+ *
+ * SVG ONLY, because the symbolic directory is declared `Type=Scalable`: the
+ * raster form GTK's own `gtk-encode-symbolic-svg` produces
+ * (`<name>-symbolic.symbolic.png`) is installed at a SIZE instead. So a PNG keeps
+ * answering the size question, and one that cannot answer it stays refused rather
+ * than quietly becoming a scalable icon that does not scale.
  */
-export function iconSizeDir(iconPath: string): string {
+export function isSymbolicIcon(iconPath: string): boolean {
+    if (extname(iconPath).toLowerCase() !== '.svg') return false;
+    if (/(?:^|[\\/])symbolic[\\/]/.test(iconPath)) return true;
+    return basename(iconPath, extname(iconPath)).endsWith('-symbolic');
+}
+
+/**
+ * The hicolor subdirectory for an icon: the `symbolic` CONTEXT, else `scalable`
+ * for an SVG, else the pixel size read from a `<n>x<n>` path component or a
+ * trailing number in the filename.
+ *
+ * Named for the theme DIRECTORY rather than a size from the moment the first of
+ * those answers stopped being one: `iconSizeDir` returning `symbolic` would be a
+ * name every caller has to read past.
+ */
+export function iconThemeDir(iconPath: string): string {
+    if (isSymbolicIcon(iconPath)) return 'symbolic';
     if (extname(iconPath).toLowerCase() === '.svg') return 'scalable';
     const square = /(?:^|[\\/])(\d{1,4})x\1(?:[\\/]|$)/.exec(iconPath);
     if (square) return `${square[1]}x${square[1]}`;

--- a/status/agent-context-budget.json
+++ b/status/agent-context-budget.json
@@ -3,7 +3,7 @@
     "packages/dom/AGENTS.md": 2081,
     "packages/framework/AGENTS.md": 20421,
     "packages/infra/AGENTS.md": 1131,
-    "packages/infra/cli/AGENTS.md": 26422,
+    "packages/infra/cli/AGENTS.md": 26644,
     "packages/infra/resolve-npm/AGENTS.md": 7939,
     "packages/infra/rolldown-plugin-gjsify/AGENTS.md": 24972,
     "packages/napi/AGENTS.md": 7179,

--- a/status/agent-context-budget.json
+++ b/status/agent-context-budget.json
@@ -3,7 +3,7 @@
     "packages/dom/AGENTS.md": 2081,
     "packages/framework/AGENTS.md": 20421,
     "packages/infra/AGENTS.md": 1131,
-    "packages/infra/cli/AGENTS.md": 26111,
+    "packages/infra/cli/AGENTS.md": 26422,
     "packages/infra/resolve-npm/AGENTS.md": 7939,
     "packages/infra/rolldown-plugin-gjsify/AGENTS.md": 24972,
     "packages/napi/AGENTS.md": 7179,

--- a/tests/e2e/ship-layout/run.mjs
+++ b/tests/e2e/ship-layout/run.mjs
@@ -278,6 +278,7 @@ describe('CLI ship layout axis E2E', { timeout: 10 * 60 * 1000 }, () => {
             `share/fonts/${APP_ID}/${FONT_LEAF}`,
             `share/glib-2.0/schemas/${APP_ID}.gschema.xml`,
             `share/icons/hicolor/scalable/apps/${APP_ID}.svg`,
+            `share/icons/hicolor/symbolic/apps/${APP_ID}-symbolic.svg`,
             `share/metainfo/${APP_ID}.metainfo.xml`,
             `share/mime/packages/${APP_ID}.xml`,
         ]);
@@ -729,7 +730,10 @@ describe('CLI ship layout axis E2E', { timeout: 10 * 60 * 1000 }, () => {
             dir,
         );
         assert.equal(status, 0);
-        assert.match(stderr, /carries 6 file\(s\)/);
+        // SEVEN since the fixture ships the icon PAIR: the symbolic half is another
+        // `share/icons/hicolor/**` file, so it is install-dependent for exactly the
+        // same reason as the scalable one and the count follows the payload.
+        assert.match(stderr, /carries 7 file\(s\)/);
         assert.match(stderr, /UNCLASSIFIED: share\/dbus-1\/services\/org\.example\.ShipDemo\.service/);
     });
 

--- a/tests/e2e/ship-macos/run.mjs
+++ b/tests/e2e/ship-macos/run.mjs
@@ -80,7 +80,7 @@ const BINARY = 'ship-demo';
  * about that name true only on an x64 runner.
  */
 const ARCH = 'arm64';
-const ZIP_NAME = `${BINARY}-1.2.3-1.${ARCH}.zip`;
+const ZIP_NAME = `${BINARY}-1.2.3-1.macos.${ARCH}.zip`;
 
 /** The ZIP writer itself, for the two red runs no CLI invocation can produce. */
 const { buildZip } = await import(

--- a/tests/e2e/ship-msi/run.mjs
+++ b/tests/e2e/ship-msi/run.mjs
@@ -316,7 +316,7 @@ describe('CLI ship Windows installer E2E', { timeout: 10 * 60 * 1000 }, () => {
         const out = join(twice, 'ship', 'out');
         assert.ok(existsSync(join(out, MSI_NAME)), 'the second run produced no installer');
         assert.ok(existsSync(join(out, APP_NAME)), 'the second run removed the first run\u2019s directory');
-        assert.ok(existsSync(join(out, `${BINARY}-1.2.3-1.${ARCH}.zip`)), 'the second run removed the zip');
+        assert.ok(existsSync(join(out, `${BINARY}-1.2.3-1.windows.${ARCH}.zip`)), 'the second run removed the zip');
         // And the installer the second run built describes the directory the first
         // one did — which is the claim the CI leg's oracle call depends on.
         oracle([join(out, MSI_NAME), join(out, APP_NAME), 'msitools']);

--- a/tests/e2e/ship-windows/run.mjs
+++ b/tests/e2e/ship-windows/run.mjs
@@ -83,7 +83,7 @@ import {
     TARGET,
 } from '../ship/windows-fixture.mjs';
 
-const ZIP_NAME = `${BINARY}-1.2.3-1.${ARCH}.zip`;
+const ZIP_NAME = `${BINARY}-1.2.3-1.windows.${ARCH}.zip`;
 
 /** The ZIP writer itself, for the red run no CLI invocation can produce. */
 const { buildZip } = await import(

--- a/tests/e2e/ship/fixture.mjs
+++ b/tests/e2e/ship/fixture.mjs
@@ -104,16 +104,25 @@ export const NODE_BUNDLE = [
 ].join('\n');
 
 /**
- * A minimal but complete GJS project: a built bundle, an icon, a schema, a licence.
+ * A minimal but complete GJS project: a built bundle, an icon PAIR, a schema, a licence.
  *
  * `mutate` receives the DIRECTORY as well as the manifest, so a caller can plant
  * a second bundle beside the first — which is the layout `resolve-gjs-entry.ts`
  * documents as normal (`dist/<name>.gjs.js` next to `dist/<name>.node.mjs`) and
  * the one a filename heuristic mis-read.
+ *
+ * THE ICON IS A PAIR because that is what a GNOME app ships, and the single
+ * scalable SVG this fixture used to carry is what hid the defect: with one icon
+ * there is nothing for a second to collide with. Learn6502's own
+ * `data/icons/meson.build` installs exactly these two paths, and pointing
+ * `gjsify.ship.icon` at that directory made `ship` refuse to run — both files
+ * were planned into `scalable/apps/<id>.svg`, because every SVG answered
+ * `scalable` and every icon was renamed to the bare app id.
  */
 export function scaffold(dir, mutate) {
     mkdirSync(join(dir, 'dist'), { recursive: true });
     mkdirSync(join(dir, 'data', 'icons', 'hicolor', 'scalable', 'apps'), { recursive: true });
+    mkdirSync(join(dir, 'data', 'icons', 'hicolor', 'symbolic', 'apps'), { recursive: true });
 
     const pkg = {
         name: 'ship-demo',
@@ -167,6 +176,10 @@ export function scaffold(dir, mutate) {
     writeFileSync(join(dir, 'data', `${APP_ID}.gschema.xml`), '<schemalist/>\n');
     writeFileSync(
         join(dir, 'data', 'icons', 'hicolor', 'scalable', 'apps', `${APP_ID}.svg`),
+        '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"/>\n',
+    );
+    writeFileSync(
+        join(dir, 'data', 'icons', 'hicolor', 'symbolic', 'apps', `${APP_ID}-symbolic.svg`),
         '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"/>\n',
     );
     writeFileSync(join(dir, 'LICENSE'), 'MIT License\n\nPermission is hereby granted, free of charge…\n');

--- a/tests/e2e/ship/run.mjs
+++ b/tests/e2e/ship/run.mjs
@@ -73,6 +73,11 @@ describe('CLI ship E2E', { timeout: 10 * 60 * 1000 }, () => {
             `share/applications/${APP_ID}.desktop`,
             `share/glib-2.0/schemas/${APP_ID}.gschema.xml`,
             `share/icons/hicolor/scalable/apps/${APP_ID}.svg`,
+            // The symbolic half of the pair, in its OWN context directory and
+            // keeping the suffix GTK looks it up by. Both facts are what the
+            // fixture's second icon holds: in a hicolor theme `symbolic` is a
+            // sibling of `scalable`, never a value of its size.
+            `share/icons/hicolor/symbolic/apps/${APP_ID}-symbolic.svg`,
             `share/metainfo/${APP_ID}.metainfo.xml`,
             `share/mime/packages/${APP_ID}.xml`,
         ]);

--- a/website/src/content/docs/ship/index.mdx
+++ b/website/src/content/docs/ship/index.mdx
@@ -44,8 +44,8 @@ different one.
 | Command | What lands in `ship/out/` | That target runs |
 |---|---|---|
 | `gjsify ship linux` | `my-app_1.2.3-1_all.deb`, `my-app-1.2.3-1.noarch.rpm` | `gjs` or `node` |
-| `gjsify ship darwin` | `My App.app`, `my-app-1.2.3-1.arm64.zip` | `node` |
-| `gjsify ship windows` | `My App/`, `my-app-1.2.3-1.x64.zip` | `node` |
+| `gjsify ship darwin` | `My App.app`, `my-app-1.2.3-1.macos.arm64.zip` | `node` |
+| `gjsify ship windows` | `My App/`, `my-app-1.2.3-1.windows.x64.zip` | `node` |
 
 Each target picks its own runtime from `gjsify.ship.app.<os>`, keyed `linux`,
 `darwin` and `win32`, falling back to `gjsify.app`. So one project can be GJS on

--- a/website/src/content/docs/ship/macos.md
+++ b/website/src/content/docs/ship/macos.md
@@ -13,12 +13,15 @@ gjsify ship darwin --arch arm64
 
 ```text
 ship/out/My App.app
-ship/out/my-app-1.2.3-1.arm64.zip
+ship/out/my-app-1.2.3-1.macos.arm64.zip
 ```
 
 The `.app` is the artifact a user drags into `/Applications`. The zip is the
-artifact a user downloads, so it carries the version and the architecture in its
-filename and avoids the spaces a display name may contain.
+artifact a user downloads, so it carries the operating system, the version and
+the architecture in its filename, and avoids the spaces a display name may
+contain. `.zip` is the only suffix `ship` uses on more than one operating system
+— a `.dmg` or an `.msi` could be nothing else — so the macOS and Windows zips say
+which one they are, and a release page holding both stays readable.
 
 `--arch` takes `x64` or `arm64` and defaults to the architecture of the host you
 run it on. It labels the artifact and picks which runtime packages are staged.

--- a/website/src/content/docs/ship/windows.md
+++ b/website/src/content/docs/ship/windows.md
@@ -14,12 +14,14 @@ gjsify ship windows
 
 ```text
 ship/out/My App/
-ship/out/my-app-1.2.3-1.x64.zip
+ship/out/my-app-1.2.3-1.windows.x64.zip
 ```
 
 The program directory is what an installer lays down and a user browses to. The
-zip is what a user downloads, so it carries the version and the architecture in
-its filename.
+zip is what a user downloads, so it carries the operating system, the version and
+the architecture in its filename. The `windows` token is there because `.zip` is
+the only suffix `ship` uses on more than one operating system: without it this
+artifact and the macOS one are two files a user cannot tell apart.
 
 `x64` is the only architecture. `gvsbuild`, the project that builds GTK for
 Windows, publishes no arm64 binaries, so there is no GTK for a Windows on ARM


### PR DESCRIPTION
Two defects in `packages/infra/cli/src/utils/ship/`, both found while wiring `gjsify ship` into
Learn6502. Neither is a style question: one makes `ship` refuse to run on an ordinary GNOME app,
the other puts two indistinguishable files on a release page.

Both premises were checked against [ADR 0024](docs/adr/0024-ship-installable-artifacts.md) first.
Neither behaviour was a decision the ADR had made — § 2's payload table says "its icons" and "zip"
and never asked what either means in detail, so both were gaps rather than choices. The ADR now
records both, in § Implementation status.

---

## 1 — the symbolic icon collided with the regular one and lost its name

Learn6502 ships the icon PAIR every modern GNOME app ships. Measured with `gjsify.ship.icon`
pointed at its `hicolor` directory:

**Before**
```
gjsify ship: …/symbolic/apps/eu.jumplink.Learn6502-symbolic.svg and
…/scalable/apps/eu.jumplink.Learn6502.svg both install as
share/icons/hicolor/scalable/apps/eu.jumplink.Learn6502.svg.
```

**After**
```
share/icons/hicolor/scalable/apps/eu.jumplink.Learn6502.svg
share/icons/hicolor/symbolic/apps/eu.jumplink.Learn6502-symbolic.svg
```

### Cause

- `plan.ts:312` (`iconSizeDir`) answered `scalable` for **every** SVG.
- `plan.ts:285` (`planIcons`) renamed every file to `${appId}${ext}`, so even without a collision
  the `-symbolic` suffix was dropped.

Either alone breaks the app; together they made `ship` refuse to pack at all. The author's only
escape was to point `icon` at a single file, which ships a `.deb`/`.rpm` **without** the symbolic
icon that the same app's Meson and Flatpak paths both install — a regression against its own
Flatpak.

### Verified against the spec and a real theme, not from memory

`refs/adwaita-icon-theme/index.theme` (submodule initialised for this) lists `symbolic/apps` in
`Directories=` as a sibling of `scalable/apps` and `16x16/apps`, and gives it its own section:

```ini
[symbolic/apps]              [scalable/apps]
Context=Applications         Context=Applications
Size=16                      Size=128
MinSize=8                    MinSize=8
MaxSize=512                  MaxSize=512
Type=Scalable                Type=Scalable
```

A `Size` of 16 where the scalable row says 128 — its own directory, emphatically not the same
one under another name. The [freedesktop icon theme specification][spec] has no notion of
`symbolic` at all: a directory's meaning comes from its `index.theme` section (`Context`, `Size`,
`Type`), which is exactly why reading the file EXTENSION cannot see it. And Learn6502's own
`data/icons/meson.build` installs `hicolor/symbolic/apps/<id>-symbolic.svg` — the `-symbolic`
suffix is the name GTK looks the icon up by, so the rename has to keep it.

[spec]: https://specifications.freedesktop.org/icon-theme/latest/

### Fix

`isSymbolicIcon()` reads the two signals the size logic already reads — a `symbolic/` path
component **or** a `-symbolic` basename — and SVG only, because the symbolic directory is declared
`Type=Scalable` and the raster form `gtk-encode-symbolic-svg` writes is installed at a size
instead. `iconSizeDir` → `iconThemeDir`: it no longer answers a size.

### Red → green

The e2e fixture shipped one lone SVG, which is what hid the defect — with one icon there is nothing
for a second to collide with. It now ships the pair. Against the **unfixed** planner, the real CLI
reproduces the consumer report verbatim:

```
✖ stages one prefix-relative payload
  Error: Command failed: … lib/index.js ship --skip-build
  gjsify ship: /tmp/…/hicolor/symbolic/apps/org.example.ShipDemo-symbolic.svg and
  /tmp/…/hicolor/scalable/apps/org.example.ShipDemo.svg both install as
  share/icons/hicolor/scalable/apps/org.example.ShipDemo.svg. …
```

Unit level, same commit, before the fix:

```
✖ planStage › stages the app icon PAIR a GNOME app ships, symbolic one included
✖ planStage › renames a symbolic icon after the app id and KEEPS the suffix
✖ iconThemeDir › answers `symbolic` for the context directory, which is not a size
✖ iconThemeDir › takes either signal — the directory the author used, or the name
```

After: `1728 tests passed · 4130 assertions`, `tests/e2e/ship` 44/44.

---

## 2 — the macOS and Windows zips had the same name

`formats.ts` gave both zip rows the identical pattern — `windows-dir-zip` was written by copying
`macos-app-zip`:

```js
// macos-app-zip  (was line 485)
fileName: (s, archLabel) => `${s.binaryName}-${s.version}-${s.release}.${archLabel}.zip`
// windows-dir-zip (was line 697)   ← byte-identical
fileName: (s, archLabel) => `${s.binaryName}-${s.version}-${s.release}.${archLabel}.zip`
```

**Before** — two files on one release page:
```
eu.jumplink.Learn6502-0.7.0-1.arm64.zip     ← which OS?
eu.jumplink.Learn6502-0.7.0-1.x64.zip       ← which OS?
```

**After**:
```
eu.jumplink.Learn6502-0.7.0-1.macos.arm64.zip
eu.jumplink.Learn6502-0.7.0-1.windows.x64.zip
```

### Cause, and why it is worse than it looks

The only thing separating the two artifacts in one `ship/out/` was a coincidence between two
unrelated arch tables: `MACOS_ARCH` (line 99) maps `x64` → `x86_64`, `WINDOWS_ARCH` (line 135)
maps it → `x64`. And `WINDOWS_ARCH` has a single row **only** because gvsbuild publishes no arm64
GTK (#1117). That is an upstream blocker standing in for a design — the day it lifts, both formats
write `…-1.arm64.zip` into the same directory and the second silently overwrites the first at
exit 0.

### Spelling, decided rather than picked

`macos`/`windows`, not `darwin`/`win32`. The label is read by whoever downloads the file, never by
`process.platform` — which is the same call `MACOS_ARCH` already makes when it writes `x86_64`
instead of `x64`, and the same one the format IDs (`macos-app-zip`, `windows-dir-zip`) already make.
Only the zip rows get a token: `.deb`, `.rpm`, `.flatpak`, `.dmg` and `.msi` each name exactly one
platform by extension, and `.zip` is the one container this table puts on two operating systems.

### The mechanism, so the class cannot come back

A test over **all** format rows, not the zip pair — because the next row added by copying its
neighbour is the one nobody thinks to check. Every row is asked for its filename with the **same**
arch label, and the set must be unique.

Holding the label fixed is the whole measurement: it asks whether a row is distinguishable *by
itself* or only by an arch table that may grow a value tomorrow. Passing the real per-row labels
would be green today and red years from now, in someone else's PR.

Verified with a discriminator rather than trusted — the first red run was a crash, not a collision,
so the guard was deliberately broken once with the fix in place:

```
❌ gives every format an artifact name no other format can produce
   Expected: []
   Actual: ["macos-app-zip and windows-dir-zip both write hello-app-1.2.3-1.macos.SAME-ARCH.zip"]
```

A second case holds the other direction, since uniqueness alone is satisfied by any two strings
that differ — including two that differ uselessly.

That first crash was itself a find: `PackSettings.name` was missing from the spec fixture and
`windows-dir` reads it. A `Partial<PackSettings>` spread satisfies the required field as far as
`tsc` is concerned, so nothing had ever noticed.

### Every co-reader pulled along

`tests/e2e/ship-macos`, `ship-windows`, `ship-msi` · `.github/ship-oracle/verify-app-zip.sh` ·
`docs/ship-formats.md` (new section: *An artifact name must identify its format on its own*) ·
`website/src/content/docs/ship/{index.mdx,macos.md,windows.md}`. Swept for any other reader of the
old pattern — none left.

---

## Breaking change: **yes**, and marked as one

A published artifact filename is an interface, and these two rows shipped in **v0.47.0, v0.48.0 and
v0.49.0** (verified with `git show <tag>:…/formats.ts`). Anything that downloads or globs the
darwin/windows zip by exact name has to be updated. Commit 2 carries `!` and a `BREAKING CHANGE:`
footer. No other artifact name changes — `.deb`, `.rpm`, `.flatpak`, `.dmg`, `.msi`, the
`<App>.app` tree and the Windows program directory are untouched.

## Validation

| | |
|---|---|
| `gjsify workspace @gjsify/cli test` | ✅ 1728 passed · 4130 assertions |
| `gjsify workspace @gjsify/cli check` (tsc) | ✅ exit 0 |
| `gjsify lint` | ✅ 0 errors |
| `gjsify format --check` | ✅ clean |
| `tests/e2e/ship` | ✅ 44/44 |
| `tests/e2e/ship-layout` | ✅ 39/39 |
| `tests/e2e/ship-macos` | ✅ 37/37 |
| `tests/e2e/ship-windows` | ✅ 29/29 |
| `tests/e2e/ship-from-stage` | ✅ 20/20 |
| `tests/e2e/ship-declaration` | ✅ 19/19 |
| `tests/e2e/ship-signing` | ✅ 21/21 |
| `tests/e2e/ship-flatpak` | ✅ 9/9 |
| `tests/e2e/ship-msi` | ⚠️ needs `msitools` (absent here, hard-fails by design) — runs in CI |

`status/agent-context-budget.json` moves twice, once per commit: the agent-context ratchet is
EXACT in both directions, so each commit that changes `packages/infra/cli/AGENTS.md` carries its own
ledger line (26111 → 26422 → 26644). Both additions are the RULE plus its incident; the reasoning
lives in `docs/ship-formats.md` and the ADR.

`ship-layout`'s install-dependent warning moved from "carries 6 file(s)" to 7: the symbolic icon is
another `share/icons/hicolor/**` file, so it is install-dependent for the same reason as the
scalable one and the count follows the payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8QkeZTJyNXrniXhrsncT6


BREAKING CHANGE: the macOS and Windows zip artifacts now carry the operating
system in their filename. `macos-app-zip` writes
`<binaryName>-<version>-<release>.macos.<arch>.zip` and `windows-dir-zip`
writes `.windows.<arch>.zip`. Anything matching the old
`<binaryName>-<version>-<release>.<arch>.zip` by exact name must be updated.
