### PR TITLE
fix(rolldown-native): keep a failing hook's message

### DIFF
--- a/packages/infra/rolldown-native/src/ts/plugins.ts
+++ b/packages/infra/rolldown-native/src/ts/plugins.ts
@@ -255,6 +255,84 @@ export function isResolveMiss(error: string): boolean {
     return error.startsWith('NotFound(');
 }
 
+/** Which plugin's which hook a failure came from. */
+interface HookSite {
+    plugin: string;
+    hook: string;
+}
+
+/**
+ * How many hook failures to spell out in full before summarising the rest.
+ *
+ * Not 1, and not unbounded. ONE is wrong because the COUNT is itself the
+ * diagnosis: 22 of a showcase's 24 `.blp` files failed in a fedora:43 container,
+ * and the two that loaded were the two without `using Adw 1;` — no single
+ * message said "libadwaita is missing", but "22, and exactly the Adw ones" did.
+ * UNBOUNDED is wrong because each blueprint-compiler failure is a five-line
+ * excerpt with a caret, and 22 of those bury the line carrying the count.
+ *
+ * Eight shows that the failures are the same failure repeated, which is the
+ * reader's actual question; the total is stated regardless.
+ */
+const HOOK_ERROR_DETAIL_LIMIT = 8;
+
+/**
+ * The plugin-hook failures of one bundle run, kept so the build can say WHY it
+ * failed.
+ *
+ * Every hook error is already known in JS — the plugin threw it and
+ * `respondError` serialised it — and then the round trip through Rust throws it
+ * away. `Bundler::generate`'s error is Debug-formatted (`session.rs`,
+ * `format!("… {e:?}")`) and rolldown's `BuildDiagnostic` has a
+ * `finish_non_exhaustive()` Debug impl, so everything past the short `message`
+ * collapses into a literal `..`. Measured on this tree, one deliberate syntax
+ * error in a `.blp`, whole output:
+ *
+ *     {"error":"rolldown: Bundler::generate: BatchedBuildDiagnostic([
+ *       BuildDiagnostic { severity: Error, kind: "UNLOADABLE_DEPENDENCY",
+ *         message: "Could not load src/header-bar.blp", .. }])"}
+ *
+ * The same build under the Node engine printed blueprint-compiler's own "Could
+ * not determine what kind of syntax is meant here" with the line and a caret.
+ * One build, two engines, and only one of them answers the question.
+ *
+ * So the JS side keeps its own copy instead of hoping the reason survives the
+ * crossing. Deliberately NOT a blueprint fix: `respondError` is the one place
+ * all twelve hooks of every plugin funnel through, so `xgettext`, `msgfmt`,
+ * `glib-compile-resources` and whatever a future plugin spawns are covered by
+ * construction.
+ */
+class HookErrorLog {
+    private readonly entries: (HookSite & { message: string })[] = [];
+
+    record(site: HookSite, message: string): void {
+        this.entries.push({ ...site, message });
+    }
+
+    /**
+     * The recorded failures as one block, or '' when there were none.
+     *
+     * COLLECTS rather than failing fast, because the JS side has no say in it:
+     * by the time a hook rejects, rolldown has already dispatched the other
+     * modules onto its worker pool, and it batches the diagnostics
+     * (`BatchedBuildDiagnostic`) before it stops. Aborting the session at the
+     * first error would therefore not save work — it would only discard the
+     * other failures, and with them the count that names the shared cause.
+     */
+    format(): string {
+        if (this.entries.length === 0) return '';
+        const shown = this.entries.slice(0, HOOK_ERROR_DETAIL_LIMIT);
+        const lines = shown.map(({ plugin, hook, message }) => `  [plugin ${plugin}] ${hook}: ${message}`);
+        const omitted = this.entries.length - shown.length;
+        if (omitted > 0) lines.push(`  … and ${omitted} more`);
+        const headline =
+            this.entries.length === 1
+                ? '1 plugin hook failed during this build:'
+                : `${this.entries.length} plugin hooks failed during this build:`;
+        return `${headline}\n${lines.join('\n')}`;
+    }
+}
+
 export function bundleWithPlugins(options: BundleOptions, plugins: NativePlugin[]): Promise<BundleResult> {
     const native = loadNativeRolldown();
     if (!native) {
@@ -264,6 +342,9 @@ export function bundleWithPlugins(options: BundleOptions, plugins: NativePlugin[
 
     const session = new NativeMod.BundlerSession();
     activeSessions.add(session);
+    // Per call, so a second bundle in the same process never inherits the
+    // first one's failures (`--globals auto` alone runs three per build).
+    const hookErrors = new HookErrorLog();
     const ctxResolveSlots = new Map<
         number,
         { resolve: (v: { id: string; external: boolean } | null) => void; reject: (e: Error) => void }
@@ -339,16 +420,19 @@ export function bundleWithPlugins(options: BundleOptions, plugins: NativePlugin[
         pluginIndex: number,
         argsBytes: GLib.Bytes,
     ): Promise<void> {
+        // Named before `plugins[pluginIndex]` is known to exist, so the two
+        // bridge-internal failures below are still attributable to something.
+        const where: HookSite = { plugin: plugins[pluginIndex]?.name ?? `#${pluginIndex}`, hook: hookName };
         let args: HookArgs;
         try {
             args = JSON.parse(dec(argsBytes)) as HookArgs;
         } catch (e) {
-            respondError(reqId, e);
+            respondError(reqId, e, where);
             return;
         }
         const plugin = plugins[pluginIndex];
         if (!plugin) {
-            respondError(reqId, new Error(`@gjsify/rolldown-native: unknown plugin index ${pluginIndex}`));
+            respondError(reqId, new Error(`@gjsify/rolldown-native: unknown plugin index ${pluginIndex}`), where);
             return;
         }
         const ctx = makeContext(reqId);
@@ -364,13 +448,13 @@ export function bundleWithPlugins(options: BundleOptions, plugins: NativePlugin[
                 }
                 const code = dec(codeBytes);
                 const result = await plugin.transform.call(ctx, code, a.id, a.moduleType);
-                respondTransform(reqId, result);
+                respondTransform(reqId, result, where);
                 return;
             }
             const result = await runHook(plugin, hookName, args, ctx);
             respondOk(reqId, result);
         } catch (e) {
-            respondError(reqId, e);
+            respondError(reqId, e, where);
         }
     }
 
@@ -387,7 +471,7 @@ export function bundleWithPlugins(options: BundleOptions, plugins: NativePlugin[
      * via `hasCodeBytes: true`. Falls back to a normal `kind:'skip'`
      * when the handler returned null/undefined.
      */
-    function respondTransform(reqId: number, value: unknown): void {
+    function respondTransform(reqId: number, value: unknown, where: HookSite): void {
         if (value === undefined || value === null) {
             session.respond(reqId, enc(JSON.stringify({ kind: 'skip' })));
             return;
@@ -413,6 +497,7 @@ export function bundleWithPlugins(options: BundleOptions, plugins: NativePlugin[
             respondError(
                 reqId,
                 new Error(`@gjsify/rolldown-native: failed to stash transform response payload for reqId ${reqId}`),
+                where,
             );
             return;
         }
@@ -427,8 +512,17 @@ export function bundleWithPlugins(options: BundleOptions, plugins: NativePlugin[
         );
     }
 
-    function respondError(reqId: number, e: unknown): void {
+    /**
+     * Answer one hook request with a failure — and keep a copy.
+     *
+     * The `hookErrors.record` call is the whole fix: the response still goes to
+     * Rust exactly as before (rolldown needs it to mark the module unloadable),
+     * but the message no longer depends on surviving the crossing. See
+     * {@link HookErrorLog}.
+     */
+    function respondError(reqId: number, e: unknown, where: HookSite): void {
         const err = e instanceof Error ? e : new Error(String(e));
+        hookErrors.record(where, err.message);
         session.respond(
             reqId,
             enc(
@@ -467,7 +561,12 @@ export function bundleWithPlugins(options: BundleOptions, plugins: NativePlugin[
             }
         });
         session.connect('error_occurred', (_self: SessionInstance, msg: string) => {
-            reject(new Error(msg));
+            // `msg` stays FIRST and verbatim: it is the only line that carries
+            // rolldown's own diagnostics — a parse error, an unresolved import,
+            // anything no JS hook was involved in — and it names the modules.
+            // The hook log is what it cannot tell you, appended after it.
+            const detail = hookErrors.format();
+            reject(new Error(detail ? `${msg}\n${detail}` : msg));
         });
 
         try {

--- a/packages/infra/vite-plugin-gettext/src/test.mts
+++ b/packages/infra/vite-plugin-gettext/src/test.mts
@@ -1,9 +1,10 @@
 import { run } from '@gjsify/unit';
 
 import guardsSuite from './guards.spec.js';
+import utilsSuite from './utils.spec.js';
 import xgettextSuite from './xgettext.spec.js';
 import linguasSuite from './linguas.spec.js';
 import catalogNamesSuite from './catalog-names.spec.js';
 import gettextSuite from './gettext.spec.js';
 
-run({ guardsSuite, xgettextSuite, linguasSuite, catalogNamesSuite, gettextSuite });
+run({ guardsSuite, utilsSuite, xgettextSuite, linguasSuite, catalogNamesSuite, gettextSuite });

--- a/packages/infra/vite-plugin-gettext/src/utils.spec.ts
+++ b/packages/infra/vite-plugin-gettext/src/utils.spec.ts
@@ -1,0 +1,64 @@
+// `checkDependencies` has to answer TWO questions with one probe: is the tool
+// there, and — if it is — does it run? It used to answer only the first, for
+// both, and the install hint it prints at someone who has gettext installed is
+// the same wrong turn `@gjsify/vite-plugin-blueprint` documents in
+// `resolve-compiler.ts`: a compiler that WAS present read as unavailable,
+// because the message never distinguished absent from broken.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { mkdtempSync, writeFileSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { checkDependencies } from './utils.js';
+
+/** What `fn` rejected with, so a case can assert on the message it carries. */
+async function rejectionOf(fn: () => Promise<unknown>): Promise<Error | undefined> {
+    try {
+        await fn();
+    } catch (error) {
+        return error as Error;
+    }
+    return undefined;
+}
+
+/**
+ * A command that EXISTS and fails, printing `stderr` — a stand-in for a gettext
+ * whose libintl went missing in a partial upgrade. A real executable rather
+ * than a stubbed `execa`, because the branch under test reads `error.code`,
+ * which is set by the spawn itself and is exactly what a mock would have to
+ * guess.
+ */
+function brokenTool(stderr: string): string {
+    const dir = mkdtempSync(join(tmpdir(), 'gettext-utils-spec-'));
+    const file = join(dir, 'msgfmt');
+    writeFileSync(file, `#!/bin/sh\necho '${stderr}' >&2\nexit 1\n`);
+    chmodSync(file, 0o755);
+    return file;
+}
+
+export default async () => {
+    await describe('checkDependencies', async () => {
+        await it('tells someone with no gettext to install gettext', async () => {
+            const error = await rejectionOf(() =>
+                checkDependencies('definitely-not-a-real-binary-xyz', 'vite-plugin-gettext', false),
+            );
+
+            expect(error !== undefined).toBe(true);
+            expect((error as Error).message.includes('not found')).toBe(true);
+            // The hint is the whole point of this branch — it must survive.
+            expect((error as Error).message.includes('sudo dnf install gettext')).toBe(true);
+        });
+
+        await it('reports an INSTALLED tool that fails with its own stderr', async () => {
+            const detail = 'libintl.so.8: cannot open shared object file';
+            const error = await rejectionOf(() => checkDependencies(brokenTool(detail), 'vite-plugin-gettext', false));
+
+            expect(error !== undefined).toBe(true);
+            // The line that says what is actually wrong.
+            expect((error as Error).message.includes(detail)).toBe(true);
+            // And NOT the install hint: it is there, installing it again fixes
+            // nothing, and saying so sends the reader down the wrong path.
+            expect((error as Error).message.includes('sudo dnf install gettext')).toBe(false);
+        });
+    });
+};

--- a/packages/infra/vite-plugin-gettext/src/utils.ts
+++ b/packages/infra/vite-plugin-gettext/src/utils.ts
@@ -7,7 +7,7 @@ import fs from 'node:fs/promises';
  * @param command The command to check (msgfmt, xgettext, etc.)
  * @param pluginName Name of the plugin for logging
  * @param verbose Enable verbose logging
- * @throws Error if the command is not found
+ * @throws Error if the command is not found, or is there and refused to run
  */
 export async function checkDependencies(command: string, pluginName: string, verbose: boolean) {
     try {
@@ -15,7 +15,21 @@ export async function checkDependencies(command: string, pluginName: string, ver
         if (verbose) {
             console.log(`[${pluginName}] Found ${command}`);
         }
-    } catch (_error) {
+    } catch (error) {
+        // ABSENT and BROKEN are different answers, and this used to give the
+        // first one to both — `catch (_error)`, install hint, every time. A
+        // gettext that is installed but cannot run (a missing libintl after a
+        // partial upgrade, a noexec mount, the wrong arch under emulation) then
+        // tells the reader to install what they have already got, and its own
+        // stderr — the part that says which library is missing — is dropped.
+        //
+        // The same distinction `@gjsify/vite-plugin-blueprint`'s
+        // `resolve-compiler.ts` was written for, after a "not found" for a
+        // compiler that WAS there cost a day.
+        if ((error as { code?: string }).code !== 'ENOENT') {
+            const detail = (error as { stderr?: string }).stderr || (error as Error).message;
+            throw new Error(`${command} is installed but failed to run:\n${detail}`);
+        }
         throw new Error(
             `${command} not found. Please install gettext:\n` +
                 '  Ubuntu/Debian: sudo apt-get install gettext\n' +

--- a/tests/integration/rolldown-native/src/bundle-with-plugins.spec.ts
+++ b/tests/integration/rolldown-native/src/bundle-with-plugins.spec.ts
@@ -272,6 +272,60 @@ export default async () => {
                 expect((observedThrow as unknown as Error).message.includes('intentional failure')).toBe(true);
             });
 
+            await it('a failing load hook puts its OWN message in the rejection', async () => {
+                // The defect this guards, measured on this tree: a `.blp` with a
+                // deliberate syntax error built under the Node engine printed
+                // blueprint-compiler's "Could not determine what kind of syntax
+                // is meant here" with the offending line and a caret, and under
+                // THIS engine printed only
+                //
+                //   {"error":"rolldown: Bundler::generate: BatchedBuildDiagnostic([
+                //     BuildDiagnostic { severity: Error, kind: "UNLOADABLE_DEPENDENCY",
+                //       message: "Could not load src/header-bar.blp", .. }])"}
+                //
+                // — no reason anywhere, for 22 of 24 files in the real incident.
+                // The test above deliberately accepts "either resolution", so
+                // the throw was observed in user-land and nobody checked that it
+                // reached the CALLER. That gap is this test.
+                const dir = tmpdir('rdn-int-hookerr');
+                writeFile(`${dir}/main.mjs`, 'import "./gen.blp";\nexport const v = 1;');
+                writeFile(`${dir}/gen.blp`, 'not javascript');
+
+                // A stand-in for blueprint-compiler's stderr: multi-line, and
+                // the useful part is NOT in the first line — same shape as the
+                // real thing, so a fix that keeps only a summary still fails.
+                const compilerStderr =
+                    'blueprint-compiler failed (/usr/bin/blueprint-compiler)\n' +
+                    'error: Namespace Adw is not available\n' +
+                    'at gen.blp line 2 column 7';
+
+                const failing: NativePlugin = {
+                    name: 'fixture-blueprint',
+                    load(id) {
+                        if (id.endsWith('.blp')) throw new Error(`${id}: ${compilerStderr}`);
+                        return null;
+                    },
+                };
+
+                let rejection: Error | null = null;
+                try {
+                    await bundleWithPlugins(
+                        { input: [{ name: 'main', import: `${dir}/main.mjs` }], cwd: dir, format: 'esm' },
+                        [failing],
+                    );
+                } catch (e) {
+                    rejection = e as Error;
+                }
+
+                expect(rejection !== null).toBe(true);
+                const message = (rejection as unknown as Error).message;
+                // The compiler's own diagnosis — the line that was missing.
+                expect(message.includes('Namespace Adw is not available')).toBe(true);
+                // Which file, and which plugin to blame for it.
+                expect(message.includes('gen.blp')).toBe(true);
+                expect(message.includes('fixture-blueprint')).toBe(true);
+            });
+
             await it('rolldown-shaped {filter, handler} hooks dispatch correctly via toNativePlugin', async () => {
                 // Mirrors how the CLI wire-up (B.5b) translates rolldown's
                 // {filter:{id:/regex/}, handler} hook form into our

--- a/tests/integration/rolldown-native/src/bundle-with-plugins.spec.ts
+++ b/tests/integration/rolldown-native/src/bundle-with-plugins.spec.ts
@@ -326,6 +326,47 @@ export default async () => {
                 expect(message.includes('fixture-blueprint')).toBe(true);
             });
 
+            await it('states the total when there are more failures than it prints', async () => {
+                // The count is the diagnosis — 22 of 24 `.blp` files, and the
+                // two that loaded were the two without `using Adw 1;`. So the
+                // total has to survive the cap that keeps 22 five-line compiler
+                // excerpts from burying it.
+                const dir = tmpdir('rdn-int-hookerr-many');
+                const failures = 12;
+                let entry = '';
+                for (let i = 0; i < failures; i++) {
+                    writeFile(`${dir}/m${i}.blp`, 'x');
+                    entry += `import "./m${i}.blp";\n`;
+                }
+                writeFile(`${dir}/main.mjs`, `${entry}export const v = 1;`);
+
+                const failing: NativePlugin = {
+                    name: 'fixture-many',
+                    load(id) {
+                        if (id.endsWith('.blp')) throw new Error(`${id}: boom`);
+                        return null;
+                    },
+                };
+
+                let rejection: Error | null = null;
+                try {
+                    await bundleWithPlugins(
+                        { input: [{ name: 'main', import: `${dir}/main.mjs` }], cwd: dir, format: 'esm' },
+                        [failing],
+                    );
+                } catch (e) {
+                    rejection = e as Error;
+                }
+
+                expect(rejection !== null).toBe(true);
+                const lines = (rejection as unknown as Error).message.split('\n');
+                expect(lines.includes(`${failures} plugin hooks failed during this build:`)).toBe(true);
+                // Capped at 8 spelled out, with the remainder accounted for
+                // rather than silently dropped.
+                expect(lines.filter((l) => l.includes('[plugin fixture-many]')).length).toBe(8);
+                expect(lines.includes(`  … and ${failures - 8} more`)).toBe(true);
+            });
+
             await it('rolldown-shaped {filter, handler} hooks dispatch correctly via toNativePlugin', async () => {
                 // Mirrors how the CLI wire-up (B.5b) translates rolldown's
                 // {filter:{id:/regex/}, handler} hook form into our


### PR DESCRIPTION
## The measurement

A `.blp` with one deliberate syntax error, one build, two engines.

Node engine (`gjsify build ... --app gjs`) — answers the question:

    Build failed with 1 error:

    [plugin vite-plugin-blueprint]
    BlueprintCompileError: .../src/header-bar.blp: blueprint-compiler failed
    error: Could not determine what kind of syntax is meant here
    at .../src/header-bar.blp line 4 column 30:
       4 |this is not blueprint syntax @@@;
         |                             ^

GJS engine (`gjs -m dist/cli.gjs.mjs build ...`) — whole output, before this PR:

    {"error":"rolldown: Bundler::generate: BatchedBuildDiagnostic([
      BuildDiagnostic { severity: Error, kind: "UNLOADABLE_DEPENDENCY",
        message: "Could not load src/header-bar.blp", .. }])"}

No reason anywhere. In the incident that prompted this — a GitHub Actions run on
`fedora:43` — 22 of 24 `.blp` files failed and the log said this and nothing else.
The cause was a missing `libadwaita`, so no `Adw-1.typelib`, which
`blueprintcompiler/gir.py` resolves `using Adw 1;` through. blueprint-compiler
itself was installed and had printed a precise message. What cracked it was a
count: exactly 22 files contain `using Adw 1;`, exactly 22 failed, and the two
pure-Gtk files loaded.

After this PR, same build:

    {"error":"rolldown: Bundler::generate: BatchedBuildDiagnostic([...])"}
    1 plugin hook failed during this build:
      [plugin vite-plugin-blueprint] load: .../src/header-bar.blp:
      blueprint-compiler failed (/usr/bin/blueprint-compiler)
    error: Could not determine what kind of syntax is meant here
    at .../src/header-bar.blp line 4 column 30:
       4 |this is not blueprint syntax @@@;
         |                             ^

With a second `.blp` broken the headline reads `2 plugin hooks failed during this
build:` and both are listed — the count that made the real incident diagnosable.

## Cause

Not the blueprint plugin. `packages/infra/vite-plugin-blueprint/src/index.ts:67-70`
already reads execa's `.stderr` and wraps it in `BlueprintCompileError`, which is
why the Node engine prints it. The message is lost one layer down, crossing back
from JS into Rust:

- `packages/infra/rolldown-native/src/rust/src/session.rs:379` —
  `.map_err(|e| format!("rolldown: Bundler::generate: {e:?}"))`
- `{e:?}` is Debug, and rolldown's `BuildDiagnostic` has a
  `finish_non_exhaustive()` Debug impl, so everything past the short `message`
  becomes the literal `..` visible in the output above.

Fixing the Rust would mean rebuilding the cdylib, which needs the `refs/rolldown`
submodule and ships as a per-platform prebuild — a release-shaped change, and not
where the information actually lives. The JS side already has every hook error:
the plugin threw it and `respondError` serialised it moments earlier. So it keeps
its own copy instead of hoping the reason survives the round trip.

- `packages/infra/rolldown-native/src/ts/plugins.ts` — `HookErrorLog`, recorded in
  `respondError`, appended in the `error_occurred` handler.

`respondError` is the single point all twelve hooks of every plugin funnel
through, so this is the mechanism and not a blueprint patch: `xgettext`, `msgfmt`,
`msgcat`, `glib-compile-resources` and anything a future plugin spawns are covered
by construction. rolldown's own `msg` stays first and verbatim — it carries
diagnostics no JS hook was involved in.

Collect, not fail fast. By the time a hook rejects, rolldown has already
dispatched the other modules onto its worker pool and batches the diagnostics
before stopping, so aborting early would save no work and would discard the other
failures — and with them the count that named the shared cause. Capped at 8
spelled out in full (each blueprint failure is a five-line excerpt with a caret;
22 of them bury the headline), with the total always stated.

## Sweep — the same class elsewhere

Audited every subprocess spawn in the plugin families; the per-site table is in a
comment below. One background fact decides most of it: execa v9 bakes the child's
stderr into `error.message` itself, so several catches that look like they discard
it do not.

The plugin layer was largely sound, which is what pins the defect on the bridge.
One real finding: `vite-plugin-gettext/src/utils.ts:18`. `checkDependencies`
caught every probe failure as `catch (_error)` and answered all of them with the
install hint — a gettext that is installed but cannot run (missing libintl after a
partial upgrade, a noexec mount, wrong arch under emulation) was told to install
what it already has, with its own stderr dropped. Measured: an absent command
rejects with `code: 'ENOENT'` and empty stderr; a present one that fails has no
`code` and a populated stderr. The second commit branches on that.

Two non-findings worth recording: `cli/src/utils/spawn.ts` never attaches stderr
to an error, but deliberately — it resolves on any exit code and hands `stderr`
back under `'capture'`, leaving the message to each call site. And
`gresource.ts`/`gsettings.ts` hand-roll `execFile` rather than using that helper,
so their correct behaviour is duplicated in two files.

## Red to green

`tests/integration/rolldown-native` — a load hook throws a multi-line message
whose useful line is not the first, mirroring blueprint-compiler's shape. Run
under GJS against the real prebuild.

Without the fix:

    ✖ a failing load hook puts its OWN message in the rejection
      — Expected values to match using ===
    ❌ [Gjs 1.88.1] 1 of 46 tests failed  (53.0ms)

With it:

    ✔ [Gjs 1.88.1] 48 completed  (56.3ms)

The pre-existing `this.error()` test deliberately accepts "either resolution is
acceptable" and asserts only the user-land throw — nobody checked that the message
reached the caller. That gap is this test.

`packages/infra/vite-plugin-gettext` — a real temp executable that exits 1 with
stderr, not a stubbed execa, because the branch reads `error.code`, which the spawn
sets and a mock would have to guess.

Without the fix:

    ✖ checkDependencies › reports an INSTALLED tool that fails with its own stderr
      — Expected values to match using ===
    ❌ [Node.js 24.19.0] 1 of 51 tests failed  (102ms)

With it:

    ✔ [Node.js 24.19.0] 52 completed  (111ms)

The sibling case ("tells someone with no gettext to install gettext") passes in
both runs, so the red is the branch and not the harness.

The cap branch. Reviewing coverage afterwards, 1 and 2 failures were exercised but
`… and N more` was not — an untested branch in the part that carries the count.
Twelve failures now assert the headline total, the eight spelled out and the
remainder; measured before committing it: `12 plugin hooks failed during this
build:`, 8 detail lines, `  … and 4 more`.

## Validation

`gjsify format --check`, `gjsify lint` and `gjsify tsc --noEmit` clean on all three
touched packages. The Rust `{e:?}` remains as-is and is the deeper fix whenever the
cdylib is next rebuilt — it would also cover diagnostics rolldown raises with no JS
hook involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8QkeZTJyNXrniXhrsncT6
