### PR TITLE
fix(gtk-host): attribute a face to its font source

### DIFF
--- a/docs/adr/0038-shipped-application-fonts.md
+++ b/docs/adr/0038-shipped-application-fonts.md
@@ -563,6 +563,20 @@ it once. `InitFontsResult.dir` still means the APPLICATION's directory alone, so
 caller asserting "my staged face was found" cannot start answering yes because the platform's
 arrived.
 
+**AND `InitFontsResult.sources` NOW CARRIES WHAT EACH SOURCE CONTRIBUTED, because keeping `dir`
+singular was not enough.** The flat `registered` / `declined` / `failed` lists SPAN both
+directories, and that widening stayed invisible for as long as the published bundles shipped no
+face. The day `@gjsify/gtk-runtime-*` started staging the six Adwaita faces, every count taken
+from those lists moved by six — including seven assertions in `fonts.spec.ts`, which turned the
+darwin legs of `gtk-os-suites.yml` red on the first scheduled run after the 0.51.0 prebuild
+pointer landed, with no source change behind it and five months after those assertions were
+written. Those legs pair the JS in the checkout with the PUBLISHED bundle, so the trigger was a
+release, not a commit. A caller cannot re-derive the attribution afterwards without comparing
+path prefixes, which is a guess about filesystem layout rather than a measurement; the loop that
+hands each file to the font map is the only place that knows which directory it came from. So
+each entry is a `FontSourceOutcome` — the same argument `families` makes about the family diff,
+one field over. Ask a source what it contributed; the flat lists are the SUM.
+
 **The per-OS honesty rows of § 3 carry over unchanged, and one of them now bites harder.** Linux
 finds `share/fonts` through the `XDG_DATA_DIRS` the loader already sets; Windows can only be
 reached by `add_font_file`, which is what makes the handover load-bearing there exactly as § 4

--- a/packages/framework/gtk-host/src/fonts.spec.ts
+++ b/packages/framework/gtk-host/src/fonts.spec.ts
@@ -21,7 +21,9 @@ import PangoCairo from 'gi://PangoCairo?version=1.0';
 import {
     adwaitaUiFontAvailability,
     applyUiFontPolicy,
+    type FontFaceFailure,
     initFonts,
+    type InitFontsResult,
     isUnsupportedByFontMap,
     matchFontFamily,
     uiFontBaseline,
@@ -132,6 +134,36 @@ const NO_REGISTRATION_REASON =
     '`initFonts` reports these as DECLINED rather than failed. Retires itself if Pango ever ' +
     'implements the vfunc on CoreText, or on any host where PANGOCAIRO_BACKEND selects fc.';
 
+/** What ONE source contributed, which is what every assertion in this file is actually about. */
+interface Accounted {
+    readonly registered: readonly string[];
+    readonly declined: readonly string[];
+    readonly failed: readonly FontFaceFailure[];
+}
+
+/** No source of that origin was resolved, so it contributed nothing. */
+const NOTHING: Accounted = { registered: [], declined: [], failed: [] };
+
+/**
+ * What the APPLICATION's directory — the one each test below stages — contributed.
+ *
+ * THE READ THAT TURNED RED ON 0.51.0, and the reason these assertions no longer touch
+ * `result.registered` at all. `initFonts` resolves TWO sources (`font-dir.ts`): the application's
+ * own faces, and the GTK runtime bundle's GNOME UI typeface, which `@gjsify/node-gi`'s loader
+ * names through `GJSIFY_GTK_RUNTIME_FONT_DIR` whenever the process runs on a batteries-included
+ * bundle. The flat `registered`/`declined`/`failed` lists span both. So on the legs that pair this
+ * checkout with a PUBLISHED bundle, every count here moved the moment that bundle started carrying
+ * the Adwaita faces — six of them — and each of these tests started measuring a number it has no
+ * business knowing: 0 became 6, one staged path became seven paths.
+ *
+ * Pinning the new number would be worse than the bug, because the seventh face would break it
+ * again and it would still be asserting nothing about the directory the test staged. Asking the
+ * source THIS TEST created what it contributed is the question each assertion was always making.
+ */
+function appFaces(result: InitFontsResult): Accounted {
+    return result.sources.find((source) => source.origin === 'app') ?? NOTHING;
+}
+
 /** Remove a flat directory and its entries — these fixtures never nest. */
 function removeTree(dir: string): void {
     const file = Gio.File.new_for_path(dir);
@@ -144,15 +176,23 @@ function removeTree(dir: string): void {
 
 export default async () => {
     await describe('initFonts — nothing to do', async () => {
-        await it('does nothing, quietly, when no directory is named', async () => {
+        await it('does nothing for the application when no directory is named', async () => {
             // `gjsify ship` exports GJSIFY_FONT_DIR only when it staged a face, so this is the
             // ordinary case for every application that ships none.
+            //
+            // `families` is deliberately NOT asserted here. With nothing staged and nothing asked
+            // about, this call takes the early return and reports `[]` no matter what the diff
+            // below it does — so an assertion here could not fail, and the one test that CAN hold
+            // the diff's guard is the sibling below, which reaches it by naming a family.
             const result = initFonts({ fontDir: '' });
             expect(result.dir).toBeUndefined();
-            expect(result.registered.length).toBe(0);
-            expect(result.declined.length).toBe(0);
-            expect(result.failed.length).toBe(0);
-            expect(result.families.length).toBe(0);
+            // No APPLICATION source was resolved at all — the claim this test makes, and the one
+            // that stays true on a host whose runtime bundle names a font directory of its own.
+            expect(result.sources.some((source) => source.origin === 'app')).toBe(false);
+            const mine = appFaces(result);
+            expect(mine.registered.length).toBe(0);
+            expect(mine.declined.length).toBe(0);
+            expect(mine.failed.length).toBe(0);
             expect(result.matches.length).toBe(0);
         });
 
@@ -161,14 +201,19 @@ export default async () => {
             // of this code ran: nothing to register, and "is the family this application asks for
             // actually here" is still a fair question. The invented family is the discriminator —
             // a check that answered `exact` for everything would satisfy the first line alone.
+            const before = families();
             const result = initFonts({ fontDir: '', expectedFamilies: [INVENTED_FAMILY] });
             expect(result.matches.length).toBe(1);
             expect(result.matches[0]?.kind).toBe('absent');
             expect(result.matches[0]?.family).toBeUndefined();
-            // And `families` stays EMPTY. Reading the map to answer the question above means
-            // there is an `after` and no `before` — subtracting one from the other would credit
-            // this call with every family on the host, which is the opposite of what it reports.
-            expect(result.families.length).toBe(0);
+            // And `families` credits this call with nothing that was already on the map. Reading
+            // the map to answer the question above means there is an `after`, and where no
+            // directory was resolved there is no `before` — subtracting one from the other would
+            // credit this call with every family on the host, which is the opposite of what it
+            // reports. Stated as the relation rather than as `length === 0`, because a host whose
+            // runtime bundle names a font directory resolves a source here and may genuinely gain
+            // a family through it.
+            for (const family of result.families) expect(before).not.toContain(family);
             expect(result.dir).toBeUndefined();
         });
 
@@ -183,22 +228,23 @@ export default async () => {
             // invisible on Linux, where the two spellings coincide.
             const missing = GLib.build_filenamev([GLib.get_tmp_dir(), `gjsify-gtk-host-absent-${Date.now()}`]);
             const result = initFonts({ fontDir: missing });
+            const mine = appFaces(result);
             expect(result.dir).toBe(missing);
-            expect(result.registered.length).toBe(0);
-            expect(result.failed.length).toBe(1);
+            expect(mine.registered.length).toBe(0);
+            expect(mine.failed.length).toBe(1);
             // Against Gio's own spelling of the same path, so this compares what the walk
             // REPORTS with what the walk was GIVEN, not with a second hand-built string.
-            expect(result.failed[0]?.path).toBe(Gio.File.new_for_path(missing).get_path());
-            expectCleanGErrorMessage(result.failed[0]?.message);
+            expect(mine.failed[0]?.path).toBe(Gio.File.new_for_path(missing).get_path());
+            expectCleanGErrorMessage(mine.failed[0]?.message);
         });
 
         await it('ignores the strays a font directory legitimately carries', async () => {
             const dir = makeTempDir('strays');
             GLib.file_set_contents(GLib.build_filenamev([dir, 'OFL.txt']), 'the license, not a face');
             GLib.file_set_contents(GLib.build_filenamev([dir, 'README.md']), 'notes');
-            const result = initFonts({ fontDir: dir });
-            expect(result.registered.length).toBe(0);
-            expect(result.failed.length).toBe(0);
+            const mine = appFaces(initFonts({ fontDir: dir }));
+            expect(mine.registered.length).toBe(0);
+            expect(mine.failed.length).toBe(0);
             removeTree(dir);
         });
 
@@ -210,10 +256,10 @@ export default async () => {
             const dir = makeTempDir('broken');
             const broken = GLib.build_filenamev([dir, 'Broken.ttf']);
             GLib.file_set_contents(broken, 'not a font at all');
-            const result = initFonts({ fontDir: dir });
-            expect(result.registered.length).toBe(0);
-            expect([...result.failed.map((f) => f.path), ...result.declined]).toStrictEqual([broken]);
-            for (const failure of result.failed) expectCleanGErrorMessage(failure.message);
+            const mine = appFaces(initFonts({ fontDir: dir }));
+            expect(mine.registered.length).toBe(0);
+            expect([...mine.failed.map((f) => f.path), ...mine.declined]).toStrictEqual([broken]);
+            for (const failure of mine.failed) expectCleanGErrorMessage(failure.message);
             removeTree(dir);
         });
     });
@@ -243,9 +289,10 @@ export default async () => {
             // is one `initFonts` would take — it is simply not in the directory it was given.
             copyFace(source, outside, 'Round9x13.ttf');
             const result = initFonts({ fontDir: empty });
+            const mine = appFaces(result);
             expect(result.dir).toBe(empty);
-            expect(result.registered.length).toBe(0);
-            expect(result.failed.length).toBe(0);
+            expect(mine.registered.length).toBe(0);
+            expect(mine.failed.length).toBe(0);
             expect(families()).not.toContain(FACE_FAMILY);
         });
 
@@ -256,9 +303,10 @@ export default async () => {
         await it('finds the staged face and accounts for it, on any font map', async () => {
             const staged = copyFace(source, inside, 'Round9x13.ttf');
             const result = initFonts({ fontDir: inside });
+            const mine = appFaces(result);
             expect(result.dir).toBe(inside);
-            expect([...result.registered, ...result.declined]).toStrictEqual([staged]);
-            expect(result.failed.length).toBe(0);
+            expect([...mine.registered, ...mine.declined]).toStrictEqual([staged]);
+            expect(mine.failed.length).toBe(0);
         });
 
         await it('routes it to `declined` exactly when the map declines, never to `failed`', async () => {
@@ -266,10 +314,10 @@ export default async () => {
             // every staged face lands in `declined`, and calling that a FAILURE would make a
             // correct `.app` — whose faces `ATSApplicationFontsPath` already activated — print a
             // warning per face about a substitution that is not happening.
-            const result = initFonts({ fontDir: inside });
-            expect(result.declined.length).toBe(REGISTRATION_SUPPORTED ? 0 : 1);
-            expect(result.registered.length).toBe(REGISTRATION_SUPPORTED ? 1 : 0);
-            expect(result.failed.length).toBe(0);
+            const mine = appFaces(initFonts({ fontDir: inside }));
+            expect(mine.declined.length).toBe(REGISTRATION_SUPPORTED ? 0 : 1);
+            expect(mine.registered.length).toBe(REGISTRATION_SUPPORTED ? 1 : 0);
+            expect(mine.failed.length).toBe(0);
         });
 
         await it.failing(
@@ -346,6 +394,82 @@ export default async () => {
             for (const dir of [outside, inside, empty]) {
                 expect(Gio.File.new_for_path(dir).query_exists(null)).toBe(false);
             }
+        });
+    });
+
+    await describe('two sources, and the runtime bundle is never the application', async () => {
+        const source = findFaceSource();
+
+        await it('has the showcase face in reach', async () => {
+            expect(source).toBeDefined();
+        });
+
+        if (source === undefined) return;
+
+        await it("keeps the runtime bundle's faces out of the application's tally", async () => {
+            // THE SHAPE THAT TURNED `main` RED AT 0.51.0, staged here instead of waited for.
+            // A batteries-included GTK runtime bundle ships the GNOME UI typeface, `@gjsify/node-gi`'s
+            // loader names that directory through `GJSIFY_GTK_RUNTIME_FONT_DIR`, and `initFonts`
+            // registers it as a SECOND source — so the flat `registered`/`declined`/`failed` lists
+            // span both directories. Nothing in this file changed; the published bundle gained six
+            // faces and seven assertions that read those flat lists started measuring the bundle.
+            //
+            // Driven from the OPTION rather than from the environment, which is what makes this a
+            // gate instead of a coincidence: the two-source shape is then exercised on every host,
+            // not only on the legs that happen to run on a bundle. It is also the discriminator for
+            // `appFaces` — if that helper stopped excluding anything, or excluded everything, this
+            // is the assertion that goes red.
+            const runtimeDir = makeTempDir('runtimefonts');
+            const runtimeFace = copyFace(source, runtimeDir, 'RuntimeFace.ttf');
+            const appDir = makeTempDir('appfonts');
+            const appFace = copyFace(source, appDir, 'AppFace.ttf');
+
+            const result = initFonts({ fontDir: appDir, runtimeFontDir: runtimeDir });
+
+            // RUNTIME FIRST — the order `resolveFontSources` promises — and `dir` stays SINGULAR:
+            // the APPLICATION's directory, which is what a caller asserting "my staged face was
+            // found" reads.
+            expect(result.sources.map((entry) => entry.origin)).toStrictEqual(['runtime', 'app']);
+            expect(result.dir).toBe(appDir);
+
+            // BOTH faces are accounted for. Dropping the runtime's would be the opposite defect,
+            // and the one #1662 exists against: off Linux nothing else installs that typeface.
+            expect([...result.registered, ...result.declined].sort()).toStrictEqual([appFace, runtimeFace].sort());
+            expect(result.failed.length).toBe(0);
+
+            // And each face is attributed to the directory it came from, which is the read every
+            // assertion above makes instead of the flat lists.
+            expect([...appFaces(result).registered, ...appFaces(result).declined]).toStrictEqual([appFace]);
+            const theirs = result.sources.find((entry) => entry.origin === 'runtime');
+            expect([...(theirs?.registered ?? []), ...(theirs?.declined ?? [])]).toStrictEqual([runtimeFace]);
+            expect(theirs?.dir).toBe(runtimeDir);
+
+            removeTree(appDir);
+            removeTree(runtimeDir);
+        });
+
+        await it('attributes an unreadable directory to the source that named it', async () => {
+            // The `failed` arm of the same split: `collectFaces` reports a directory it cannot
+            // read, and that report belongs to the source whose directory it was. One live
+            // directory beside one missing one, so the assertion cannot pass by both being empty.
+            const runtimeDir = makeTempDir('runtimeok');
+            const runtimeFace = copyFace(source, runtimeDir, 'RuntimeFace.ttf');
+            const missing = GLib.build_filenamev([GLib.get_tmp_dir(), `gjsify-gtk-host-gone-${Date.now()}`]);
+
+            const result = initFonts({ fontDir: missing, runtimeFontDir: runtimeDir });
+
+            const mine = appFaces(result);
+            expect(mine.failed.map((failure) => failure.path)).toStrictEqual([
+                Gio.File.new_for_path(missing).get_path(),
+            ]);
+            expect(mine.registered.length).toBe(0);
+            expect(mine.declined.length).toBe(0);
+
+            const theirs = result.sources.find((entry) => entry.origin === 'runtime');
+            expect(theirs?.failed.length).toBe(0);
+            expect([...(theirs?.registered ?? []), ...(theirs?.declined ?? [])]).toStrictEqual([runtimeFace]);
+
+            removeTree(runtimeDir);
         });
     });
 

--- a/packages/framework/gtk-host/src/fonts.ts
+++ b/packages/framework/gtk-host/src/fonts.ts
@@ -126,6 +126,30 @@ export interface FontFaceFailure {
     readonly message: string;
 }
 
+/**
+ * A {@link FontSource} and the faces IT contributed.
+ *
+ * WHY THE ATTRIBUTION IS PART OF THE RESULT rather than something a caller re-derives. Since the
+ * GTK runtime bundle started carrying the GNOME UI typeface there are TWO sources, and the flat
+ * {@link InitFontsResult.registered}, {@link InitFontsResult.declined} and
+ * {@link InitFontsResult.failed} lists span both — so "did MY staged face arrive" stopped being
+ * answerable from them the day a published bundle gained a face, silently, with no caller
+ * changing a line. The loop that hands each file to the font map is the only place that knows
+ * which directory it came from; anything downstream is reduced to comparing path prefixes, which
+ * is a guess about filesystem layout rather than a measurement.
+ *
+ * The same argument {@link InitFontsResult.families} makes about the family diff, one field over:
+ * only the call that did the work is in a position to take the reading.
+ */
+export interface FontSourceOutcome extends FontSource {
+    /** Faces from THIS directory now on the default font map. */
+    readonly registered: readonly string[];
+    /** Faces from THIS directory the font map declined — see {@link isUnsupportedByFontMap}. */
+    readonly declined: readonly string[];
+    /** Faces from THIS directory that failed otherwise, plus the directory itself if unreadable. */
+    readonly failed: readonly FontFaceFailure[];
+}
+
 /** What {@link initFonts} did, so a caller that cares can assert on it. */
 export interface InitFontsResult {
     /**
@@ -136,8 +160,16 @@ export interface InitFontsResult {
      * answering `true` because the platform's were. {@link sources} is the full list.
      */
     readonly dir: string | undefined;
-    /** Every directory registered, runtime first. See {@link FontSource}. */
-    readonly sources: readonly FontSource[];
+    /**
+     * Every directory registered, runtime first, and what each one contributed.
+     *
+     * THE ONLY PLACE A FACE IS ATTRIBUTED TO A DIRECTORY. Read this, not the flat lists below,
+     * whenever the question is about ONE source — "did the face I staged arrive", "did the
+     * runtime bundle bring its own" — because the flat lists answer for all of them at once and
+     * their counts move whenever a published bundle changes what it carries. See
+     * {@link FontSourceOutcome}.
+     */
+    readonly sources: readonly FontSourceOutcome[];
     /**
      * What the UI-font-size policy did, or `undefined` when it did not run.
      *
@@ -145,11 +177,17 @@ export interface InitFontsResult {
      * there, so the default leaves `gtk-font-name` alone entirely.
      */
     readonly uiFont: UiFontPlan | undefined;
-    /** Faces now on the default font map. */
+    /** Faces now on the default font map, ACROSS EVERY {@link sources} entry. */
     readonly registered: readonly string[];
-    /** Faces the font map declined as unsupported — see {@link isUnsupportedByFontMap}. */
+    /**
+     * Faces the font map declined as unsupported, across every {@link sources} entry — see
+     * {@link isUnsupportedByFontMap}.
+     */
     readonly declined: readonly string[];
-    /** Faces that failed for any other reason. Each was warned about; none threw. */
+    /**
+     * Faces that failed for any other reason, across every {@link sources} entry. Each was warned
+     * about; none threw.
+     */
     readonly failed: readonly FontFaceFailure[];
     /**
      * The family names the default font map GAINED across this call, sorted.
@@ -234,15 +272,16 @@ export function isUnsupportedByFontMap(error: unknown): boolean {
  * `gjsify ship` staged one, so an unset variable is the ordinary case and does nothing quietly.
  */
 export function initFonts(options: InitFontsOptions = {}): InitFontsResult {
-    const sources = resolveFontSources({
+    const requested = resolveFontSources({
         ...options,
         env: {
             GJSIFY_FONT_DIR: GLib.getenv('GJSIFY_FONT_DIR') ?? undefined,
             GJSIFY_GTK_RUNTIME_FONT_DIR: GLib.getenv('GJSIFY_GTK_RUNTIME_FONT_DIR') ?? undefined,
         },
     });
-    const dir = sources.find((source) => source.origin === 'app')?.dir;
+    const dir = requested.find((source) => source.origin === 'app')?.dir;
 
+    const sources: FontSourceOutcome[] = [];
     const registered: string[] = [];
     const declined: string[] = [];
     const failed: FontFaceFailure[] = [];
@@ -258,7 +297,7 @@ export function initFonts(options: InitFontsOptions = {}): InitFontsResult {
     // family this application asks for actually here" is a fair question even when nothing was
     // staged, which is the macOS shape — a shipped `.app` had the OS activate the directory
     // declaratively, before any of this ran.
-    if (sources.length === 0 && expected.length === 0) {
+    if (requested.length === 0 && expected.length === 0) {
         return { dir, sources, uiFont: undefined, registered, declined, failed, families: [], matches: [] };
     }
 
@@ -267,27 +306,43 @@ export function initFonts(options: InitFontsOptions = {}): InitFontsResult {
     // The BEFORE half of the diff, taken only when there is something to register: a family list
     // is a walk over every family the map knows, and with no directory there is nothing to
     // attribute to this call anyway.
-    const before = sources.length === 0 ? [] : familyNames(fontMap);
+    const before = requested.length === 0 ? [] : familyNames(fontMap);
 
-    for (const source of sources) {
+    for (const source of requested) {
         const faces: string[] = [];
-        collectFaces(Gio.File.new_for_path(source.dir), faces, failed);
+        // Per source, then concatenated — the flat lists are the SUM and the per-source lists are
+        // the attribution, and the sum cannot be split back up afterwards without guessing at path
+        // prefixes. See {@link FontSourceOutcome}.
+        const sourceRegistered: string[] = [];
+        const sourceDeclined: string[] = [];
+        const sourceFailed: FontFaceFailure[] = [];
+        collectFaces(Gio.File.new_for_path(source.dir), faces, sourceFailed);
 
         for (const path of faces.sort()) {
             try {
                 fontMap.add_font_file(path);
-                registered.push(path);
+                sourceRegistered.push(path);
             } catch (error) {
                 // `add_font_file` is `throws="1"` in `Pango-1.0.gir` (since 1.56), and both arms
                 // are live: a map that does no runtime registration answers NOT_SUPPORTED, and a
                 // file that FreeType cannot open answers something else.
                 if (isUnsupportedByFontMap(error)) {
-                    declined.push(path);
+                    sourceDeclined.push(path);
                     continue;
                 }
-                failed.push({ path, message: messageOf(error) });
+                sourceFailed.push({ path, message: messageOf(error) });
             }
         }
+
+        registered.push(...sourceRegistered);
+        declined.push(...sourceDeclined);
+        failed.push(...sourceFailed);
+        sources.push({
+            ...source,
+            registered: sourceRegistered,
+            declined: sourceDeclined,
+            failed: sourceFailed,
+        });
     }
 
     // AFTER, and it is read once for both questions. `families` is what this call added;
@@ -300,7 +355,7 @@ export function initFonts(options: InitFontsOptions = {}): InitFontsResult {
     // a live one would report every family on the host as having been added by a call that
     // registered nothing — a field whose whole purpose is to say what THIS call contributed.
     const after = familyNames(fontMap);
-    const families = sources.length === 0 ? [] : after.filter((name) => !before.includes(name)).sort();
+    const families = requested.length === 0 ? [] : after.filter((name) => !before.includes(name)).sort();
     const matches = matchFontFamilies(expected, after);
 
     // THE SETTING, after the faces. Registering a typeface and rewriting `gtk-font-name` are two


### PR DESCRIPTION
The two darwin legs of `gtk-os-suites.yml` went red on `main` at b84c214 with no source change
behind them. Those legs pair the JS in the checkout with the PUBLISHED GTK bundle, so what moved
was the release: 0.51.0 is the first bundle to carry the six Adwaita faces (#1662), and the
prebuild-pointer commit aimed `main` at it.

`initFonts()` resolves TWO font sources — the application's own directory (`GJSIFY_FONT_DIR`) and
the runtime bundle's (`GJSIFY_GTK_RUNTIME_FONT_DIR`) — but reported them in ONE flat pair of
lists. `InitFontsResult.dir` was deliberately kept singular when the second source landed, so a
caller asking "was my staged face found" could not start answering yes because the platform's
arrived. `registered`/`declined`/`failed` were not given the same treatment, and seven assertions
in `fonts.spec.ts` had been reading them as "what MY staged directory contributed" since before
any published bundle carried a face. 0 became 6; one staged path became seven paths.

Finding those faces is correct and is the whole point of #1662, so this is a test defect. But
pinning 6 would be worse than the bug: the seventh face breaks it again, and it would still be
asserting nothing about the directory the test staged.

So the attribution moves into the result. `InitFontsResult.sources` now carries a
`FontSourceOutcome` per directory — what THAT source registered, what it declined, what failed —
computed in the loop that hands each file to the font map, which is the only place that knows
where a face came from. A caller cannot re-derive it afterwards without comparing path prefixes,
which is a guess about filesystem layout rather than a measurement. The spec now asks the source
it staged what it contributed, so no count in it knows how many faces a bundle carries.

win32 carries the same assumption and was ALREADY failing it — seven tests, three more than
darwin, because its font map registers faces where CoreText declines them. That leg reports green
only because `@gjsify/gtk-host` runs there as a `continue-on-error` probe, gating blocked on the
Unix-only table rows (#1446), so the failures never reached the job status. Linux has no
batteries-included runtime bundle at all, so the variable is never set there and the assumption
is latent rather than triggered.

Which is why the fix is not only the seven reads. A new suite stages BOTH directories from the
options instead of waiting for an environment to supply one, so the two-source shape is exercised
on every host — linux included, where nothing would otherwise reach it. That suite is also the
discriminator for the per-source read itself: it fails if the attribution stops excluding the
bundle, and it fails if it starts excluding everything.

Measured on Fedora 44 / Node 24 / `PangoCairoFcFontMap`, with the host's own six Adwaita faces
staged as a stand-in for the bundle's font directory:

- before, `GJSIFY_GTK_RUNTIME_FONT_DIR` set: 7 of 697 failed — the same seven the win32 leg lists
- after, same variable set: 700 of 700 passed
- after, variable unset: 700 of 700 passed, identical 3119 assertions

Each touched assertion was then broken on purpose to check it can still fail. Dropping the
`families` diff guard turns one red. Making the per-source read answer with the flat lists turns
nine red — the original seven plus both new ones. Emptying the attribution inside `initFonts()`
turns six red. One assertion could NOT be made to fail and is gone rather than kept: with nothing
staged and no family named, `initFonts()` takes its early return and reports an empty `families`
whatever the diff below it does, so the guard is held by the sibling test that reaches it.

ADR 0038's amendment records the widening, since it is the half that was missing when the second
source landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8QkeZTJyNXrniXhrsncT6
