### PR TITLE
fix(gtk-host): say when the UI font policy never ran

### DIFF
--- a/packages/framework/gtk-host/src/fonts.spec.ts
+++ b/packages/framework/gtk-host/src/fonts.spec.ts
@@ -26,6 +26,7 @@ import {
     type InitFontsResult,
     isUnsupportedByFontMap,
     matchFontFamily,
+    planUiFontPolicy,
     uiFontBaseline,
 } from './fonts.js';
 import { ADWAITA_UI_FONT_FAMILY, GNOME_UI_FONT_POINT_SIZE, UI_FONT_POLICIES } from './ui-font.js';
@@ -700,6 +701,35 @@ export default async () => {
                 expect(back.kind).toBe('restored');
                 expect(back.next).toBe(baseline);
                 expect(settings.gtk_font_name).toBe(baseline);
+            });
+
+            await it('says it never ran when there is no Gtk.Settings to act on', async () => {
+                // THE ARM A CONSUMER ACTUALLY HIT, and the reason it is now its own `kind`.
+                // `Gtk.Settings.get_default()` answers null before `Gtk.init()`, so an
+                // application that applies its stored policy at module scope — which reads like
+                // the right place, because the baseline must be captured before anything writes —
+                // gets a plan back that is indistinguishable from "this host needed nothing".
+                // Learn6502 0.8.0 shipped exactly that and printed `-> unparsed (unchanged)` on
+                // Windows, the platform the policy exists for.
+                //
+                // Reached through the `settings` seam because on a host with a display there is
+                // no other way in: once GTK is up, `get_default()` never answers null again.
+                const plan = applyUiFontPolicy({ policy: 'size', settings: null });
+                expect(plan.kind).toBe('uninitialised');
+                expect(plan.next).toBeUndefined();
+
+                // And it is DISTINCT from the arm it used to be reported as. An unreadable font
+                // name is the policy running and correctly declining; this is the policy not
+                // running. Asserting both keeps a future "simplification" from merging them back.
+                expect(planUiFontPolicy({ policy: 'size', current: 'Segoe UI' }).kind).toBe('unparsed');
+
+                // The real settings object is untouched — the null arm writes nothing anywhere.
+                const live = Gtk.Settings.get_default();
+                if (live !== null) {
+                    const before = live.gtk_font_name;
+                    applyUiFontPolicy({ policy: 'adwaita', settings: null });
+                    expect(live.gtk_font_name).toBe(before);
+                }
             });
 
             await it('re-applying a state writes nothing the second time', async () => {

--- a/packages/framework/gtk-host/src/fonts.ts
+++ b/packages/framework/gtk-host/src/fonts.ts
@@ -392,6 +392,14 @@ export function initFonts(options: InitFontsOptions = {}): InitFontsResult {
 /** Everything {@link planUiFontPolicy} takes except what this module supplies itself. */
 export interface ApplyUiFontPolicyOptions extends PlanUiFontOptions {
     readonly policy: UiFontPolicy;
+    /**
+     * The settings object to act on. Defaults to `Gtk.Settings.get_default()`.
+     *
+     * A seam, not a knob: the null arm below is the one a real consumer hit, and on a host with a
+     * display there is no way to reach it through the default — `get_default()` never answers null
+     * once GTK is up. Passing `null` explicitly is how the test for it exists at all.
+     */
+    readonly settings?: Gtk.Settings | null;
 }
 
 // THE BASELINE: `gtk-font-name` as this process first saw it.
@@ -446,16 +454,26 @@ export function uiFontBaseline(): string | undefined {
  * captured before the first write, which is why switching `adwaita` → `system` at runtime
  * returns the host's own `Segoe UI 9` rather than an approximation of it.
  *
- * `Gtk.Settings.get_default()` answers null before `Gtk.init()`, and that is a legitimate state
- * rather than an error: a program may register its faces before it initialises the toolkit. It
- * reports `unparsed` — the arm that already means "nothing to act on, so nothing changed" —
- * instead of throwing a caller out of a font call over a setting.
+ * `Gtk.Settings.get_default()` answers null before `Gtk.init()`. That is not an error to throw
+ * over — a program may register its faces before it initialises the toolkit — but it is NOT the
+ * same answer as "the policy ran and had nothing to do", and reporting it as `unparsed` said it
+ * was. A consumer that called this at module scope got a plan indistinguishable from a host that
+ * needed no correction, so its setting silently did nothing: measured in Learn6502 0.8.0, where
+ * `ui-font: policy=size -> unparsed (unchanged)` was printed on macOS and on Windows — the one
+ * platform whose 16 px against GNOME's 19 is the reason the policy exists. It now reports
+ * `uninitialised` and says so once, because a caller that is too early can only find out from
+ * here.
  */
 export function applyUiFontPolicy(request: UiFontPolicy | ApplyUiFontPolicyOptions): UiFontPlan {
     const options: ApplyUiFontPolicyOptions = typeof request === 'string' ? { policy: request } : request;
-    const settings = Gtk.Settings.get_default();
+    const settings = options.settings === undefined ? Gtk.Settings.get_default() : options.settings;
     if (settings === null) {
-        return { next: undefined, kind: 'unparsed', family: undefined, size: undefined };
+        console.warn(
+            'applyUiFontPolicy: no Gtk.Settings — the toolkit is not initialised yet, so the ' +
+                "policy was NOT applied. Call this after Gtk.init() (or from an application's " +
+                '`startup`), which is still before any window is built.',
+        );
+        return { next: undefined, kind: 'uninitialised', family: undefined, size: undefined };
     }
     // BEFORE the read of `current`, so the very first call through this function still records
     // the host's own value even when it is about to overwrite it.

--- a/packages/framework/gtk-host/src/ui-font.ts
+++ b/packages/framework/gtk-host/src/ui-font.ts
@@ -80,7 +80,7 @@ export type UiFontPolicy = 'system' | 'size' | 'adwaita';
 export const UI_FONT_POLICIES: readonly UiFontPolicy[] = ['system', 'size', 'adwaita'];
 
 /** The reasons a plan gives. See {@link UiFontPlan.kind}. */
-export type UiFontPlanKind = 'raised' | 'family' | 'restored' | 'kept' | 'unparsed';
+export type UiFontPlanKind = 'raised' | 'family' | 'restored' | 'kept' | 'unparsed' | 'uninitialised';
 
 /** What {@link planUiFont} or {@link planUiFontPolicy} decided, and why. */
 export interface UiFontPlan {
@@ -91,7 +91,17 @@ export interface UiFontPlan {
      * `family` — a family override was asked for and applied;
      * `restored` — the host's ORIGINAL value is being put back (the `system` policy);
      * `kept` — nothing to do: the setting already says what the policy wants;
-     * `unparsed` — the current value carries no point size this can reason about.
+     * `unparsed` — the current value carries no point size this can reason about;
+     * `uninitialised` — there was no `Gtk.Settings` to act on, so the policy did NOT run.
+     *
+     * THE LAST TWO ARE NOT THE SAME ANSWER and used to be reported as one. Both leave
+     * `gtk-font-name` alone, which is why collapsing them looked harmless — but `unparsed` means
+     * the policy ran and correctly declined, while `uninitialised` means it never ran at all. A
+     * consumer that calls this before `Gtk.init()` gets a plan that reads exactly like a host
+     * that needed nothing, so the setting it built is dead and its own log line says so in words
+     * that look fine. Learn6502 shipped that: `ui-font: policy=size -> unparsed (unchanged)` on
+     * macOS AND Windows, from a call at module scope, with the size correction never applied on
+     * the one platform it exists for.
      */
     readonly kind: UiFontPlanKind;
     /** The family in effect after the plan, for reporting. */


### PR DESCRIPTION
`applyUiFontPolicy` reported `unparsed` when there was no `Gtk.Settings` to act
on — the same answer it gives when the host's font name carries no readable
point size.

They are not the same answer. `unparsed` means the policy ran and correctly
declined; a null settings object means it **never ran**, because
`Gtk.Settings.get_default()` answers null before `Gtk.init()`. Both leave
`gtk-font-name` alone, which is why collapsing them looked harmless.

**Found by a consumer, not by a test.** Learn6502 0.8.0 applies its stored
policy at module scope — which reads like the right place, since the baseline
has to be captured before anything writes. Both platform builds printed:

    ui-font: policy=size -> unparsed (unchanged)

on macOS *and* on Windows. On macOS that is the correct outcome and on Windows
it is not, and the line is identical either way. The setting the app had just
shipped — a combo row in Preferences, a GSettings key, a schema — did nothing
at all on the one platform whose 16 px against GNOME's 19 px is the reason the
policy exists.

**What changed.** A distinct `uninitialised` kind, plus one `console.warn`
naming the fix: call it after `Gtk.init()`, or from an application's `startup`,
which is still before any window is built. No behaviour change for anyone
already calling it correctly.

**The test, and its break.** The null arm is unreachable through the default on
a host with a display — once GTK is up, `get_default()` never answers null
again — so `ApplyUiFontPolicyOptions` gains a `settings` seam and the test
passes `null` explicitly. It also asserts the neighbouring `unparsed` arm in
the same test, so a future simplification cannot merge them back silently.

    break: report 'unparsed' again  ->  1 of 701 tests failed
    fixed:                          ->  701 tests passed, 3124 assertions

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8QkeZTJyNXrniXhrsncT6
