### PR TITLE
fix(node-gi): template property setters, and a call with too few arguments

### DIFF
--- a/docs/node-gi-gjs-surface.md
+++ b/docs/node-gi-gjs-surface.md
@@ -97,6 +97,26 @@ accepts BOTH `null` and `undefined` as a NULL string/object (gjs refuses
 `undefined` everywhere and `null` for non-nullable args) — see
 `status/open-todos.md`.
 
+**Too FEW arguments is a REFUSAL, not a pad.** A call supplying fewer than the
+callable's JS arity throws gjs's own `TypeError` before any marshalling —
+`method GObject.Object.get_property: At least 2 arguments required, but only 1
+passed`, down to the singular/plural of "argument" and gjs's `format_name()`
+spelling (`method <ns>.<class>.<name>` / `function <ns>.<name>`). The demanded
+count is `JsInArgCount`, the same pre-scan the invoke loop consumes arguments
+with and the same number `Function.length` reports, so what is demanded is by
+construction what is consumed. It used to pad the missing ones with `undefined`
+and marshal THAT, which is not leniency but a wrong call: on a GValue parameter
+`undefined` becomes gjs's null guess, a `G_TYPE_POINTER` GValue, so
+`label.get_property('label')` printed `g_object_get_property: can't retrieve
+property 'label' of type 'gchararray' as value of type 'gpointer'` and evaluated
+to `undefined` — on stock GTK classes and registerClass'd ones alike, with the
+`set_property` twin mirroring it (`unable to set property … from value of type
+'gpointer'`). Silent, and the one-argument spelling it invited throws on gjs, so
+it never worked anywhere; consumers just got `undefined` and no error to follow.
+Too MANY arguments stays permitted — gjs only warns there, through a JS warning
+reporter node-gi has no equivalent of. Pinned by the `callable-too-few-args`
+conformance program.
+
 ## The raw engine API (`@gjsify/node-gi`)
 
 The low-level entry points the L1 layer is built on. Most code should use L1 below; these

--- a/docs/node-gi-gjs-surface.md
+++ b/docs/node-gi-gjs-surface.md
@@ -405,6 +405,32 @@ defaults to the class name. The parent namespace/type is read from the class's
 `extends` (its `$gtypeName`), so it works for both `GObject.Object` and real GI
 classes (`class extends Gio.SimpleAction { … }`).
 
+**A custom property's JS SETTER runs whenever the property is set.** A class may
+declare a GObject property AND a matching accessor over a backing field; gjs
+routes its set_property vfunc through the wrapper (`gjs_object_set_gproperty` →
+`jsobj_set_gproperty` → `JS_SetProperty`), and node-gi does the same. The lookup
+covers the three spellings gjs makes equivalent — dash, underscore and camelCase
+— so a `line-numbers` property reaches a `lineNumbers` setter, which is what
+`_checkAccessors` (refs/gjs/modules/core/_common.js) buys on gjs by mirroring the
+declared accessor onto all three. A property with NO accessor is untouched and
+keeps the engine's per-instance store as its single backing store.
+
+It happens at **two times, and the split is load-bearing**: a set that lands
+while the instance already has a wrapper (GtkBuilder applying a non-construct
+template property through `g_object_set`, a binding, `set_property`) delegates
+immediately; a set that lands during construction — g_object_new applying
+construct properties, before node-gi has built the wrapper — has nothing to call
+into and is replayed from the base constructor, before the user ctor body, in the
+order the values were actually applied. Only properties that were REALLY SET are
+replayed (the per-instance store's keys, in first-set order): replaying every
+declared property instead runs a setter for one nobody assigned, against state
+the ctor body has not created yet, which is the Learn6502 SourceView
+`selectable` → `_signalHandlers.forEach` crash. Until 0.51 only CONSTRUCT-flagged
+properties reached a setter at all, so a plain READWRITE one set from a
+GtkBuilder template never did — every Learn6502 tutorial code block rendered
+empty on `--app node` while the same source worked on gjs. Pinned by the
+`custom-property-js-setter` conformance program.
+
 Caveats (this is the no-toggle-ref object model): the user class's JS constructor
 body is not run — GObject-idiomatic init belongs in `vfunc_constructed`;
 instances are Proxies over a native handle (but `instanceof` still works — it is

--- a/packages/node-gi/node-gi/conformance/golden/callable-too-few-args.txt
+++ b/packages/node-gi/node-gi/conformance/golden/callable-too-few-args.txt
@@ -1,0 +1,8 @@
+get_property/1: TypeError: method GObject.Object.get_property: At least 2 arguments required, but only 1 passed
+get_property/0: TypeError: method GObject.Object.get_property: At least 2 arguments required, but only 0 passed
+set_property/1: TypeError: method GObject.Object.set_property: At least 2 arguments required, but only 1 passed
+method/0 of 1: TypeError: method Gio.File.get_child: At least 1 argument required, but only 0 passed
+function/0 of 1: TypeError: function GLib.path_is_absolute: At least 1 argument required, but only 0 passed
+function/3 of 4: TypeError: function GObject.signal_emitv: At least 4 arguments required, but only 3 passed
+get_property/2: "probe"
+too many: true

--- a/packages/node-gi/node-gi/conformance/golden/custom-property-js-setter.txt
+++ b/packages/node-gi/node-gi/conformance/golden/custom-property-js-setter.txt
@@ -1,0 +1,15 @@
+-- construct with no arguments (CONSTRUCT default only)
+setter counted=7
+a.counted = 7
+a.plain   = <unset>
+-- set_property after construction
+setter plain=AFTER
+a.plain   = AFTER
+-- compound name reaches the camelCase accessor
+setter lineNumbers=true
+-- a property passed to the constructor
+setter counted=7
+setter plain=AT-NEW
+b.plain   = AT-NEW
+-- a property nobody set never ran its setter
+a._ran = []

--- a/packages/node-gi/node-gi/conformance/programs/callable-too-few-args.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/callable-too-few-args.conf.mjs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// A GI call with too FEW arguments must be REFUSED, with gjs's message — and the
+// refusal has to happen before any marshalling, or the missing argument gets
+// invented. node-gi read a missing JS argument as `undefined` and marshalled that,
+// so on a GValue parameter it became gjs's null guess (a G_TYPE_POINTER GValue) and
+// the callee was handed the wrong type:
+//
+//   label.get_property('label')
+//     → GLib-GObject-CRITICAL: g_object_get_property: can't retrieve property
+//       'label' of type 'gchararray' as value of type 'gpointer'
+//     → undefined
+//
+// Type- and class-independent — stock GTK classes and registerClass'd ones alike,
+// with the set_property twin mirroring it ("unable to set property … from value of
+// type 'gpointer'"). Silent, so every consumer that reached for the one-argument
+// spelling got `undefined` and no error to follow.
+//
+// The messages below are gjs's, down to the singular/plural of "argument" and its
+// `format_name()` spelling (method Ns.Class.name / function Ns.name,
+// refs/gjs/gi/function.cpp:801) — which is why this is a conformance program and
+// not only an assertion: the golden IS gjs's output.
+//
+// Too MANY arguments is deliberately the other way: gjs warns and runs the call, so
+// the last case must print a RESULT, not a refusal.
+import GLib from 'gi://GLib?version=2.0';
+import GObject from 'gi://GObject?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
+
+function show(label, fn) {
+    try {
+        print(label + ': ' + JSON.stringify(fn()));
+    } catch (e) {
+        print(label + ': ' + e.constructor.name + ': ' + e.message);
+    }
+}
+
+const object = new GObject.Object();
+show('get_property/1', () => object.get_property('some-property'));
+show('get_property/0', () => object.get_property());
+show('set_property/1', () => object.set_property('some-property'));
+
+const file = Gio.File.new_for_path('/tmp');
+show('method/0 of 1', () => file.get_child());
+show('function/0 of 1', () => GLib.path_is_absolute());
+show('function/3 of 4', () => GObject.signal_emitv([], GObject.signal_lookup('notify', GObject.Object.$gtype), 0));
+
+// The two-argument spelling is the one that always worked, on both runtimes.
+const action = new Gio.SimpleAction({ name: 'probe' });
+const value = new GObject.Value();
+value.init(GObject.TYPE_STRING);
+action.get_property('name', value);
+print('get_property/2: ' + JSON.stringify(value.get_string()));
+
+// Extra arguments stay permitted.
+show('too many', () => GLib.path_is_absolute('/a', 'stray'));

--- a/packages/node-gi/node-gi/conformance/programs/custom-property-js-setter.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/custom-property-js-setter.conf.mjs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+// A custom GObject property's JS SETTER must run whenever the property is SET —
+// gjs routes its set_property vfunc through the wrapper (refs/gjs/gi/gobject.cpp
+// gjs_object_set_gproperty → jsobj_set_gproperty → JS_SetProperty), so a class that
+// declares a property AND an accessor over a backing field sees the value land.
+//
+// node-gi only ever wrote its per-instance store, so the setter never ran for a
+// plain READWRITE property. That is what left every Learn6502 tutorial code block
+// empty on `--app node`: its SourceView takes `code`, `copyable` and `line-numbers`
+// from a GtkBuilder template, and GtkBuilder applies a NON-construct property AFTER
+// construction via g_object_set.
+//
+// Pinned here rather than only in node:test because the four columns are the point:
+// the JS-setter round trip has to read identically on gjs and on all three Node-API
+// runtimes. What the GtkBuilder end of it looks like needs a display and lives in
+// test/custom-property-js-setter.test.mjs.
+//
+// The `untouched` case is the counterweight and is NOT decoration: a property nobody
+// set must never have its setter run, or the setter fires against state the ctor body
+// has not created yet (the Learn6502 SourceView `selectable` → `_signalHandlers`
+// forEach crash).
+import GObject from 'gi://GObject?version=2.0';
+
+const Probe = GObject.registerClass(
+    {
+        GTypeName: 'ConfCustomPropSetter',
+        Properties: {
+            plain: GObject.ParamSpec.string('plain', 'Plain', '', GObject.ParamFlags.READWRITE, ''),
+            'line-numbers': GObject.ParamSpec.boolean(
+                'line-numbers',
+                'Line numbers',
+                '',
+                GObject.ParamFlags.READWRITE,
+                false,
+            ),
+            counted: GObject.ParamSpec.int(
+                'counted',
+                'Counted',
+                '',
+                GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+                0,
+                100,
+                7,
+            ),
+            untouched: GObject.ParamSpec.boolean('untouched', 'Untouched', '', GObject.ParamFlags.READWRITE, false),
+        },
+    },
+    class Probe extends GObject.Object {
+        constructor(params) {
+            super(params);
+            if (this._ran === undefined) this._ran = [];
+        }
+        get plain() {
+            return this._plain ?? '<unset>';
+        }
+        set plain(v) {
+            this._plain = v;
+            print('setter plain=' + v);
+        }
+        set lineNumbers(v) {
+            this._lineNumbers = v;
+            print('setter lineNumbers=' + v);
+        }
+        get counted() {
+            return this._counted ?? '<unset>';
+        }
+        set counted(v) {
+            this._counted = v;
+            print('setter counted=' + v);
+        }
+        set untouched(v) {
+            // Only survivable once the ctor body has run.
+            this._ran.push(v);
+            print('setter untouched=' + v);
+        }
+    },
+);
+
+print('-- construct with no arguments (CONSTRUCT default only)');
+const a = new Probe();
+print('a.counted = ' + a.counted);
+print('a.plain   = ' + a.plain);
+
+print('-- set_property after construction');
+a.set_property('plain', 'AFTER');
+print('a.plain   = ' + a.plain);
+
+print('-- compound name reaches the camelCase accessor');
+a.set_property('line-numbers', true);
+
+print('-- a property passed to the constructor');
+const b = new Probe({ plain: 'AT-NEW' });
+print('b.plain   = ' + b.plain);
+
+print('-- a property nobody set never ran its setter');
+print('a._ran = ' + JSON.stringify(a._ran));

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -832,31 +832,99 @@ function assignTemplateChildren(instance, handle, reg) {
     }
 }
 
-// Push construct-time GObject-property values through the class's own JS SETTERS.
+// The prototype SETTER a GObject property name resolves to, across the three
+// spellings GJS makes equivalent, or undefined when the class declares none.
 //
-// A class can declare a GObject property (`Properties: { displayWidth: ParamSpec }`,
-// often CONSTRUCT with a default) AND a matching JS accessor
-// (`get/set displayWidth` over a `_displayWidth` backing field). On GJS the property
-// set vfunc delegates to the JS setter (`JS_SetProperty`), so the CONSTRUCT default
-// reaches `_displayWidth` at construction. node-gi builds the wrapper AFTER
-// g_object_new, so at construct time there is no USER_PROTO to route through — the
-// value lands only in the engine's per-instance store, and the class's getter
-// (reading `_displayWidth`) sees `undefined` (the Learn6502 Display "DrawingArea is
-// required" wall). Once USER_PROTO is attached (here, right after construction), read
-// each such property's construct value back out (from the store, or the ParamSpec
-// default) and run it through the JS setter — the node-gi analogue of GJS applying a
-// CONSTRUCT property via the JS setter, and BEFORE the user ctor body runs (same
-// order as GJS). Only properties whose name resolves to a prototype SETTER are
-// touched, so a plain GObject property (no JS accessor) keeps the store as its single
-// backing store — unchanged.
-function flushConstructProperties(instance, handle, reg) {
-    if (reg.constructPropertyNames === undefined) return;
+// GJS's set_property vfunc writes only the UNDERSCORE spelling
+// (refs/gjs/gi/gobject.cpp jsobj_set_gproperty → JS_SetProperty(underscore_name)),
+// and reaches a camelCase accessor anyway because registerClass has already mirrored
+// whichever spelling the class declared onto the dash, underscore AND camel names
+// (`_checkAccessors`, refs/gjs/modules/core/_common.js). node-gi keeps the engine
+// store as the backing store rather than installing GJS's generated accessors, so it
+// resolves the same three spellings at the point of use instead — same reachability,
+// no accessor synthesis. Learn6502's SourceView is exactly why this matters: its
+// property is `line-numbers` and its accessor is `lineNumbers`.
+function findPropertySetter(userProto, propertyName) {
+    const underscored = propertyName.replace(/-/g, '_');
+    const camel = propertyName.replace(/-([a-z])/g, (m) => m[1].toUpperCase());
+    for (const spelling of [propertyName, underscored, camel]) {
+        const desc = findProtoDescriptor(userProto, spelling);
+        if (desc !== undefined && typeof desc.set === 'function') return desc.set;
+    }
+    return undefined;
+}
+
+// Run a class's own JS setter for a custom property the ENGINE has just stored —
+// the L1 half of NodeGiSetProperty (src/class.cc), which is node-gi's
+// gjs_object_set_gproperty. The engine calls this only once the instance HAS a
+// wrapper, so a set that lands during construction never reaches here; those are
+// replayed by flushPropertiesToJsSetters below.
+function runJsPropertySetter(handle, propertyName) {
+    const instance = instanceCache.get(handle);
+    if (instance === undefined) return;
     const up = instance[USER_PROTO];
     if (up === undefined) return;
-    for (const name of reg.constructPropertyNames) {
-        const desc = findProtoDescriptor(up, name);
-        if (desc === undefined || typeof desc.set !== 'function') continue;
-        desc.set.call(instance, wrapReturn(native.getProperty(handle, name)));
+    const set = findPropertySetter(up, propertyName);
+    if (set === undefined) return; // no JS accessor: the store is the single backing store
+    set.call(instance, wrapReturn(native.getProperty(handle, propertyName)));
+}
+// Guarded because the addon paired with this JS may PREDATE it, and that pairing is
+// deliberate rather than hypothetical: gtk-os-suites.yml's shipped-closure legs run
+// this checkout's JS against the PUBLISHED addon (`NODE_GI_NATIVE=prebuild`, logged
+// as "node-gi JS: (this checkout) / addon: (published)"), so a bare call to a new
+// native export takes those three legs down with `native.<new export> is not a
+// function` until the next release republishes the binary. Every native call added
+// here degrades instead; without the callback, a post-construction set simply does
+// not reach the JS setter, which is what 0.50.0 did.
+if (typeof native.setPropertySetCallback === 'function') {
+    native.setPropertySetCallback(runJsPropertySetter);
+}
+
+// Which properties the construct-time replay must run.
+//
+// `native.storedPropertyNames` is the honest answer — what was ACTUALLY set, in
+// first-set order. An addon older than this JS does not export it (same cross-version
+// pairing as the guard above), so the fallback is the CONSTRUCT-flag filter this used
+// to be: narrower, since it misses a plain property passed to `new`, but never wrong
+// — GObject does apply CONSTRUCT properties at construction. Keeping it is what makes
+// the shipped-closure legs measure the published addon rather than this gap.
+function propertiesToReplay(handle, reg) {
+    if (typeof native.storedPropertyNames === 'function') return native.storedPropertyNames(handle);
+    return reg.constructPropertyNames ?? [];
+}
+
+// Replay the properties set DURING construction through the class's own JS SETTERS.
+//
+// A class can declare a GObject property (`Properties: { displayWidth: ParamSpec }`)
+// AND a matching JS accessor (`get/set displayWidth` over a `_displayWidth` backing
+// field). On GJS the set vfunc delegates to the JS setter, so a value applied by
+// g_object_new reaches `_displayWidth` at construction. node-gi builds the wrapper
+// AFTER g_object_new, so during construction there is no USER_PROTO to route through
+// — the value lands only in the engine's per-instance store, and the class's getter
+// (reading `_displayWidth`) sees `undefined` (the Learn6502 Display "DrawingArea is
+// required" wall). Once USER_PROTO is attached (here, right after construction), read
+// each such value back out and run it through the JS setter, BEFORE the user ctor
+// body runs — the same order GJS produces.
+//
+// WHICH properties: the ones the engine actually STORED, i.e. that something really
+// set (`native.storedPropertyNames`). Not every declared property — flushing those
+// runs a setter for a property nobody assigned, against state the ctor body has not
+// created yet, which is the Learn6502 SourceView `selectable` → `_signalHandlers`
+// forEach crash. "Was it set?" is the honest question and the store is its honest
+// answer; the CONSTRUCT flag is only a proxy for it (GObject applies a CONSTRUCT
+// property's default at construction, so it is stored too, and a plain READWRITE
+// property passed to `new` is stored as well — which GJS also routes through the
+// setter, and the old CONSTRUCT-only filter missed).
+//
+// Only properties whose name resolves to a prototype SETTER are touched, so a plain
+// GObject property (no JS accessor) keeps the store as its single backing store.
+function flushPropertiesToJsSetters(instance, handle, reg) {
+    const up = instance[USER_PROTO];
+    if (up === undefined) return;
+    for (const name of propertiesToReplay(handle, reg)) {
+        const set = findPropertySetter(up, name);
+        if (set === undefined) continue;
+        set.call(instance, wrapReturn(native.getProperty(handle, name)));
     }
 }
 
@@ -1605,7 +1673,7 @@ function makeClass(namespace, typeName) {
                 assignTemplateChildren(instance, handle, reg);
                 // Route construct-time property values through the class's JS setters now
                 // that USER_PROTO is attached — before the user ctor body runs (GJS order).
-                flushConstructProperties(instance, handle, reg);
+                flushPropertiesToJsSetters(instance, handle, reg);
                 return instance;
             }
             // `nt` is a subclass of this introspected GObject class but was NEVER passed to
@@ -2340,13 +2408,11 @@ function registerClass(metaOrClass, maybeClass) {
     // Record the registration so the introspected base ctor (makeClass) routes
     // `new X(args)` (where new.target === klass) to constructType(typeHandle, …) +
     // the canonical wrapper. Template children move here from the old Subclass.
-    // The names of CONSTRUCT / CONSTRUCT_ONLY properties — the ONLY ones GObject
-    // applies at construction. The flush (flushConstructProperties) must be limited to
-    // these: a plain READWRITE property is NOT set during construction, so running its
-    // JS setter early (GObject never would) fires the setter's side effects against
-    // still-uninitialised instance state (the SourceView `selectable` → `_signalHandlers`
-    // forEach crash). Matches GJS, which only runs setters for props GObject applies at
-    // construct. Flags are the ABI-stable G_PARAM_CONSTRUCT (1<<2) | CONSTRUCT_ONLY (1<<3).
+    // Which properties the construct-time flush replays is a question about this
+    // INSTANCE ("what was actually set?"), and the engine's per-instance store answers
+    // it directly. These CONSTRUCT / CONSTRUCT_ONLY names are only the FALLBACK for an
+    // addon too old to answer it — see propertiesToReplay. Flags are the ABI-stable
+    // G_PARAM_CONSTRUCT (1<<2) | CONSTRUCT_ONLY (1<<3).
     const PARAM_CONSTRUCT_MASK = 0x4 | 0x8;
     const constructPropertyNames = properties
         .filter((p) => typeof p.flags === 'number' && (p.flags & PARAM_CONSTRUCT_MASK) !== 0)
@@ -2356,7 +2422,6 @@ function registerClass(metaOrClass, maybeClass) {
         typeHandle,
         children: children.length > 0 ? children : undefined,
         internalChildren: internalChildren.length > 0 ? internalChildren : undefined,
-        // CONSTRUCT-property names, for the construct-property flush (below).
         constructPropertyNames: constructPropertyNames.length > 0 ? constructPropertyNames : undefined,
     });
     // Reverse index for runCtorForCObject: the engine identifies a C-created instance

--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -277,6 +277,17 @@ export const setTemplateCallbackResolver = native.setTemplateCallbackResolver;
 // Reflect.constructs the class in adopt mode — see gi.js runCtorForCObject.
 export const setConstructCallback = native.setConstructCallback;
 
+// Registers the L1 callback the engine's set_property vfunc invokes after storing a
+// custom property: given (instanceHandle, propertyName) it runs the class's own JS
+// setter — see gi.js runJsPropertySetter. The engine calls it only once the instance
+// HAS a wrapper, so a construct-time set never reaches it; those are replayed from
+// the base ctor over storedPropertyNames.
+export const setPropertySetCallback = native.setPropertySetCallback;
+
+// The custom properties actually SET on an instance (the per-instance store's keys) —
+// what that construct-time replay has to push through the class's JS setters.
+export const storedPropertyNames = native.storedPropertyNames;
+
 export const logSetWriterFunc = native.logSetWriterFunc;
 export const logSetWriterDefault = native.logSetWriterDefault;
 export const bindPropertyFull = native.bindPropertyFull;

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -130,6 +130,8 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("setTemplateCallbackResolver",
               Napi::Function::New(env, SetTemplateCallbackResolver));
   exports.Set("setConstructCallback", Napi::Function::New(env, SetConstructCallback));
+  exports.Set("setPropertySetCallback", Napi::Function::New(env, SetPropertySetCallback));
+  exports.Set("storedPropertyNames", Napi::Function::New(env, StoredPropertyNames));
   // GjsPrivate-mirroring helpers (private.cc): the structured-log writer func +
   // the bind_property_full / BindingGroup.bind_full transform trampolines.
   exports.Set("logSetWriterFunc", Napi::Function::New(env, LogSetWriterFunc));

--- a/packages/node-gi/node-gi/src/calls.cc
+++ b/packages/node-gi/node-gi/src/calls.cc
@@ -513,6 +513,34 @@ int JsInArgCount(GICallableInfo* callable) {
   return count;
 }
 
+// gjs's Gjs::Function::format_name (refs/gjs/gi/function.cpp:801) — the spelling its
+// argument-count TypeError carries, so a refusal reads identically on both runtimes.
+// Deliberately NOT the `displayName` the other refusals here use: that one names the
+// RUNTIME type the call was made on (`GtkLabel.get_property`), which is the useful
+// thing to say about a marshalling failure but not what gjs prints for arity. gjs
+// names the DECLARING info — `method GObject.Object.get_property` — and consumers
+// byte-compare these.
+static std::string GjsCallableName(GICallableInfo* callable) {
+  GIBaseInfo* base = reinterpret_cast<GIBaseInfo*>(callable);
+  bool isMethod = gi_callable_info_is_method(callable);
+  std::string name = isMethod ? "method " : "function ";
+  const char* ns = gi_base_info_get_namespace(base);
+  if (ns != nullptr) name += ns;
+  name += '.';
+  if (isMethod) {
+    // Borrowed ref — no unref (same contract as the container read below).
+    GIBaseInfo* container = gi_base_info_get_container(base);
+    const char* containerName = container != nullptr ? gi_base_info_get_name(container) : nullptr;
+    if (containerName != nullptr) {
+      name += containerName;
+      name += '.';
+    }
+  }
+  const char* fn = gi_base_info_get_name(base);
+  if (fn != nullptr) name += fn;
+  return name;
+}
+
 static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpointer instance,
                                       Napi::Array args, const std::string& displayName) {
   GICallableInfo* callable = reinterpret_cast<GICallableInfo*>(func);
@@ -573,6 +601,35 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
   std::vector<bool> skip(n_args, false);
   std::vector<bool> isLenArg(n_args, false);
   ComputeSkippedArgs(callable, n_args, &skip, &isLenArg);
+
+  // Too FEW arguments is a REFUSAL — gjs does the same at
+  // refs/gjs/gi/function.cpp:891 (JS::CallArgs::reportMoreArgsNeeded). node-gi used
+  // to read a missing argument as `undefined` and marshal THAT, which is not leniency
+  // but a wrong call: on a GValue parameter `undefined` becomes gjs's null guess, a
+  // G_TYPE_POINTER GValue (JsToFreshGValue), so `label.get_property('label')` — one
+  // of the two arguments gjs demands — printed "g_object_get_property: can't retrieve
+  // property 'label' of type 'gchararray' as value of type 'gpointer'" and evaluated
+  // to `undefined`, on stock and custom classes alike, with the set_property twin
+  // mirroring it. Counted off the pre-scan JUST computed rather than by calling
+  // JsInArgCount (which would redo it on every call, on the hottest path in the
+  // binding) — same walk, so what is demanded is by construction what the loop below
+  // consumes, and stays equal to the `Function.length` the method reports. Placed
+  // here, before the marshalling loop: nothing above has taken ownership of anything,
+  // so the early return needs no unwinding. Too MANY stays permitted — gjs only warns
+  // there, through a JS warning reporter node-gi has no equivalent of.
+  int required = 0;
+  for (unsigned int i = 0; i < n_args; i++) {
+    if (skip[i]) continue;
+    if (dirs[i] == GI_DIRECTION_IN || dirs[i] == GI_DIRECTION_INOUT) required++;
+  }
+  if (required > 0 && args.Length() < static_cast<uint32_t>(required)) {
+    Napi::TypeError::New(env, GjsCallableName(callable) + ": At least " +
+                                  std::to_string(required) + " argument" +
+                                  (required == 1 ? "" : "s") + " required, but only " +
+                                  std::to_string(args.Length()) + " passed")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
 
   // Caller-allocates OUT storage (fixed C array or boxed struct): blob != nullptr
   // marks the arg; boxedGType != 0 selects the boxed copy/free path on read-back.

--- a/packages/node-gi/node-gi/src/class.cc
+++ b/packages/node-gi/node-gi/src/class.cc
@@ -299,6 +299,17 @@ static GQuark NodeGiInstancePropsQuark() {
   static GQuark q = g_quark_from_static_string("node-gi-instance-props");
   return q;
 }
+// The ORDER in which this instance's custom properties were first set. A GHashTable
+// has no order, and the construct-time replay is visible output: gjs runs the JS
+// setters in the order g_object_new applied the values (CONSTRUCT properties, then
+// the rest), so replaying in hash order prints the same setters in a different
+// sequence. Recording what actually happened is cheaper than modelling GObject's
+// application order, and it stays right for paths that do not go through
+// g_object_new at all (GtkBuilder, a binding).
+static GQuark NodeGiInstancePropOrderQuark() {
+  static GQuark q = g_quark_from_static_string("node-gi-instance-prop-order");
+  return q;
+}
 
 static void FreeStoredGValue(gpointer p) {
   GValue* v = static_cast<GValue*>(p);
@@ -362,6 +373,72 @@ static void NodeGiGetProperty(GObject* obj, guint prop_id, GValue* value, GParam
   if (cd != nullptr && cd->parentGet != nullptr) cd->parentGet(obj, prop_id, value, pspec);
 }
 
+// Push a just-set custom property through the class's own JS setter, the way gjs's
+// set_property vfunc does (refs/gjs/gi/gobject.cpp gjs_object_set_gproperty →
+// jsobj_set_gproperty → JS_SetProperty on the wrapper).
+//
+// THE GATE IS THE WRAPPER, AND THAT IS THE WHOLE DESIGN — do not replace it with a
+// flag. gjs bails when `priv->wrapper()` is null and so do we, which means a set that
+// lands DURING construction (g_object_new applying construct properties, before
+// node-gi has built the wrapper) has nothing to call into and cannot run a setter
+// early. That is not an accident to tidy up: running a plain READWRITE property's
+// setter at construct time is what crashed Learn6502's SourceView (`selectable` →
+// `_signalHandlers.forEach` against state the ctor body had not created yet). The
+// construct-time values are replayed later, from the base ctor, once the wrapper
+// exists — see gi.js flushPropertiesToJsSetters. A set that lands AFTER construction
+// (GtkBuilder applying a non-construct template property via g_object_set, a
+// property binding, set_property) is the case this branch exists for, and it is the
+// one that left every Learn6502 tutorial code block empty on `--app node`.
+static void MaybeRunJsPropertySetter(NodeGiClassData* cd, GObject* obj, const char* name) {
+  if (cd == nullptr || cd->env == nullptr) return;
+  napi_env env = cd->env;
+  // Never enter JS during GC / env teardown (same gate as the vfunc trampoline and
+  // RunJsConstructorForCObject); the property is already stored either way.
+  if (!NodeGiJsAvailable(env)) return;
+  Napi::Env napiEnv(env);
+  Napi::HandleScope scope(napiEnv);
+  NodeGiPumpJsDispatchScope pumpWindow;
+
+  Napi::Value handle = PeekGObjectHandle(napiEnv, obj);
+  if (handle.IsEmpty()) return;  // construction has not reached the wrap yet
+
+  NodeGiEnvData* d = EnvData(env);
+  napi_value cb = nullptr;
+  if (d == nullptr || d->propertySetCallback == nullptr ||
+      napi_get_reference_value(env, d->propertySetCallback, &cb) != napi_ok || cb == nullptr) {
+    return;  // L1 hasn't registered the callback (nothing to run)
+  }
+  napi_value nameVal = nullptr;
+  napi_create_string_utf8(env, name, NAPI_AUTO_LENGTH, &nameVal);
+  napi_value args[2] = {handle, nameVal};
+  napi_value undef = nullptr;
+  napi_get_undefined(env, &undef);
+  napi_value ret = nullptr;
+  // A plain call, not napi_make_callback: g_object_set may be running inside GTK's
+  // own frame and must not get a microtask checkpoint in the middle of it — the same
+  // reasoning as RunJsConstructorForCObject, and gjs's JS_SetProperty takes no
+  // checkpoint either.
+  if (napi_call_function(env, undef, cb, 2, args, &ret) != napi_ok) {
+    // The setter threw. A pending JS exception must never cross back into GObject
+    // (g_object_set has no way to report one), so fold it into a g_warning — gjs logs
+    // the uncaught exception at the same point (gjs_log_exception_uncaught).
+    napi_value ex = nullptr;
+    if (napi_get_and_clear_last_exception(env, &ex) == napi_ok && ex != nullptr) {
+      napi_value msg = nullptr;
+      std::string detail;
+      if (napi_get_named_property(env, ex, "message", &msg) == napi_ok) {
+        size_t len = 0;
+        if (napi_get_value_string_utf8(env, msg, nullptr, 0, &len) == napi_ok) {
+          detail.resize(len);
+          napi_get_value_string_utf8(env, msg, detail.data(), len + 1, &len);
+        }
+      }
+      g_warning("node-gi: JS setter for %s.%s threw: %s", g_type_name(G_OBJECT_TYPE(obj)), name,
+                detail.empty() ? "(no message)" : detail.c_str());
+    }
+  }
+}
+
 static void NodeGiSetProperty(GObject* obj, guint prop_id, const GValue* value, GParamSpec* pspec) {
   NodeGiClassData* ownerCd =
       static_cast<NodeGiClassData*>(g_type_get_qdata(pspec->owner_type, NodeGiClassDataQuark()));
@@ -372,10 +449,26 @@ static void NodeGiSetProperty(GObject* obj, guint prop_id, const GValue* value, 
       g_object_set_qdata_full(obj, NodeGiInstancePropsQuark(), store,
                               reinterpret_cast<GDestroyNotify>(g_hash_table_destroy));
     }
+    // Record first-set order alongside the value (see NodeGiInstancePropOrderQuark).
+    // This is the ONLY writer of either structure, so they cannot drift.
+    if (!g_hash_table_contains(store, pspec->name)) {
+      GPtrArray* order =
+          static_cast<GPtrArray*>(g_object_get_qdata(obj, NodeGiInstancePropOrderQuark()));
+      if (order == nullptr) {
+        order = g_ptr_array_new_with_free_func(g_free);
+        g_object_set_qdata_full(obj, NodeGiInstancePropOrderQuark(), order,
+                                reinterpret_cast<GDestroyNotify>(g_ptr_array_unref));
+      }
+      g_ptr_array_add(order, g_strdup(pspec->name));
+    }
     GValue* copy = g_new0(GValue, 1);
     g_value_init(copy, G_VALUE_TYPE(value));
     g_value_copy(value, copy);
     g_hash_table_replace(store, g_strdup(pspec->name), copy);
+    // Before the notify, so a ::notify handler observes the JS-side state the setter
+    // wrote — GObject emits its own notify after this vfunc returns, which is the
+    // order gjs's handlers see.
+    MaybeRunJsPropertySetter(ownerCd, obj, pspec->name);
     g_object_notify_by_pspec(obj, pspec);
     return;
   }
@@ -1500,6 +1593,48 @@ Napi::Value SetConstructCallback(const Napi::CallbackInfo& info) {
   }
   napi_create_reference(env, info[0], 1, &d->constructCallback);
   return env.Undefined();
+}
+
+// setPropertySetCallback(cb) -> void. L1 registers the callback NodeGiSetProperty
+// invokes after storing a custom property: (instanceHandle, propertyName) → run the
+// class's own JS setter (see gi.js runJsPropertySetter). Mirrors
+// setConstructCallback.
+Napi::Value SetPropertySetCallback(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsFunction()) {
+    Napi::TypeError::New(env, "setPropertySetCallback(cb: function)").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  NodeGiEnvData* d = EnvData(env);
+  if (d == nullptr) return env.Undefined();
+  if (d->propertySetCallback != nullptr) {
+    napi_delete_reference(env, d->propertySetCallback);
+    d->propertySetCallback = nullptr;
+  }
+  napi_create_reference(env, info[0], 1, &d->propertySetCallback);
+  return env.Undefined();
+}
+
+// storedPropertyNames(handle) -> string[]. The custom properties that have actually
+// been SET on this instance, in the order they were first set — which is the only
+// honest record of it, since a property nobody set is absent (NodeGiGetProperty
+// answers such a read from the ParamSpec default instead). The base ctor reads it to
+// replay construct-time sets through the JS setters that did not exist yet, and
+// "actually set" is exactly the discriminator that keeps a declared-but-untouched
+// property's setter from firing early (the SourceView `selectable` crash). Order is
+// part of the contract, not a detail: the replay runs those setters, and gjs runs
+// them in the order g_object_new applied the values.
+Napi::Value StoredPropertyNames(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  GObject* obj = UnwrapGObject(env, info[0]);
+  if (obj == nullptr) return Napi::Array::New(env, 0);
+  GPtrArray* order =
+      static_cast<GPtrArray*>(g_object_get_qdata(obj, NodeGiInstancePropOrderQuark()));
+  if (order == nullptr) return Napi::Array::New(env, 0);
+  Napi::Array out = Napi::Array::New(env, order->len);
+  for (guint i = 0; i < order->len; i++)
+    out.Set(i, Napi::String::New(env, static_cast<const char*>(g_ptr_array_index(order, i))));
+  return out;
 }
 
 }  // namespace nodegi

--- a/packages/node-gi/node-gi/src/common.h
+++ b/packages/node-gi/node-gi/src/common.h
@@ -95,6 +95,12 @@ struct NodeGiEnvData {
   // Reflect.construct(class) in adopt mode (see gi.js runCtorForCObject). Per-env
   // for the same reason as errorBuilder (a napi_ref is env-specific).
   napi_ref constructCallback = nullptr;
+  // L1 callback that pushes a just-set custom GObject property through the class's
+  // own JS setter — invoked by NodeGiSetProperty once the instance HAS a wrapper
+  // (handle, propertyName) → see gi.js runJsPropertySetter. gjs reaches the same
+  // setter from its set_property vfunc (refs/gjs/gi/gobject.cpp jsobj_set_gproperty).
+  // Per-env for the same reason as errorBuilder (a napi_ref is env-specific).
+  napi_ref propertySetCallback = nullptr;
 };
 
 void NodeGiEnvDataFinalize(napi_env env, void* data, void* hint);
@@ -458,6 +464,9 @@ void NodeGiToggleDebugLog(const char* fmt, ...) G_GNUC_PRINTF(1, 2);
 
 Napi::Value MakeGObjectHandle(Napi::Env env, GObject* obj);
 Napi::Value WrapGObject(Napi::Env env, GObject* obj, GITransfer transfer);
+// The wrapper `obj` already has in `env`, or an empty value — never creates one. See
+// toggle.cc; the caller that needs it is the set_property vfunc (class.cc).
+Napi::Value PeekGObjectHandle(Napi::Env env, GObject* obj);
 
 extern int g_syncEmitDepth;
 
@@ -665,6 +674,8 @@ Napi::Value CallParentVfunc(const Napi::CallbackInfo& info);
 Napi::Value HasClassVfunc(const Napi::CallbackInfo& info);
 Napi::Value CallClassVfunc(const Napi::CallbackInfo& info);
 Napi::Value SetConstructCallback(const Napi::CallbackInfo& info);
+Napi::Value SetPropertySetCallback(const Napi::CallbackInfo& info);
+Napi::Value StoredPropertyNames(const Napi::CallbackInfo& info);
 
 // template.cc
 Napi::Value GetTemplateChild(const Napi::CallbackInfo& info);

--- a/packages/node-gi/node-gi/src/repo.cc
+++ b/packages/node-gi/node-gi/src/repo.cc
@@ -19,6 +19,7 @@ void NodeGiEnvDataFinalize(napi_env env, void* data, void* /*hint*/) {
   if (d->cairoWrappers != nullptr) napi_delete_reference(env, d->cairoWrappers);
   if (d->microtaskDrain != nullptr) napi_delete_reference(env, d->microtaskDrain);
   if (d->constructCallback != nullptr) napi_delete_reference(env, d->constructCallback);
+  if (d->propertySetCallback != nullptr) napi_delete_reference(env, d->propertySetCallback);
   delete d;
 }
 

--- a/packages/node-gi/node-gi/src/toggle.cc
+++ b/packages/node-gi/node-gi/src/toggle.cc
@@ -807,6 +807,23 @@ Napi::Value WrapGObject(Napi::Env env, GObject* obj, GITransfer transfer) {
   return MakeGObjectHandle(env, obj);
 }
 
+// The canonical wrapper `obj` ALREADY has in this env, or an empty value when it has
+// none. Never creates one and never touches a refcount — the whole point is to ask
+// "is there a JS object to call into yet?" without bringing one into being, which is
+// gjs's `priv->wrapper()` test (refs/gjs/gi/gobject.cpp gjs_object_set_gproperty
+// bails when it is null). Same cross-env gate as WrapGObject's cache hit: a napi_ref
+// belongs to inst->env and dereferencing it from another env is a UAF.
+Napi::Value PeekGObjectHandle(Napi::Env env, GObject* obj) {
+  if (obj == nullptr) return Napi::Value();
+  NodeGiInstance* inst =
+      static_cast<NodeGiInstance*>(g_object_get_qdata(obj, NodeGiWrapperQuark()));
+  if (inst == nullptr || inst->env != static_cast<napi_env>(env)) return Napi::Value();
+  napi_value cached = nullptr;
+  if (napi_get_reference_value(env, inst->handle_ref, &cached) != napi_ok || cached == nullptr)
+    return Napi::Value();  // collected, teardown pending — there is nothing live to call
+  return Napi::Value(env, cached);
+}
+
 // ============================ TEST-ONLY ===============================
 // __stressRefUnrefOffThread(handle, iterations) — the GLib-thread vehicle the
 // cross-thread GC stress test needs (there is no headless JS way to make another

--- a/packages/node-gi/node-gi/test/byvalue-elements.test.mjs
+++ b/packages/node-gi/node-gi/test/byvalue-elements.test.mjs
@@ -57,9 +57,12 @@ function needs(namespace, version) {
 }
 
 test('a by-value GValue array lands at the record’s own stride', () => {
-    // `GObject.signal_emitv(instance_and_params[], signal_id, detail)` is the core
-    // subject for this: one C array of GValue BY VALUE, and the callee reads BOTH cells
-    // — element 0 for the instance to emit on, element 1 for the signal's parameter.
+    // `GObject.signal_emitv(instance_and_params[], signal_id, detail, return_value)` is
+    // the core subject for this: one C array of GValue BY VALUE, and the callee reads
+    // BOTH cells — element 0 for the instance to emit on, element 1 for the signal's
+    // parameter. The trailing `return_value` is spelled out because gjs demands it
+    // (its arity is 4, measured on 1.88.1); a three-argument call throws there, so
+    // leaving it off would test a call shape that only ever worked on node-gi.
     //
     // That is what makes it a stride assertion rather than a smoke test. At an
     // eight-byte stride element 1 would be read out of element 0's interior, so the
@@ -79,7 +82,7 @@ test('a by-value GValue array lands at the record’s own stride', () => {
     parameter.init(GObject.TYPE_VARIANT);
     parameter.set_variant(GLib.Variant.new_string('the second cell'));
 
-    GObject.signal_emitv([instance, parameter], GObject.signal_lookup('activate', Gio.SimpleAction.$gtype), 0);
+    GObject.signal_emitv([instance, parameter], GObject.signal_lookup('activate', Gio.SimpleAction.$gtype), 0, null);
 
     assert.deepEqual(received, ['the second cell'], 'both cells must reach the callee intact');
 });

--- a/packages/node-gi/node-gi/test/callable-too-few-args.test.mjs
+++ b/packages/node-gi/node-gi/test/callable-too-few-args.test.mjs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — a GI call with too FEW arguments throws gjs's TypeError instead of
+// padding the missing ones with `undefined`.
+//
+// The defect this pins is type- and class-independent, and it is silent. node-gi read
+// a missing JS argument as `undefined` and marshalled it, so on a GValue parameter
+// `JsToFreshGValue` guessed `G_TYPE_POINTER` (gjs's guess for null) and handed that to
+// the callee. `get_property` is where users meet it: on ANY class, custom or stock,
+//
+//     label.get_property('label')
+//       → GLib-GObject-CRITICAL: g_object_get_property: can't retrieve property
+//         'label' of type 'gchararray' as value of type 'gpointer'
+//       → undefined
+//
+// and the set_property twin mirrors it ("unable to set property … from value of type
+// 'gpointer'"). gjs refuses the same call BEFORE any marshalling
+// (refs/gjs/gi/function.cpp:891 → JS::CallArgs::reportMoreArgsNeeded), so the two-arg
+// spelling is the only one that ever worked on either runtime — the fix converts a
+// silently wrong answer into the identical refusal.
+//
+// Messages are byte-compared against gjs 1.88.1, including the singular/plural of
+// "argument" and gjs's `format_name()` spelling (method Ns.Class.name / function
+// Ns.name, refs/gjs/gi/function.cpp:801).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi } from '../gi.js';
+import { haveDisplay } from './display-gate.mjs';
+
+const GObject = requireGi('GObject', '2.0');
+const GLib = requireGi('GLib', '2.0');
+const Gio = requireGi('Gio', '2.0');
+
+test("get_property with one argument throws gjs's arity TypeError", () => {
+    const obj = new GObject.Object();
+    assert.throws(() => obj.get_property('some-property'), {
+        name: 'TypeError',
+        message: 'method GObject.Object.get_property: At least 2 arguments required, but only 1 passed',
+    });
+});
+
+test('set_property with one argument throws too', () => {
+    const obj = new GObject.Object();
+    assert.throws(() => obj.set_property('some-property'), {
+        name: 'TypeError',
+        message: 'method GObject.Object.set_property: At least 2 arguments required, but only 1 passed',
+    });
+});
+
+test('the two-argument get_property/set_property spelling still works', () => {
+    // A stock C class with no JS in play: the property round-trips through a caller
+    // GValue exactly as on gjs.
+    const file = Gio.File.new_for_path('/tmp/node-gi-arity-probe');
+    const value = new GObject.Value();
+    value.init(GObject.TYPE_STRING);
+    // GFile has no writable property to round-trip, so use a GObject that has one.
+    const action = new Gio.SimpleAction({ name: 'probe' });
+    action.get_property('name', value);
+    assert.equal(value.get_string(), 'probe', 'the caller GValue was filled');
+    assert.ok(file, 'the stock file handle is intact');
+});
+
+test('a namespace function reports the singular "argument"', () => {
+    assert.throws(() => GLib.path_is_absolute(), {
+        name: 'TypeError',
+        message: 'function GLib.path_is_absolute: At least 1 argument required, but only 0 passed',
+    });
+});
+
+test('a method reports its DECLARING class, as gjs does', () => {
+    const file = Gio.File.new_for_path('/tmp');
+    assert.throws(() => file.get_child(), {
+        name: 'TypeError',
+        message: 'method Gio.File.get_child: At least 1 argument required, but only 0 passed',
+    });
+});
+
+test('too MANY arguments stay permitted (gjs only warns)', () => {
+    // gjs emits a JS warning and runs the call; node-gi has no JS warning reporter, so
+    // it runs the call silently. Either way the extra argument must not turn into a
+    // refusal — a consumer passing a stray argument keeps working on both runtimes.
+    assert.equal(GLib.path_is_absolute('/a', 'stray'), true);
+});
+
+test('a stock widget property is refused identically', { skip: !haveDisplay && 'needs a display' }, () => {
+    const Gtk = requireGi('Gtk', '4.0');
+    Gtk.init();
+    const label = new Gtk.Label({ label: 'hello' });
+    assert.throws(() => label.get_property('label'), {
+        name: 'TypeError',
+        message: 'method GObject.Object.get_property: At least 2 arguments required, but only 1 passed',
+    });
+    // The accessor path is untouched and still answers.
+    assert.equal(label.label, 'hello');
+});

--- a/packages/node-gi/node-gi/test/custom-property-js-setter.test.mjs
+++ b/packages/node-gi/node-gi/test/custom-property-js-setter.test.mjs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — a custom GObject property's JS SETTER runs whenever the property
+// is set, not only when it is CONSTRUCT-flagged.
+//
+// The wall this guards (Learn6502's tutorial on `--app node`, macOS + Windows): its
+// `SourceView` declares `code`, `copyable` and `line-numbers` as plain READWRITE
+// properties with JS setters, and the tutorial sets all three from a GtkBuilder
+// template. GtkBuilder applies a NON-construct property AFTER construction via
+// g_object_set, and node-gi's set_property vfunc only ever wrote the engine's
+// per-instance store — so every code block rendered empty and the copy button never
+// appeared, while the identical source worked on gjs. gjs routes the vfunc through
+// the wrapper's JS setter (refs/gjs/gi/gobject.cpp gjs_object_set_gproperty →
+// jsobj_set_gproperty → JS_SetProperty); node-gi now does the same.
+//
+// TWO TIMES, ONE RULE — do not collapse them: a set that lands BEFORE the wrapper
+// exists (construct properties, g_object_new) has nothing to call into and is
+// replayed by the flush in the base ctor; a set that lands after (GtkBuilder, a
+// binding, set_property) delegates immediately. The construct-time half is exactly
+// where a setter must NOT fire for a property nobody set — see the `untouched` case.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi } from '../gi.js';
+import { haveDisplay } from './display-gate.mjs';
+
+const GObject = requireGi('GObject', '2.0');
+
+const Widget = GObject.registerClass(
+    {
+        GTypeName: 'NodeGiCustomPropSetter',
+        Properties: {
+            plain: GObject.ParamSpec.string(
+                'plain',
+                'Plain',
+                'A plain READWRITE string with a JS accessor',
+                GObject.ParamFlags.READWRITE,
+                '',
+            ),
+            // A COMPOUND name: gjs mirrors a declared accessor onto the dash, underscore
+            // AND camelCase spellings (_checkAccessors in refs/gjs/modules/core/_common.js),
+            // so a `line-numbers` property reaches a `lineNumbers` setter. Learn6502's
+            // SourceView is exactly this shape.
+            'line-numbers': GObject.ParamSpec.boolean(
+                'line-numbers',
+                'Line numbers',
+                'A compound-named property whose accessor is camelCase',
+                GObject.ParamFlags.READWRITE,
+                false,
+            ),
+            // No JS accessor: the engine store stays its single backing store.
+            storeOnly: GObject.ParamSpec.string(
+                'store-only',
+                'Store only',
+                'A property with NO JS accessor',
+                GObject.ParamFlags.READWRITE,
+                'default',
+            ),
+            // Declared with a setter that only works once the ctor body has run. Nothing
+            // ever sets it, so its setter must never fire — the Learn6502 SourceView
+            // `selectable` → `_signalHandlers.forEach` crash.
+            untouched: GObject.ParamSpec.boolean(
+                'untouched',
+                'Untouched',
+                'A READWRITE bool nobody sets; its setter must never run',
+                GObject.ParamFlags.READWRITE,
+                false,
+            ),
+        },
+    },
+    class Widget extends GObject.Object {
+        constructor(params) {
+            super(params);
+            if (this._log === undefined) this._log = [];
+        }
+        get plain() {
+            return this._plain ?? '<unset>';
+        }
+        set plain(v) {
+            this._sets = [...(this._sets ?? []), `plain=${v}`];
+            this._plain = v;
+        }
+        get lineNumbers() {
+            return this._lineNumbers ?? '<unset>';
+        }
+        set lineNumbers(v) {
+            this._sets = [...(this._sets ?? []), `lineNumbers=${v}`];
+            this._lineNumbers = v;
+        }
+        set untouched(v) {
+            // Throws unless the ctor body has already initialised _log.
+            this._log.push(v);
+        }
+    },
+);
+
+test('set_property on a custom property runs the class JS setter', () => {
+    const w = new Widget();
+    assert.equal(w.plain, '<unset>', 'nothing set it yet');
+    w.set_property('plain', 'FROM-SET-PROPERTY');
+    assert.deepEqual(w._sets, ['plain=FROM-SET-PROPERTY'], 'the JS setter ran exactly once');
+    assert.equal(w.plain, 'FROM-SET-PROPERTY', 'the class getter sees the value');
+    assert.equal(w._plain, 'FROM-SET-PROPERTY', 'the backing field carries it');
+});
+
+test('a compound property name reaches a camelCase JS setter', () => {
+    const w = new Widget();
+    w.set_property('line-numbers', true);
+    assert.deepEqual(w._sets, ['lineNumbers=true'], 'the camelCase setter ran');
+    assert.equal(w._lineNumbers, true, 'the backing field carries it');
+});
+
+test('a property passed to the constructor runs the JS setter', () => {
+    const w = new Widget({ plain: 'FROM-NEW' });
+    assert.deepEqual(w._sets, ['plain=FROM-NEW'], 'the JS setter ran exactly once');
+    assert.equal(w.plain, 'FROM-NEW', 'the class getter sees the constructed value');
+});
+
+test('a property with NO JS accessor keeps the engine store as its backing store', () => {
+    const w = new Widget();
+    assert.equal(w.store_only, 'default', 'the declared default comes from the store');
+    w.set_property('store-only', 'stored');
+    assert.equal(w.store_only, 'stored', 'the store round-trips');
+});
+
+test('a setter for a property nobody set NEVER runs', () => {
+    // If construction flushed every declared property (rather than only the ones
+    // actually set), `set untouched` would run before the ctor body and throw on the
+    // undefined `_log`.
+    const w = new Widget();
+    assert.deepEqual(w._log, [], 'the untouched setter did not run during construction');
+    // It still works normally once something does set it.
+    w.set_property('untouched', true);
+    assert.deepEqual(w._log, [true], 'the setter ran exactly once, post-construction');
+});
+
+test('a GtkBuilder template value reaches the JS setter', { skip: !haveDisplay && 'needs a display' }, () => {
+    const Gtk = requireGi('Gtk', '4.0');
+    Gtk.init();
+
+    const seen = [];
+    GObject.registerClass(
+        {
+            GTypeName: 'NodeGiTemplatePropSetter',
+            Properties: {
+                code: GObject.ParamSpec.string(
+                    'code',
+                    'Code',
+                    'The Learn6502 SourceView shape: a plain READWRITE string',
+                    GObject.ParamFlags.READWRITE,
+                    '',
+                ),
+                'line-numbers': GObject.ParamSpec.boolean(
+                    'line-numbers',
+                    'Line numbers',
+                    'A compound name with a camelCase setter',
+                    GObject.ParamFlags.READWRITE,
+                    false,
+                ),
+            },
+        },
+        class TemplateProbe extends Gtk.Box {
+            set code(v) {
+                seen.push(`code=${v}`);
+                this._code = v;
+            }
+            get code() {
+                return this._code ?? '<unset>';
+            }
+            set lineNumbers(v) {
+                seen.push(`lineNumbers=${v}`);
+                this._lineNumbers = v;
+            }
+        },
+    );
+
+    const builder = Gtk.Builder.new_from_string(
+        '<interface><object class="NodeGiTemplatePropSetter" id="probe">' +
+            '<property name="code">LDA #$01</property>' +
+            '<property name="line-numbers">true</property>' +
+            '</object></interface>',
+        -1,
+    );
+    const probe = builder.get_object('probe');
+
+    assert.deepEqual(seen, ['code=LDA #$01', 'lineNumbers=true'], 'both template values ran their setters');
+    assert.equal(probe.code, 'LDA #$01', 'the class getter returns the template value');
+    assert.equal(probe._lineNumbers, true, 'the compound-named backing field carries it');
+});

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -443,6 +443,14 @@ without aligning the call shape would make the reported arity lie about the
 invoke. Fix the calling convention first; the arity then follows for free from
 the shared pre-scan.
 
+Since 0.51 the arity is also ENFORCED (a call with too few arguments throws
+gjs's `TypeError` rather than padding with `undefined`), so the second of these
+two now has a visible consequence rather than only a wrong length: node-gi
+demands 2 for `add_data`, so `add_data(bytes)` — which gjs accepts — is refused
+there. It is the same defect from the same line, still fixed by aligning the
+calling convention; the refusal is merely no longer silent. `read` diverges the
+lenient way (node-gi demands 1, gjs 2) and refuses nothing gjs accepts.
+
 One string/object leniency measured in the same pass and also left open:
 node-gi accepts BOTH `null` and `undefined` as a NULL utf8/object IN arg,
 while gjs throws `Expected type string … got type undefined` for `undefined`


### PR DESCRIPTION
Two independent node-gi defects, one commit each, both gjs-parity gaps with the
measurement in front of the fix. Learn6502's `--app node` artifacts on macOS and
Windows are blocked on the first.

## 1. A custom property's JS setter never ran (`6302ee5`)

Learn6502's SourceView declares `code`, `copyable` and `line-numbers` as plain
READWRITE GObject properties with JS accessors, and the tutorial sets all three
from a GtkBuilder template. Every code block rendered EMPTY and the copy button
was missing, on both platforms, while the identical source works on gjs.

GtkBuilder applies a NON-construct property AFTER construction via `g_object_set`.
node-gi's set_property vfunc — `src/class.cc:365` `NodeGiSetProperty` — only ever
wrote the engine's per-instance store and never touched the wrapper, so the
class's setter never ran and its getter read an untouched backing field. gjs
routes the same vfunc through the wrapper: `refs/gjs/gi/gobject.cpp:203`
`gjs_object_set_gproperty` → `:56` `jsobj_set_gproperty` → `JS_SetProperty`.

Measured, it was three faces of one gap — a template value, a value passed to
`new`, and a bare `set_property` all reached the store and never the setter.
Only CONSTRUCT-flagged properties were routed, by the construct-property flush
at `gi.js:852`.

The vfunc now delegates, and the gate is the WRAPPER, exactly as gjs bails when
`priv->wrapper()` is null.

**The construction-time trap, kept explicit in the code.** That gate IS the
design. A set landing during construction — before node-gi has built the wrapper
— has nothing to call into and therefore cannot fire a setter early. Firing one
early is what crashed this same SourceView before (`selectable` →
`_signalHandlers.forEach` against state the ctor body had not created yet), which
is why the previous work was scoped to CONSTRUCT only. The two times are not the
same time: GtkBuilder sets non-construct properties AFTER construction, and
delegating there is what gjs does and was never the cause of that crash. A
comment at the gate says so, because the next simplification is what brings it
back.

Construct-time values are replayed from the base ctor once the wrapper exists,
before the user ctor body, in gjs's order. Which ones: those the engine actually
STORED, in first-set order. That replaces the CONSTRUCT-flag filter with the
honest question — a property nobody set is absent from the store — so the
early-setter crash is now excluded structurally rather than by a flag, and a
plain property passed to `new` is no longer missed. Order is recorded because it
is visible output: a GHashTable has none, and conformance caught exactly that.

Setter lookup covers the dash, underscore and camelCase spellings gjs makes
equivalent via `_checkAccessors` (`refs/gjs/modules/core/_common.js:65`), which
is what lets a `line-numbers` property reach a `lineNumbers` setter.

## 2. `get_property()` answered `undefined` on every class (`1b93222`)

Type- and class-independent, and silent:

```
label.get_property('label')
  -> GLib-GObject-CRITICAL: g_object_get_property: can't retrieve property
     'label' of type 'gchararray' as value of type 'gpointer'
  -> undefined
```

Not the store and not the property path: the accessor `label.label` always
answered, and the two-argument `get_property(name, value)` always filled its
caller GValue. The cause is that node-gi checked no argument COUNT at all. A
missing JS argument was read as `undefined` (`src/calls.cc:730/776/799`) and
marshalled, so on a GValue parameter `JsToFreshGValue` (`src/marshal.cc:216`)
applied gjs's guess for null — `G_TYPE_POINTER` — and handed the callee a GValue
of the wrong type. `set_property` mirrors it ("unable to set property ... from
value of type 'gpointer'").

That is not leniency but a wrong call: gjs refuses the same one before any
marshalling (`refs/gjs/gi/function.cpp:891` → `reportMoreArgsNeeded`), so the
one-argument spelling it invited has never worked on either runtime — consumers
got `undefined` and no error to follow. `InvokeFunctionInfo` now throws gjs's
TypeError with gjs's message, down to the singular/plural of "argument" and its
`format_name()` spelling (`refs/gjs/gi/function.cpp:801`). Too MANY arguments
stays permitted: gjs only warns there, through a reporter node-gi has no
equivalent of.

## Before / after

Original reproduction, verbatim. Before:

```
JS-setter ran for : atconstruct=FROM-TEMPLATE
p.plain           : ""
p.atconstruct     : "FROM-TEMPLATE"
(process:...): GLib-GObject-CRITICAL **: g_object_get_property: can't retrieve
   property 'plain' of type 'gchararray' as value of type 'gpointer'
get_property      : undefined
```

After — byte-identical to `gjs -m` on the same program:

```
JS-setter ran for : atconstruct=FROM-TEMPLATE, plain=FROM-TEMPLATE
p.plain           : "FROM-TEMPLATE"
p.atconstruct     : "FROM-TEMPLATE"
get_property THREW: method GObject.Object.get_property: At least 2 arguments
   required, but only 1 passed
```

## Red to green

Both tests written first and watched fail. Red, on the unfixed engine: 10 of 13
failing, the 3 passing ones being the no-regression guards (two-argument
get_property, too-many-arguments, a store-backed property with no accessor) —
so the suite was not vacuous. Green after: 13/13.

## Blast radius

Baseline measured on `origin/main` with the same build, because two tests here
are already flaky: `gc-cross-thread` (red in 2 of 3 baseline headless runs) and
`Gtk.Application.run() runs a real app` (red in 2 of 3 baseline display runs).
Both remain the only failures, neither is touched by this change.

- node:test headless: baseline 634 pass / 0 fail, now 645 / 0, three runs
- node:test display: baseline 656 pass, now 669, same single pre-existing flake
- The counts reconcile exactly: 13 new tests, 2 of them display-gated
- conformance golden-diff: 36 programs x gjs/node/bun/deno, all green
- GC-stress leg: 685 pass / 0 fail; D-Bus leg 8/8
- GIMarshallingTests oracle: 370 pass / 0 fail, unchanged
- Bun 38/38; Deno 36/38 with the known #47 teardown-exit files, 0 test failures

One real hit, and it was a test asserting a call gjs rejects:
`GObject.signal_emitv` with three arguments in `byvalue-elements`. gjs demands
four (measured, arity 4) and throws on three, so that spelling only ever worked
here; the test now passes the `return_value` gjs wants and its stride assertion
is unchanged.

## End-to-end

The real Learn6502 `--app node` bundle, run against the fixed node-gi, its live
widget tree walked from OUTSIDE the app (no file in the easy6502 checkout was
modified; the node-gi swap was reverted afterwards).

SourceViews carrying their template code: 5 of 35 before, 31 of 35 after.
SourceViews with `copyable` true: 0 before, 21 after. The four still empty are
the editor and quick-help views, which legitimately start empty.

## Mechanism, not just a fix

Each defect gets a conformance program whose golden IS gjs's stdout, so both are
held on gjs, node, bun and deno rather than by a Linux-only assertion:
`custom-property-js-setter` and `callable-too-few-args`.

Divergences documented in `docs/node-gi-gjs-surface.md`. No AGENTS.md touched, so
the agent-context ratchet is untouched; `check-agent-context-size --check` green.
`oxfmt --check` and `oxlint` clean on every file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8QkeZTJyNXrniXhrsncT6
