### PR TITLE
fix(ci): read the renamed windows ship zip

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -2958,7 +2958,7 @@ jobs:
           python3 "${GITHUB_WORKSPACE}/.github/ship-oracle/verify-program-dir.py" \
             "ship/out/Ship Window Demo" ship/stage/.gjsify-ship-stage.json
           bash "${GITHUB_WORKSPACE}/.github/ship-oracle/verify-app-zip.sh" \
-            ship/out/ship-window-demo-1.0.0-1.x64.zip "ship/out/Ship Window Demo" "program directory"
+            ship/out/ship-window-demo-1.0.0-1.windows.x64.zip "ship/out/Ship Window Demo" "program directory"
           test -f "ship/out/Ship Window Demo/node.exe" || {
             echo "the directory carries no interpreter — the next job would run the runner's node"; exit 1
           }

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -4,6 +4,29 @@
      it) — the status-data check rejects struck-through / ✓ / "Completed"
      headings, so the done-log cannot regrow. -->
 
+### A renamed ship artifact broke a workflow, and only one of nine references noticed
+
+#1655 gave the two zip rows an OS label — `windows-dir-zip` became
+`<binary>-<version>-<release>.windows.<arch>.zip`, `macos-app-zip` the `.macos.` twin — and its
+own suite pins both names. What nothing pinned is the CONSUMER: `node-gi.yml` hard-codes the
+old spelling at one site, so `Assemble a self-contained Windows program directory` exited 1 on
+the next commit that ran it, and the two Windows jobs downstream failed at
+`Unable to download artifact` — a chain whose first link is three jobs away from the rename.
+
+The other eight references to a ship artifact in that workflow use a glob (`*.zip`,
+`Get-ChildItem -Filter *.zip`, `ls *.zip | head -1`) and survived. That is the wrong lesson to
+draw: a glob survives a rename by not checking it. The hard-coded one is the only site that
+asserts the name at all, which is why it is the one that reported the change.
+
+What is missing is the check that a format's `fileName` and the workflow text that consumes it
+agree. `FORMATS` knows every name it can produce, and `.github/workflows/**` is a fixed set of
+files, so the comparison is mechanical. Until it exists, a rename lands green and the breakage
+appears in a job that names neither the format nor the PR that renamed it.
+
+Related: the same shape as `CI's build-output cache key is the third answer to "what are this
+package's inputs"` — a value with several copies, only one of which is held.
+
+
 ### `acceptsPropValue` is an oracle for the VOCABULARY, not for the type
 
 `@gjsify/react-native/prop-table` answers "would `<P prop={value}>` render" for the two


### PR DESCRIPTION
#1655 gave the two zip rows an OS label, and its own suite pins both new names.
What nothing pinned is the consumer: `node-gi.yml` hard-codes the old spelling
at one site.

The chain that follows is three jobs long and names neither the rename nor the
PR that made it. `Assemble a self-contained Windows program directory` exits 1
on the missing file, then `MSI installs, runs and uninstalls` and
`Self-contained program directory opens a window` both fail at `Unable to
download artifact`. It first went red on #1642, which touches none of this.

Cross-checked against the rule rather than guessed: `formats.ts:720` emits
`${binaryName}-${version}-${release}.windows.${archLabel}.zip`, and the fixture
is `ship-window-demo` at 1.0.0, release 1, x64.

The eight other ship-artifact references in that workflow use a glob and
survived. That is not an argument for globs: a glob survives a rename by not
checking it. The hard-coded site is the only one that asserts the name, which
is why it is the one that reported the change. `status/open-todos.md` carries
what is still missing, a check that a format's `fileName` and the workflow text
consuming it agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4yEeHoGMC4pvbkqxMsYfj
